### PR TITLE
[doc]The SQL keywords are not consistent in case. It is recommended to use uppercase letters uniformly

### DIFF
--- a/website/docs/quickstart/security.md
+++ b/website/docs/quickstart/security.md
@@ -39,7 +39,7 @@ Before proceeding with this guide, ensure that [Docker](https://docs.docker.com/
 All commands were tested with Docker version 27.4.0 and Docker Compose version v2.30.3.
 
 :::note
-We encourage you to use a recent version of Docker and [Compose v2](https://docs.docker.com/compose/releases/migrate/) (however, Compose v1 might work with a few adaptions).
+We encourage you to use a recent version of Docker and [Compose v2](https://docs.docker.com/compose/releases/migrate/) (however, Compose v1 might work with a few adaptations).
 :::
 
 #### Starting required components
@@ -555,9 +555,9 @@ Output will show like:
 The `marketing` user can only see the `marketing_db` database
 ```sql title="Flink SQL"
 -- switch to marketing user context
-use catalog marketing_catalog;
+USE CATALOG marketing_catalog;
 -- show databases using marketing user credentials
-show databases;
+SHOW DATABASES;
 ```
 **Output:**
 ```text
@@ -572,9 +572,9 @@ show databases;
 The `finance` user can only see the `finance_db` database:
 ```sql title="Flink SQL"
 -- switch to finance user context
-use catalog finance_catalog;
+USE CATALOG finance_catalog;
 -- show databases using finance user credentials
-show databases;
+SHOW DATABASES;
 ```
 
 **Output:**
@@ -591,7 +591,7 @@ show databases;
 The `marketing` user can operate on their own database:
 ```sql title="Flink SQL"
 -- switch to marketing user context
-use catalog marketing_catalog;
+USE CATALOG marketing_catalog;
 -- create table using marketing user credentials
 CREATE TABLE `marketing_db`.`order` (
      `order_key`  INT NOT NULL,
@@ -609,7 +609,7 @@ CREATE TABLE `marketing_db`.`order` (
 The `finance` user cannot access the `marketing` database:
 ```sql title="Flink SQL"
 -- switch to finance user context
-use catalog finance_catalog;
+USE CATALOG finance_catalog;
 -- create table using finance user credentials
 CREATE TABLE `marketing_db`.`order` (
      `order_key`  INT NOT NULL,


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
The SQL keywords are not consistent in case. It is recommended to use uppercase letters uniformly


### Brief change log

**Please describe the changes**:
1.The SQL keywords are not consistent in case. It is recommended to use uppercase letters uniformly