### PR TITLE
[doc] fix typos, format in deploying-local-cluster.md

### DIFF
--- a/website/docs/install-deploy/deploying-local-cluster.md
+++ b/website/docs/install-deploy/deploying-local-cluster.md
@@ -28,7 +28,7 @@ This page provides instructions on how to deploy a *local cluster* (on one machi
 ## Requirements
 
 Fluss runs on all *UNIX-like environments*, e.g. **Linux**, **Mac OS X**.
-Before you start to setup the system, make sure you have the following software installed on your test machine:
+Before you start to set up the system, make sure you have the following software installed on your test machine:
 
 - **Java 17** or higher (Java 8 and Java 11 are not recommended)
 
@@ -60,8 +60,8 @@ After that, the Fluss local cluster is started.
 
 ## Interacting with Fluss
 
-After Fluss local cluster is started, you can use **Fluss Client** (Currently, only support Flink Sql Client) to interact with Fluss.
-The following subsections will show you how to use Flink Sql Client to interact with Fluss.
+After Fluss local cluster is started, you can use **Fluss Client** (Currently, only support Flink SQL Client) to interact with Fluss.
+The following subsections will show you how to use Flink SQL Client to interact with Fluss.
 
 ### Flink SQL Client
 
@@ -86,4 +86,4 @@ CREATE CATALOG fluss_catalog WITH (
 #### Do more with Fluss
 
 After the catalog is created, you can use Flink SQL Client to do more with Fluss, for example, create a table, insert data, query data, etc.
-More details please refer to [Flink Getting started](engine-flink/getting-started.md)
+More details please refer to [Flink Getting Started](engine-flink/getting-started.md)


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
fix typos, format in deploying-local-cluster.md

### Brief change log

**Please describe the changes**:
1、.…start to setup the system… → …start to set up the system（动词短语用set up）
2、 …only support Flink Sql Client… → Flink SQL Client（SQL大写）
3、…More details please refer to Flink Getting started → More details please refer to Flink Getting Started（Flink Getting Started标题大写）