### PR TITLE
[server] force unmap mmap file on linux when call AbstractIndex.resize()

### DIFF
--- a/fluss-server/src/test/java/com/alibaba/fluss/server/log/AbstractIndexTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/log/AbstractIndexTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.log;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link AbstractIndex}. */
+public class AbstractIndexTest {
+
+    private @TempDir File tempDir;
+
+    @Test
+    public void testResizeInvokeUnmap() throws IOException {
+        File testIndex = new File(tempDir, "test.index");
+        TestIndex idx = new TestIndex(testIndex, 0L, 100, true);
+        MappedByteBuffer oldMmap = idx.mmap();
+        assertThat(idx.mmap()).isNotNull();
+        assertThat(idx.unmapInvoked).isFalse();
+
+        boolean changed = idx.resize(80);
+        assertThat(changed).isTrue();
+        // Unmap should have been invoked after resize.
+        assertThat(idx.unmapInvoked).isTrue();
+        // old mmap should be unmapped.
+        assertThat(idx.unmappedBuffer).isEqualTo(oldMmap);
+        assertThat(idx.unmappedBuffer).isNotEqualTo(idx.mmap());
+    }
+
+    private static class TestIndex extends AbstractIndex {
+        private boolean unmapInvoked = false;
+        private MappedByteBuffer unmappedBuffer = null;
+
+        public TestIndex(File file, long baseOffset, int maxIndexSize, boolean writable)
+                throws IOException {
+            super(file, baseOffset, maxIndexSize, writable);
+        }
+
+        @Override
+        protected int entrySize() {
+            return 1;
+        }
+
+        @Override
+        protected IndexEntry parseEntry(ByteBuffer buffer, int n) {
+            return null;
+        }
+
+        @Override
+        public void sanityCheck() {
+            // unused
+        }
+
+        @Override
+        protected void truncate() {
+            // unused
+        }
+
+        @Override
+        public void truncateTo(long offset) {
+            // unused
+        }
+
+        @Override
+        public void forceUnmap() throws IOException {
+            unmapInvoked = true;
+            unmappedBuffer = mmap();
+        }
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #1377 

<!-- What is the purpose of the change -->

This pr is aims to fix the error mentioned in #1377. 

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
