### PR TITLE
[doc]Remove redundant statement terminators in the reads document

### DIFF
--- a/website/docs/engine-flink/reads.md
+++ b/website/docs/engine-flink/reads.md
@@ -182,7 +182,6 @@ INSERT INTO log_table
 VALUES (1, 'Customer1', 'IVhzIApeRb ot,c,E', 15, '25-989-741-2988', 711.56, 'BUILDING', 'comment1'),
        (2, 'Customer2', 'XSTf4,NCwDVaWNe6tEgvwfmRchLXak', 13, '23-768-687-3665', 121.65, 'AUTOMOBILE', 'comment2'),
        (3, 'Customer3', 'MG9kdTD2WBHm', 1, '11-719-748-3364', 7498.12, 'AUTOMOBILE', 'comment3');
-;
 ```
 
 2. Query from table.


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
Remove redundant statement terminators in the reads document
https://fluss.apache.org/docs/engine-flink/reads/
<img width="1872" height="932" alt="1752555520604" src="https://github.com/user-attachments/assets/1b94ccb6-0026-4597-acc6-ac3c326d222b" />

### Brief change log

**Please describe the changes**:
1. Remove redundant statement terminators in the reads document
