### PR TITLE
[client] Introduce AdminApiDriver for workflows which lookup broker first then send request.

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
@@ -16,6 +16,10 @@
 
 package com.alibaba.fluss.client.admin;
 
+import com.alibaba.fluss.client.admin.internal.AdminApiFuture;
+import com.alibaba.fluss.client.admin.internal.AdminApiHandler;
+import com.alibaba.fluss.client.admin.internal.AdminApiWorkflow;
+import com.alibaba.fluss.client.admin.internal.ListOffsetsHandler;
 import com.alibaba.fluss.client.metadata.KvSnapshotMetadata;
 import com.alibaba.fluss.client.metadata.KvSnapshots;
 import com.alibaba.fluss.client.metadata.LakeSnapshot;
@@ -37,7 +41,6 @@ import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.rpc.GatewayClientProxy;
 import com.alibaba.fluss.rpc.RpcClient;
 import com.alibaba.fluss.rpc.gateway.AdminGateway;
-import com.alibaba.fluss.rpc.gateway.TabletServerGateway;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.CreateTableRequest;
 import com.alibaba.fluss.rpc.messages.DatabaseExistsRequest;
@@ -52,29 +55,20 @@ import com.alibaba.fluss.rpc.messages.GetTableInfoRequest;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaRequest;
 import com.alibaba.fluss.rpc.messages.ListDatabasesRequest;
 import com.alibaba.fluss.rpc.messages.ListDatabasesResponse;
-import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
 import com.alibaba.fluss.rpc.messages.ListPartitionInfosRequest;
 import com.alibaba.fluss.rpc.messages.ListTablesRequest;
 import com.alibaba.fluss.rpc.messages.ListTablesResponse;
-import com.alibaba.fluss.rpc.messages.PbListOffsetsRespForBucket;
 import com.alibaba.fluss.rpc.messages.TableExistsRequest;
 import com.alibaba.fluss.rpc.messages.TableExistsResponse;
-import com.alibaba.fluss.rpc.protocol.ApiError;
-import com.alibaba.fluss.utils.MapUtils;
-
-import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static com.alibaba.fluss.client.utils.ClientRpcMessageUtils.makeCreatePartitionRequest;
 import static com.alibaba.fluss.client.utils.ClientRpcMessageUtils.makeDropPartitionRequest;
-import static com.alibaba.fluss.client.utils.ClientRpcMessageUtils.makeListOffsetsRequest;
 import static com.alibaba.fluss.client.utils.MetadataUtils.sendMetadataRequestAndRebuildCluster;
 import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
 
@@ -346,74 +340,18 @@ public class FlussAdmin implements Admin {
             metadataUpdater.checkAndUpdatePartitionMetadata(physicalTablePath);
             partitionId = metadataUpdater.getPartitionIdOrElseThrow(physicalTablePath);
         }
-        Map<Integer, ListOffsetsRequest> requestMap =
-                prepareListOffsetsRequests(
-                        metadataUpdater, tableId, partitionId, buckets, offsetSpec);
-        Map<Integer, CompletableFuture<Long>> bucketToOffsetMap = MapUtils.newConcurrentHashMap();
-        for (int bucket : buckets) {
-            bucketToOffsetMap.put(bucket, new CompletableFuture<>());
-        }
 
-        sendListOffsetsRequest(metadataUpdater, client, requestMap, bucketToOffsetMap);
-        return new ListOffsetsResult(bucketToOffsetMap);
+        AdminApiFuture.SimpleAdminApiFuture<Integer, Long> future =
+                ListOffsetsHandler.newFuture(buckets);
+        AdminApiHandler<Integer, Long> handler =
+                new ListOffsetsHandler(metadataUpdater, tableId, partitionId, offsetSpec, client);
+        AdminApiWorkflow<Integer, Long> adminApiDriver = new AdminApiWorkflow<>(future, handler);
+        CompletableFuture.runAsync(adminApiDriver::maybeSendRequests);
+        return new ListOffsetsResult(future.all());
     }
 
     @Override
     public void close() {
         // nothing to do yet
-    }
-
-    private static Map<Integer, ListOffsetsRequest> prepareListOffsetsRequests(
-            MetadataUpdater metadataUpdater,
-            long tableId,
-            @Nullable Long partitionId,
-            Collection<Integer> buckets,
-            OffsetSpec offsetSpec) {
-        Map<Integer, List<Integer>> nodeForBucketList = new HashMap<>();
-        for (Integer bucketId : buckets) {
-            int leader = metadataUpdater.leaderFor(new TableBucket(tableId, partitionId, bucketId));
-            nodeForBucketList.computeIfAbsent(leader, k -> new ArrayList<>()).add(bucketId);
-        }
-
-        Map<Integer, ListOffsetsRequest> listOffsetsRequests = new HashMap<>();
-        nodeForBucketList.forEach(
-                (leader, ids) ->
-                        listOffsetsRequests.put(
-                                leader,
-                                makeListOffsetsRequest(tableId, partitionId, ids, offsetSpec)));
-        return listOffsetsRequests;
-    }
-
-    private static void sendListOffsetsRequest(
-            MetadataUpdater metadataUpdater,
-            RpcClient client,
-            Map<Integer, ListOffsetsRequest> leaderToRequestMap,
-            Map<Integer, CompletableFuture<Long>> bucketToOffsetMap) {
-        leaderToRequestMap.forEach(
-                (leader, request) -> {
-                    TabletServerGateway gateway =
-                            GatewayClientProxy.createGatewayProxy(
-                                    () -> metadataUpdater.getTabletServer(leader),
-                                    client,
-                                    TabletServerGateway.class);
-                    gateway.listOffsets(request)
-                            .thenAccept(
-                                    r -> {
-                                        for (PbListOffsetsRespForBucket resp :
-                                                r.getBucketsRespsList()) {
-                                            if (resp.hasErrorCode()) {
-                                                bucketToOffsetMap
-                                                        .get(resp.getBucketId())
-                                                        .completeExceptionally(
-                                                                ApiError.fromErrorMessage(resp)
-                                                                        .exception());
-                                            } else {
-                                                bucketToOffsetMap
-                                                        .get(resp.getBucketId())
-                                                        .complete(resp.getOffset());
-                                            }
-                                        }
-                                    });
-                });
     }
 }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/AdminApiFuture.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/AdminApiFuture.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.client.admin.internal;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/* This file is based on source code of Apache Kafka Project (https://kafka.apache.org/), licensed by the Apache
+ * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. */
+
+/** A future that can be used to track the completion of a set of lookup keys. */
+public interface AdminApiFuture<K, V> {
+
+    /**
+     * The initial set of lookup keys. Although this will usually match the fulfillment keys, it
+     * does not necessarily have to. For example, in the case of {@link
+     * BucketLeaderTabletServerLookupStrategy}, we use the lookup phase in order to discover the set
+     * of keys that will be searched during the fulfillment phase.
+     *
+     * @return non-empty set of initial lookup keys
+     */
+    Set<K> lookupKeys();
+
+    /**
+     * Complete the futures associated with the given keys.
+     *
+     * @param values the completed keys with their respective values
+     */
+    void complete(Map<K, V> values);
+
+    /**
+     * Invoked when lookup of a set of keys succeeds.
+     *
+     * @param serverIdMapping the discovered mapping from key to the respective serverId that will
+     *     handle the fulfillment request
+     */
+    default void completeLookup(Map<K, Integer> serverIdMapping) {}
+
+    /**
+     * Invoked when lookup fails with a fatal error on a set of keys.
+     *
+     * @param lookupErrors the set of keys that failed lookup with their respective errors
+     */
+    default void completeLookupExceptionally(Map<K, Throwable> lookupErrors) {
+        completeExceptionally(lookupErrors);
+    }
+
+    /**
+     * Complete the futures associated with the given keys exceptionally.
+     *
+     * @param errors the failed keys with their respective errors
+     */
+    void completeExceptionally(Map<K, Throwable> errors);
+
+    static <K, V> SimpleAdminApiFuture<K, V> forKeys(Set<K> keys) {
+        return new SimpleAdminApiFuture<>(keys);
+    }
+
+    /** This class can be used when the set of keys is known ahead of time. */
+    class SimpleAdminApiFuture<K, V> implements AdminApiFuture<K, V> {
+        private final Map<K, CompletableFuture<V>> futures;
+
+        public SimpleAdminApiFuture(Set<K> keys) {
+            this.futures =
+                    keys.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            Function.identity(), k -> new CompletableFuture<>()));
+        }
+
+        @Override
+        public Set<K> lookupKeys() {
+            return futures.keySet();
+        }
+
+        @Override
+        public void complete(Map<K, V> values) {
+            values.forEach(this::complete);
+        }
+
+        private void complete(K key, V value) {
+            futureOrThrow(key).complete(value);
+        }
+
+        @Override
+        public void completeExceptionally(Map<K, Throwable> errors) {
+            errors.forEach(this::completeExceptionally);
+        }
+
+        private void completeExceptionally(K key, Throwable t) {
+            futureOrThrow(key).completeExceptionally(t);
+        }
+
+        private CompletableFuture<V> futureOrThrow(K key) {
+            CompletableFuture<V> future = futures.get(key);
+            if (future == null) {
+                throw new IllegalArgumentException(
+                        "Attempt to complete future for " + key + ", which was not requested");
+            } else {
+                return future;
+            }
+        }
+
+        public Map<K, CompletableFuture<V>> all() {
+            return futures;
+        }
+
+        public CompletableFuture<V> get(K key) {
+            return futures.get(key);
+        }
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/AdminApiHandler.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/AdminApiHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.admin.internal;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/* This file is based on source code of Apache Kafka Project (https://kafka.apache.org/), licensed by the Apache
+ * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. */
+
+/**
+ * A handler to lookup server id for keys and then send request to these servers.
+ *
+ * @param <K>
+ * @param <V>
+ */
+public interface AdminApiHandler<K, V> {
+
+    /**
+     * Get the lookup strategy that is responsible for finding the server id which will handle each
+     * respective key.
+     *
+     * @return non-null lookup strategy
+     */
+    TabletServerLookupStrategy<K> lookupStrategy();
+
+    /**
+     * Handle the given keys by sending the respective requests to the given serverId. The handler
+     * should parse the response, check for errors, and return a result which indicates which keys
+     * (if any) have either been completed or failed with an unrecoverable error. It is also
+     * possible that the response indicates an incorrect target serverId (e. g. in the case of a
+     * NotLeader error when the request is bound for a partition leader). In this case the key will
+     * be "unmapped" from the target serverId and lookup will be retried. Note that keys which
+     * received a retriable error should be left out of the result. They will be retried
+     * automatically.
+     *
+     * @param node the node to send the requests to
+     * @param keys the keys to handle
+     * @return result indicating key completion, failure, and unmapping
+     */
+    CompletableFuture<ApiResult<K, V>> handle(int node, Set<K> keys);
+
+    class ApiResult<K, V> {
+        public final Map<K, V> completedKeys;
+        public final Map<K, Throwable> failedKeys;
+        public final Set<K> unmappedKeys;
+
+        public ApiResult(
+                Map<K, V> completedKeys, Map<K, Throwable> failedKeys, Set<K> unmappedKeys) {
+            this.completedKeys = Collections.unmodifiableMap(completedKeys);
+            this.failedKeys = Collections.unmodifiableMap(failedKeys);
+            this.unmappedKeys = Collections.unmodifiableSet(unmappedKeys);
+        }
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/AdminApiWorkflow.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/AdminApiWorkflow.java
@@ -1,0 +1,205 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.client.admin.internal;
+
+import com.alibaba.fluss.annotation.Internal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/* This file is based on source code of Apache Kafka Project (https://kafka.apache.org/), licensed by the Apache
+ * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. */
+
+/**
+ * A workflow for multi-stage request workflows, such as those seen with the ListOffsets API or any
+ * request that needs to be sent to a bucket leader. These APIs typically have two main stages:
+ *
+ * <p>1. **Lookup**: Find the tablet server that can fulfill the request (e.g., bucket leader or
+ * coordinator).
+ *
+ * <p>2. **Fulfillment**: Send the request to the servers identified in the Lookup stage.
+ *
+ * <p>This process is complicated by the fact that `Admin` APIs are often batched. The Lookup stage
+ * may result in a set of servers. For example, a `ListOffsets` request for multiple table buckets
+ * will involve finding the bucket leader servers for these buckets in the Lookup stage. In the
+ * Fulfillment stage, requests are grouped according to the IDs of the discovered leaders.
+ *
+ * <p>Additionally, the flow between these two stages is bidirectional. After sending a
+ * `ListOffsets` request to an expected bucket leader sever, a leader change might be detected,
+ * causing a table bucket to be sent back to the Lookup stage for re-evaluation.
+ *
+ * @param <K> The key type, which determines the granularity of request routing. For example, this
+ *     could be `TableBucket` for requests intended for a bucket leader in`ListOffsets`
+ * @param <V> The fulfillment type for each key. For example, this could be the offset for each
+ *     bucket in`ListOffsets`.
+ */
+@Internal
+public class AdminApiWorkflow<K, V> {
+    private static final long RETRY_DELAY_MS = 100L;
+
+    private final Set<K> lookupKeys;
+    private final BiMultimap<Integer, K> fulfillmentMap;
+    private final AdminApiFuture<K, V> future;
+    private final AdminApiHandler<K, V> handler;
+
+    public AdminApiWorkflow(AdminApiFuture<K, V> future, AdminApiHandler<K, V> handler) {
+        this.future = future;
+        this.handler = handler;
+        this.lookupKeys = new HashSet<>();
+        this.fulfillmentMap = new BiMultimap<>();
+        retryLookup(future.lookupKeys());
+    }
+
+    public void maybeSendRequests() {
+        if (!lookupKeys.isEmpty()) {
+            handler.lookupStrategy()
+                    .lookup(Collections.unmodifiableSet(lookupKeys))
+                    .thenAcceptAsync(
+                            lookupResult -> {
+                                completeLookup(lookupResult.mappedKeys);
+                                completeLookupExceptionally(lookupResult.failedKeys);
+                                try {
+                                    Thread.sleep(RETRY_DELAY_MS);
+                                } catch (InterruptedException e) {
+                                    throw new RuntimeException(e);
+                                }
+                                // maybe send requests again if not finished.
+                                maybeSendRequests();
+                            });
+        }
+
+        for (Map.Entry<Integer, Set<K>> entry : fulfillmentMap.entrySet()) {
+            handler.handle(entry.getKey(), entry.getValue())
+                    .thenAcceptAsync(
+                            apiResult -> {
+                                complete(apiResult.completedKeys);
+                                completeExceptionally(apiResult.failedKeys);
+                                retryLookup(apiResult.unmappedKeys);
+                                // maybe send requests again if not finished.
+                                maybeSendRequests();
+                            });
+        }
+    }
+
+    private void retryLookup(Collection<K> keys) {
+        keys.forEach(this::unmap);
+    }
+
+    private void completeLookup(Map<K, Integer> nodeIdMapping) {
+        if (!nodeIdMapping.isEmpty()) {
+            future.completeLookup(nodeIdMapping);
+            nodeIdMapping.forEach(this::map);
+        }
+    }
+
+    private void completeLookupExceptionally(Map<K, Throwable> errors) {
+        if (!errors.isEmpty()) {
+            future.completeLookupExceptionally(errors);
+            clear(errors.keySet());
+        }
+    }
+
+    /**
+     * Complete the future associated with the given key. After this is called, all keys will be
+     * taken out of both the Lookup and Fulfillment stages so that request are not retried.
+     */
+    private void complete(Map<K, V> values) {
+        if (!values.isEmpty()) {
+            future.complete(values);
+            clear(values.keySet());
+        }
+    }
+
+    /**
+     * Complete the future associated with the given key exceptionally. After is called, the key
+     * will be taken out of both the Lookup and Fulfillment stages so that request are not retried.
+     */
+    private void completeExceptionally(Map<K, Throwable> errors) {
+        if (!errors.isEmpty()) {
+            future.completeExceptionally(errors);
+            clear(errors.keySet());
+        }
+    }
+
+    /**
+     * Associate a key with a server id. This is called after a response in the Lookup stage reveals
+     * the mapping.
+     *
+     * <p>For example, when handling a <code>listOffsets</code> request, this method would then
+     * associate the <code>bucket</code> (as the key) with the <code>tablet server node</code> (as
+     * the serverId).
+     *
+     * @param lookupKey The key to be associated, typically used to identify a specific resource or
+     *     request. For instance, a bucket identifier.
+     * @param serverId The identifier of the server, used to establish an association between the
+     *     key and the server. For instance, the tablet server node identifier.
+     */
+    private void map(K lookupKey, Integer serverId) {
+        lookupKeys.remove(lookupKey);
+        fulfillmentMap.put(serverId, lookupKey);
+    }
+
+    /**
+     * Disassociates a key from its currently mapped tablet server ID. This action sends the key
+     * back to the Lookup stage, enabling another attempt at lookup.
+     */
+    private void unmap(K lookupKey) {
+        fulfillmentMap.remove(lookupKey);
+        lookupKeys.add(lookupKey);
+    }
+
+    private void clear(Collection<K> keys) {
+        keys.forEach(
+                key -> {
+                    lookupKeys.remove(key);
+                    fulfillmentMap.remove(key);
+                });
+    }
+
+    private static class BiMultimap<K, V> {
+        private final Map<V, K> reverseMap = new HashMap<>();
+        private final Map<K, Set<V>> map = new HashMap<>();
+
+        void put(K key, V value) {
+            remove(value);
+            reverseMap.put(value, key);
+            map.computeIfAbsent(key, k -> new HashSet<>()).add(value);
+        }
+
+        void remove(V value) {
+            K key = reverseMap.remove(value);
+            if (key != null) {
+                Set<V> set = map.get(key);
+                if (set != null) {
+                    set.remove(value);
+                    if (set.isEmpty()) {
+                        map.remove(key);
+                    }
+                }
+            }
+        }
+
+        Set<Map.Entry<K, Set<V>>> entrySet() {
+            return Collections.unmodifiableMap(map).entrySet();
+        }
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/BucketLeaderTabletServerLookupStrategy.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/BucketLeaderTabletServerLookupStrategy.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.client.admin.internal;
+
+import com.alibaba.fluss.client.metadata.MetadataUpdater;
+import com.alibaba.fluss.exception.LeaderNotAvailableException;
+import com.alibaba.fluss.metadata.TableBucket;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Strategy to lookup leader tablet servers ID for bucket. This strategy is responsible for finding
+ * the leader tablet servers for a given set of buckets.
+ */
+public class BucketLeaderTabletServerLookupStrategy implements TabletServerLookupStrategy<Integer> {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(BucketLeaderTabletServerLookupStrategy.class);
+
+    private final MetadataUpdater metadataUpdater;
+    private final long tableId;
+    private final @Nullable Long partitionId;
+
+    public BucketLeaderTabletServerLookupStrategy(
+            MetadataUpdater metadataUpdater, long tableId, @Nullable Long partitionId) {
+        this.metadataUpdater = metadataUpdater;
+        this.tableId = tableId;
+        this.partitionId = partitionId;
+    }
+
+    @Override
+    public CompletableFuture<LookupServerResult<Integer>> lookup(Set<Integer> buckets) {
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    Map<Integer, Integer> mappedKeys = new HashMap<>();
+                    Map<Integer, Throwable> failedKeys = new HashMap<>();
+                    for (Integer bucketId : buckets) {
+                        try {
+                            int leader =
+                                    metadataUpdater.leaderFor(
+                                            new TableBucket(tableId, partitionId, bucketId));
+                            mappedKeys.put(bucketId, leader);
+                        } catch (LeaderNotAvailableException e) {
+                            LOG.warn("Leader not available and will retry lookup later", e);
+                        } catch (Throwable t) {
+                            LOG.warn("Failed to lookup bucket leader", t);
+                            failedKeys.put(bucketId, t);
+                        }
+                    }
+                    return new LookupServerResult<>(mappedKeys, failedKeys);
+                });
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/ListOffsetsHandler.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/ListOffsetsHandler.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.admin.internal;
+
+import com.alibaba.fluss.annotation.Internal;
+import com.alibaba.fluss.client.admin.OffsetSpec;
+import com.alibaba.fluss.client.metadata.MetadataUpdater;
+import com.alibaba.fluss.exception.ApiException;
+import com.alibaba.fluss.exception.LeaderNotAvailableException;
+import com.alibaba.fluss.exception.NotLeaderOrFollowerException;
+import com.alibaba.fluss.exception.RetriableException;
+import com.alibaba.fluss.rpc.GatewayClientProxy;
+import com.alibaba.fluss.rpc.RpcClient;
+import com.alibaba.fluss.rpc.gateway.TabletServerGateway;
+import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
+import com.alibaba.fluss.rpc.messages.PbListOffsetsRespForBucket;
+import com.alibaba.fluss.rpc.protocol.ApiError;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static com.alibaba.fluss.client.utils.ClientRpcMessageUtils.makeListOffsetsRequest;
+
+/** ListOffsetsHandler is used to list offsets for a set of buckets. */
+@Internal
+public class ListOffsetsHandler implements AdminApiHandler<Integer, Long> {
+    private static final Logger LOG = LoggerFactory.getLogger(ListOffsetsHandler.class);
+
+    private final TabletServerLookupStrategy<Integer> lookupStrategy;
+    private final MetadataUpdater metadataUpdater;
+    private final long tableId;
+    private final @Nullable Long partitionId;
+    private final OffsetSpec offsetSpec;
+    private final RpcClient client;
+
+    public ListOffsetsHandler(
+            MetadataUpdater metadataUpdater,
+            long tableId,
+            @Nullable Long partitionId,
+            OffsetSpec offsetSpec,
+            RpcClient client) {
+        this.lookupStrategy =
+                new BucketLeaderTabletServerLookupStrategy(metadataUpdater, tableId, partitionId);
+        this.metadataUpdater = metadataUpdater;
+        this.tableId = tableId;
+        this.partitionId = partitionId;
+        this.offsetSpec = offsetSpec;
+        this.client = client;
+    }
+
+    @Override
+    public TabletServerLookupStrategy<Integer> lookupStrategy() {
+        return lookupStrategy;
+    }
+
+    @Override
+    public CompletableFuture<ApiResult<Integer, Long>> handle(int leader, Set<Integer> bucketIds) {
+        CompletableFuture<ApiResult<Integer, Long>> future = new CompletableFuture<>();
+        ListOffsetsRequest listOffsetsRequest =
+                makeListOffsetsRequest(tableId, partitionId, bucketIds, offsetSpec);
+        sendListOffsetsRequest(
+                metadataUpdater, client, leader, listOffsetsRequest, future, bucketIds);
+        return future;
+    }
+
+    private static void sendListOffsetsRequest(
+            MetadataUpdater metadataUpdater,
+            RpcClient client,
+            int leader,
+            ListOffsetsRequest request,
+            CompletableFuture<ApiResult<Integer, Long>> future,
+            Set<Integer> bucketIds) {
+
+        TabletServerGateway gateway =
+                GatewayClientProxy.createGatewayProxy(
+                        () -> metadataUpdater.getTabletServer(leader),
+                        client,
+                        TabletServerGateway.class);
+        gateway.listOffsets(request)
+                .thenAccept(
+                        r -> {
+                            Map<Integer, Long> completedKeys = new HashMap<>();
+                            Map<Integer, Throwable> failedKeys = new HashMap<>();
+                            Set<Integer> unmappedKeys = new HashSet<>();
+                            Set<Integer> retryKeys = new HashSet<>();
+
+                            for (PbListOffsetsRespForBucket resp : r.getBucketsRespsList()) {
+                                if (resp.hasErrorCode()) {
+                                    ApiException exception =
+                                            ApiError.fromErrorMessage(resp).exception();
+
+                                    if (exception instanceof LeaderNotAvailableException
+                                            || exception instanceof NotLeaderOrFollowerException) {
+                                        LOG.info(
+                                                "Server {} is not leader or not available for bucket {}, will retry to lookup leader server later.",
+                                                leader,
+                                                resp.getBucketId());
+                                        unmappedKeys.add(resp.getBucketId());
+                                        // Even leader server can be lookup, server which hasn't
+                                        // receive the NotifyLeaderAndIsrRequest still will throw
+                                        // UNKNOWN_TABLE_OR_BUCKET_EXCEPTION.
+                                    } else if (exception instanceof RetriableException) {
+                                        LOG.warn(
+                                                "Server {} return retry exception for table bucket {} , will retry to list offsets later.); The exception is: {} ",
+                                                leader,
+                                                resp.getBucketId(),
+                                                exception);
+                                        retryKeys.add(resp.getBucketId());
+                                    } else {
+                                        failedKeys.put(resp.getBucketId(), exception);
+                                    }
+                                } else {
+                                    completedKeys.put(resp.getBucketId(), resp.getOffset());
+                                }
+                            }
+                            // Sanity-check if the current leader for these partitions returned
+                            // results for all of them
+                            for (Integer bucketId : bucketIds) {
+                                if (unmappedKeys.isEmpty()
+                                        && !completedKeys.containsKey(bucketId)
+                                        && !failedKeys.containsKey(bucketId)
+                                        && !retryKeys.contains(bucketId)) {
+                                    ApiException sanityCheckException =
+                                            new ApiException(
+                                                    "The response from server "
+                                                            + leader
+                                                            + " did not contain a result for table bucket "
+                                                            + bucketId);
+                                    LOG.error(
+                                            "ListOffsets request for table bucket {} failed sanity check",
+                                            bucketId,
+                                            sanityCheckException);
+                                    failedKeys.put(bucketId, sanityCheckException);
+                                }
+                            }
+
+                            future.complete(
+                                    new ApiResult<>(completedKeys, failedKeys, unmappedKeys));
+                        });
+    }
+
+    public static AdminApiFuture.SimpleAdminApiFuture<Integer, Long> newFuture(
+            Collection<Integer> bucketIds) {
+        return AdminApiFuture.forKeys(new HashSet<>(bucketIds));
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/TabletServerLookupStrategy.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/internal/TabletServerLookupStrategy.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.client.admin.internal;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/* This file is based on source code of Apache Kafka Project (https://kafka.apache.org/), licensed by the Apache
+ * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. */
+
+/**
+ * Defines an interface for a strategy to lookup tablet servers. This interface specifies how to
+ * find or select tablet servers for subsequent data processing or operations.
+ *
+ * @param <K> Represents the key type used in the lookup strategy. This allows different
+ *     implementations to look up tablet servers based on different key types.
+ */
+public interface TabletServerLookupStrategy<K> {
+
+    /**
+     * Looks up the tablet server IDs for the given keys. The handler should parse the response,
+     * check for errors, and return a result indicating which keys were successfully mapped to a
+     * tablet server ID and which keys encountered a fatal error.
+     *
+     * <p>- Keys with retriable errors should be omitted from the result; they will be automatically
+     * retried.
+     *
+     * <p>- For example, if the response of a `ListOffset` request indicates no leader is ready, the
+     * key should be excluded from the result to allow for retry.
+     *
+     * @param keys the set of keys that require lookup
+     * @return a CompletableFuture containing a result indicating which keys mapped successfully to
+     *     a tablet server id and which encountered a fatal error
+     */
+    CompletableFuture<LookupServerResult<K>> lookup(Set<K> keys);
+
+    class LookupServerResult<K> {
+
+        // This is the set of keys that have been mapped to a specific server for
+        // fulfillment of the API request.
+        public final Map<K, Integer> mappedKeys;
+
+        // This is the set of keys that have encountered a fatal error during the lookup
+        // phase. The driver will not attempt lookup or fulfillment for failed keys.
+        public final Map<K, Throwable> failedKeys;
+
+        public LookupServerResult(Map<K, Integer> mappedKeys, Map<K, Throwable> failedKeys) {
+            this.mappedKeys = Collections.unmodifiableMap(mappedKeys);
+            this.failedKeys = Collections.unmodifiableMap(failedKeys);
+        }
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
@@ -25,6 +25,7 @@ import com.alibaba.fluss.cluster.ServerType;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.FlussRuntimeException;
+import com.alibaba.fluss.exception.LeaderNotAvailableException;
 import com.alibaba.fluss.exception.RetriableException;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TableBucket;
@@ -135,7 +136,7 @@ public class MetadataUpdater {
             }
 
             if (serverNode == null) {
-                throw new FlussRuntimeException(
+                throw new LeaderNotAvailableException(
                         "Leader not found after retry  "
                                 + MAX_RETRY_TIMES
                                 + " times for table bucket: "

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/utils/ClientRpcMessageUtils.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/utils/ClientRpcMessageUtils.java
@@ -351,7 +351,7 @@ public class ClientRpcMessageUtils {
     public static ListOffsetsRequest makeListOffsetsRequest(
             long tableId,
             @Nullable Long partitionId,
-            List<Integer> bucketIdList,
+            Collection<Integer> bucketIdList,
             OffsetSpec offsetSpec) {
         ListOffsetsRequest listOffsetsRequest = new ListOffsetsRequest();
         listOffsetsRequest

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
@@ -46,6 +46,7 @@ import com.alibaba.fluss.metadata.DatabaseInfo;
 import com.alibaba.fluss.metadata.KvFormat;
 import com.alibaba.fluss.metadata.LogFormat;
 import com.alibaba.fluss.metadata.PartitionInfo;
+import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.SchemaInfo;
 import com.alibaba.fluss.metadata.TableBucket;
@@ -773,6 +774,19 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
                                     .getTableName())
                     .isEqualTo("test_table_1");
         }
+    }
+
+    @Test
+    void testListOffsets() throws Exception {
+        TablePath newTablePath = TablePath.of("test_db", "new_table");
+        createTable(newTablePath, DEFAULT_TABLE_DESCRIPTOR, true);
+        ListOffsetsResult listOffsetsResult =
+                admin.listOffsets(
+                        PhysicalTablePath.of(newTablePath),
+                        Arrays.asList(0, 1, 2),
+                        new OffsetSpec.LatestSpec());
+        assertThat(listOffsetsResult.all().get().values())
+                .hasSameElementsAs(Arrays.asList(0L, 0L, 0L));
     }
 
     private void assertHasTabletServerNumber(int tabletServerNumber) {

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/internal/AdminApiWorkflowTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/internal/AdminApiWorkflowTest.java
@@ -1,0 +1,220 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.client.admin.internal;
+
+import com.alibaba.fluss.exception.InvalidBucketsException;
+import com.alibaba.fluss.exception.InvalidOffsetException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link AdminApiWorkflow}. */
+public class AdminApiWorkflowTest {
+
+    @Test
+    void testNormal() throws ExecutionException, InterruptedException {
+        Set<String> lookupKeys = new HashSet<>(Arrays.asList("bucket1", "bucket2"));
+        AdminApiFuture.SimpleAdminApiFuture<String, Long> future =
+                AdminApiFuture.forKeys(lookupKeys);
+        MockLookupStrategy<String> lookupStrategy = new MockLookupStrategy<>();
+        MockAdminApiHandler<String, Long> adminApiHandler =
+                new MockAdminApiHandler<>(lookupStrategy);
+        AdminApiWorkflow<String, Long> driver = new AdminApiWorkflow<>(future, adminApiHandler);
+
+        lookupStrategy.expectLookupResult("bucket1", 1).expectLookupResult("bucket2", 2);
+        adminApiHandler.expectResult(1, 1L).expectResult(2, 2L);
+        driver.maybeSendRequests();
+        assertThat(future.get("bucket1").get()).isEqualTo(1);
+        assertThat(future.get("bucket2").get()).isEqualTo(2);
+    }
+
+    @Test
+    void testKeyLookupFailure() {
+        Set<String> lookupKeys = Collections.singleton("bucket1");
+        AdminApiFuture.SimpleAdminApiFuture<String, Long> future =
+                AdminApiFuture.forKeys(lookupKeys);
+        MockLookupStrategy<String> lookupStrategy = new MockLookupStrategy<>();
+        MockAdminApiHandler<String, Long> adminApiHandler =
+                new MockAdminApiHandler<>(lookupStrategy);
+        AdminApiWorkflow<String, Long> driver = new AdminApiWorkflow<>(future, adminApiHandler);
+        lookupStrategy.expectLookupException(
+                "bucket1", new InvalidBucketsException("Test lookup failure."));
+        driver.maybeSendRequests();
+
+        assertThatThrownBy(() -> future.get("bucket1").get())
+                .cause()
+                .isExactlyInstanceOf(InvalidBucketsException.class)
+                .hasMessageContaining("Test lookup failure.");
+    }
+
+    @Test
+    void testKeyLookupRetriable() throws ExecutionException, InterruptedException {
+        Set<String> lookupKeys = new HashSet<>(Arrays.asList("bucket1", "bucket2"));
+        AdminApiFuture.SimpleAdminApiFuture<String, Long> future =
+                AdminApiFuture.forKeys(lookupKeys);
+        MockLookupStrategy<String> lookupStrategy = new MockLookupStrategy<>();
+        MockAdminApiHandler<String, Long> adminApiHandler =
+                new MockAdminApiHandler<>(lookupStrategy);
+        AdminApiWorkflow<String, Long> driver = new AdminApiWorkflow<>(future, adminApiHandler);
+
+        // server of bucket1 is ready while server of bucket2 is not ready
+        lookupStrategy.expectLookupResult("bucket1", 1);
+        adminApiHandler.expectResult(1, 1L).expectResult(2, 2L);
+
+        driver.maybeSendRequests();
+        assertThat(future.get("bucket1").get()).isEqualTo(1);
+        assertThat(future.get("bucket2").isDone()).isFalse();
+
+        // partition of bucket2 is ready
+        lookupStrategy.expectLookupResult("bucket2", 2);
+        assertThat(future.get("bucket2").get()).isEqualTo(2);
+    }
+
+    @Test
+    void testFulfillmentFailure() throws ExecutionException, InterruptedException {
+        Set<String> lookupKeys = new HashSet<>(Arrays.asList("bucket1", "bucket2"));
+        AdminApiFuture.SimpleAdminApiFuture<String, Long> future =
+                AdminApiFuture.forKeys(lookupKeys);
+        MockLookupStrategy<String> lookupStrategy = new MockLookupStrategy<>();
+        MockAdminApiHandler<String, Long> adminApiHandler =
+                new MockAdminApiHandler<>(lookupStrategy);
+        AdminApiWorkflow<String, Long> driver = new AdminApiWorkflow<>(future, adminApiHandler);
+
+        lookupStrategy.expectLookupResult("bucket1", 1).expectLookupResult("bucket2", 2);
+        adminApiHandler
+                .expectResult(1, 1L)
+                .expectException(2, new InvalidOffsetException("Test fulfillment failure."));
+
+        driver.maybeSendRequests();
+        assertThat(future.get("bucket1").get()).isEqualTo(1);
+        assertThatThrownBy(() -> future.get("bucket2").get())
+                .cause()
+                .isExactlyInstanceOf(InvalidOffsetException.class)
+                .hasMessageContaining("Test fulfillment failure.");
+    }
+
+    @Test
+    void testFulfillmentRetriable() throws ExecutionException, InterruptedException {
+        Set<String> lookupKeys = new HashSet<>(Arrays.asList("bucket1", "bucket2"));
+        AdminApiFuture.SimpleAdminApiFuture<String, Long> future =
+                AdminApiFuture.forKeys(lookupKeys);
+        MockLookupStrategy<String> lookupStrategy = new MockLookupStrategy<>();
+        MockAdminApiHandler<String, Long> adminApiHandler =
+                new MockAdminApiHandler<>(lookupStrategy);
+        AdminApiWorkflow<String, Long> driver = new AdminApiWorkflow<>(future, adminApiHandler);
+
+        // Though both server of bucket1 and bucket2 can be lookup, server 2 is not ready now(maybe
+        // in recovery).
+        lookupStrategy.expectLookupResult("bucket1", 1).expectLookupResult("bucket2", 2);
+        adminApiHandler.expectResult(1, 1L);
+        driver.maybeSendRequests();
+        assertThat(future.get("bucket1").get()).isEqualTo(1);
+        assertThat(future.get("bucket2").isDone()).isFalse();
+
+        // server 2 is ready now.
+        adminApiHandler.expectResult(2, 2L);
+        assertThat(future.get("bucket2").get()).isEqualTo(2);
+    }
+
+    private static class MockLookupStrategy<K> implements TabletServerLookupStrategy<K> {
+        private final Map<K, Integer> expectedLookups = new HashMap<>();
+        private final Map<K, Throwable> expectedLookupExceptions = new HashMap<>();
+
+        @Override
+        public CompletableFuture<LookupServerResult<K>> lookup(Set<K> keys) {
+            return CompletableFuture.supplyAsync(
+                    () -> {
+                        Map<K, Integer> mappedKeys = new HashMap<>();
+                        Map<K, Throwable> failedKeys = new HashMap<>();
+                        for (K key : keys) {
+                            if (expectedLookups.containsKey(key)) {
+                                mappedKeys.put(key, expectedLookups.get(key));
+                            } else if (expectedLookupExceptions.containsKey(key)) {
+                                failedKeys.put(key, expectedLookupExceptions.get(key));
+                            }
+                        }
+
+                        return new LookupServerResult<>(mappedKeys, failedKeys);
+                    });
+        }
+
+        public MockLookupStrategy<K> expectLookupResult(K key, Integer serverId) {
+            expectedLookups.put(key, serverId);
+            return this;
+        }
+
+        public MockLookupStrategy<K> expectLookupException(K key, Throwable throwable) {
+            expectedLookupExceptions.put(key, throwable);
+            return this;
+        }
+    }
+
+    private static class MockAdminApiHandler<K, V> implements AdminApiHandler<K, V> {
+        private final Map<Integer, V> expectedResults = new HashMap<>();
+        private final Map<Integer, Throwable> expectedExceptions = new HashMap<>();
+        private final MockLookupStrategy<K> lookupStrategy;
+
+        private MockAdminApiHandler(MockLookupStrategy<K> lookupStrategy) {
+            this.lookupStrategy = lookupStrategy;
+        }
+
+        @Override
+        public TabletServerLookupStrategy<K> lookupStrategy() {
+            return lookupStrategy;
+        }
+
+        @Override
+        public CompletableFuture<ApiResult<K, V>> handle(int node, Set<K> keys) {
+            return CompletableFuture.supplyAsync(
+                    () -> {
+                        Map<K, V> completedKeys = new HashMap<>();
+                        Map<K, Throwable> failedKeys = new HashMap<>();
+                        Set<K> unmappedKeys = new HashSet<>();
+                        if (expectedResults.containsKey(node)) {
+                            completedKeys.put(keys.iterator().next(), expectedResults.get(node));
+                        } else if (expectedExceptions.containsKey(node)) {
+                            failedKeys.put(keys.iterator().next(), expectedExceptions.get(node));
+                        } else {
+                            unmappedKeys.addAll(keys);
+                        }
+                        return new AdminApiHandler.ApiResult<K, V>(
+                                completedKeys, failedKeys, unmappedKeys);
+                    });
+        }
+
+        public MockAdminApiHandler<K, V> expectResult(int node, V result) {
+            expectedResults.put(node, result);
+            return this;
+        }
+
+        public MockAdminApiHandler<K, V> expectException(int node, Throwable exception) {
+            expectedExceptions.put(node, exception);
+            return this;
+        }
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/LeaderNotAvailableException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/LeaderNotAvailableException.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.exception;
+
+/** This exception is thrown when the leader is not available. */
+public class LeaderNotAvailableException extends RetriableException {
+    public LeaderNotAvailableException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #288 

Inspired by https://issues.apache.org/jira/browse/KAFKA-12609, which introduce AdminApiDriver do theses things:

- Retry lookup stage on receiving `NOT_LEADER_OR_FOLLOWER` and `LEADER_NOT_AVAILABLE`, whereas in the past we failed the partition directly without retry.

-  retry fulfillment stage on `RetriableException`

<!-- What is the purpose of the change -->

### Tests

- AdminApiDriverTest for AdminApiDriver
- com.alibaba.fluss.client.admin.FlussAdminITCase#testListOffsets for Admin#ListOffsets

### API and Format

Some internal interface:

- AdminApiDriver
- AdminApiHandler
- AdminApiFuture
- AdminApiLookupBrokerIdStrategy

### Documentation

<!-- Does this change introduce a new feature -->
