### PR TITLE
[Client] Make bucketAssigner for lake table pluggable

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/lakehouse/AbstractBucketAssigner.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/lakehouse/AbstractBucketAssigner.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.lakehouse;
+
+import com.alibaba.fluss.row.InternalRow;
+
+/**
+ * the bucket extractor of bucket, fluss will use the bucket that bucket assign to align with lake
+ * table when data lake is enabled.
+ */
+public interface AbstractBucketAssigner {
+
+    int assignBucket(InternalRow row);
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/lakehouse/paimon/PaimonBucketAssigner.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/lakehouse/paimon/PaimonBucketAssigner.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.client.lakehouse.paimon;
 
+import com.alibaba.fluss.client.lakehouse.AbstractBucketAssigner;
 import com.alibaba.fluss.row.InternalRow;
 import com.alibaba.fluss.row.ProjectedRow;
 import com.alibaba.fluss.types.RowType;
@@ -28,7 +29,7 @@ import org.apache.paimon.types.DataType;
 import java.util.List;
 
 /** A bucket assigner to align with Paimon. */
-public class PaimonBucketAssigner {
+public class PaimonBucketAssigner implements AbstractBucketAssigner {
 
     private final int bucketNum;
 
@@ -56,6 +57,7 @@ public class PaimonBucketAssigner {
         return bucketKeyIndex;
     }
 
+    @Override
     public int assignBucket(InternalRow row) {
         BinaryRow bucketKey = getBucketRow(row);
         return KeyAndBucketExtractor.bucket(

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/FlussTable.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/FlussTable.java
@@ -201,7 +201,8 @@ public class FlussTable implements Table {
                         new LakeTableBucketAssigner(
                                 keyRowType,
                                 tableInfo.getTableDescriptor().getBucketKey(),
-                                numBuckets);
+                                numBuckets,
+                                tableInfo.getTableDescriptor().getDataLakeType());
             }
             return lakeTableBucketAssigner.assignBucket(
                     keyBytes, key, metadataUpdater.getCluster());

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -18,6 +18,7 @@ package com.alibaba.fluss.config;
 
 import com.alibaba.fluss.annotation.Internal;
 import com.alibaba.fluss.annotation.PublicEvolving;
+import com.alibaba.fluss.lakehouse.DataLakeType;
 import com.alibaba.fluss.metadata.KvFormat;
 import com.alibaba.fluss.metadata.LogFormat;
 import com.alibaba.fluss.utils.ArrayUtils;
@@ -883,6 +884,12 @@ public class ConfigOptions {
                             "Whether enable lakehouse storage for the table. Disabled by default. "
                                     + "When this option is set to ture and the datalake tiering service is up,"
                                     + " the table will be tiered and compacted into datalake format stored on lakehouse storage.");
+
+    public static final ConfigOption<DataLakeType> TABLE_DATALAKE_TYPE =
+            key("table.datalake.type")
+                    .enumType(DataLakeType.class)
+                    .defaultValue(DataLakeType.PAIMON)
+                    .withDescription("Datalake type, currently only supports paimon.");
 
     // ------------------------------------------------------------------------
     //  ConfigOptions for Kv

--- a/fluss-common/src/main/java/com/alibaba/fluss/lakehouse/DataLakeType.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/lakehouse/DataLakeType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.lakehouse;
+
+/** The type of data lake. */
+public enum DataLakeType {
+    PAIMON
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
@@ -22,6 +22,7 @@ import com.alibaba.fluss.config.ConfigOption;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.config.ConfigurationUtils;
+import com.alibaba.fluss.lakehouse.DataLakeType;
 import com.alibaba.fluss.utils.AutoPartitionStrategy;
 import com.alibaba.fluss.utils.Preconditions;
 import com.alibaba.fluss.utils.json.JsonSerdeUtils;
@@ -242,6 +243,10 @@ public final class TableDescriptor implements Serializable {
     /** Whether the data lake is enabled. */
     public boolean isDataLakeEnabled() {
         return configuration().get(ConfigOptions.TABLE_DATALAKE_ENABLED);
+    }
+
+    public DataLakeType getDataLakeType() {
+        return configuration().get(ConfigOptions.TABLE_DATALAKE_TYPE);
     }
 
     public TableDescriptor copy(Map<String, String> newProperties) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #124

Currently, LakeTableBucketAssigner is a fixed PaimonBucketAssigner. More data lakes may be supported in the future, so we should add a configuration item to make LakeTableBucketAssigner pluggable.

