### PR TITLE
Potential fix for code scanning alert no. 5: Implicit narrowing conversion in compound assignment

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/row/TimestampNtz.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/row/TimestampNtz.java
@@ -116,7 +116,7 @@ public class TimestampNtz implements Comparable<TimestampNtz>, Serializable {
     /** Converts this {@link TimestampNtz} object to a {@link LocalDateTime}. */
     public LocalDateTime toLocalDateTime() {
         int date = (int) (millisecond / MILLIS_PER_DAY);
-        int time = (int) (millisecond % MILLIS_PER_DAY);
+        long time = millisecond % MILLIS_PER_DAY;
         if (time < 0) {
             --date;
             time += MILLIS_PER_DAY;


### PR DESCRIPTION
Potential fix for [https://github.com/apache/fluss/security/code-scanning/5](https://github.com/apache/fluss/security/code-scanning/5)

To resolve the issue, we can ensure that `time` is explicitly widened to a `long` type before adding `MILLIS_PER_DAY`. This avoids implicit narrowing when the result is assigned back to `time`. Alternatively, we can change the type of `time` itself to `long` to ensure safe arithmetic operations throughout the method. Changing `time` to `long` is the more robust solution, as it aligns with the type of `MILLIS_PER_DAY` and avoids potential issues in other operations involving `time`.

**Steps to fix:**
1. Change the declaration of `time` on line 119 from `int` to `long`.
2. Update any subsequent uses of `time` in the method to accommodate the new type.

This prevents the need for narrowing conversions and ensures consistency in numeric operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
