### PR TITLE
[hotfix] Optimize the createLogicalScope method by adding empty groupName checks to avoid unnecessary delimiter concatenation.

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/metrics/groups/AbstractMetricGroup.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metrics/groups/AbstractMetricGroup.java
@@ -163,9 +163,13 @@ public abstract class AbstractMetricGroup implements MetricGroup {
 
     protected String createLogicalScope(CharacterFilter filter, char delimiter) {
         final String groupName = getGroupName(filter);
-        return parent == null
-                ? groupName
-                : parent.getLogicalScope(filter, delimiter) + delimiter + groupName;
+        if (parent == null) {
+            return groupName;
+        }
+        if (groupName == null || groupName.isEmpty()) {
+            return parent.getLogicalScope(filter, delimiter);
+        }
+        return parent.getLogicalScope(filter, delimiter) + delimiter + groupName;
     }
 
     /** Return the parent of the metric group. */


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/fluss/issues/1362

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Optimize the createLogicalScope method by adding empty groupName checks to avoid unnecessary delimiter concatenation.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
