### PR TITLE
[flink/ci] Add watchdog for flink timeout failure stack trace at 95 percent time completion

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,10 +46,18 @@ jobs:
       - name: Test
         timeout-minutes: 60
         run: |
-          TEST_MODULES=$(./.github/workflows/stage.sh ${{ matrix.module }})
-          echo "github ref: ${{ github.ref }}"
-          echo "Start testing modules: $TEST_MODULES"
-          mvn -B verify $TEST_MODULES -Ptest-coverage -Ptest-${{ matrix.module }} -Dlog.dir=${{ runner.temp }}/fluss-logs -Dlog4j.configurationFile=${{ github.workspace }}/tools/ci/log4j.properties
+            TEST_MODULES=$(./.github/workflows/stage.sh ${{ matrix.module }})
+            echo "github ref: ${{ github.ref }}"
+            echo "Start testing modules: $TEST_MODULES"
+            
+            if [ "${{ matrix.module }}" = "flink" ]; then
+              # Use watchdog for Flink tests
+              chmod +x ./tools/ci/flink_watchdog.sh
+              ./tools/ci/flink_watchdog.sh mvn -B verify $TEST_MODULES -Ptest-coverage -Ptest-${{ matrix.module }} -Dlog.dir=${{ runner.temp }}/fluss-logs -Dlog4j.configurationFile=${{ github.workspace }}/tools/ci/log4j.properties
+            else
+              # Regular execution for core tests
+              mvn -B verify $TEST_MODULES -Ptest-coverage -Ptest-${{ matrix.module }} -Dlog.dir=${{ runner.temp }}/fluss-logs -Dlog4j.configurationFile=${{ github.workspace }}/tools/ci/log4j.properties
+            fi
         env:
           MAVEN_OPTS: -Xmx4096m
           ARTIFACTS_OSS_ENDPOINT: ${{ secrets.ARTIFACTS_OSS_ENDPOINT }}
@@ -71,3 +79,9 @@ jobs:
         with:
           name: jacoco-report-${{ matrix.module }}-${{ github.run_number}}#${{ github.run_attempt }}
           path: ${{ github.workspace }}/fluss-test-coverage/target/site/jacoco-aggregate/*
+      - name: Upload Flink debug artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() && matrix.module == 'flink' }}
+        with:
+          name: flink-debug-${{ github.run_number}}
+          path: ${{ runner.temp }}/flink-debug/*

--- a/tools/ci/flink_watchdog.sh
+++ b/tools/ci/flink_watchdog.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Simple watchdog for Flink tests in Fluss CI
+# Captures thread dumps when tests are approaching timeout
+
+COMMAND=$@
+
+if [ -n "${GITHUB_ACTIONS+x}" ]; then
+  echo "[INFO] GitHub Actions environment detected"
+  job_timeout=${FLINK_TEST_TIMEOUT:-60}
+  temporary_folder="${RUNNER_TEMP}"
+else
+  echo "[ERROR] Only GitHub Actions environment is supported"
+  exit 1
+fi
+
+# Setup debug directory
+debug_dir="${temporary_folder}/flink-debug"
+mkdir -p $debug_dir || { echo "FAILURE: cannot create debug directory" ; exit 1; }
+
+# Install moreutils for timestamping
+sudo apt-get install -y moreutils
+
+# Time calculations
+REAL_START_SECONDS=$(date +"%s")
+REAL_TIMEOUT_SECONDS=$((job_timeout * 60))
+KILL_SECONDS_BEFORE_TIMEOUT=$((2 * 60))
+
+echo "Running Flink tests with timeout of $job_timeout minutes"
+
+MAIN_PID_FILE="/tmp/flink_watchdog_main.pid"
+
+function print_stacktraces() {
+  echo "=== Java processes ==="
+  jps -v || echo "jps not available"
+  echo ""
+
+  echo "=== Thread dumps ==="
+  for pid in $(jps -q); do
+    if [ -n "$pid" ]; then
+      echo "Stack trace for PID $pid:"
+      jstack $pid || echo "Could not get stack trace for $pid"
+      echo ""
+    fi
+  done
+}
+
+function timeout_watchdog() {
+  # 95%
+  sleep $(($REAL_TIMEOUT_SECONDS * 95 / 100))
+  echo "=========================================================================================="
+  echo "=== WARNING: Flink tests took 95% of available time budget of $job_timeout minutes ==="
+  echo "=========================================================================================="
+  print_stacktraces | tee "$debug_dir/jps-traces.0"
+
+  # Final stack trace and kill 2 min before timeout
+  local secondsToKill=$(($REAL_TIMEOUT_SECONDS - $(($REAL_TIMEOUT_SECONDS * 95 / 100)) - $KILL_SECONDS_BEFORE_TIMEOUT))
+  if [[ $secondsToKill -lt 0 ]]; then
+    secondsToKill=0
+  fi
+  sleep ${secondsToKill}
+  print_stacktraces | tee "$debug_dir/jps-traces.1"
+
+  echo "============================="
+  echo "=== WARNING: Killing Flink tests ==="
+  echo "============================="
+  pkill -P $(<$MAIN_PID_FILE)
+  kill $(<$MAIN_PID_FILE)
+
+  exit 42
+}
+
+timeout_watchdog &
+WATCHDOG_PID=$!
+
+# Run the command with timestamping
+( $COMMAND & PID=$! ; echo $PID >$MAIN_PID_FILE ; wait $PID ) | ts | tee $debug_dir/test-output
+TEST_EXIT_CODE=${PIPESTATUS[0]}
+
+if [[ "$TEST_EXIT_CODE" == 0 ]]; then
+  echo "[INFO] Flink tests passed. Cleaning up."
+  kill $WATCHDOG_PID
+  rm $debug_dir/test-output
+  rm -f $debug_dir/jps-traces.*
+fi
+
+exit $TEST_EXIT_CODE


### PR DESCRIPTION
Purpose
<!-- Linking this pull request to the issue -->
Linked issue: close #1031 
<!-- What is the purpose of the change -->
Add watchdog monitoring for Flink tests to capture debugging information when CI builds timeout, helping identify root causes of stuck test processes.
Brief change log
<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- Added tools/ci/flink_watchdog.sh: New watchdog script that monitors Flink test execution and captures thread dumps when tests approach timeout limits

- Modified .github/workflows/ci.yaml: Updated CI workflow to use watchdog specifically for Flink module tests (matrix.module == 'flink')

- Enhanced debugging capabilities: Watchdog captures Java process information and thread dumps (jstack) at 95% of timeout and just before process termination

- Artifact collection: Added new CI step to upload debug artifacts (thread dumps, execution logs) when Flink tests fail due to timeout

- Zero impact on core tests: Core module tests continue to run without any watchdog overhead

This introduces a new CI debugging feature for Flink tests. Key aspects:

Debug artifacts: When Flink tests timeout, three files are created and uploaded:

1. test-output: Complete timestamped execution log
2. jps-traces.0: Thread dump captured at 95% of timeout (shows stuck processes)
3. jps-traces.1: Final thread dump before process termination


Artifact download: Failed Flink CI runs will have downloadable flink-debug-{run-number} artifacts containing all debugging information

Tests
<!-- List UT and IT cases to verify this change -->

- Local testing: Watchdog script tested locally with simulated timeout scenarios using sleep commands


API and Format
<!-- Does this change affect API or storage format -->
None

Documentation
<!-- Does this change introduce a new feature -->
None

