### PR TITLE
[docs] Fix: Correct column specification in T table INSERT statements

### DIFF
--- a/website/docs/table-design/table-types/pk-table/index.md
+++ b/website/docs/table-design/table-types/pk-table/index.md
@@ -130,8 +130,8 @@ be generated. For example, the following Flink SQL statements illustrate this be
 SET execution.runtime-mode = batch;
 
 -- insert to records with the same primary key k=1
-INSERT INTO T (k, v1) VALUES (1, 2.0,'apple');
-INSERT INTO T (k, v1) VALUES (1, 4.0,'banana');
+INSERT INTO T (k, v1, v2) VALUES (1, 2.0, 'apple');
+INSERT INTO T (k, v1, v2) VALUES (1, 4.0, 'banana');
 
 -- delete the record with primary key k=1
 DELETE FROM T WHERE k = 1;
@@ -144,14 +144,14 @@ SELECT * FROM T;
 Generate the following output in the Flink SQL CLI:
 
 ```
-+-----------------------------+
++------+------+------+--------+
 | op   | k    | v1   | v2     |
 | ---- | ---- | ---- | ------ |
 | +I   | 1    | 2.0  | apple  |
 | -U   | 1    | 2.0  | apple  |
 | +U   | 1    | 4.0  | banana |
 | -D   | 1    | 4.0  | banana |
-+-----------------------------+
++------+------+------+--------+
 4 rows in set
 ```
 


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
Fix: Correct column specification in T table INSERT statements
https://fluss.apache.org/docs/table-design/table-types/pk-table/#lookup
### Brief change log

**Please describe the changes**:
1. Background: The original INSERT statements specified only partial columns (k, v1), but the VALUES clause contained more data points that didn't match the actual column structure of table T. This could lead to logical errors in data insertion.
﻿
2. Changes made: Added missing columns to the INSERT INTO statements. Based on the complete column definition of table T (assumed to be k INT, v1 DOUBLE, v2 STRING), all columns (k, v1, v2) are now explicitly specified to ensure full-column insertion that matches the table structure and business requirements.
﻿
3. Impact scope: Only affects the INSERT statement logic for table T. Does not impact DELETE, SET operations, or subsequent query logic. After this fix, data will be inserted completely, preventing potential data issues caused by column mismatch.
