### PR TITLE
[lake] Ensure LakeStoragePlugin uses the plugin classloader for all operations

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/LakeStoragePluginSetUp.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/LakeStoragePluginSetUp.java
@@ -17,9 +17,6 @@
 
 package com.alibaba.fluss.lake.lakestorage;
 
-import com.alibaba.fluss.config.ConfigOptions;
-import com.alibaba.fluss.config.Configuration;
-import com.alibaba.fluss.metadata.DataLakeFormat;
 import com.alibaba.fluss.plugin.PluginManager;
 import com.alibaba.fluss.shaded.guava32.com.google.common.collect.Iterators;
 
@@ -36,28 +33,26 @@ import java.util.ServiceLoader;
 public class LakeStoragePluginSetUp {
 
     @Nullable
-    public static LakeStoragePlugin fromConfiguration(
-            final Configuration configuration, @Nullable final PluginManager pluginManager) {
-        DataLakeFormat dataLakeFormat = configuration.get(ConfigOptions.DATALAKE_FORMAT);
+    public static LakeStoragePlugin fromDataLakeFormat(
+            final String dataLakeFormat, @Nullable final PluginManager pluginManager) {
         if (dataLakeFormat == null) {
             return null;
         }
-        String dataLakeIdentifier = dataLakeFormat.toString();
         // now, load lake storage plugin
         Iterator<LakeStoragePlugin> lakeStoragePluginIterator =
                 getAllLakeStoragePlugins(pluginManager);
 
         while (lakeStoragePluginIterator.hasNext()) {
             LakeStoragePlugin lakeStoragePlugin = lakeStoragePluginIterator.next();
-            if (Objects.equals(lakeStoragePlugin.identifier(), dataLakeIdentifier)) {
-                return lakeStoragePlugin;
+            if (Objects.equals(lakeStoragePlugin.identifier(), dataLakeFormat)) {
+                return PluginLakeStorageWrapper.of(lakeStoragePlugin);
             }
         }
 
         // if come here, means we haven't found LakeStoragePlugin match the configured
         // datalake, throw exception
         throw new UnsupportedOperationException(
-                "No LakeStoragePlugin can be found for datalake format: " + dataLakeIdentifier);
+                "No LakeStoragePlugin can be found for datalake format: " + dataLakeFormat);
     }
 
     private static Iterator<LakeStoragePlugin> getAllLakeStoragePlugins(

--- a/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/LakeStoragePluginSetUp.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/LakeStoragePluginSetUp.java
@@ -32,12 +32,8 @@ import java.util.ServiceLoader;
  */
 public class LakeStoragePluginSetUp {
 
-    @Nullable
     public static LakeStoragePlugin fromDataLakeFormat(
             final String dataLakeFormat, @Nullable final PluginManager pluginManager) {
-        if (dataLakeFormat == null) {
-            return null;
-        }
         // now, load lake storage plugin
         Iterator<LakeStoragePlugin> lakeStoragePluginIterator =
                 getAllLakeStoragePlugins(pluginManager);

--- a/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/PluginLakeStorageWrapper.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/PluginLakeStorageWrapper.java
@@ -27,7 +27,7 @@ import com.alibaba.fluss.utils.WrappingProxy;
 
 /**
  * A wrapper around {@link LakeStoragePlugin} that ensures the plugin classloader is used for all
- * {@link LakeCatalog} and {@link LakeStorage} operations.
+ * {@link LakeCatalog} operations.
  */
 public class PluginLakeStorageWrapper implements LakeStoragePlugin {
     private final LakeStoragePlugin inner;
@@ -107,9 +107,7 @@ public class PluginLakeStorageWrapper implements LakeStoragePlugin {
 
         @Override
         public LakeTieringFactory<?, ?> createLakeTieringFactory() {
-            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
-                return inner.createLakeTieringFactory();
-            }
+            return inner.createLakeTieringFactory();
         }
 
         @Override

--- a/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/PluginLakeStorageWrapper.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/PluginLakeStorageWrapper.java
@@ -25,6 +25,10 @@ import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.utils.TemporaryClassLoaderContext;
 import com.alibaba.fluss.utils.WrappingProxy;
 
+/**
+ * A wrapper around {@link LakeStoragePlugin} that ensures the plugin classloader is used for all
+ * {@link LakeCatalog} and {@link LakeStorage} operations.
+ */
 public class PluginLakeStorageWrapper implements LakeStoragePlugin {
     private final LakeStoragePlugin inner;
     private final ClassLoader loader;

--- a/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/PluginLakeStorageWrapper.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/lake/lakestorage/PluginLakeStorageWrapper.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.lake.lakestorage;
+
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.TableAlreadyExistException;
+import com.alibaba.fluss.lake.writer.LakeTieringFactory;
+import com.alibaba.fluss.metadata.TableDescriptor;
+import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.utils.TemporaryClassLoaderContext;
+import com.alibaba.fluss.utils.WrappingProxy;
+
+public class PluginLakeStorageWrapper implements LakeStoragePlugin {
+    private final LakeStoragePlugin inner;
+    private final ClassLoader loader;
+
+    private PluginLakeStorageWrapper(final LakeStoragePlugin inner, final ClassLoader loader) {
+        this.inner = inner;
+        this.loader = loader;
+    }
+
+    public static PluginLakeStorageWrapper of(final LakeStoragePlugin inner) {
+        return new PluginLakeStorageWrapper(inner, inner.getClass().getClassLoader());
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return inner.getClassLoader();
+    }
+
+    @Override
+    public String identifier() {
+        return inner.identifier();
+    }
+
+    @Override
+    public LakeStorage createLakeStorage(Configuration configuration) {
+        try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+            return new ClassLoaderFixingLakeStorage(inner.createLakeStorage(configuration), loader);
+        }
+    }
+
+    static class ClassLoaderFixingLakeCatalog implements LakeCatalog, WrappingProxy<LakeCatalog> {
+
+        private final LakeCatalog inner;
+        private final ClassLoader loader;
+
+        private ClassLoaderFixingLakeCatalog(final LakeCatalog inner, final ClassLoader loader) {
+            this.inner = inner;
+            this.loader = loader;
+        }
+
+        @Override
+        public void createTable(TablePath tablePath, TableDescriptor tableDescriptor)
+                throws TableAlreadyExistException {
+            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+                inner.createTable(tablePath, tableDescriptor);
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+                inner.close();
+            }
+        }
+
+        @Override
+        public LakeCatalog getWrappedDelegate() {
+            return inner;
+        }
+    }
+
+    static class ClassLoaderFixingLakeStorage implements LakeStorage, WrappingProxy<LakeStorage> {
+
+        private final LakeStorage inner;
+        private final ClassLoader loader;
+
+        private ClassLoaderFixingLakeStorage(final LakeStorage inner, final ClassLoader loader) {
+            this.inner = inner;
+            this.loader = loader;
+        }
+
+        @Override
+        public LakeStorage getWrappedDelegate() {
+            return inner;
+        }
+
+        @Override
+        public LakeTieringFactory<?, ?> createLakeTieringFactory() {
+            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+                return inner.createLakeTieringFactory();
+            }
+        }
+
+        @Override
+        public LakeCatalog createLakeCatalog() {
+            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+                return new ClassLoaderFixingLakeCatalog(inner.createLakeCatalog(), loader);
+            }
+        }
+    }
+}

--- a/fluss-common/src/test/java/com/alibaba/fluss/lake/lakestorage/LakeStorageTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/lake/lakestorage/LakeStorageTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.lake.lakestorage;
+
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.TableAlreadyExistException;
+import com.alibaba.fluss.lake.writer.LakeTieringFactory;
+import com.alibaba.fluss.metadata.TableDescriptor;
+import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.plugin.PluginManager;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the {@link LakeStorage} base class. */
+public class LakeStorageTest {
+    private static String TEST_LAKE_PLUGIN_FORMAT = "test-plugin";
+
+    @Test
+    void testInvalidPlugin(@TempDir Path tempDir) throws Exception {
+        final Map<Class<?>, Iterator<?>> lakeStoragePlugins = new HashMap<>();
+        // use LocalFileSystem as the filesystem of schema 'testPluginSchema'
+        lakeStoragePlugins.put(
+                LakeStoragePlugin.class,
+                Collections.singletonList(new LakeStorageTest.TestPluginLakeStoragePlugin())
+                        .iterator());
+
+        assertThatThrownBy(
+                        () ->
+                                LakeStoragePluginSetUp.fromDataLakeFormat(
+                                        TEST_LAKE_PLUGIN_FORMAT + "1",
+                                        new TestingPluginManager(lakeStoragePlugins)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("No LakeStoragePlugin can be found for datalake format: ");
+        ;
+    }
+
+    @Test
+    void testWithPluginManager(@TempDir Path tempDir) throws Exception {
+
+        final Map<Class<?>, Iterator<?>> lakeStoragePlugins = new HashMap<>();
+
+        lakeStoragePlugins.put(
+                LakeStoragePlugin.class,
+                Collections.singletonList(new LakeStorageTest.TestPluginLakeStoragePlugin())
+                        .iterator());
+
+        LakeStoragePlugin lakeStoragePlugin =
+                LakeStoragePluginSetUp.fromDataLakeFormat(
+                        TEST_LAKE_PLUGIN_FORMAT, new TestingPluginManager(lakeStoragePlugins));
+
+        assertThat(lakeStoragePlugin).isInstanceOf(PluginLakeStorageWrapper.class);
+        LakeStorage lakeStorage = lakeStoragePlugin.createLakeStorage(new Configuration());
+
+        // the LakeStorage should wrap TestPaimonLakeStorage
+        assertThat(lakeStorage)
+                .isInstanceOf(PluginLakeStorageWrapper.ClassLoaderFixingLakeStorage.class);
+        assertThat(
+                        ((PluginLakeStorageWrapper.ClassLoaderFixingLakeStorage) lakeStorage)
+                                .getWrappedDelegate())
+                .isInstanceOf(TestPaimonLakeStorage.class);
+
+        // the LakeCatalog should wrap TestPaimonLakeCatalog
+        LakeCatalog lakeCatalog = lakeStorage.createLakeCatalog();
+        assertThat(lakeCatalog)
+                .isInstanceOf(PluginLakeStorageWrapper.ClassLoaderFixingLakeCatalog.class);
+        assertThat(
+                        ((PluginLakeStorageWrapper.ClassLoaderFixingLakeCatalog) lakeCatalog)
+                                .getWrappedDelegate())
+                .isInstanceOf(TestPaimonLakeCatalog.class);
+    }
+
+    private static class TestingPluginManager implements PluginManager {
+
+        private final Map<Class<?>, Iterator<?>> plugins;
+
+        private TestingPluginManager(Map<Class<?>, Iterator<?>> plugins) {
+            this.plugins = plugins;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <P> Iterator<P> load(Class<P> service) {
+            return (Iterator<P>) plugins.get(service);
+        }
+    }
+
+    private static class TestPluginLakeStoragePlugin implements LakeStoragePlugin {
+
+        private static final String IDENTIFIER = TEST_LAKE_PLUGIN_FORMAT;
+
+        @Override
+        public String identifier() {
+            return IDENTIFIER;
+        }
+
+        @Override
+        public LakeStorage createLakeStorage(Configuration configuration) {
+            return new TestPaimonLakeStorage();
+        }
+    }
+
+    private static class TestPaimonLakeStorage implements LakeStorage {
+
+        public TestPaimonLakeStorage() {}
+
+        @Override
+        public LakeTieringFactory<?, ?> createLakeTieringFactory() {
+            return null;
+        }
+
+        @Override
+        public TestPaimonLakeCatalog createLakeCatalog() {
+            return new TestPaimonLakeCatalog();
+        }
+    }
+
+    private static class TestPaimonLakeCatalog implements LakeCatalog {
+
+        @Override
+        public void createTable(TablePath tablePath, TableDescriptor tableDescriptor)
+                throws TableAlreadyExistException {}
+    }
+}

--- a/fluss-common/src/test/java/com/alibaba/fluss/lake/lakestorage/LakeStorageTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/lake/lakestorage/LakeStorageTest.java
@@ -24,9 +24,7 @@ import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.plugin.PluginManager;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,13 +34,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link LakeStorage} base class. */
-public class LakeStorageTest {
+class LakeStorageTest {
     private static final String TEST_LAKE_PLUGIN_FORMAT = "test-plugin";
 
     @Test
-    void testInvalidPlugin(@TempDir Path tempDir) throws Exception {
+    void testInvalidPlugin() throws Exception {
         final Map<Class<?>, Iterator<?>> lakeStoragePlugins = new HashMap<>();
-        // use LocalFileSystem as the filesystem of schema 'testPluginSchema'
         lakeStoragePlugins.put(
                 LakeStoragePlugin.class,
                 Collections.singletonList(new LakeStorageTest.TestPluginLakeStoragePlugin())
@@ -54,12 +51,11 @@ public class LakeStorageTest {
                                         TEST_LAKE_PLUGIN_FORMAT + "1",
                                         new TestingPluginManager(lakeStoragePlugins)))
                 .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessageContaining("No LakeStoragePlugin can be found for datalake format: ");
+                .hasMessage("No LakeStoragePlugin can be found for datalake format: test-plugin1");
     }
 
     @Test
-    void testWithPluginManager(@TempDir Path tempDir) throws Exception {
-
+    void testWithPluginManager() throws Exception {
         final Map<Class<?>, Iterator<?>> lakeStoragePlugins = new HashMap<>();
 
         lakeStoragePlugins.put(

--- a/fluss-common/src/test/java/com/alibaba/fluss/lake/lakestorage/LakeStorageTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/lake/lakestorage/LakeStorageTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link LakeStorage} base class. */
 public class LakeStorageTest {
-    private static String TEST_LAKE_PLUGIN_FORMAT = "test-plugin";
+    private static final String TEST_LAKE_PLUGIN_FORMAT = "test-plugin";
 
     @Test
     void testInvalidPlugin(@TempDir Path tempDir) throws Exception {
@@ -55,7 +55,6 @@ public class LakeStorageTest {
                                         new TestingPluginManager(lakeStoragePlugins)))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("No LakeStoragePlugin can be found for datalake format: ");
-        ;
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/LakeTieringJobBuilder.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/LakeTieringJobBuilder.java
@@ -72,7 +72,6 @@ public class LakeTieringJobBuilder {
         // get the lake storage plugin
         LakeStoragePlugin lakeStoragePlugin =
                 LakeStoragePluginSetUp.fromDataLakeFormat(dataLakeFormat, null);
-
         // create lake storage from configurations
         LakeStorage lakeStorage = checkNotNull(lakeStoragePlugin).createLakeStorage(dataLakeConfig);
 

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/LakeTieringJobBuilder.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/LakeTieringJobBuilder.java
@@ -17,7 +17,6 @@
 
 package com.alibaba.fluss.flink.tiering;
 
-import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.flink.tiering.committer.CommittableMessageTypeInfo;
 import com.alibaba.fluss.flink.tiering.committer.TieringCommitOperatorFactory;
@@ -34,8 +33,6 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
-
-import java.util.Collections;
 
 import static com.alibaba.fluss.flink.tiering.source.TieringSource.TIERING_SOURCE_TRANSFORMATION_UID;
 import static com.alibaba.fluss.flink.tiering.source.TieringSourceOptions.POLL_TIERING_TABLE_INTERVAL;
@@ -74,11 +71,8 @@ public class LakeTieringJobBuilder {
     public JobClient build() throws Exception {
         // get the lake storage plugin
         LakeStoragePlugin lakeStoragePlugin =
-                LakeStoragePluginSetUp.fromConfiguration(
-                        Configuration.fromMap(
-                                Collections.singletonMap(
-                                        ConfigOptions.DATALAKE_FORMAT.key(), dataLakeFormat)),
-                        null);
+                LakeStoragePluginSetUp.fromDataLakeFormat(dataLakeFormat, null);
+
         // create lake storage from configurations
         LakeStorage lakeStorage = checkNotNull(lakeStoragePlugin).createLakeStorage(dataLakeConfig);
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -27,6 +27,7 @@ import com.alibaba.fluss.lake.lakestorage.LakeCatalog;
 import com.alibaba.fluss.lake.lakestorage.LakeStorage;
 import com.alibaba.fluss.lake.lakestorage.LakeStoragePlugin;
 import com.alibaba.fluss.lake.lakestorage.LakeStoragePluginSetUp;
+import com.alibaba.fluss.metadata.DataLakeFormat;
 import com.alibaba.fluss.metadata.DatabaseDescriptor;
 import com.alibaba.fluss.metrics.registry.MetricRegistry;
 import com.alibaba.fluss.rpc.RpcClient;
@@ -247,8 +248,9 @@ public class CoordinatorServer extends ServerBase {
 
     @Nullable
     private LakeCatalog createLakeCatalog() {
+        DataLakeFormat dataLakeFormat = conf.get(ConfigOptions.DATALAKE_FORMAT);
         LakeStoragePlugin lakeStoragePlugin =
-                LakeStoragePluginSetUp.fromConfiguration(conf, pluginManager);
+                LakeStoragePluginSetUp.fromDataLakeFormat(dataLakeFormat.toString(), pluginManager);
         if (lakeStoragePlugin == null) {
             return null;
         }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -249,12 +249,11 @@ public class CoordinatorServer extends ServerBase {
     @Nullable
     private LakeCatalog createLakeCatalog() {
         DataLakeFormat dataLakeFormat = conf.get(ConfigOptions.DATALAKE_FORMAT);
-        LakeStoragePlugin lakeStoragePlugin =
-                LakeStoragePluginSetUp.fromDataLakeFormat(
-                        dataLakeFormat == null ? null : dataLakeFormat.toString(), pluginManager);
-        if (lakeStoragePlugin == null) {
+        if (dataLakeFormat == null) {
             return null;
         }
+        LakeStoragePlugin lakeStoragePlugin =
+                LakeStoragePluginSetUp.fromDataLakeFormat(dataLakeFormat.toString(), pluginManager);
         Map<String, String> lakeProperties = extractLakeProperties(conf);
         LakeStorage lakeStorage =
                 lakeStoragePlugin.createLakeStorage(

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -250,7 +250,8 @@ public class CoordinatorServer extends ServerBase {
     private LakeCatalog createLakeCatalog() {
         DataLakeFormat dataLakeFormat = conf.get(ConfigOptions.DATALAKE_FORMAT);
         LakeStoragePlugin lakeStoragePlugin =
-                LakeStoragePluginSetUp.fromDataLakeFormat(dataLakeFormat.toString(), pluginManager);
+                LakeStoragePluginSetUp.fromDataLakeFormat(
+                        dataLakeFormat == null ? null : dataLakeFormat.toString(), pluginManager);
         if (lakeStoragePlugin == null) {
             return null;
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1168

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

Use plugin classloader as thread current classloader, and ensure LakeStoragePlugin uses the plugin classloader for all operations

### Tests

<!-- List UT and IT cases to verify this change -->
com.alibaba.fluss.lake.lakestorage.LakeStorageTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
