### PR TITLE
[doc]Remove the extra period at the end of the sentence

### DIFF
--- a/website/docs/quickstart/flink.md
+++ b/website/docs/quickstart/flink.md
@@ -1,5 +1,5 @@
 ---
-title: Real-Time Analytics with Flink.
+title: Real-Time Analytics with Flink
 sidebar_position: 1
 ---
 


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
Remove the extra period at the end of the sentence
<img width="1872" height="932" alt="c2c07d70484d9870ab2112ade23f967" src="https://github.com/user-attachments/assets/ad757697-5d1f-4529-812e-c2c8bf3d1457" />



### Brief change log

**Please describe the changes**:
1.Remove the extra period at the end of the sentence in flink.md