### PR TITLE
[feature] partition key support more data types (#489)

### DIFF
--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
@@ -58,7 +58,6 @@ import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.server.kv.snapshot.CompletedSnapshot;
 import com.alibaba.fluss.server.kv.snapshot.KvSnapshotHandle;
 import com.alibaba.fluss.types.DataTypes;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -566,29 +565,6 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         expectedNodes.add(FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode());
         expectedNodes.addAll(FLUSS_CLUSTER_EXTENSION.getTabletServerNodes());
         assertThat(serverNodes).containsExactlyInAnyOrderElementsOf(expectedNodes);
-    }
-
-    @Test
-    void testCreateIllegalPartitionTable() {
-        String dbName = DEFAULT_TABLE_PATH.getDatabaseName();
-        TableDescriptor partitionedTable =
-                TableDescriptor.builder()
-                        .schema(
-                                Schema.newBuilder()
-                                        .column("id", DataTypes.STRING())
-                                        .column("name", DataTypes.STRING())
-                                        .column("dt", DataTypes.DATE())
-                                        .build())
-                        .distributedBy(3, "id")
-                        .partitionedBy("name", "dt")
-                        .build();
-        TablePath tablePath = TablePath.of(dbName, "test_create_illegal_partitioned_table_1");
-        assertThatThrownBy(() -> admin.createTable(tablePath, partitionedTable, true).get())
-                .cause()
-                .isInstanceOf(InvalidTableException.class)
-                .hasMessageContaining(
-                        "Currently, partitioned table supported partition key type are [STRING], "
-                                + "but got partition key 'dt' with data type DATE.");
     }
 
     @Test

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/table/NewPartitionedTableITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/table/NewPartitionedTableITCase.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.table;
+
+import com.alibaba.fluss.client.admin.ClientToServerITCaseBase;
+import com.alibaba.fluss.client.table.writer.AppendWriter;
+import com.alibaba.fluss.metadata.PartitionInfo;
+import com.alibaba.fluss.metadata.Schema;
+import com.alibaba.fluss.metadata.TableDescriptor;
+import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.row.BinaryString;
+import com.alibaba.fluss.row.InternalRow;
+import com.alibaba.fluss.row.TimestampLtz;
+import com.alibaba.fluss.row.TimestampNtz;
+import com.alibaba.fluss.types.BigIntType;
+import com.alibaba.fluss.types.BinaryType;
+import com.alibaba.fluss.types.BooleanType;
+import com.alibaba.fluss.types.BytesType;
+import com.alibaba.fluss.types.CharType;
+import com.alibaba.fluss.types.DataTypeRoot;
+import com.alibaba.fluss.types.DateType;
+import com.alibaba.fluss.types.DoubleType;
+import com.alibaba.fluss.types.FloatType;
+import com.alibaba.fluss.types.IntType;
+import com.alibaba.fluss.types.LocalZonedTimestampType;
+import com.alibaba.fluss.types.SmallIntType;
+import com.alibaba.fluss.types.StringType;
+import com.alibaba.fluss.types.TimeType;
+import com.alibaba.fluss.types.TimestampType;
+import com.alibaba.fluss.types.TinyIntType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.alibaba.fluss.testutils.DataTestUtils.row;
+import static com.alibaba.fluss.utils.PartitionUtils.convertValueOfType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT case for Fluss partitioned table supporting partition key of different types. */
+class NewPartitionedTableITCase extends ClientToServerITCaseBase {
+    Schema.Builder schemaBuilder =
+            Schema.newBuilder()
+                    .column("a", new StringType())
+                    .column("char", new CharType())
+                    .column("binary", new BinaryType())
+                    .column("boolean", new BooleanType())
+                    .column("bytes", new BytesType())
+                    .column("tinyInt", new TinyIntType())
+                    .column("smallInt", new SmallIntType())
+                    .column("int", new IntType())
+                    .column("bigInt", new BigIntType())
+                    .column("date", new DateType())
+                    .column("float", new FloatType())
+                    .column("double", new DoubleType())
+                    .column("time", new TimeType())
+                    .column("timeStampNTZ", new TimestampType())
+                    .column("timeStampLTZ", new LocalZonedTimestampType());
+
+    Schema schema = schemaBuilder.build();
+    DataTypeRoot[] allPartitionKeyTypes =
+            new DataTypeRoot[] {
+                DataTypeRoot.STRING,
+                DataTypeRoot.CHAR,
+                DataTypeRoot.BINARY,
+                DataTypeRoot.BOOLEAN,
+                DataTypeRoot.BYTES,
+                DataTypeRoot.TINYINT,
+                DataTypeRoot.SMALLINT,
+                DataTypeRoot.INTEGER,
+                DataTypeRoot.BIGINT,
+                DataTypeRoot.DATE,
+                DataTypeRoot.FLOAT,
+                DataTypeRoot.DOUBLE,
+                DataTypeRoot.TIME_WITHOUT_TIME_ZONE,
+                DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
+                DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+            };
+
+    Object[] allPartitionKeyValues =
+            new Object[] {
+                BinaryString.fromString("a"),
+                BinaryString.fromString("F"),
+                new byte[] {0x10, 0x20, 0x30, 0x40, 0x50, (byte) 0b11111111},
+                true,
+                new byte[] {0x10, 0x20, 0x30, 0x40, 0x50, (byte) 0b11111111},
+                (byte) 100,
+                (short) -32760, // smallint
+                299000, // Integer
+                1748662955428L, // Bigint
+                20235, // Date
+                5.73f, // Float
+                5.73, // Double
+                5402199, // Time
+                TimestampNtz.fromMillis(1748662955428L), // TIME_WITHOUT_TIME_ZONE
+                TimestampLtz.fromEpochMillis(1748662955428L) // TIMESTAMP_WITH_LOCAL_TIME_ZONE
+            };
+
+    Schema.Column[] extraColumn =
+            new Schema.Column[] {
+                new Schema.Column("a", new StringType()),
+                new Schema.Column("char", new CharType()),
+                new Schema.Column("binary", new BinaryType()),
+                new Schema.Column("boolean", new BooleanType()),
+                new Schema.Column("bytes", new BytesType()),
+                new Schema.Column("tinyInt", new TinyIntType()),
+                new Schema.Column("smallInt", new SmallIntType()),
+                new Schema.Column("int", new IntType()),
+                new Schema.Column("bigInt", new BigIntType()),
+                new Schema.Column("date", new DateType()),
+                new Schema.Column("float", new FloatType()),
+                new Schema.Column("double", new DoubleType()),
+                new Schema.Column("time", new TimeType()),
+                new Schema.Column("timeStampNTZ", new TimestampType()),
+                new Schema.Column("timeStampLTZ", new LocalZonedTimestampType())
+            };
+
+    List<String> result =
+            Arrays.asList(
+                    "a",
+                    "F",
+                    "1020304050ff",
+                    "true",
+                    "1020304050ff",
+                    "100",
+                    "-32760",
+                    "299000",
+                    "1748662955428",
+                    "2025-05-27",
+                    "5_73",
+                    "5_73",
+                    "01-30-02_199",
+                    "2025-05-31-03-42-35_428",
+                    "2025-05-31-03-42-35_428");
+
+    @Test
+    void testMultipleTypedPartitionedTable() throws Exception {
+
+        for (int i = 0; i < allPartitionKeyTypes.length; i++) {
+            String partitionKey = extraColumn[i].getName();
+            TablePath tablePath =
+                    TablePath.of("test_part_db_" + i, "test_static_partitioned_pk_table_" + i);
+            createPartitionedTable(tablePath, partitionKey);
+            String partitionValue =
+                    convertValueOfType(allPartitionKeyValues[i], allPartitionKeyTypes[i]);
+
+            admin.createPartition(tablePath, newPartitionSpec(partitionKey, partitionValue), true)
+                    .get();
+
+            Map<String, Long> partitionIdByNames =
+                    FLUSS_CLUSTER_EXTENSION.waitUntilPartitionAllReady(tablePath, 1);
+
+            List<PartitionInfo> partitionInfos = admin.listPartitionInfos(tablePath).get();
+            List<String> expectedPartitions = new ArrayList<>(partitionIdByNames.keySet());
+            assertThat(
+                            partitionInfos.stream()
+                                    .map(PartitionInfo::getPartitionName)
+                                    .collect(Collectors.toList()))
+                    .containsExactlyInAnyOrderElementsOf(expectedPartitions);
+
+            Table table = conn.getTable(tablePath);
+            AppendWriter appendWriter = table.newAppend().createWriter();
+            Map<Long, List<InternalRow>> expectPartitionAppendRows = new HashMap<>();
+            for (String partition : partitionIdByNames.keySet()) {
+                for (int j = 0; j < allPartitionKeyValues.length; j++) {
+                    InternalRow row = row(allPartitionKeyValues);
+                    appendWriter.append(row);
+                    expectPartitionAppendRows
+                            .computeIfAbsent(
+                                    partitionIdByNames.get(partition), k -> new ArrayList<>())
+                            .add(row);
+                }
+            }
+            appendWriter.flush();
+
+            assertThat(admin.listPartitionInfos(tablePath).get().get(0).getPartitionName())
+                    .isEqualTo(result.get(i));
+        }
+    }
+
+    private void createPartitionedTable(TablePath tablePath, String partitionKey) throws Exception {
+        TableDescriptor partitionTableDescriptor =
+                TableDescriptor.builder().schema(schema).partitionedBy(partitionKey).build();
+        createTable(tablePath, partitionTableDescriptor, false);
+    }
+}

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/table/PartitionedTableITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/table/PartitionedTableITCase.java
@@ -45,7 +45,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * AutoPartitionedTableITCase}.
  */
 class PartitionedTableITCase extends ClientToServerITCaseBase {
-
     @Test
     void testPartitionedPrimaryKeyTable() throws Exception {
         TablePath tablePath = TablePath.of("test_db_1", "test_static_partitioned_pk_table_1");

--- a/fluss-common/src/main/java/com/alibaba/fluss/types/PartitionNameConverters.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/types/PartitionNameConverters.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/fluss-common/src/main/java/com/alibaba/fluss/types/PartitionNameConverters.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/types/PartitionNameConverters.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.types;
+
+import com.alibaba.fluss.row.TimestampLtz;
+import com.alibaba.fluss.row.TimestampNtz;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+
+/**
+ * We replace "." with "_" and replace ":" in date format with "-" so that
+ * TablePath.detectInvalidName validation will accept the partition name.
+ */
+public class PartitionNameConverters {
+
+    private PartitionNameConverters() {}
+
+    public static String hexString(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : bytes) {
+            String hex = Integer.toHexString(0xFF & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+
+    public static String reformatFloat(Float value) {
+        if (value.isNaN()) {
+            return "NaN";
+        } else if (value.isInfinite()) {
+            return (value > 0) ? "Inf" : "-Inf";
+        } else {
+            return String.valueOf(value).replace(".", "_");
+        }
+    }
+
+    public static String reformatDouble(Double value) {
+        if (value.isNaN()) {
+            return "NaN";
+        } else if (value.isInfinite()) {
+            return (value > 0) ? "Inf" : "-Inf";
+        } else {
+            return String.valueOf(value).replace(".", "_");
+        }
+    }
+
+    private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
+
+    public static String dayToString(int days) {
+        OffsetDateTime day = EPOCH.plusDays(days);
+        return String.format(
+                Locale.ROOT,
+                "%04d-%02d-%02d",
+                day.getYear(),
+                day.getMonth().getValue(),
+                day.getDayOfMonth());
+    }
+
+    public static String milliToString(int milli) {
+        int millisPerSecond = 1000;
+        int millisPerMinute = 60 * millisPerSecond;
+        int millisPerHour = 60 * millisPerMinute;
+
+        int hour = Math.floorDiv(milli, millisPerHour);
+        int min = Math.floorDiv(Math.floorMod(milli, millisPerHour), millisPerMinute);
+        int seconds =
+                Math.floorDiv(
+                        Math.floorMod(Math.floorMod(milli, millisPerHour), millisPerMinute),
+                        millisPerSecond);
+
+        return String.format(
+                Locale.ROOT,
+                "%02d-%02d-%02d_%03d",
+                hour,
+                min,
+                seconds,
+                Math.floorMod(milli, millisPerSecond));
+    }
+
+    private static final DateTimeFormatter TimestampFormatter =
+            new DateTimeFormatterBuilder()
+                    .appendPattern("yyyy-[MM]-[dd]")
+                    .optionalStart()
+                    .appendPattern("-[HH]-[mm]-[ss]_")
+                    .appendFraction(NANO_OF_SECOND, 0, 9, false)
+                    .optionalEnd()
+                    .toFormatter();
+
+    /** always add nanoseconds whether TimestampNTZ and TimestampLTZ are compact or not. */
+    public static String timestampToString(TimestampNtz timestampNtz) {
+        return ChronoUnit.MILLIS
+                .addTo(EPOCH, timestampNtz.getMillisecond())
+                .plusNanos(timestampNtz.getNanoOfMillisecond())
+                .toLocalDateTime()
+                .atOffset(ZoneOffset.UTC)
+                .format(TimestampFormatter);
+    }
+
+    public static String timestampToString(TimestampLtz timestampLtz) {
+        return ChronoUnit.MILLIS
+                .addTo(EPOCH, timestampLtz.getEpochMillisecond())
+                .plusNanos(timestampLtz.getNanoOfMillisecond())
+                .toLocalDateTime()
+                .atOffset(ZoneOffset.UTC)
+                .format(TimestampFormatter);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
@@ -22,12 +22,15 @@ import com.alibaba.fluss.exception.InvalidPartitionException;
 import com.alibaba.fluss.metadata.PartitionSpec;
 import com.alibaba.fluss.metadata.ResolvedPartitionSpec;
 import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.row.TimestampLtz;
+import com.alibaba.fluss.row.TimestampNtz;
 import com.alibaba.fluss.types.DataTypeRoot;
+import com.alibaba.fluss.types.PartitionNameConverters;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +41,21 @@ public class PartitionUtils {
 
     // TODO Support other data types, trace by https://github.com/alibaba/fluss/issues/489
     public static final List<DataTypeRoot> PARTITION_KEY_SUPPORTED_TYPES =
-            Collections.singletonList(DataTypeRoot.STRING);
+            Arrays.asList(
+                    DataTypeRoot.STRING,
+                    DataTypeRoot.BOOLEAN,
+                    DataTypeRoot.BINARY,
+                    DataTypeRoot.BYTES,
+                    DataTypeRoot.TINYINT,
+                    DataTypeRoot.SMALLINT,
+                    DataTypeRoot.INTEGER,
+                    DataTypeRoot.DATE,
+                    DataTypeRoot.TIME_WITHOUT_TIME_ZONE,
+                    DataTypeRoot.BIGINT,
+                    DataTypeRoot.FLOAT,
+                    DataTypeRoot.DOUBLE,
+                    DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
+                    DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
 
     private static final String YEAR_FORMAT = "yyyy";
     private static final String QUARTER_FORMAT = "yyyyQ";
@@ -132,5 +149,61 @@ public class PartitionUtils {
 
     private static String getFormattedTime(ZonedDateTime zonedDateTime, String format) {
         return DateTimeFormatter.ofPattern(format).format(zonedDateTime);
+    }
+
+    public static String convertValueOfType(Object value, DataTypeRoot type) {
+        String stringPartitionKey = "";
+        switch (type) {
+            case BOOLEAN:
+                Boolean booleanValue = (Boolean) value;
+                stringPartitionKey = booleanValue.toString();
+                break;
+            case BINARY:
+            case BYTES:
+                byte[] bytesValue = (byte[]) value;
+                stringPartitionKey = PartitionNameConverters.hexString(bytesValue);
+                break;
+            case TINYINT:
+                Byte tinyIntValue = (Byte) value;
+                stringPartitionKey = tinyIntValue.toString();
+                break;
+            case SMALLINT:
+                Short smallIntValue = (Short) value;
+                stringPartitionKey = smallIntValue.toString();
+                break;
+            case INTEGER:
+                Integer intValue = (Integer) value;
+                stringPartitionKey = intValue.toString();
+                break;
+            case DATE:
+                Integer dateValue = (Integer) value;
+                stringPartitionKey = PartitionNameConverters.dayToString(dateValue);
+                break;
+            case TIME_WITHOUT_TIME_ZONE:
+                Integer timeValue = (Integer) value;
+                stringPartitionKey = PartitionNameConverters.milliToString(timeValue);
+                break;
+            case FLOAT:
+                Float floatValue = (Float) value;
+                stringPartitionKey = PartitionNameConverters.reformatFloat(floatValue);
+                break;
+            case DOUBLE:
+                Double doubleValue = (Double) value;
+                stringPartitionKey = PartitionNameConverters.reformatDouble(doubleValue);
+                break;
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                TimestampLtz timeStampLTZValue = (TimestampLtz) value;
+                stringPartitionKey = PartitionNameConverters.timestampToString(timeStampLTZValue);
+                break;
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                TimestampNtz timeStampNTZValue = (TimestampNtz) value;
+                stringPartitionKey = PartitionNameConverters.timestampToString(timeStampNTZValue);
+                break;
+            case BIGINT:
+                Long bigIntValue = (Long) value;
+                stringPartitionKey = bigIntValue.toString();
+                break;
+        }
+        return stringPartitionKey;
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
@@ -39,7 +39,6 @@ import static com.alibaba.fluss.metadata.TablePath.detectInvalidName;
 /** Utils for partition. */
 public class PartitionUtils {
 
-    // TODO Support other data types, trace by https://github.com/alibaba/fluss/issues/489
     public static final List<DataTypeRoot> PARTITION_KEY_SUPPORTED_TYPES =
             Arrays.asList(
                     DataTypeRoot.STRING,

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
@@ -22,6 +22,7 @@ import com.alibaba.fluss.exception.InvalidPartitionException;
 import com.alibaba.fluss.metadata.PartitionSpec;
 import com.alibaba.fluss.metadata.ResolvedPartitionSpec;
 import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.row.BinaryString;
 import com.alibaba.fluss.row.TimestampLtz;
 import com.alibaba.fluss.row.TimestampNtz;
 import com.alibaba.fluss.types.DataTypeRoot;
@@ -41,6 +42,7 @@ public class PartitionUtils {
 
     public static final List<DataTypeRoot> PARTITION_KEY_SUPPORTED_TYPES =
             Arrays.asList(
+                    DataTypeRoot.CHAR,
                     DataTypeRoot.STRING,
                     DataTypeRoot.BOOLEAN,
                     DataTypeRoot.BINARY,
@@ -153,6 +155,10 @@ public class PartitionUtils {
     public static String convertValueOfType(Object value, DataTypeRoot type) {
         String stringPartitionKey = "";
         switch (type) {
+            case CHAR:
+            case STRING:
+                stringPartitionKey = ((BinaryString) value).toString();
+                break;
             case BOOLEAN:
                 Boolean booleanValue = (Boolean) value;
                 stringPartitionKey = booleanValue.toString();

--- a/fluss-common/src/test/java/com/alibaba/fluss/utils/PartitionUtilsTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/utils/PartitionUtilsTest.java
@@ -23,6 +23,7 @@ import com.alibaba.fluss.metadata.PartitionSpec;
 import com.alibaba.fluss.metadata.ResolvedPartitionSpec;
 import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TableInfo;
+import com.alibaba.fluss.row.BinaryString;
 import com.alibaba.fluss.row.TimestampLtz;
 import com.alibaba.fluss.row.TimestampNtz;
 import com.alibaba.fluss.types.DataTypeRoot;
@@ -151,6 +152,28 @@ class PartitionUtilsTest {
                             autoPartitionTimeUnit);
             assertThat(resolvedPartitionSpec.getPartitionName()).isEqualTo(expected[i]);
         }
+    }
+
+    @Test
+    void testString() {
+        Object value = BinaryString.fromString("Fluss");
+        DataTypeRoot type = DataTypeRoot.STRING;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("Fluss");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testCharConvert() {
+        Object value = BinaryString.fromString("F");
+        DataTypeRoot type = DataTypeRoot.CHAR;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("F");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
     }
 
     @Test
@@ -285,6 +308,17 @@ class PartitionUtilsTest {
 
         String toStringResult = convertValueOfType(timestampLTZ, type);
         assertThat(toStringResult).isEqualTo("2025-05-31-03-42-35_428099988");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testBigInt() {
+        long value = 1748662955428L;
+        DataTypeRoot type = DataTypeRoot.BIGINT;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("1748662955428");
         String detectInvalid = detectInvalidName(toStringResult);
         assertThat(detectInvalid).isEqualTo(null);
     }

--- a/fluss-common/src/test/java/com/alibaba/fluss/utils/PartitionUtilsTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/utils/PartitionUtilsTest.java
@@ -23,6 +23,9 @@ import com.alibaba.fluss.metadata.PartitionSpec;
 import com.alibaba.fluss.metadata.ResolvedPartitionSpec;
 import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TableInfo;
+import com.alibaba.fluss.row.TimestampLtz;
+import com.alibaba.fluss.row.TimestampNtz;
+import com.alibaba.fluss.types.DataTypeRoot;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,8 +35,10 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static com.alibaba.fluss.metadata.TablePath.detectInvalidName;
 import static com.alibaba.fluss.record.TestData.DATA1_SCHEMA;
 import static com.alibaba.fluss.record.TestData.DATA1_TABLE_PATH;
+import static com.alibaba.fluss.utils.PartitionUtils.convertValueOfType;
 import static com.alibaba.fluss.utils.PartitionUtils.generateAutoPartition;
 import static com.alibaba.fluss.utils.PartitionUtils.validatePartitionSpec;
 import static com.alibaba.fluss.utils.PartitionUtils.validatePartitionValues;
@@ -146,5 +151,141 @@ class PartitionUtilsTest {
                             autoPartitionTimeUnit);
             assertThat(resolvedPartitionSpec.getPartitionName()).isEqualTo(expected[i]);
         }
+    }
+
+    @Test
+    void testBooleanConvert() {
+        Object value = true;
+        DataTypeRoot type = DataTypeRoot.BOOLEAN;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("true");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testByteConvert() {
+        Object value = new byte[] {0x10, 0x20, 0x30, 0x40, 0x50, (byte) 0b11111111};
+        DataTypeRoot type = DataTypeRoot.BYTES;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("1020304050ff");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testBinaryConvert() {
+        Object value = new byte[] {0x10, 0x20, 0x30, 0x40, 0x50, (byte) 0b11111111};
+        DataTypeRoot type = DataTypeRoot.BINARY;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult.equals("1020304050ff"));
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testTinyInt() {
+        Object value = (byte) 100;
+        DataTypeRoot type = DataTypeRoot.TINYINT;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("100");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testSmallInt() {
+        Object value = (short) -32760;
+        DataTypeRoot type = DataTypeRoot.SMALLINT;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("-32760");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testInt() {
+        Object value = 299000;
+        DataTypeRoot type = DataTypeRoot.INTEGER;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("299000");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testDate() {
+        Object value = 20235;
+        DataTypeRoot type = DataTypeRoot.DATE;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("2025-05-27");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testTimeNTZ() {
+        int value = 5402199;
+        DataTypeRoot type = DataTypeRoot.TIME_WITHOUT_TIME_ZONE;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("01-30-02_199");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testFloat() {
+        Object value = 5.73f;
+        DataTypeRoot type = DataTypeRoot.FLOAT;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("5_73");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testDouble() {
+        Object value = 5.73;
+        DataTypeRoot type = DataTypeRoot.DOUBLE;
+
+        String toStringResult = convertValueOfType(value, type);
+        assertThat(toStringResult).isEqualTo("5_73");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testTimestampNTZ() {
+        long millis = 1748662955428L;
+        int nanos = 99988;
+        TimestampNtz timeStampNTZValue = TimestampNtz.fromMillis(millis, nanos);
+        DataTypeRoot type = DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
+
+        String toStringResult = convertValueOfType(timeStampNTZValue, type);
+        assertThat(toStringResult).isEqualTo("2025-05-31-03-42-35_428099988");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
+    }
+
+    @Test
+    void testTimestampLTZ() {
+        long millis = 1748662955428L;
+        int nanos = 99988;
+        TimestampLtz timestampLTZ = TimestampLtz.fromEpochMillis(millis, nanos);
+        DataTypeRoot type = DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
+
+        String toStringResult = convertValueOfType(timestampLTZ, type);
+        assertThat(toStringResult).isEqualTo("2025-05-31-03-42-35_428099988");
+        String detectInvalid = detectInvalidName(toStringResult);
+        assertThat(detectInvalid).isEqualTo(null);
     }
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminGateway.java
@@ -72,7 +72,7 @@ public interface AdminGateway extends AdminReadOnlyGateway {
     CompletableFuture<DropTableResponse> dropTable(DropTableRequest request);
 
     /**
-     * create a new partition for a partitioned table.
+     * Create a new partition for a partitioned table.
      *
      * @param request Create partition request
      */

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TableManagerITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TableManagerITCase.java
@@ -416,30 +416,6 @@ class TableManagerITCase {
         assertThat(zkClient.getPartitions(tablePath)).isEmpty();
     }
 
-    @Test
-    void testCreateInvalidPartitionedTable() throws Exception {
-        AdminGateway adminGateway = getAdminGateway();
-        String db1 = "db1";
-        String tb1 = "tb1";
-        TablePath tablePath = TablePath.of(db1, tb1);
-        // first create a database
-        adminGateway.createDatabase(newCreateDatabaseRequest(db1, false)).get();
-
-        TableDescriptor tableWithIntPartKey =
-                newPartitionedTableBuilder(null).partitionedBy("id").build();
-        assertThatThrownBy(
-                        () ->
-                                adminGateway
-                                        .createTable(
-                                                newCreateTableRequest(
-                                                        tablePath, tableWithIntPartKey, false))
-                                        .get())
-                .cause()
-                .isInstanceOf(InvalidTableException.class)
-                .hasMessageContaining(
-                        "Currently, partitioned table supported partition key type are [STRING], but got partition key 'id' with data type INT NOT NULL.");
-    }
-
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testMetadata(boolean isCoordinatorServer) throws Exception {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #489 

### Brief change log
 Add partition value -> string conversion to support more data types for partition key.

### Tests
`com.alibaba.fluss.utils.PartitionUtils`

### API and Format

This extends the partition name to include more data types.

