### PR TITLE
[flink] FlinkCatalog supports create and drop materialized table

### DIFF
--- a/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
+++ b/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.factories.DynamicTableFactory;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A common parent that describes the <i>unresolved</i> metadata of a table or view in a catalog.
+ *
+ * <p>Copy from Apache Flink, modified the TableKind enum to add MATERIALIZED_TABLE.
+ *
+ * @see CatalogTable
+ * @see CatalogView
+ */
+@PublicEvolving
+public interface CatalogBaseTable {
+
+    /** The kind of {@link CatalogBaseTable}. */
+    @PublicEvolving
+    enum TableKind {
+        TABLE,
+        MATERIALIZED_TABLE,
+        VIEW
+    }
+
+    /** The kind of table this {@link CatalogBaseTable} describes. */
+    TableKind getTableKind();
+
+    /**
+     * Returns a map of string-based options.
+     *
+     * <p>In case of {@link CatalogTable}, these options may determine the kind of connector and its
+     * configuration for accessing the data in the external system. See {@link DynamicTableFactory}
+     * for more information. If a {@link CatalogTable} should not be serializable, an implementation
+     * can simply throw a runtime exception in this method.
+     */
+    Map<String, String> getOptions();
+
+    /**
+     * @deprecated This method returns the deprecated {@link TableSchema} class. The old class was a
+     *     hybrid of resolved and unresolved schema information. It has been replaced by the new
+     *     {@link Schema} which is always unresolved and will be resolved by the framework later.
+     */
+    @Deprecated
+    default TableSchema getSchema() {
+        return null;
+    }
+
+    /**
+     * Returns the schema of the table or view.
+     *
+     * <p>The schema can reference objects from other catalogs and will be resolved and validated by
+     * the framework when accessing the table or view.
+     *
+     * @see ResolvedCatalogTable
+     * @see ResolvedCatalogView
+     */
+    default Schema getUnresolvedSchema() {
+        final TableSchema oldSchema = getSchema();
+        if (oldSchema == null) {
+            throw new UnsupportedOperationException(
+                    "A CatalogBaseTable must implement getUnresolvedSchema().");
+        }
+        return oldSchema.toSchema();
+    }
+
+    /**
+     * Get comment of the table or view.
+     *
+     * @return comment of the table/view.
+     */
+    String getComment();
+
+    /**
+     * Get a deep copy of the CatalogBaseTable instance.
+     *
+     * @return a copy of the CatalogBaseTable instance
+     */
+    CatalogBaseTable copy();
+
+    /**
+     * Get a brief description of the table or view.
+     *
+     * @return an optional short description of the table/view
+     */
+    Optional<String> getDescription();
+
+    /**
+     * Get a detailed description of the table or view.
+     *
+     * @return an optional long description of the table/view
+     */
+    Optional<String> getDetailedDescription();
+}

--- a/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
+++ b/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+/**
+ * Dummy placeholder to resolve compatibility issue of CatalogMaterializedTable(introduced in flink
+ * 1.20).
+ */
+public interface CatalogMaterializedTable {
+
+    /** Dummy LogicalRefreshMode placeholder. */
+    enum LogicalRefreshMode {}
+
+    /** Dummy RefreshMode placeholder. */
+    enum RefreshMode {}
+
+    /** Dummy RefreshStatus placeholder. */
+    enum RefreshStatus {}
+}

--- a/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/table/catalog/IntervalFreshness.java
+++ b/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/table/catalog/IntervalFreshness.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+/**
+ * Dummy placeholder to resolve compatibility issue of CatalogMaterializedTable(introduced in flink
+ * 1.20).
+ */
+public interface IntervalFreshness {
+
+    /** Dummy TimeUnit placeholder. */
+    enum TimeUnit {}
+}

--- a/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/table/catalog/TableChange.java
+++ b/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/table/catalog/TableChange.java
@@ -1,0 +1,1106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/** {@link TableChange} represents the modification of the table. */
+@PublicEvolving
+public interface TableChange {
+
+    /**
+     * A table change to add the column at last.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD &lt;column_definition&gt;
+     * </pre>
+     *
+     * @param column the added column definition.
+     * @return a TableChange represents the modification.
+     */
+    static AddColumn add(Column column) {
+        return new AddColumn(column, null);
+    }
+
+    /**
+     * A table change to add the column with specified position.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD &lt;column_definition&gt; &lt;column_position&gt;
+     * </pre>
+     *
+     * @param column the added column definition.
+     * @param position added column position.
+     * @return a TableChange represents the modification.
+     */
+    static AddColumn add(Column column, @Nullable ColumnPosition position) {
+        return new AddColumn(column, position);
+    }
+
+    /**
+     * A table change to add a unique constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD PRIMARY KEY (&lt;column_name&gt;...) NOT ENFORCED
+     * </pre>
+     *
+     * @param constraint the added constraint definition.
+     * @return a TableChange represents the modification.
+     */
+    static AddUniqueConstraint add(UniqueConstraint constraint) {
+        return new AddUniqueConstraint(constraint);
+    }
+
+    /**
+     * A table change to add a watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD WATERMARK FOR &lt;row_time&gt; AS &lt;row_time_expression&gt;
+     * </pre>
+     *
+     * @param watermarkSpec the added watermark definition.
+     * @return a TableChange represents the modification.
+     */
+    static AddWatermark add(WatermarkSpec watermarkSpec) {
+        return new AddWatermark(watermarkSpec);
+    }
+
+    /**
+     * A table change to modify a column. The modification includes:
+     *
+     * <ul>
+     *   <li>change column data type
+     *   <li>reorder column position
+     *   <li>modify column comment
+     *   <li>rename column name
+     *   <li>change the computed expression
+     *   <li>change the metadata column expression
+     * </ul>
+     *
+     * <p>Some fine-grained column changes are represented by the {@link
+     * TableChange#modifyPhysicalColumnType}, {@link TableChange#modifyColumnName}, {@link
+     * TableChange#modifyColumnComment} and {@link TableChange#modifyColumnPosition}.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_definition&gt; COMMENT '&lt;column_comment&gt;' &lt;column_position&gt;
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param newColumn the definition of the new column.
+     * @param columnPosition the new position of the column.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyColumn modify(
+            Column oldColumn, Column newColumn, @Nullable ColumnPosition columnPosition) {
+        return new ModifyColumn(oldColumn, newColumn, columnPosition);
+    }
+
+    /**
+     * A table change that modify the physical column data type.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;new_column_type&gt;
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param newType the type of the new column.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyPhysicalColumnType modifyPhysicalColumnType(Column oldColumn, DataType newType) {
+        return new ModifyPhysicalColumnType(oldColumn, newType);
+    }
+
+    /**
+     * A table change to modify the column name.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; RENAME &lt;old_column_name&gt; TO &lt;new_column_name&gt;
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param newName the name of the new column.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyColumnName modifyColumnName(Column oldColumn, String newName) {
+        return new ModifyColumnName(oldColumn, newName);
+    }
+
+    /**
+     * A table change to modify the column comment.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;original_column_type&gt; COMMENT '&lt;new_column_comment&gt;'
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param newComment the modified comment.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyColumnComment modifyColumnComment(Column oldColumn, String newComment) {
+        return new ModifyColumnComment(oldColumn, newComment);
+    }
+
+    /**
+     * A table change to modify the column position.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;original_column_type&gt; &lt;column_position&gt;
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param columnPosition the new position of the column.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyColumnPosition modifyColumnPosition(
+            Column oldColumn, ColumnPosition columnPosition) {
+        return new ModifyColumnPosition(oldColumn, columnPosition);
+    }
+
+    /**
+     * A table change to modify a unique constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY PRIMARY KEY (&lt;column_name&gt;...) NOT ENFORCED;
+     * </pre>
+     *
+     * @param newConstraint the modified constraint definition.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyUniqueConstraint modify(UniqueConstraint newConstraint) {
+        return new ModifyUniqueConstraint(newConstraint);
+    }
+
+    /**
+     * A table change to modify a watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY WATERMARK FOR &lt;row_time&gt; AS &lt;row_time_expression&gt;
+     * </pre>
+     *
+     * @param newWatermarkSpec the modified watermark definition.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyWatermark modify(WatermarkSpec newWatermarkSpec) {
+        return new ModifyWatermark(newWatermarkSpec);
+    }
+
+    /**
+     * A table change to drop column.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP COLUMN &lt;column_name&gt;
+     * </pre>
+     *
+     * @param columnName the column to drop.
+     * @return a TableChange represents the modification.
+     */
+    static DropColumn dropColumn(String columnName) {
+        return new DropColumn(columnName);
+    }
+
+    /**
+     * A table change to drop watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP WATERMARK
+     * </pre>
+     *
+     * @return a TableChange represents the modification.
+     */
+    static DropWatermark dropWatermark() {
+        return DropWatermark.INSTANCE;
+    }
+
+    /**
+     * A table change to drop constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP CONSTRAINT &lt;constraint_name&gt;
+     * </pre>
+     *
+     * @param constraintName the constraint to drop.
+     * @return a TableChange represents the modification.
+     */
+    static DropConstraint dropConstraint(String constraintName) {
+        return new DropConstraint(constraintName);
+    }
+
+    /**
+     * A table change to set the table option.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; SET '&lt;key&gt;' = '&lt;value&gt;';
+     * </pre>
+     *
+     * @param key the option name to set.
+     * @param value the option value to set.
+     * @return a TableChange represents the modification.
+     */
+    static SetOption set(String key, String value) {
+        return new SetOption(key, value);
+    }
+
+    /**
+     * A table change to reset the table option.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; RESET '&lt;key&gt;'
+     * </pre>
+     *
+     * @param key the option name to reset.
+     * @return a TableChange represents the modification.
+     */
+    static ResetOption reset(String key) {
+        return new ResetOption(key);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Add Change
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * A table change to add a column.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD &lt;column_definition&gt; &lt;column_position&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class AddColumn implements TableChange {
+
+        private final Column column;
+        private final ColumnPosition position;
+
+        private AddColumn(Column column, ColumnPosition position) {
+            this.column = column;
+            this.position = position;
+        }
+
+        public Column getColumn() {
+            return column;
+        }
+
+        @Nullable
+        public ColumnPosition getPosition() {
+            return position;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AddColumn)) {
+                return false;
+            }
+            AddColumn addColumn = (AddColumn) o;
+            return Objects.equals(column, addColumn.column)
+                    && Objects.equals(position, addColumn.position);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(column, position);
+        }
+
+        @Override
+        public String toString() {
+            return "AddColumn{" + "column=" + column + ", position=" + position + '}';
+        }
+    }
+
+    /**
+     * A table change to add a unique constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD PRIMARY KEY (&lt;column_name&gt;...) NOT ENFORCED;
+     * </pre>
+     */
+    @PublicEvolving
+    class AddUniqueConstraint implements TableChange {
+
+        private final UniqueConstraint constraint;
+
+        private AddUniqueConstraint(UniqueConstraint constraint) {
+            this.constraint = constraint;
+        }
+
+        /** Returns the unique constraint to add. */
+        public UniqueConstraint getConstraint() {
+            return constraint;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AddUniqueConstraint)) {
+                return false;
+            }
+            AddUniqueConstraint that = (AddUniqueConstraint) o;
+            return Objects.equals(constraint, that.constraint);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(constraint);
+        }
+
+        @Override
+        public String toString() {
+            return "AddUniqueConstraint{" + "constraint=" + constraint + '}';
+        }
+    }
+
+    /**
+     * A table change to add a watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD WATERMARK FOR &lt;row_time&gt; AS &lt;row_time_expression&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class AddWatermark implements TableChange {
+
+        private final WatermarkSpec watermarkSpec;
+
+        private AddWatermark(WatermarkSpec watermarkSpec) {
+            this.watermarkSpec = watermarkSpec;
+        }
+
+        /** Returns the watermark to add. */
+        public WatermarkSpec getWatermark() {
+            return watermarkSpec;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AddWatermark)) {
+                return false;
+            }
+            AddWatermark that = (AddWatermark) o;
+            return Objects.equals(watermarkSpec, that.watermarkSpec);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(watermarkSpec);
+        }
+
+        @Override
+        public String toString() {
+            return "AddWatermark{" + "watermarkSpec=" + watermarkSpec + '}';
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Modify Change
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * A base schema change to modify a column. The modification includes:
+     *
+     * <ul>
+     *   <li>change column data type
+     *   <li>reorder column position
+     *   <li>modify column comment
+     *   <li>rename column name
+     *   <li>change the computed expression
+     *   <li>change the metadata column expression
+     * </ul>
+     *
+     * <p>Some fine-grained column changes are defined in the {@link ModifyPhysicalColumnType},
+     * {@link ModifyColumnComment}, {@link ModifyColumnPosition} and {@link ModifyColumnName}.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_definition&gt; COMMENT '&lt;column_comment&gt;' &lt;column_position&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyColumn implements TableChange {
+
+        protected final Column oldColumn;
+        protected final Column newColumn;
+
+        protected final @Nullable ColumnPosition newPosition;
+
+        public ModifyColumn(
+                Column oldColumn, Column newColumn, @Nullable ColumnPosition newPosition) {
+            this.oldColumn = oldColumn;
+            this.newColumn = newColumn;
+            this.newPosition = newPosition;
+        }
+
+        /** Returns the original {@link Column} instance. */
+        public Column getOldColumn() {
+            return oldColumn;
+        }
+
+        /** Returns the modified {@link Column} instance. */
+        public Column getNewColumn() {
+            return newColumn;
+        }
+
+        /**
+         * Returns the position of the modified {@link Column} instance. When the return value is
+         * null, it means modify the column at the original position. When the return value is
+         * FIRST, it means move the modified column to the first. When the return value is AFTER, it
+         * means move the column after the referred column.
+         */
+        public @Nullable ColumnPosition getNewPosition() {
+            return newPosition;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ModifyColumn)) {
+                return false;
+            }
+            ModifyColumn that = (ModifyColumn) o;
+            return Objects.equals(oldColumn, that.oldColumn)
+                    && Objects.equals(newColumn, that.newColumn)
+                    && Objects.equals(newPosition, that.newPosition);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(oldColumn, newColumn, newPosition);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyColumn{"
+                    + "oldColumn="
+                    + oldColumn
+                    + ", newColumn="
+                    + newColumn
+                    + ", newPosition="
+                    + newPosition
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change to modify the column comment.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;original_column_type&gt; COMMENT '&lt;new_column_comment&gt;'
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyColumnComment extends ModifyColumn {
+
+        private final String newComment;
+
+        private ModifyColumnComment(Column oldColumn, String newComment) {
+            super(oldColumn, oldColumn.withComment(newComment), null);
+            this.newComment = newComment;
+        }
+
+        /** Get the new comment for the column. */
+        public String getNewComment() {
+            return newComment;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof ModifyColumnComment) && super.equals(o);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyColumnComment{"
+                    + "Column="
+                    + oldColumn
+                    + ", newComment='"
+                    + newComment
+                    + '\''
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change to modify the column position.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;original_column_type&gt; &lt;column_position&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyColumnPosition extends ModifyColumn {
+
+        public ModifyColumnPosition(Column oldColumn, ColumnPosition newPosition) {
+            super(oldColumn, oldColumn, newPosition);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof ModifyColumnPosition) && super.equals(o);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyColumnPosition{"
+                    + "Column="
+                    + oldColumn
+                    + ", newPosition="
+                    + newPosition
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change that modify the physical column data type.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;new_column_type&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyPhysicalColumnType extends ModifyColumn {
+
+        private ModifyPhysicalColumnType(Column oldColumn, DataType newType) {
+            super(oldColumn, oldColumn.copy(newType), null);
+            Preconditions.checkArgument(oldColumn.isPhysical());
+        }
+
+        /** Get the column type for the new column. */
+        public DataType getNewType() {
+            return newColumn.getDataType();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof ModifyPhysicalColumnType) && super.equals(o);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyPhysicalColumnType{"
+                    + "Column="
+                    + oldColumn
+                    + ", newType="
+                    + getNewType()
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change to modify the column name.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; RENAME &lt;old_column_name&gt; TO &lt;new_column_name&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyColumnName extends ModifyColumn {
+
+        private ModifyColumnName(Column oldColumn, String newName) {
+            super(oldColumn, createNewColumn(oldColumn, newName), null);
+        }
+
+        private static Column createNewColumn(Column oldColumn, String newName) {
+            if (oldColumn instanceof Column.PhysicalColumn) {
+                return Column.physical(newName, oldColumn.getDataType())
+                        .withComment(oldColumn.comment);
+            } else if (oldColumn instanceof Column.MetadataColumn) {
+                Column.MetadataColumn metadataColumn = (Column.MetadataColumn) oldColumn;
+                return Column.metadata(
+                                newName,
+                                oldColumn.getDataType(),
+                                metadataColumn.getMetadataKey().orElse(null),
+                                metadataColumn.isVirtual())
+                        .withComment(oldColumn.comment);
+            } else {
+                return Column.computed(newName, ((Column.ComputedColumn) oldColumn).getExpression())
+                        .withComment(oldColumn.comment);
+            }
+        }
+
+        /** Returns the origin column name. */
+        public String getOldColumnName() {
+            return oldColumn.getName();
+        }
+
+        /** Returns the new column name after renaming the column name. */
+        public String getNewColumnName() {
+            return newColumn.getName();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof ModifyColumnName) && super.equals(o);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyColumnName{"
+                    + "Column="
+                    + oldColumn
+                    + ", newName="
+                    + getNewColumnName()
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change to modify a unique constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY PRIMARY KEY (&lt;column_name&gt; ...) NOT ENFORCED
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyUniqueConstraint implements TableChange {
+
+        private final UniqueConstraint newConstraint;
+
+        public ModifyUniqueConstraint(UniqueConstraint newConstraint) {
+            this.newConstraint = newConstraint;
+        }
+
+        /** Returns the modified unique constraint. */
+        public UniqueConstraint getNewConstraint() {
+            return newConstraint;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ModifyUniqueConstraint)) {
+                return false;
+            }
+            ModifyUniqueConstraint that = (ModifyUniqueConstraint) o;
+            return Objects.equals(newConstraint, that.newConstraint);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(newConstraint);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyUniqueConstraint{" + "newConstraint=" + newConstraint + '}';
+        }
+    }
+
+    /**
+     * A table change to modify the watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY WATERMARK FOR &lt;row_time_column_name&gt; AS &lt;watermark_expression&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyWatermark implements TableChange {
+
+        private final WatermarkSpec newWatermark;
+
+        public ModifyWatermark(WatermarkSpec newWatermark) {
+            this.newWatermark = newWatermark;
+        }
+
+        /** Returns the modified watermark. */
+        public WatermarkSpec getNewWatermark() {
+            return newWatermark;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ModifyWatermark)) {
+                return false;
+            }
+            ModifyWatermark that = (ModifyWatermark) o;
+            return Objects.equals(newWatermark, that.newWatermark);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(newWatermark);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyWatermark{" + "newWatermark=" + newWatermark + '}';
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Drop Change
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * A table change to drop the column.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP COLUMN &lt;column_name&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class DropColumn implements TableChange {
+
+        private final String columnName;
+
+        private DropColumn(String columnName) {
+            this.columnName = columnName;
+        }
+
+        /** Returns the column name. */
+        public String getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DropColumn)) {
+                return false;
+            }
+            DropColumn that = (DropColumn) o;
+            return Objects.equals(columnName, that.columnName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(columnName);
+        }
+
+        @Override
+        public String toString() {
+            return "DropColumn{" + "columnName='" + columnName + '\'' + '}';
+        }
+    }
+
+    /**
+     * A table change to drop the watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP WATERMARK
+     * </pre>
+     */
+    @PublicEvolving
+    class DropWatermark implements TableChange {
+        static final DropWatermark INSTANCE = new DropWatermark();
+
+        @Override
+        public String toString() {
+            return "DropWatermark";
+        }
+    }
+
+    /**
+     * A table change to drop the constraints.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP CONSTRAINT &lt;constraint_name&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class DropConstraint implements TableChange {
+
+        private final String constraintName;
+
+        private DropConstraint(String constraintName) {
+            this.constraintName = constraintName;
+        }
+
+        /** Returns the constraint name. */
+        public String getConstraintName() {
+            return constraintName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DropConstraint)) {
+                return false;
+            }
+            DropConstraint that = (DropConstraint) o;
+            return Objects.equals(constraintName, that.constraintName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(constraintName);
+        }
+
+        @Override
+        public String toString() {
+            return "DropConstraint{" + "constraintName='" + constraintName + '\'' + '}';
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Property change
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * A table change to set the table option.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; SET '&lt;key&gt;' = '&lt;value&gt;';
+     * </pre>
+     */
+    @PublicEvolving
+    class SetOption implements TableChange {
+
+        private final String key;
+        private final String value;
+
+        private SetOption(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        /** Returns the Option key to set. */
+        public String getKey() {
+            return key;
+        }
+
+        /** Returns the Option value to set. */
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof SetOption)) {
+                return false;
+            }
+            SetOption setOption = (SetOption) o;
+            return Objects.equals(key, setOption.key) && Objects.equals(value, setOption.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
+
+        @Override
+        public String toString() {
+            return "SetOption{" + "key='" + key + '\'' + ", value='" + value + '\'' + '}';
+        }
+    }
+
+    /**
+     * A table change to reset the table option.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; RESET '&lt;key&gt;'
+     * </pre>
+     */
+    @PublicEvolving
+    class ResetOption implements TableChange {
+
+        private final String key;
+
+        public ResetOption(String key) {
+            this.key = key;
+        }
+
+        /** Returns the Option key to reset. */
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ResetOption)) {
+                return false;
+            }
+            ResetOption that = (ResetOption) o;
+            return Objects.equals(key, that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key);
+        }
+
+        @Override
+        public String toString() {
+            return "ResetOption{" + "key='" + key + '\'' + '}';
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    /** The position of the modified or added column. */
+    @PublicEvolving
+    interface ColumnPosition {
+
+        /** Get the position to place the column at the first. */
+        static ColumnPosition first() {
+            return First.INSTANCE;
+        }
+
+        /** Get the position to place the column after the specified column. */
+        static ColumnPosition after(String column) {
+            return new After(column);
+        }
+    }
+
+    /** Column position FIRST means the specified column should be the first column. */
+    @PublicEvolving
+    final class First implements ColumnPosition {
+        private static final First INSTANCE = new First();
+
+        private First() {}
+
+        @Override
+        public String toString() {
+            return "FIRST";
+        }
+    }
+
+    /** Column position AFTER means the specified column should be put after the given `column`. */
+    @PublicEvolving
+    final class After implements ColumnPosition {
+        private final String column;
+
+        private After(String column) {
+            this.column = column;
+        }
+
+        public String column() {
+            return column;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof After)) {
+                return false;
+            }
+            After after = (After) o;
+            return Objects.equals(column, after.column);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(column);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("AFTER %s", EncodingUtils.escapeIdentifier(column));
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Materialized table change
+    // --------------------------------------------------------------------------------------------
+    /** {@link MaterializedTableChange} represents the modification of the materialized table. */
+    @PublicEvolving
+    interface MaterializedTableChange extends TableChange {}
+}

--- a/fluss-flink/fluss-flink-1.19/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
+++ b/fluss-flink/fluss-flink-1.19/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.factories.DynamicTableFactory;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A common parent that describes the <i>unresolved</i> metadata of a table or view in a catalog.
+ *
+ * <p>p> Copy from Apache Flink, modified the TableKind enum to add MATERIALIZED_TABLE.
+ *
+ * @see CatalogTable
+ * @see CatalogView
+ */
+@PublicEvolving
+public interface CatalogBaseTable {
+
+    /** The kind of {@link CatalogBaseTable}. */
+    @PublicEvolving
+    enum TableKind {
+        TABLE,
+        MATERIALIZED_TABLE,
+        VIEW
+    }
+
+    /** The kind of table this {@link CatalogBaseTable} describes. */
+    TableKind getTableKind();
+
+    /**
+     * Returns a map of string-based options.
+     *
+     * <p>In case of {@link CatalogTable}, these options may determine the kind of connector and its
+     * configuration for accessing the data in the external system. See {@link DynamicTableFactory}
+     * for more information. If a {@link CatalogTable} should not be serializable, an implementation
+     * can simply throw a runtime exception in this method.
+     */
+    Map<String, String> getOptions();
+
+    /**
+     * @deprecated This method returns the deprecated {@link TableSchema} class. The old class was a
+     *     hybrid of resolved and unresolved schema information. It has been replaced by the new
+     *     {@link Schema} which is always unresolved and will be resolved by the framework later.
+     */
+    @Deprecated
+    default TableSchema getSchema() {
+        return null;
+    }
+
+    /**
+     * Returns the schema of the table or view.
+     *
+     * <p>The schema can reference objects from other catalogs and will be resolved and validated by
+     * the framework when accessing the table or view.
+     *
+     * @see ResolvedCatalogTable
+     * @see ResolvedCatalogView
+     */
+    default Schema getUnresolvedSchema() {
+        final TableSchema oldSchema = getSchema();
+        if (oldSchema == null) {
+            throw new UnsupportedOperationException(
+                    "A CatalogBaseTable must implement getUnresolvedSchema().");
+        }
+        return oldSchema.toSchema();
+    }
+
+    /**
+     * Get comment of the table or view.
+     *
+     * @return comment of the table/view.
+     */
+    String getComment();
+
+    /**
+     * Get a deep copy of the CatalogBaseTable instance.
+     *
+     * @return a copy of the CatalogBaseTable instance
+     */
+    CatalogBaseTable copy();
+
+    /**
+     * Get a brief description of the table or view.
+     *
+     * @return an optional short description of the table/view
+     */
+    Optional<String> getDescription();
+
+    /**
+     * Get a detailed description of the table or view.
+     *
+     * @return an optional long description of the table/view
+     */
+    Optional<String> getDetailedDescription();
+}

--- a/fluss-flink/fluss-flink-1.19/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
+++ b/fluss-flink/fluss-flink-1.19/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+/**
+ * Dummy placeholder to resolve compatibility issue of CatalogMaterializedTable(introduced in flink
+ * 1.20).
+ */
+public interface CatalogMaterializedTable {
+
+    /** Dummy LogicalRefreshMode placeholder. */
+    enum LogicalRefreshMode {}
+
+    /** Dummy RefreshMode placeholder. */
+    enum RefreshMode {}
+
+    /** Dummy RefreshStatus placeholder. */
+    enum RefreshStatus {}
+}

--- a/fluss-flink/fluss-flink-1.19/src/main/java/org/apache/flink/table/catalog/IntervalFreshness.java
+++ b/fluss-flink/fluss-flink-1.19/src/main/java/org/apache/flink/table/catalog/IntervalFreshness.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+/**
+ * Dummy placeholder to resolve compatibility issue of CatalogMaterializedTable(introduced in flink
+ * 1.20).
+ */
+public interface IntervalFreshness {
+
+    /** Dummy TimeUnit placeholder. */
+    enum TimeUnit {}
+}

--- a/fluss-flink/fluss-flink-1.19/src/main/java/org/apache/flink/table/catalog/TableChange.java
+++ b/fluss-flink/fluss-flink-1.19/src/main/java/org/apache/flink/table/catalog/TableChange.java
@@ -1,0 +1,1106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/** {@link TableChange} represents the modification of the table. */
+@PublicEvolving
+public interface TableChange {
+
+    /**
+     * A table change to add the column at last.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD &lt;column_definition&gt;
+     * </pre>
+     *
+     * @param column the added column definition.
+     * @return a TableChange represents the modification.
+     */
+    static AddColumn add(Column column) {
+        return new AddColumn(column, null);
+    }
+
+    /**
+     * A table change to add the column with specified position.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD &lt;column_definition&gt; &lt;column_position&gt;
+     * </pre>
+     *
+     * @param column the added column definition.
+     * @param position added column position.
+     * @return a TableChange represents the modification.
+     */
+    static AddColumn add(Column column, @Nullable ColumnPosition position) {
+        return new AddColumn(column, position);
+    }
+
+    /**
+     * A table change to add a unique constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD PRIMARY KEY (&lt;column_name&gt;...) NOT ENFORCED
+     * </pre>
+     *
+     * @param constraint the added constraint definition.
+     * @return a TableChange represents the modification.
+     */
+    static AddUniqueConstraint add(UniqueConstraint constraint) {
+        return new AddUniqueConstraint(constraint);
+    }
+
+    /**
+     * A table change to add a watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD WATERMARK FOR &lt;row_time&gt; AS &lt;row_time_expression&gt;
+     * </pre>
+     *
+     * @param watermarkSpec the added watermark definition.
+     * @return a TableChange represents the modification.
+     */
+    static AddWatermark add(WatermarkSpec watermarkSpec) {
+        return new AddWatermark(watermarkSpec);
+    }
+
+    /**
+     * A table change to modify a column. The modification includes:
+     *
+     * <ul>
+     *   <li>change column data type
+     *   <li>reorder column position
+     *   <li>modify column comment
+     *   <li>rename column name
+     *   <li>change the computed expression
+     *   <li>change the metadata column expression
+     * </ul>
+     *
+     * <p>Some fine-grained column changes are represented by the {@link
+     * TableChange#modifyPhysicalColumnType}, {@link TableChange#modifyColumnName}, {@link
+     * TableChange#modifyColumnComment} and {@link TableChange#modifyColumnPosition}.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_definition&gt; COMMENT '&lt;column_comment&gt;' &lt;column_position&gt;
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param newColumn the definition of the new column.
+     * @param columnPosition the new position of the column.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyColumn modify(
+            Column oldColumn, Column newColumn, @Nullable ColumnPosition columnPosition) {
+        return new ModifyColumn(oldColumn, newColumn, columnPosition);
+    }
+
+    /**
+     * A table change that modify the physical column data type.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;new_column_type&gt;
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param newType the type of the new column.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyPhysicalColumnType modifyPhysicalColumnType(Column oldColumn, DataType newType) {
+        return new ModifyPhysicalColumnType(oldColumn, newType);
+    }
+
+    /**
+     * A table change to modify the column name.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; RENAME &lt;old_column_name&gt; TO &lt;new_column_name&gt;
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param newName the name of the new column.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyColumnName modifyColumnName(Column oldColumn, String newName) {
+        return new ModifyColumnName(oldColumn, newName);
+    }
+
+    /**
+     * A table change to modify the column comment.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;original_column_type&gt; COMMENT '&lt;new_column_comment&gt;'
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param newComment the modified comment.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyColumnComment modifyColumnComment(Column oldColumn, String newComment) {
+        return new ModifyColumnComment(oldColumn, newComment);
+    }
+
+    /**
+     * A table change to modify the column position.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;original_column_type&gt; &lt;column_position&gt;
+     * </pre>
+     *
+     * @param oldColumn the definition of the old column.
+     * @param columnPosition the new position of the column.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyColumnPosition modifyColumnPosition(
+            Column oldColumn, ColumnPosition columnPosition) {
+        return new ModifyColumnPosition(oldColumn, columnPosition);
+    }
+
+    /**
+     * A table change to modify a unique constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY PRIMARY KEY (&lt;column_name&gt;...) NOT ENFORCED;
+     * </pre>
+     *
+     * @param newConstraint the modified constraint definition.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyUniqueConstraint modify(UniqueConstraint newConstraint) {
+        return new ModifyUniqueConstraint(newConstraint);
+    }
+
+    /**
+     * A table change to modify a watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY WATERMARK FOR &lt;row_time&gt; AS &lt;row_time_expression&gt;
+     * </pre>
+     *
+     * @param newWatermarkSpec the modified watermark definition.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyWatermark modify(WatermarkSpec newWatermarkSpec) {
+        return new ModifyWatermark(newWatermarkSpec);
+    }
+
+    /**
+     * A table change to drop column.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP COLUMN &lt;column_name&gt;
+     * </pre>
+     *
+     * @param columnName the column to drop.
+     * @return a TableChange represents the modification.
+     */
+    static DropColumn dropColumn(String columnName) {
+        return new DropColumn(columnName);
+    }
+
+    /**
+     * A table change to drop watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP WATERMARK
+     * </pre>
+     *
+     * @return a TableChange represents the modification.
+     */
+    static DropWatermark dropWatermark() {
+        return DropWatermark.INSTANCE;
+    }
+
+    /**
+     * A table change to drop constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP CONSTRAINT &lt;constraint_name&gt;
+     * </pre>
+     *
+     * @param constraintName the constraint to drop.
+     * @return a TableChange represents the modification.
+     */
+    static DropConstraint dropConstraint(String constraintName) {
+        return new DropConstraint(constraintName);
+    }
+
+    /**
+     * A table change to set the table option.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; SET '&lt;key&gt;' = '&lt;value&gt;';
+     * </pre>
+     *
+     * @param key the option name to set.
+     * @param value the option value to set.
+     * @return a TableChange represents the modification.
+     */
+    static SetOption set(String key, String value) {
+        return new SetOption(key, value);
+    }
+
+    /**
+     * A table change to reset the table option.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; RESET '&lt;key&gt;'
+     * </pre>
+     *
+     * @param key the option name to reset.
+     * @return a TableChange represents the modification.
+     */
+    static ResetOption reset(String key) {
+        return new ResetOption(key);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Add Change
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * A table change to add a column.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD &lt;column_definition&gt; &lt;column_position&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class AddColumn implements TableChange {
+
+        private final Column column;
+        private final ColumnPosition position;
+
+        private AddColumn(Column column, ColumnPosition position) {
+            this.column = column;
+            this.position = position;
+        }
+
+        public Column getColumn() {
+            return column;
+        }
+
+        @Nullable
+        public ColumnPosition getPosition() {
+            return position;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AddColumn)) {
+                return false;
+            }
+            AddColumn addColumn = (AddColumn) o;
+            return Objects.equals(column, addColumn.column)
+                    && Objects.equals(position, addColumn.position);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(column, position);
+        }
+
+        @Override
+        public String toString() {
+            return "AddColumn{" + "column=" + column + ", position=" + position + '}';
+        }
+    }
+
+    /**
+     * A table change to add a unique constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD PRIMARY KEY (&lt;column_name&gt;...) NOT ENFORCED;
+     * </pre>
+     */
+    @PublicEvolving
+    class AddUniqueConstraint implements TableChange {
+
+        private final UniqueConstraint constraint;
+
+        private AddUniqueConstraint(UniqueConstraint constraint) {
+            this.constraint = constraint;
+        }
+
+        /** Returns the unique constraint to add. */
+        public UniqueConstraint getConstraint() {
+            return constraint;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AddUniqueConstraint)) {
+                return false;
+            }
+            AddUniqueConstraint that = (AddUniqueConstraint) o;
+            return Objects.equals(constraint, that.constraint);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(constraint);
+        }
+
+        @Override
+        public String toString() {
+            return "AddUniqueConstraint{" + "constraint=" + constraint + '}';
+        }
+    }
+
+    /**
+     * A table change to add a watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; ADD WATERMARK FOR &lt;row_time&gt; AS &lt;row_time_expression&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class AddWatermark implements TableChange {
+
+        private final WatermarkSpec watermarkSpec;
+
+        private AddWatermark(WatermarkSpec watermarkSpec) {
+            this.watermarkSpec = watermarkSpec;
+        }
+
+        /** Returns the watermark to add. */
+        public WatermarkSpec getWatermark() {
+            return watermarkSpec;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AddWatermark)) {
+                return false;
+            }
+            AddWatermark that = (AddWatermark) o;
+            return Objects.equals(watermarkSpec, that.watermarkSpec);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(watermarkSpec);
+        }
+
+        @Override
+        public String toString() {
+            return "AddWatermark{" + "watermarkSpec=" + watermarkSpec + '}';
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Modify Change
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * A base schema change to modify a column. The modification includes:
+     *
+     * <ul>
+     *   <li>change column data type
+     *   <li>reorder column position
+     *   <li>modify column comment
+     *   <li>rename column name
+     *   <li>change the computed expression
+     *   <li>change the metadata column expression
+     * </ul>
+     *
+     * <p>Some fine-grained column changes are defined in the {@link ModifyPhysicalColumnType},
+     * {@link ModifyColumnComment}, {@link ModifyColumnPosition} and {@link ModifyColumnName}.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_definition&gt; COMMENT '&lt;column_comment&gt;' &lt;column_position&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyColumn implements TableChange {
+
+        protected final Column oldColumn;
+        protected final Column newColumn;
+
+        protected final @Nullable ColumnPosition newPosition;
+
+        public ModifyColumn(
+                Column oldColumn, Column newColumn, @Nullable ColumnPosition newPosition) {
+            this.oldColumn = oldColumn;
+            this.newColumn = newColumn;
+            this.newPosition = newPosition;
+        }
+
+        /** Returns the original {@link Column} instance. */
+        public Column getOldColumn() {
+            return oldColumn;
+        }
+
+        /** Returns the modified {@link Column} instance. */
+        public Column getNewColumn() {
+            return newColumn;
+        }
+
+        /**
+         * Returns the position of the modified {@link Column} instance. When the return value is
+         * null, it means modify the column at the original position. When the return value is
+         * FIRST, it means move the modified column to the first. When the return value is AFTER, it
+         * means move the column after the referred column.
+         */
+        public @Nullable ColumnPosition getNewPosition() {
+            return newPosition;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ModifyColumn)) {
+                return false;
+            }
+            ModifyColumn that = (ModifyColumn) o;
+            return Objects.equals(oldColumn, that.oldColumn)
+                    && Objects.equals(newColumn, that.newColumn)
+                    && Objects.equals(newPosition, that.newPosition);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(oldColumn, newColumn, newPosition);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyColumn{"
+                    + "oldColumn="
+                    + oldColumn
+                    + ", newColumn="
+                    + newColumn
+                    + ", newPosition="
+                    + newPosition
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change to modify the column comment.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;original_column_type&gt; COMMENT '&lt;new_column_comment&gt;'
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyColumnComment extends ModifyColumn {
+
+        private final String newComment;
+
+        private ModifyColumnComment(Column oldColumn, String newComment) {
+            super(oldColumn, oldColumn.withComment(newComment), null);
+            this.newComment = newComment;
+        }
+
+        /** Get the new comment for the column. */
+        public String getNewComment() {
+            return newComment;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof ModifyColumnComment) && super.equals(o);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyColumnComment{"
+                    + "Column="
+                    + oldColumn
+                    + ", newComment='"
+                    + newComment
+                    + '\''
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change to modify the column position.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;original_column_type&gt; &lt;column_position&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyColumnPosition extends ModifyColumn {
+
+        public ModifyColumnPosition(Column oldColumn, ColumnPosition newPosition) {
+            super(oldColumn, oldColumn, newPosition);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof ModifyColumnPosition) && super.equals(o);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyColumnPosition{"
+                    + "Column="
+                    + oldColumn
+                    + ", newPosition="
+                    + newPosition
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change that modify the physical column data type.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY &lt;column_name&gt; &lt;new_column_type&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyPhysicalColumnType extends ModifyColumn {
+
+        private ModifyPhysicalColumnType(Column oldColumn, DataType newType) {
+            super(oldColumn, oldColumn.copy(newType), null);
+            Preconditions.checkArgument(oldColumn.isPhysical());
+        }
+
+        /** Get the column type for the new column. */
+        public DataType getNewType() {
+            return newColumn.getDataType();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof ModifyPhysicalColumnType) && super.equals(o);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyPhysicalColumnType{"
+                    + "Column="
+                    + oldColumn
+                    + ", newType="
+                    + getNewType()
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change to modify the column name.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; RENAME &lt;old_column_name&gt; TO &lt;new_column_name&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyColumnName extends ModifyColumn {
+
+        private ModifyColumnName(Column oldColumn, String newName) {
+            super(oldColumn, createNewColumn(oldColumn, newName), null);
+        }
+
+        private static Column createNewColumn(Column oldColumn, String newName) {
+            if (oldColumn instanceof Column.PhysicalColumn) {
+                return Column.physical(newName, oldColumn.getDataType())
+                        .withComment(oldColumn.comment);
+            } else if (oldColumn instanceof Column.MetadataColumn) {
+                Column.MetadataColumn metadataColumn = (Column.MetadataColumn) oldColumn;
+                return Column.metadata(
+                                newName,
+                                oldColumn.getDataType(),
+                                metadataColumn.getMetadataKey().orElse(null),
+                                metadataColumn.isVirtual())
+                        .withComment(oldColumn.comment);
+            } else {
+                return Column.computed(newName, ((Column.ComputedColumn) oldColumn).getExpression())
+                        .withComment(oldColumn.comment);
+            }
+        }
+
+        /** Returns the origin column name. */
+        public String getOldColumnName() {
+            return oldColumn.getName();
+        }
+
+        /** Returns the new column name after renaming the column name. */
+        public String getNewColumnName() {
+            return newColumn.getName();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof ModifyColumnName) && super.equals(o);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyColumnName{"
+                    + "Column="
+                    + oldColumn
+                    + ", newName="
+                    + getNewColumnName()
+                    + '}';
+        }
+    }
+
+    /**
+     * A table change to modify a unique constraint.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY PRIMARY KEY (&lt;column_name&gt; ...) NOT ENFORCED
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyUniqueConstraint implements TableChange {
+
+        private final UniqueConstraint newConstraint;
+
+        public ModifyUniqueConstraint(UniqueConstraint newConstraint) {
+            this.newConstraint = newConstraint;
+        }
+
+        /** Returns the modified unique constraint. */
+        public UniqueConstraint getNewConstraint() {
+            return newConstraint;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ModifyUniqueConstraint)) {
+                return false;
+            }
+            ModifyUniqueConstraint that = (ModifyUniqueConstraint) o;
+            return Objects.equals(newConstraint, that.newConstraint);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(newConstraint);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyUniqueConstraint{" + "newConstraint=" + newConstraint + '}';
+        }
+    }
+
+    /**
+     * A table change to modify the watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; MODIFY WATERMARK FOR &lt;row_time_column_name&gt; AS &lt;watermark_expression&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class ModifyWatermark implements TableChange {
+
+        private final WatermarkSpec newWatermark;
+
+        public ModifyWatermark(WatermarkSpec newWatermark) {
+            this.newWatermark = newWatermark;
+        }
+
+        /** Returns the modified watermark. */
+        public WatermarkSpec getNewWatermark() {
+            return newWatermark;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ModifyWatermark)) {
+                return false;
+            }
+            ModifyWatermark that = (ModifyWatermark) o;
+            return Objects.equals(newWatermark, that.newWatermark);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(newWatermark);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyWatermark{" + "newWatermark=" + newWatermark + '}';
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Drop Change
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * A table change to drop the column.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP COLUMN &lt;column_name&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class DropColumn implements TableChange {
+
+        private final String columnName;
+
+        private DropColumn(String columnName) {
+            this.columnName = columnName;
+        }
+
+        /** Returns the column name. */
+        public String getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DropColumn)) {
+                return false;
+            }
+            DropColumn that = (DropColumn) o;
+            return Objects.equals(columnName, that.columnName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(columnName);
+        }
+
+        @Override
+        public String toString() {
+            return "DropColumn{" + "columnName='" + columnName + '\'' + '}';
+        }
+    }
+
+    /**
+     * A table change to drop the watermark.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP WATERMARK
+     * </pre>
+     */
+    @PublicEvolving
+    class DropWatermark implements TableChange {
+        static final DropWatermark INSTANCE = new DropWatermark();
+
+        @Override
+        public String toString() {
+            return "DropWatermark";
+        }
+    }
+
+    /**
+     * A table change to drop the constraints.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; DROP CONSTRAINT &lt;constraint_name&gt;
+     * </pre>
+     */
+    @PublicEvolving
+    class DropConstraint implements TableChange {
+
+        private final String constraintName;
+
+        private DropConstraint(String constraintName) {
+            this.constraintName = constraintName;
+        }
+
+        /** Returns the constraint name. */
+        public String getConstraintName() {
+            return constraintName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DropConstraint)) {
+                return false;
+            }
+            DropConstraint that = (DropConstraint) o;
+            return Objects.equals(constraintName, that.constraintName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(constraintName);
+        }
+
+        @Override
+        public String toString() {
+            return "DropConstraint{" + "constraintName='" + constraintName + '\'' + '}';
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Property change
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * A table change to set the table option.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; SET '&lt;key&gt;' = '&lt;value&gt;';
+     * </pre>
+     */
+    @PublicEvolving
+    class SetOption implements TableChange {
+
+        private final String key;
+        private final String value;
+
+        private SetOption(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        /** Returns the Option key to set. */
+        public String getKey() {
+            return key;
+        }
+
+        /** Returns the Option value to set. */
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof SetOption)) {
+                return false;
+            }
+            SetOption setOption = (SetOption) o;
+            return Objects.equals(key, setOption.key) && Objects.equals(value, setOption.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
+
+        @Override
+        public String toString() {
+            return "SetOption{" + "key='" + key + '\'' + ", value='" + value + '\'' + '}';
+        }
+    }
+
+    /**
+     * A table change to reset the table option.
+     *
+     * <p>It is equal to the following statement:
+     *
+     * <pre>
+     *    ALTER TABLE &lt;table_name&gt; RESET '&lt;key&gt;'
+     * </pre>
+     */
+    @PublicEvolving
+    class ResetOption implements TableChange {
+
+        private final String key;
+
+        public ResetOption(String key) {
+            this.key = key;
+        }
+
+        /** Returns the Option key to reset. */
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ResetOption)) {
+                return false;
+            }
+            ResetOption that = (ResetOption) o;
+            return Objects.equals(key, that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key);
+        }
+
+        @Override
+        public String toString() {
+            return "ResetOption{" + "key='" + key + '\'' + '}';
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    /** The position of the modified or added column. */
+    @PublicEvolving
+    interface ColumnPosition {
+
+        /** Get the position to place the column at the first. */
+        static ColumnPosition first() {
+            return First.INSTANCE;
+        }
+
+        /** Get the position to place the column after the specified column. */
+        static ColumnPosition after(String column) {
+            return new After(column);
+        }
+    }
+
+    /** Column position FIRST means the specified column should be the first column. */
+    @PublicEvolving
+    final class First implements ColumnPosition {
+        private static final First INSTANCE = new First();
+
+        private First() {}
+
+        @Override
+        public String toString() {
+            return "FIRST";
+        }
+    }
+
+    /** Column position AFTER means the specified column should be put after the given `column`. */
+    @PublicEvolving
+    final class After implements ColumnPosition {
+        private final String column;
+
+        private After(String column) {
+            this.column = column;
+        }
+
+        public String column() {
+            return column;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof After)) {
+                return false;
+            }
+            After after = (After) o;
+            return Objects.equals(column, after.column);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(column);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("AFTER %s", EncodingUtils.escapeIdentifier(column));
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Materialized table change
+    // --------------------------------------------------------------------------------------------
+    /** {@link MaterializedTableChange} represents the modification of the materialized table. */
+    @PublicEvolving
+    interface MaterializedTableChange extends TableChange {}
+}

--- a/fluss-flink/fluss-flink-1.20/pom.xml
+++ b/fluss-flink/fluss-flink-1.20/pom.xml
@@ -153,6 +153,28 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-gateway</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-gateway</artifactId>
+            <version>${flink.minor.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fluss-flink/fluss-flink-1.20/src/test/java/org/apache/fluss/flink/catalog/Flink120MaterializedTableITCase.java
+++ b/fluss-flink/fluss-flink-1.20/src/test/java/org/apache/fluss/flink/catalog/Flink120MaterializedTableITCase.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.catalog;
+
+/** IT case for materialized table in Flink 1.20. */
+public class Flink120MaterializedTableITCase extends MaterializedTableITCase {}

--- a/fluss-flink/fluss-flink-2.1/pom.xml
+++ b/fluss-flink/fluss-flink-2.1/pom.xml
@@ -150,6 +150,28 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-gateway</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-gateway</artifactId>
+            <version>${flink.minor.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fluss-flink/fluss-flink-2.1/src/test/java/org/apache/fluss/flink/catalog/Flink21MaterializedTableITCase.java
+++ b/fluss-flink/fluss-flink-2.1/src/test/java/org/apache/fluss/flink/catalog/Flink21MaterializedTableITCase.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.catalog;
+
+/** IT case for materialized table in Flink 2.1. */
+public class Flink21MaterializedTableITCase extends MaterializedTableITCase {}

--- a/fluss-flink/fluss-flink-common/pom.xml
+++ b/fluss-flink/fluss-flink-common/pom.xml
@@ -179,6 +179,28 @@
             <type>test-jar</type>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-gateway</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-gateway</artifactId>
+            <version>${flink.minor.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/FlinkConnectorOptions.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/FlinkConnectorOptions.java
@@ -24,6 +24,8 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.description.InlineElement;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.IntervalFreshness;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -143,6 +145,61 @@ public class FlinkConnectorOptions {
 
     public static final List<String> ALTER_DISALLOW_OPTIONS =
             Arrays.asList(BUCKET_NUMBER.key(), BUCKET_KEY.key(), BOOTSTRAP_SERVERS.key());
+
+    // -------------------------------------------------------------------------------------------
+    // Only used internally to support materialized table
+    // -------------------------------------------------------------------------------------------
+
+    public static final String MATERIALIZED_TABLE_PREFIX = "materialized-table.";
+
+    public static final ConfigOption<String> MATERIALIZED_TABLE_DEFINITION_QUERY =
+            ConfigOptions.key("materialized-table.definition-query")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The definition query text of materialized table, text is expanded in contrast to the original SQL.");
+    public static final ConfigOption<String> MATERIALIZED_TABLE_INTERVAL_FRESHNESS =
+            ConfigOptions.key("materialized-table.interval-freshness")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The freshness interval of materialized table which is used to determine the physical refresh mode.");
+    public static final ConfigOption<IntervalFreshness.TimeUnit>
+            MATERIALIZED_TABLE_INTERVAL_FRESHNESS_TIME_UNIT =
+                    ConfigOptions.key("materialized-table.interval-freshness.time-unit")
+                            .enumType(IntervalFreshness.TimeUnit.class)
+                            .noDefaultValue()
+                            .withDescription("The time unit of freshness interval.");
+    public static final ConfigOption<CatalogMaterializedTable.LogicalRefreshMode>
+            MATERIALIZED_TABLE_LOGICAL_REFRESH_MODE =
+                    ConfigOptions.key("materialized-table.logical-refresh-mode")
+                            .enumType(CatalogMaterializedTable.LogicalRefreshMode.class)
+                            .noDefaultValue()
+                            .withDescription("The logical refresh mode of materialized table.");
+    public static final ConfigOption<CatalogMaterializedTable.RefreshMode>
+            MATERIALIZED_TABLE_REFRESH_MODE =
+                    ConfigOptions.key("materialized-table.refresh-mode")
+                            .enumType(CatalogMaterializedTable.RefreshMode.class)
+                            .noDefaultValue()
+                            .withDescription("The physical refresh mode of materialized table.");
+    public static final ConfigOption<CatalogMaterializedTable.RefreshStatus>
+            MATERIALIZED_TABLE_REFRESH_STATUS =
+                    ConfigOptions.key("materialized-table.refresh-status")
+                            .enumType(CatalogMaterializedTable.RefreshStatus.class)
+                            .noDefaultValue()
+                            .withDescription("The refresh status of materialized table.");
+    public static final ConfigOption<String> MATERIALIZED_TABLE_REFRESH_HANDLER_DESCRIPTION =
+            ConfigOptions.key("materialized-table.refresh-handler-description")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The summary description of materialized table's refresh handler");
+    public static final ConfigOption<String> MATERIALIZED_TABLE_REFRESH_HANDLER_BYTES =
+            ConfigOptions.key("materialized-table.refresh-handler-bytes")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The serialized base64 bytes of refresh handler of materialized table.");
 
     // ------------------------------------------------------------------------------------------
 

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalogOptions.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalogOptions.java
@@ -19,78 +19,15 @@ package org.apache.fluss.flink.catalog;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
-import org.apache.flink.table.catalog.CatalogMaterializedTable;
-import org.apache.flink.table.catalog.IntervalFreshness;
 
 /** Options for flink catalog. */
 public class FlinkCatalogOptions {
-
-    public static final String MATERIALIZED_TABLE_PREFIX = "materialized-table.";
 
     public static final ConfigOption<String> DEFAULT_DATABASE =
             ConfigOptions.key("default-database")
                     .stringType()
                     .defaultValue("fluss")
                     .withDescription("Default database name used when none is specified.");
-
-    // -------------------------------------------------------------------------------------------
-    // Only used internally to support materialized table
-    // -------------------------------------------------------------------------------------------
-
-    public static final ConfigOption<String> MATERIALIZED_TABLE_DEFINITION_QUERY =
-            ConfigOptions.key("materialized-table.definition-query")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "The definition query text of materialized table, text is expanded in contrast to the original SQL.");
-
-    public static final ConfigOption<String> MATERIALIZED_TABLE_INTERVAL_FRESHNESS =
-            ConfigOptions.key("materialized-table.interval-freshness")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "The freshness interval of materialized table which is used to determine the physical refresh mode.");
-
-    public static final ConfigOption<IntervalFreshness.TimeUnit>
-            MATERIALIZED_TABLE_INTERVAL_FRESHNESS_TIME_UNIT =
-                    ConfigOptions.key("materialized-table.interval-freshness.time-unit")
-                            .enumType(IntervalFreshness.TimeUnit.class)
-                            .noDefaultValue()
-                            .withDescription("The time unit of freshness interval.");
-
-    public static final ConfigOption<CatalogMaterializedTable.LogicalRefreshMode>
-            MATERIALIZED_TABLE_LOGICAL_REFRESH_MODE =
-                    ConfigOptions.key("materialized-table.logical-refresh-mode")
-                            .enumType(CatalogMaterializedTable.LogicalRefreshMode.class)
-                            .noDefaultValue()
-                            .withDescription("The logical refresh mode of materialized table.");
-
-    public static final ConfigOption<CatalogMaterializedTable.RefreshMode>
-            MATERIALIZED_TABLE_REFRESH_MODE =
-                    ConfigOptions.key("materialized-table.refresh-mode")
-                            .enumType(CatalogMaterializedTable.RefreshMode.class)
-                            .noDefaultValue()
-                            .withDescription("The physical refresh mode of materialized table.");
-
-    public static final ConfigOption<CatalogMaterializedTable.RefreshStatus>
-            MATERIALIZED_TABLE_REFRESH_STATUS =
-                    ConfigOptions.key("materialized-table.refresh-status")
-                            .enumType(CatalogMaterializedTable.RefreshStatus.class)
-                            .noDefaultValue()
-                            .withDescription("The refresh status of materialized table.");
-
-    public static final ConfigOption<String> MATERIALIZED_TABLE_REFRESH_HANDLER_DESCRIPTION =
-            ConfigOptions.key("materialized-table.refresh-handler-description")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "The summary description of materialized table's refresh handler");
-
-    public static final ConfigOption<String> MATERIALIZED_TABLE_REFRESH_HANDLER_BYTES =
-            ConfigOptions.key("materialized-table.refresh-handler-bytes")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription("The serialized refresh handler of materialized table.");
 
     private FlinkCatalogOptions() {}
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalogOptions.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalogOptions.java
@@ -19,15 +19,78 @@ package org.apache.fluss.flink.catalog;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.IntervalFreshness;
 
 /** Options for flink catalog. */
 public class FlinkCatalogOptions {
+
+    public static final String MATERIALIZED_TABLE_PREFIX = "materialized-table.";
 
     public static final ConfigOption<String> DEFAULT_DATABASE =
             ConfigOptions.key("default-database")
                     .stringType()
                     .defaultValue("fluss")
                     .withDescription("Default database name used when none is specified.");
+
+    // -------------------------------------------------------------------------------------------
+    // Only used internally to support materialized table
+    // -------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> MATERIALIZED_TABLE_DEFINITION_QUERY =
+            ConfigOptions.key("materialized-table.definition-query")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The definition query text of materialized table, text is expanded in contrast to the original SQL.");
+
+    public static final ConfigOption<String> MATERIALIZED_TABLE_INTERVAL_FRESHNESS =
+            ConfigOptions.key("materialized-table.interval-freshness")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The freshness interval of materialized table which is used to determine the physical refresh mode.");
+
+    public static final ConfigOption<IntervalFreshness.TimeUnit>
+            MATERIALIZED_TABLE_INTERVAL_FRESHNESS_TIME_UNIT =
+                    ConfigOptions.key("materialized-table.interval-freshness.time-unit")
+                            .enumType(IntervalFreshness.TimeUnit.class)
+                            .noDefaultValue()
+                            .withDescription("The time unit of freshness interval.");
+
+    public static final ConfigOption<CatalogMaterializedTable.LogicalRefreshMode>
+            MATERIALIZED_TABLE_LOGICAL_REFRESH_MODE =
+                    ConfigOptions.key("materialized-table.logical-refresh-mode")
+                            .enumType(CatalogMaterializedTable.LogicalRefreshMode.class)
+                            .noDefaultValue()
+                            .withDescription("The logical refresh mode of materialized table.");
+
+    public static final ConfigOption<CatalogMaterializedTable.RefreshMode>
+            MATERIALIZED_TABLE_REFRESH_MODE =
+                    ConfigOptions.key("materialized-table.refresh-mode")
+                            .enumType(CatalogMaterializedTable.RefreshMode.class)
+                            .noDefaultValue()
+                            .withDescription("The physical refresh mode of materialized table.");
+
+    public static final ConfigOption<CatalogMaterializedTable.RefreshStatus>
+            MATERIALIZED_TABLE_REFRESH_STATUS =
+                    ConfigOptions.key("materialized-table.refresh-status")
+                            .enumType(CatalogMaterializedTable.RefreshStatus.class)
+                            .noDefaultValue()
+                            .withDescription("The refresh status of materialized table.");
+
+    public static final ConfigOption<String> MATERIALIZED_TABLE_REFRESH_HANDLER_DESCRIPTION =
+            ConfigOptions.key("materialized-table.refresh-handler-description")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The summary description of materialized table's refresh handler");
+
+    public static final ConfigOption<String> MATERIALIZED_TABLE_REFRESH_HANDLER_BYTES =
+            ConfigOptions.key("materialized-table.refresh-handler-bytes")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The serialized refresh handler of materialized table.");
 
     private FlinkCatalogOptions() {}
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/FlinkConversions.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/FlinkConversions.java
@@ -34,13 +34,19 @@ import org.apache.fluss.utils.StringUtils;
 import org.apache.fluss.utils.TimeUtils;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
-import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.IntervalFreshness;
+import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.types.RowKind;
+
+import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -53,10 +59,23 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
+import static org.apache.flink.table.utils.EncodingUtils.decodeBase64ToBytes;
+import static org.apache.flink.table.utils.EncodingUtils.encodeBytesToBase64;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.fluss.config.FlussConfigUtils.isTableStorageConfig;
 import static org.apache.fluss.flink.FlinkConnectorOptions.BUCKET_KEY;
 import static org.apache.fluss.flink.FlinkConnectorOptions.BUCKET_NUMBER;
 import static org.apache.fluss.flink.adapter.CatalogTableAdapter.toCatalogTable;
+import static org.apache.fluss.flink.catalog.FlinkCatalogOptions.MATERIALIZED_TABLE_DEFINITION_QUERY;
+import static org.apache.fluss.flink.catalog.FlinkCatalogOptions.MATERIALIZED_TABLE_INTERVAL_FRESHNESS;
+import static org.apache.fluss.flink.catalog.FlinkCatalogOptions.MATERIALIZED_TABLE_INTERVAL_FRESHNESS_TIME_UNIT;
+import static org.apache.fluss.flink.catalog.FlinkCatalogOptions.MATERIALIZED_TABLE_LOGICAL_REFRESH_MODE;
+import static org.apache.fluss.flink.catalog.FlinkCatalogOptions.MATERIALIZED_TABLE_PREFIX;
+import static org.apache.fluss.flink.catalog.FlinkCatalogOptions.MATERIALIZED_TABLE_REFRESH_HANDLER_BYTES;
+import static org.apache.fluss.flink.catalog.FlinkCatalogOptions.MATERIALIZED_TABLE_REFRESH_HANDLER_DESCRIPTION;
+import static org.apache.fluss.flink.catalog.FlinkCatalogOptions.MATERIALIZED_TABLE_REFRESH_MODE;
+import static org.apache.fluss.flink.catalog.FlinkCatalogOptions.MATERIALIZED_TABLE_REFRESH_STATUS;
+import static org.apache.fluss.utils.PropertiesUtils.excludeByPrefix;
 
 /** Utils for conversion between Flink and Fluss. */
 public class FlinkConversions {
@@ -89,7 +108,7 @@ public class FlinkConversions {
     }
 
     /** Convert Fluss's table to Flink's table. */
-    public static CatalogTable toFlinkTable(TableInfo tableInfo) {
+    public static CatalogBaseTable toFlinkTable(TableInfo tableInfo) {
         Map<String, String> newOptions = new HashMap<>(tableInfo.getCustomProperties().toMap());
 
         // put fluss table properties into flink options, to make the properties visible to users
@@ -133,6 +152,16 @@ public class FlinkConversions {
 
         // deserialize watermark
         CatalogPropertiesUtils.deserializeWatermark(newOptions, schemaBuilder);
+
+        // Check if this is a materialized table based on specific options
+        if (isMaterializedTable(newOptions)) {
+            return toFlinkMaterializedTable(
+                    schemaBuilder.build(),
+                    tableInfo.getComment().orElse(null),
+                    tableInfo.getPartitionKeys(),
+                    newOptions);
+        }
+
         return toCatalogTable(
                 schemaBuilder.build(),
                 tableInfo.getComment().orElse(null),
@@ -141,8 +170,8 @@ public class FlinkConversions {
     }
 
     /** Convert Flink's table to Fluss's table. */
-    public static TableDescriptor toFlussTable(ResolvedCatalogTable catalogTable) {
-        Configuration flinkTableConf = Configuration.fromMap(catalogTable.getOptions());
+    public static TableDescriptor toFlussTable(ResolvedCatalogBaseTable<?> catalogBaseTable) {
+        Configuration flinkTableConf = Configuration.fromMap(catalogBaseTable.getOptions());
         String connector = flinkTableConf.get(CONNECTOR);
         if (!StringUtils.isNullOrWhitespaceOnly(connector)
                 && !FlinkCatalogFactory.IDENTIFIER.equals(connector)) {
@@ -154,7 +183,7 @@ public class FlinkConversions {
                             + " You can create TEMPORARY table instead if you want to create the table of other connector.");
         }
 
-        ResolvedSchema resolvedSchema = catalogTable.getResolvedSchema();
+        ResolvedSchema resolvedSchema = catalogBaseTable.getResolvedSchema();
 
         // now, build Fluss's table
         Schema.Builder schemBuilder = Schema.newBuilder();
@@ -186,13 +215,31 @@ public class FlinkConversions {
                                     "Metadata column " + col + " is not supported.");
                         });
 
+        CatalogBaseTable.TableKind tableKind = catalogBaseTable.getTableKind();
+        List<String> partitionKeys =
+                CatalogBaseTable.TableKind.TABLE == tableKind
+                        ? ((ResolvedCatalogTable) catalogBaseTable).getPartitionKeys()
+                        : ((ResolvedCatalogMaterializedTable) catalogBaseTable).getPartitionKeys();
+
         Map<String, String> customProperties = flinkTableConf.toMap();
         CatalogPropertiesUtils.serializeComputedColumns(
                 customProperties, resolvedSchema.getColumns());
         CatalogPropertiesUtils.serializeWatermarkSpecs(
-                customProperties, catalogTable.getResolvedSchema().getWatermarkSpecs());
+                customProperties, catalogBaseTable.getResolvedSchema().getWatermarkSpecs());
 
-        String comment = catalogTable.getComment();
+        // Set materialized table flags to fluss table custom properties
+        if (CatalogBaseTable.TableKind.MATERIALIZED_TABLE == tableKind) {
+            CatalogMaterializedTable.RefreshMode refreshMode =
+                    ((ResolvedCatalogMaterializedTable) catalogBaseTable).getRefreshMode();
+            if (refreshMode == CatalogMaterializedTable.RefreshMode.FULL) {
+                throw new UnsupportedOperationException(
+                        "Fluss currently supports only continuous refresh mode for materialized tables.");
+            }
+            serializeMaterializedTableToCustomProperties(
+                    (CatalogMaterializedTable) catalogBaseTable, customProperties);
+        }
+
+        String comment = catalogBaseTable.getComment();
 
         // convert some flink options to fluss table configs.
         Map<String, String> properties = convertFlinkOptionsToFlussTableProperties(flinkTableConf);
@@ -212,7 +259,7 @@ public class FlinkConversions {
                                     pk -> {
                                         List<String> bucketKeys =
                                                 new ArrayList<>(pk.getColumnNames());
-                                        bucketKeys.removeAll(catalogTable.getPartitionKeys());
+                                        bucketKeys.removeAll(partitionKeys);
                                         return bucketKeys;
                                     })
                             .orElse(Collections.emptyList());
@@ -221,7 +268,7 @@ public class FlinkConversions {
 
         return TableDescriptor.builder()
                 .schema(schema)
-                .partitionedBy(catalogTable.getPartitionKeys())
+                .partitionedBy(partitionKeys)
                 .distributedBy(bucketNum, bucketKey)
                 .comment(comment)
                 .properties(properties)
@@ -339,22 +386,24 @@ public class FlinkConversions {
                 });
     }
 
-    public static TableChange toFlussTableChange(
+    public static List<TableChange> toFlussTableChanges(
             org.apache.flink.table.catalog.TableChange tableChange) {
-        TableChange flussTableChange;
-        if (tableChange instanceof org.apache.flink.table.catalog.TableChange.SetOption) {
-            flussTableChange =
+        if (tableChange
+                instanceof org.apache.flink.table.catalog.TableChange.MaterializedTableChange) {
+            // MaterializedTableChange may produce multiple fluss TableChange,
+            return convertMaterializedTableChange(tableChange);
+        } else if (tableChange instanceof org.apache.flink.table.catalog.TableChange.SetOption) {
+            return Collections.singletonList(
                     convertSetOption(
-                            (org.apache.flink.table.catalog.TableChange.SetOption) tableChange);
+                            (org.apache.flink.table.catalog.TableChange.SetOption) tableChange));
         } else if (tableChange instanceof org.apache.flink.table.catalog.TableChange.ResetOption) {
-            flussTableChange =
+            return Collections.singletonList(
                     convertResetOption(
-                            (org.apache.flink.table.catalog.TableChange.ResetOption) tableChange);
+                            (org.apache.flink.table.catalog.TableChange.ResetOption) tableChange));
         } else {
             throw new UnsupportedOperationException(
                     String.format("Unsupported flink table change: %s.", tableChange));
         }
-        return flussTableChange;
     }
 
     private static TableChange.SetOption convertSetOption(
@@ -365,5 +414,177 @@ public class FlinkConversions {
     private static TableChange.ResetOption convertResetOption(
             org.apache.flink.table.catalog.TableChange.ResetOption flinkResetOption) {
         return TableChange.reset(flinkResetOption.getKey());
+    }
+
+    /** Converts a {@code MaterializedTableChange} to a list of Fluss TableChanges. */
+    private static List<TableChange> convertMaterializedTableChange(
+            org.apache.flink.table.catalog.TableChange materializedTableChange) {
+        List<TableChange> flussTableChanges = new ArrayList<>();
+        // Handle different types of MaterializedTableChange
+        if (materializedTableChange
+                instanceof org.apache.flink.table.catalog.TableChange.ModifyRefreshStatus) {
+            convertModifyRefreshStatus(
+                    (org.apache.flink.table.catalog.TableChange.ModifyRefreshStatus)
+                            materializedTableChange,
+                    flussTableChanges);
+        } else if (materializedTableChange
+                instanceof org.apache.flink.table.catalog.TableChange.ModifyRefreshHandler) {
+            convertModifyRefreshHandler(
+                    (org.apache.flink.table.catalog.TableChange.ModifyRefreshHandler)
+                            materializedTableChange,
+                    flussTableChanges);
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Unsupported flink materialized table change: %s",
+                            materializedTableChange));
+        }
+
+        return flussTableChanges;
+    }
+
+    /** Handles {@code ModifyRefreshStatus} change. */
+    private static void convertModifyRefreshStatus(
+            org.apache.flink.table.catalog.TableChange.ModifyRefreshStatus modifyRefreshStatus,
+            List<TableChange> flussTableChanges) {
+        CatalogMaterializedTable.RefreshStatus newRefreshStatus =
+                modifyRefreshStatus.getRefreshStatus();
+        flussTableChanges.add(
+                TableChange.set(MATERIALIZED_TABLE_REFRESH_STATUS.key(), newRefreshStatus.name()));
+    }
+
+    /**
+     * Handles {@code ModifyRefreshHandler} change. This change produces two TableChanges: one for
+     * description and one for bytes.
+     */
+    private static void convertModifyRefreshHandler(
+            org.apache.flink.table.catalog.TableChange.ModifyRefreshHandler modifyRefreshHandler,
+            List<TableChange> flussTableChanges) {
+        String newHandlerDesc = modifyRefreshHandler.getRefreshHandlerDesc();
+        byte[] newHandlerBytes = modifyRefreshHandler.getRefreshHandlerBytes();
+        flussTableChanges.add(
+                TableChange.set(
+                        MATERIALIZED_TABLE_REFRESH_HANDLER_DESCRIPTION.key(), newHandlerDesc));
+        flussTableChanges.add(
+                TableChange.set(
+                        MATERIALIZED_TABLE_REFRESH_HANDLER_BYTES.key(),
+                        encodeBytesToBase64(newHandlerBytes)));
+    }
+
+    /**
+     * Determines if the given options represent a materialized table.
+     *
+     * @param options the table options to check
+     * @return true if this is a materialized table, false otherwise
+     */
+    private static boolean isMaterializedTable(Map<String, String> options) {
+        return options.keySet().stream().anyMatch(key -> key.startsWith(MATERIALIZED_TABLE_PREFIX));
+    }
+
+    private static void serializeMaterializedTableToCustomProperties(
+            CatalogMaterializedTable mt, Map<String, String> customProperties) {
+        // Serialize core materialized table properties
+        customProperties.put(MATERIALIZED_TABLE_DEFINITION_QUERY.key(), mt.getDefinitionQuery());
+        // Serialize freshness configuration
+        IntervalFreshness freshness = mt.getDefinitionFreshness();
+        customProperties.put(MATERIALIZED_TABLE_INTERVAL_FRESHNESS.key(), freshness.getInterval());
+        customProperties.put(
+                MATERIALIZED_TABLE_INTERVAL_FRESHNESS_TIME_UNIT.key(),
+                freshness.getTimeUnit().name());
+        // Serialize refresh configuration
+        customProperties.put(
+                MATERIALIZED_TABLE_LOGICAL_REFRESH_MODE.key(), mt.getLogicalRefreshMode().name());
+        customProperties.put(MATERIALIZED_TABLE_REFRESH_MODE.key(), mt.getRefreshMode().name());
+        customProperties.put(MATERIALIZED_TABLE_REFRESH_STATUS.key(), mt.getRefreshStatus().name());
+        // Serialize optional refresh handler information
+        serializeRefreshHandler(mt, customProperties);
+    }
+
+    /**
+     * Serializes the refresh handler information if present.
+     *
+     * @param mt the materialized table
+     * @param customProperties the properties map to update
+     */
+    private static void serializeRefreshHandler(
+            CatalogMaterializedTable mt, Map<String, String> customProperties) {
+        // Serialize refresh handler description if present
+        mt.getRefreshHandlerDescription()
+                .ifPresent(
+                        desc ->
+                                customProperties.put(
+                                        MATERIALIZED_TABLE_REFRESH_HANDLER_DESCRIPTION.key(),
+                                        desc));
+        // Serialize refresh handler bytes if present
+        byte[] serializedRefreshHandler = mt.getSerializedRefreshHandler();
+        if (serializedRefreshHandler != null) {
+            customProperties.put(
+                    MATERIALIZED_TABLE_REFRESH_HANDLER_BYTES.key(),
+                    encodeBytesToBase64(serializedRefreshHandler));
+        }
+    }
+
+    private static CatalogMaterializedTable toFlinkMaterializedTable(
+            org.apache.flink.table.api.Schema schema,
+            String comment,
+            List<String> partitionKeys,
+            Map<String, String> options) {
+        // Validate required materialized table options first
+        String definitionQuery = options.get(MATERIALIZED_TABLE_DEFINITION_QUERY.key());
+        String intervalFreshness = options.get(MATERIALIZED_TABLE_INTERVAL_FRESHNESS.key());
+        String timeUnitStr = options.get(MATERIALIZED_TABLE_INTERVAL_FRESHNESS_TIME_UNIT.key());
+        String logicalRefreshModeStr = options.get(MATERIALIZED_TABLE_LOGICAL_REFRESH_MODE.key());
+        String refreshModeStr = options.get(MATERIALIZED_TABLE_REFRESH_MODE.key());
+        String refreshStatusStr = options.get(MATERIALIZED_TABLE_REFRESH_STATUS.key());
+
+        // Validate required materialized table options first
+        checkNotNull(
+                definitionQuery, "Materialized table definition query is required but missing");
+        checkNotNull(
+                intervalFreshness, "Materialized table interval freshness is required but missing");
+        checkNotNull(
+                timeUnitStr,
+                "Materialized table interval freshness time unit is required but missing");
+        checkNotNull(
+                logicalRefreshModeStr,
+                "Materialized table logical refresh mode is required but missing");
+        checkNotNull(refreshModeStr, "Materialized table refresh mode is required but missing");
+        checkNotNull(refreshStatusStr, "Materialized table refresh status is required but missing");
+
+        // Parse validated values
+        IntervalFreshness.TimeUnit timeUnit = IntervalFreshness.TimeUnit.valueOf(timeUnitStr);
+        IntervalFreshness freshness = IntervalFreshness.of(intervalFreshness, timeUnit);
+        CatalogMaterializedTable.LogicalRefreshMode logicalRefreshMode =
+                CatalogMaterializedTable.LogicalRefreshMode.valueOf(logicalRefreshModeStr);
+        CatalogMaterializedTable.RefreshMode refreshMode =
+                CatalogMaterializedTable.RefreshMode.valueOf(refreshModeStr);
+        CatalogMaterializedTable.RefreshStatus refreshStatus =
+                CatalogMaterializedTable.RefreshStatus.valueOf(refreshStatusStr);
+
+        @Nullable
+        String refreshHandlerDesc =
+                options.get(MATERIALIZED_TABLE_REFRESH_HANDLER_DESCRIPTION.key());
+        @Nullable
+        String refreshHandlerStringBytes =
+                options.get(MATERIALIZED_TABLE_REFRESH_HANDLER_BYTES.key());
+        @Nullable
+        byte[] refreshHandlerBytes =
+                StringUtils.isNullOrWhitespaceOnly(refreshHandlerStringBytes)
+                        ? null
+                        : decodeBase64ToBytes(refreshHandlerStringBytes);
+
+        CatalogMaterializedTable.Builder builder = CatalogMaterializedTable.newBuilder();
+        builder.schema(schema)
+                .comment(comment)
+                .partitionKeys(partitionKeys)
+                .options(excludeByPrefix(options, MATERIALIZED_TABLE_PREFIX))
+                .definitionQuery(definitionQuery)
+                .freshness(freshness)
+                .logicalRefreshMode(logicalRefreshMode)
+                .refreshMode(refreshMode)
+                .refreshStatus(refreshStatus)
+                .refreshHandlerDescription(refreshHandlerDesc)
+                .serializedRefreshHandler(refreshHandlerBytes);
+        return builder.build();
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/MaterializedTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/MaterializedTableITCase.java
@@ -1,0 +1,477 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.catalog;
+
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.server.testutils.FlussClusterExtension;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointConfigHeaders;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointConfigInfo;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatistics;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatisticsHeaders;
+import org.apache.flink.runtime.rest.util.RestMapperUtils;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.gateway.api.endpoint.EndpointVersion;
+import org.apache.flink.table.gateway.api.operation.OperationHandle;
+import org.apache.flink.table.gateway.api.session.SessionEnvironment;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestEndpointExtension;
+import org.apache.flink.table.gateway.service.SqlGatewayServiceImpl;
+import org.apache.flink.table.gateway.service.utils.IgnoreExceptionHandler;
+import org.apache.flink.table.gateway.service.utils.SqlGatewayServiceExtension;
+import org.apache.flink.table.refresh.ContinuousRefreshHandler;
+import org.apache.flink.table.refresh.ContinuousRefreshHandlerSerializer;
+import org.apache.flink.test.junit5.InjectClusterClient;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.table.catalog.CommonCatalogOptions.TABLE_CATALOG_STORE_KIND;
+import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.awaitOperationTermination;
+import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.fetchAllResults;
+import static org.apache.flink.test.util.TestUtils.waitUntilAllTasksAreRunning;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test the support of Materialized Table. */
+public abstract class MaterializedTableITCase {
+
+    private static final String FILE_CATALOG_STORE = "file_store";
+
+    static Configuration initClusterConf() {
+        Configuration clusterConf = new Configuration();
+        // use a small check interval to cleanup partitions quickly
+        clusterConf.set(ConfigOptions.AUTO_PARTITION_CHECK_INTERVAL, Duration.ofSeconds(3));
+        return clusterConf;
+    }
+
+    @RegisterExtension
+    public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
+            FlussClusterExtension.builder()
+                    .setNumOfTabletServers(1)
+                    .setClusterConf(initClusterConf())
+                    .build();
+
+    @RegisterExtension
+    @Order(1)
+    static final MiniClusterExtension MINI_CLUSTER =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(2)
+                            .build());
+
+    @RegisterExtension
+    @Order(2)
+    protected static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
+            new SqlGatewayServiceExtension(MINI_CLUSTER::getClientConfiguration);
+
+    @RegisterExtension
+    @Order(3)
+    protected static final TestExecutorExtension<ExecutorService> EXECUTOR_EXTENSION =
+            new TestExecutorExtension<>(
+                    () ->
+                            Executors.newCachedThreadPool(
+                                    new ExecutorThreadFactory(
+                                            "SqlGatewayService Test Pool",
+                                            IgnoreExceptionHandler.INSTANCE)));
+
+    @RegisterExtension
+    @Order(4)
+    protected static final SqlGatewayRestEndpointExtension SQL_GATEWAY_REST_ENDPOINT_EXTENSION =
+            new SqlGatewayRestEndpointExtension(SQL_GATEWAY_SERVICE_EXTENSION::getService);
+
+    protected static SqlGatewayServiceImpl service;
+    private static SessionEnvironment defaultSessionEnvironment;
+
+    static final String CATALOG_NAME = "testcatalog";
+    static final String DEFAULT_DB = FlinkCatalogOptions.DEFAULT_DATABASE.defaultValue();
+
+    protected SessionHandle sessionHandle;
+    protected RestClusterClient<?> restClusterClient;
+
+    @BeforeAll
+    static void setUp(@TempDir Path temporaryFolder) throws Exception {
+        service = (SqlGatewayServiceImpl) SQL_GATEWAY_SERVICE_EXTENSION.getService();
+
+        // initialize file catalog store path
+        Path fileCatalogStore = temporaryFolder.resolve(FILE_CATALOG_STORE);
+        Files.createDirectory(fileCatalogStore);
+        Map<String, String> catalogStoreOptions = new HashMap<>();
+        catalogStoreOptions.put(TABLE_CATALOG_STORE_KIND.key(), "file");
+        catalogStoreOptions.put("table.catalog-store.file.path", fileCatalogStore.toString());
+
+        defaultSessionEnvironment =
+                SessionEnvironment.newBuilder()
+                        .addSessionConfig(catalogStoreOptions)
+                        .setSessionEndpointVersion(new EndpointVersion() {})
+                        .build();
+    }
+
+    @BeforeEach
+    void before(@InjectClusterClient RestClusterClient<?> injectClusterClient) {
+        // initialize session handle, create paimon catalog and register it to catalog
+        // store
+        sessionHandle = initializeSession();
+        // init rest cluster client
+        restClusterClient = injectClusterClient;
+    }
+
+    @Test
+    void testCreateMaterializedTableInContinuousMode() throws Exception {
+        String materializedTableDDL =
+                "CREATE MATERIALIZED TABLE shop_detail\n"
+                        + " FRESHNESS = INTERVAL '3' SECOND\n"
+                        + " AS SELECT \n"
+                        + "  DATE_FORMAT(order_created_at, 'yyyy-MM-dd') AS ds,\n"
+                        + "  user_id,\n"
+                        + "  shop_id,\n"
+                        + "  payment_amount_cents\n"
+                        + " FROM datagenSource";
+        OperationHandle materializedTableHandle =
+                service.executeStatement(
+                        sessionHandle,
+                        materializedTableDDL,
+                        -1,
+                        new org.apache.flink.configuration.Configuration());
+        awaitOperationTermination(service, sessionHandle, materializedTableHandle);
+
+        // validate materialized table: schema, refresh mode, refresh status, refresh handler,
+        // doesn't check the data because it generates randomly.
+        ResolvedCatalogMaterializedTable actualMaterializedTable =
+                (ResolvedCatalogMaterializedTable)
+                        service.getTable(
+                                sessionHandle,
+                                ObjectIdentifier.of(CATALOG_NAME, DEFAULT_DB, "shop_detail"));
+
+        // Expected schema
+        ResolvedSchema expectedSchema =
+                ResolvedSchema.of(
+                        Arrays.asList(
+                                Column.physical("ds", DataTypes.STRING()),
+                                Column.physical("user_id", DataTypes.BIGINT().notNull()),
+                                Column.physical("shop_id", DataTypes.BIGINT().notNull()),
+                                Column.physical("payment_amount_cents", DataTypes.BIGINT())));
+
+        assertThat(actualMaterializedTable.getResolvedSchema()).isEqualTo(expectedSchema);
+        assertThat(actualMaterializedTable.getFreshness()).isEqualTo(Duration.ofSeconds(3));
+        assertThat(actualMaterializedTable.getLogicalRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC);
+        assertThat(actualMaterializedTable.getRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.RefreshMode.CONTINUOUS);
+        assertThat(actualMaterializedTable.getRefreshStatus())
+                .isEqualTo(CatalogMaterializedTable.RefreshStatus.ACTIVATED);
+        assertThat(actualMaterializedTable.getRefreshHandlerDescription()).isNotEmpty();
+        assertThat(actualMaterializedTable.getSerializedRefreshHandler()).isNotEmpty();
+
+        ContinuousRefreshHandler activeRefreshHandler =
+                ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
+                        actualMaterializedTable.getSerializedRefreshHandler(),
+                        getClass().getClassLoader());
+
+        waitUntilAllTasksAreRunning(
+                restClusterClient, JobID.fromHexString(activeRefreshHandler.getJobId()));
+
+        // verify the background job is running
+        String describeJobDDL = String.format("DESCRIBE JOB '%s'", activeRefreshHandler.getJobId());
+        OperationHandle describeJobHandle =
+                service.executeStatement(
+                        sessionHandle,
+                        describeJobDDL,
+                        -1,
+                        new org.apache.flink.configuration.Configuration());
+        awaitOperationTermination(service, sessionHandle, describeJobHandle);
+        List<RowData> jobResults = fetchAllResults(service, sessionHandle, describeJobHandle);
+        assertThat(jobResults.get(0).getString(2).toString()).isEqualTo("RUNNING");
+
+        // get checkpoint interval
+        long checkpointInterval =
+                getCheckpointIntervalConfig(restClusterClient, activeRefreshHandler.getJobId());
+        assertThat(checkpointInterval).isEqualTo(3 * 1000);
+
+        // drop materialized table
+        dropMaterializedTable(ObjectIdentifier.of(CATALOG_NAME, DEFAULT_DB, "shop_detail"));
+    }
+
+    @Test
+    void testSuspendAndResumeMaterializedTableInContinuousMode(@TempDir Path temporaryPath)
+            throws Exception {
+        String materializedTableDDL =
+                "CREATE MATERIALIZED TABLE shop_detail\n"
+                        + " FRESHNESS = INTERVAL '3' SECOND\n"
+                        + " AS SELECT \n"
+                        + "  DATE_FORMAT(order_created_at, 'yyyy-MM-dd') AS ds,\n"
+                        + "  user_id,\n"
+                        + "  shop_id,\n"
+                        + "  payment_amount_cents\n"
+                        + " FROM datagenSource";
+        OperationHandle materializedTableHandle =
+                service.executeStatement(
+                        sessionHandle,
+                        materializedTableDDL,
+                        -1,
+                        new org.apache.flink.configuration.Configuration());
+        awaitOperationTermination(service, sessionHandle, materializedTableHandle);
+
+        ObjectIdentifier mtIdentifier =
+                ObjectIdentifier.of(CATALOG_NAME, DEFAULT_DB, "shop_detail");
+        // validate materialized table: refresh status, refresh handler,
+        // doesn't check the data because it generates randomly.
+        ResolvedCatalogMaterializedTable activeMaterializedTable =
+                (ResolvedCatalogMaterializedTable) service.getTable(sessionHandle, mtIdentifier);
+
+        assertThat(activeMaterializedTable.getRefreshStatus())
+                .isEqualTo(CatalogMaterializedTable.RefreshStatus.ACTIVATED);
+
+        ContinuousRefreshHandler activeRefreshHandler =
+                ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
+                        activeMaterializedTable.getSerializedRefreshHandler(),
+                        getClass().getClassLoader());
+        waitUntilAllTasksAreRunning(
+                restClusterClient, JobID.fromHexString(activeRefreshHandler.getJobId()));
+
+        // set up savepoint dir
+        String savepointDir = temporaryPath.toString();
+        String alterJobSavepointDDL =
+                String.format(
+                        "SET 'execution.checkpointing.savepoint-dir' = 'file://%s'", savepointDir);
+        OperationHandle alterMaterializedTableSavepointHandle =
+                service.executeStatement(
+                        sessionHandle,
+                        alterJobSavepointDDL,
+                        -1,
+                        new org.apache.flink.configuration.Configuration());
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableSavepointHandle);
+
+        // suspend materialized table
+        String alterMaterializedTableSuspendDDL = "ALTER MATERIALIZED TABLE shop_detail SUSPEND";
+        OperationHandle alterMaterializedTableSuspendHandle =
+                service.executeStatement(
+                        sessionHandle,
+                        alterMaterializedTableSuspendDDL,
+                        -1,
+                        new org.apache.flink.configuration.Configuration());
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableSuspendHandle);
+
+        ResolvedCatalogMaterializedTable suspendMaterializedTable =
+                (ResolvedCatalogMaterializedTable) service.getTable(sessionHandle, mtIdentifier);
+        assertThat(suspendMaterializedTable.getRefreshStatus())
+                .isEqualTo(CatalogMaterializedTable.RefreshStatus.SUSPENDED);
+
+        // verify background job is stopped
+        byte[] refreshHandler = suspendMaterializedTable.getSerializedRefreshHandler();
+        ContinuousRefreshHandler suspendRefreshHandler =
+                ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
+                        refreshHandler, getClass().getClassLoader());
+        String suspendJobId = suspendRefreshHandler.getJobId();
+
+        // validate the job is finished
+        String describeJobDDL = String.format("DESCRIBE JOB '%s'", suspendJobId);
+        OperationHandle describeJobHandle =
+                service.executeStatement(
+                        sessionHandle,
+                        describeJobDDL,
+                        -1,
+                        new org.apache.flink.configuration.Configuration());
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableSuspendHandle);
+        List<RowData> jobResults = fetchAllResults(service, sessionHandle, describeJobHandle);
+        assertThat(jobResults.get(0).getString(2).toString()).isEqualTo("FINISHED");
+
+        // verify savepoint is created
+        assertThat(suspendRefreshHandler.getRestorePath()).isNotEmpty();
+        String actualSavepointPath = suspendRefreshHandler.getRestorePath().get();
+
+        // resume materialized table
+        String alterMaterializedTableResumeDDL = "ALTER MATERIALIZED TABLE shop_detail RESUME";
+        OperationHandle alterMaterializedTableResumeHandle =
+                service.executeStatement(
+                        sessionHandle,
+                        alterMaterializedTableResumeDDL,
+                        -1,
+                        new org.apache.flink.configuration.Configuration());
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableResumeHandle);
+
+        ResolvedCatalogMaterializedTable resumedCatalogMaterializedTable =
+                (ResolvedCatalogMaterializedTable) service.getTable(sessionHandle, mtIdentifier);
+        assertThat(resumedCatalogMaterializedTable.getRefreshStatus())
+                .isEqualTo(CatalogMaterializedTable.RefreshStatus.ACTIVATED);
+
+        waitUntilAllTasksAreRunning(
+                restClusterClient,
+                JobID.fromHexString(
+                        ContinuousRefreshHandlerSerializer.INSTANCE
+                                .deserialize(
+                                        resumedCatalogMaterializedTable
+                                                .getSerializedRefreshHandler(),
+                                        getClass().getClassLoader())
+                                .getJobId()));
+
+        // verify background job is running
+        refreshHandler = resumedCatalogMaterializedTable.getSerializedRefreshHandler();
+        ContinuousRefreshHandler resumeRefreshHandler =
+                ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
+                        refreshHandler, getClass().getClassLoader());
+        String resumeJobId = resumeRefreshHandler.getJobId();
+        String describeResumeJobDDL = String.format("DESCRIBE JOB '%s'", resumeJobId);
+        OperationHandle describeResumeJobHandle =
+                service.executeStatement(
+                        sessionHandle,
+                        describeResumeJobDDL,
+                        -1,
+                        new org.apache.flink.configuration.Configuration());
+        awaitOperationTermination(service, sessionHandle, describeResumeJobHandle);
+        jobResults = fetchAllResults(service, sessionHandle, describeResumeJobHandle);
+        assertThat(jobResults.get(0).getString(2).toString()).isEqualTo("RUNNING");
+
+        // verify resumed job is restored from savepoint
+        Optional<String> actualRestorePath =
+                getJobRestoreSavepointPath(restClusterClient, resumeJobId);
+        assertThat(actualRestorePath).isNotEmpty();
+        assertThat(actualRestorePath.get()).isEqualTo(actualSavepointPath);
+
+        // drop the materialized table
+        dropMaterializedTable(mtIdentifier);
+    }
+
+    public void dropMaterializedTable(ObjectIdentifier objectIdentifier) throws Exception {
+        String dropMaterializedTableDDL =
+                String.format(
+                        "DROP MATERIALIZED TABLE %s", objectIdentifier.asSerializableString());
+        OperationHandle dropMaterializedTableHandle =
+                service.executeStatement(
+                        sessionHandle,
+                        dropMaterializedTableDDL,
+                        -1,
+                        new org.apache.flink.configuration.Configuration());
+        awaitOperationTermination(service, sessionHandle, dropMaterializedTableHandle);
+    }
+
+    private long getCheckpointIntervalConfig(RestClusterClient<?> restClusterClient, String jobId)
+            throws Exception {
+        CheckpointConfigInfo checkpointConfigInfo =
+                sendJobRequest(
+                        restClusterClient,
+                        CheckpointConfigHeaders.getInstance(),
+                        EmptyRequestBody.getInstance(),
+                        jobId);
+        return RestMapperUtils.getStrictObjectMapper()
+                .readTree(
+                        RestMapperUtils.getStrictObjectMapper()
+                                .writeValueAsString(checkpointConfigInfo))
+                .get("interval")
+                .asLong();
+    }
+
+    private Optional<String> getJobRestoreSavepointPath(
+            RestClusterClient<?> restClusterClient, String jobId) throws Exception {
+        CheckpointingStatistics checkpointingStatistics =
+                sendJobRequest(
+                        restClusterClient,
+                        CheckpointingStatisticsHeaders.getInstance(),
+                        EmptyRequestBody.getInstance(),
+                        jobId);
+
+        CheckpointingStatistics.RestoredCheckpointStatistics restoredCheckpointStatistics =
+                checkpointingStatistics.getLatestCheckpoints().getRestoredCheckpointStatistics();
+        return restoredCheckpointStatistics != null
+                ? Optional.ofNullable(restoredCheckpointStatistics.getExternalPath())
+                : Optional.empty();
+    }
+
+    private <M extends JobMessageParameters, R extends RequestBody, P extends ResponseBody>
+            P sendJobRequest(
+                    RestClusterClient<?> restClusterClient,
+                    MessageHeaders<R, P, M> headers,
+                    R requestBody,
+                    String jobId)
+                    throws Exception {
+        M jobMessageParameters = headers.getUnresolvedMessageParameters();
+        jobMessageParameters.jobPathParameter.resolve(JobID.fromHexString(jobId));
+
+        return restClusterClient
+                .sendRequest(headers, jobMessageParameters, requestBody)
+                .get(5, TimeUnit.SECONDS);
+    }
+
+    private SessionHandle initializeSession() {
+        SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
+        Configuration flussConf = FLUSS_CLUSTER_EXTENSION.getClientConfig();
+        String bootstrapServers = String.join(",", flussConf.get(ConfigOptions.BOOTSTRAP_SERVERS));
+        String catalogDDL =
+                String.format(
+                        "CREATE CATALOG IF NOT EXISTS %s\n"
+                                + "WITH (\n"
+                                + "  'type' = 'fluss',\n"
+                                + "  'bootstrap.servers' = '%s'\n"
+                                + "  )",
+                        CATALOG_NAME, bootstrapServers);
+        service.configureSession(sessionHandle, catalogDDL, -1);
+        service.configureSession(sessionHandle, String.format("USE CATALOG %s", CATALOG_NAME), -1);
+
+        // create source table
+        String dataGenSource =
+                "CREATE TEMPORARY TABLE datagenSource (\n"
+                        + "  order_id BIGINT,\n"
+                        + "  order_number VARCHAR(20),\n"
+                        + "  user_id BIGINT NOT NULL,\n"
+                        + "  shop_id BIGINT NOT NULL,\n"
+                        + "  product_id BIGINT,\n"
+                        + "  status BIGINT,\n"
+                        + "  order_type BIGINT,\n"
+                        + "  order_created_at TIMESTAMP NOT NULL,\n"
+                        + "  payment_amount_cents BIGINT\n"
+                        + ")\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'datagen',\n"
+                        + "  'rows-per-second' = '10'\n"
+                        + ")";
+        service.configureSession(sessionHandle, dataGenSource, -1);
+        return sessionHandle;
+    }
+}

--- a/fluss-test-coverage/pom.xml
+++ b/fluss-test-coverage/pom.xml
@@ -419,36 +419,8 @@
                                         </exclude>
                                         <exclude>org.apache.fluss.flink.tiering.FlussLakeTieringEntrypoint</exclude>
                                         <!-- end exclude for flink tiering service -->
-                                        <exclude>org.apache.flink.table.catalog.CatalogBaseTable</exclude>
-                                        <exclude>org.apache.flink.table.catalog.CatalogBaseTable.TableKind</exclude>
-                                        <exclude>org.apache.flink.table.catalog.CatalogMaterializedTable</exclude>
-                                        <exclude>org.apache.flink.table.catalog.CatalogMaterializedTable.LogicalRefreshMode</exclude>
-                                        <exclude>org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshMode</exclude>
-                                        <exclude>org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshStatus</exclude>
-                                        <exclude>org.apache.flink.table.catalog.IntervalFreshness</exclude>
-                                        <exclude>org.apache.flink.table.catalog.IntervalFreshness.TimeUnit</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.AddColumn</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.AddUniqueConstraint</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.AddWatermark</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyColumn</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyColumnComment</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyColumnPosition</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyPhysicalColumnType</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyColumnName</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyUniqueConstraint</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyWatermark</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyWatermark</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyWatermark</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.DropColumn</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.DropWatermark</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.DropConstraint</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.SetOption</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ResetOption</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.ColumnPosition</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.First</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.After</exclude>
-                                        <exclude>org.apache.flink.table.catalog.TableChange.MaterializedTableChange</exclude>
+                                        <!-- exclude flink compatibility class for catalogs -->
+                                        <exclude>org.apache.flink.table.catalog.*</exclude>
                                     </excludes>
                                 </rule>
                             </rules>

--- a/fluss-test-coverage/pom.xml
+++ b/fluss-test-coverage/pom.xml
@@ -419,6 +419,36 @@
                                         </exclude>
                                         <exclude>org.apache.fluss.flink.tiering.FlussLakeTieringEntrypoint</exclude>
                                         <!-- end exclude for flink tiering service -->
+                                        <exclude>org.apache.flink.table.catalog.CatalogBaseTable</exclude>
+                                        <exclude>org.apache.flink.table.catalog.CatalogBaseTable.TableKind</exclude>
+                                        <exclude>org.apache.flink.table.catalog.CatalogMaterializedTable</exclude>
+                                        <exclude>org.apache.flink.table.catalog.CatalogMaterializedTable.LogicalRefreshMode</exclude>
+                                        <exclude>org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshMode</exclude>
+                                        <exclude>org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshStatus</exclude>
+                                        <exclude>org.apache.flink.table.catalog.IntervalFreshness</exclude>
+                                        <exclude>org.apache.flink.table.catalog.IntervalFreshness.TimeUnit</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.AddColumn</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.AddUniqueConstraint</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.AddWatermark</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyColumn</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyColumnComment</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyColumnPosition</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyPhysicalColumnType</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyColumnName</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyUniqueConstraint</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyWatermark</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyWatermark</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ModifyWatermark</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.DropColumn</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.DropWatermark</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.DropConstraint</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.SetOption</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ResetOption</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.ColumnPosition</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.First</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.After</exclude>
+                                        <exclude>org.apache.flink.table.catalog.TableChange.MaterializedTableChange</exclude>
                                     </excludes>
                                 </rule>
                             </rules>


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #861 

<!-- What is the purpose of the change -->

### Brief change log

- `FlinkCatalog` supports create/get/drop materialized table
- Since materialized table is a concept introduced by Flink, we convert it into a common Fluss table, introduce relevant options, and save them in `customProperties` to identify it as a materialized table. This is also the current implementation method of Paimon
- Since Paimon already supports materialized tables and has introduced related options, the options introduced in Fluss are aligned with those in Paimon. Since Fluss supports tiering tables to Paimon, when a Fluss materialized table is sync to Paimon, it should also be a Paimon materialized table, so the option names of the two are kept consistent. Reference: https://github.com/apache/paimon/blob/master/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java#L1664

### Tests

- Add unit test in FlinkConversionsTest
- Add unit test in FlinkCatalogTest
- Add integration test in MaterializedTableITCase

### API and Format

No

### Documentation

Yes, we will add the docs after finishing all pr.
