### PR TITLE
[filesystem] Exclude com.alibaba.fluss.fs.hdfs.HadoopFsPlugin from META-INF for fluss-fs-oss plugin

### DIFF
--- a/fluss-filesystems/fluss-fs-oss/pom.xml
+++ b/fluss-filesystems/fluss-fs-oss/pom.xml
@@ -226,6 +226,12 @@
                                         <exclude>NOTICE</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>com.alibaba.fluss:fluss-fs-hadoop</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <relocations>
                                 <relocation>


### PR DESCRIPTION

Linked issue: close #1322 

Exclude `com.alibaba.fluss.fs.hdfs.HadoopFsPlugin` from META-INF in the `fluss-fs-oss plugin` to resolve the `ClassNotFoundException` caused by missing Hadoop dependencies.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

For `fluss-fs-oss-0.8-SNAPSHOT.jar`

Before:
 ``` 
    com.alibaba.fluss.fs.oss.OSSFileSystemPlugin
    com.alibaba.fluss.fs.hdfs.HadoopFsPlugin
```

After fix :
   ```
        com.alibaba.fluss.fs.oss.OSSFileSystemPlugin
   ```


### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
