### PR TITLE
Add exception in throwable in lake writer & committer

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/PaimonLakeCommitter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/PaimonLakeCommitter.java
@@ -183,7 +183,7 @@ public class PaimonLakeCommitter implements LakeCommitter<PaimonWriteResult, Pai
                 paimonCatalog.close();
             }
         } catch (Exception e) {
-            throw new IOException("Fail to close PaimonLakeCommitter.", e);
+            throw new IOException("Failed to close PaimonLakeCommitter.", e);
         }
     }
 
@@ -191,7 +191,7 @@ public class PaimonLakeCommitter implements LakeCommitter<PaimonWriteResult, Pai
         try {
             return (FileStoreTable) paimonCatalog.getTable(toPaimon(tablePath));
         } catch (Exception e) {
-            throw new IOException("Fail to get table " + tablePath + " in Paimon.");
+            throw new IOException("Failed to get table " + tablePath + " in Paimon.", e);
         }
     }
 

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/PaimonLakeWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/PaimonLakeWriter.java
@@ -66,7 +66,7 @@ public class PaimonLakeWriter implements LakeWriter<PaimonWriteResult> {
         try {
             recordWriter.write(record);
         } catch (Exception e) {
-            throw new IOException("Fail to write Fluss record to Paimon.", e);
+            throw new IOException("Failed to write Fluss record to Paimon.", e);
         }
     }
 
@@ -76,7 +76,7 @@ public class PaimonLakeWriter implements LakeWriter<PaimonWriteResult> {
         try {
             commitMessage = recordWriter.complete();
         } catch (Exception e) {
-            throw new IOException("Fail to complete Paimon write.", e);
+            throw new IOException("Failed to complete Paimon write.", e);
         }
         return new PaimonWriteResult(commitMessage);
     }
@@ -91,7 +91,7 @@ public class PaimonLakeWriter implements LakeWriter<PaimonWriteResult> {
                 paimonCatalog.close();
             }
         } catch (Exception e) {
-            throw new IOException("Fail to close PaimonLakeWriter.", e);
+            throw new IOException("Failed to close PaimonLakeWriter.", e);
         }
     }
 
@@ -99,7 +99,7 @@ public class PaimonLakeWriter implements LakeWriter<PaimonWriteResult> {
         try {
             return (FileStoreTable) paimonCatalog.getTable(toPaimon(tablePath));
         } catch (Exception e) {
-            throw new IOException("Fail to get table " + tablePath + " in Paimon.");
+            throw new IOException("Failed to get table " + tablePath + " in Paimon.", e);
         }
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/MetadataManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/MetadataManager.java
@@ -305,7 +305,8 @@ public class MetadataManager {
         try {
             optionalTable = zookeeperClient.getTable(tablePath);
         } catch (Exception e) {
-            throw new FlussRuntimeException(String.format("Fail to get table '%s'.", tablePath), e);
+            throw new FlussRuntimeException(
+                    String.format("Failed to get table '%s'.", tablePath), e);
         }
         if (!optionalTable.isPresent()) {
             throw new TableNotExistException("Table '" + tablePath + "' does not exist.");


### PR DESCRIPTION
Small improvement to add a exception root cause when trying to debug why the lakewriter or committer fail.