### PR TITLE
[fix](HomepageHeader): Update GitHub link in HomepageHeader

### DIFF
--- a/website/community/how-to-contribute/bug-reports-feature-requests.md
+++ b/website/community/how-to-contribute/bug-reports-feature-requests.md
@@ -60,7 +60,7 @@ When filing an issue, make sure to answer these five questions:
 5. What did you see instead?
 
 Troubleshooting questions should be posted on:
-* [Slack (#troubleshooting)](https://join.slack.com/t/fluss-hq/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw)
+* [Slack (#troubleshooting)](https://join.slack.com/t/apache-fluss/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw)
 * [GitHub Discussions](https://github.com/apache/fluss/discussions)
 
 ## How to suggest a feature or enhancement

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -43,7 +43,7 @@ function HomepageHeader() {
 
                     <Link
                         className={clsx("button button--secondary button--lg", styles.buttonWithIcon, styles.buttonWidth)}
-                        to="https://github.com/alibaba/fluss">
+                        to="https://github.com/apache/fluss">
                         <img
                             src="img/github_icon.svg"
                             alt="GitHub"
@@ -54,7 +54,7 @@ function HomepageHeader() {
 
                     <Link
                         className={clsx("button button--secondary button--lg", styles.buttonWithIcon, styles.buttonWidth)}
-                        to="https://join.slack.com/t/fluss-hq/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw">
+                        to="https://join.slack.com/t/apache-fluss/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw">
                         <img
                             src="img/slack_icon.svg"
                             alt="Slack"


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
Update GitHub link in HomepageHeader
<img width="1872" height="932" alt="bd04ed16268cd016d90632398778683" src="https://github.com/user-attachments/assets/08be4a84-1818-4852-8170-0414b66aaa58" />
<img width="1831" height="605" alt="1f4313bb3f24bdd9ca09695d3204d09" src="https://github.com/user-attachments/assets/f686cb8f-5ab6-4cfb-94d6-404d9733ae61" />
<img width="872" height="81" alt="aee2006bac2b81e84dbaf789545442c" src="https://github.com/user-attachments/assets/c1faf8ff-d905-4f6b-b2e5-689c670bb26a" />


### Brief change log

**Please describe the changes**:
1. Update GitHub link in HomepageHeader