### PR TITLE
[server] FETCH_LOG should return 1 remote segments file rather than all the segments by default.

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
@@ -94,6 +94,7 @@ public class LogFetcher implements Closeable {
     private final RpcClient rpcClient;
     private final int maxFetchBytes;
     private final int maxBucketFetchBytes;
+    private final long maxBucketRemoteFetchBytes;
     private final int minFetchBytes;
     private final int maxFetchWaitMs;
     private final boolean isCheckCrcs;
@@ -133,6 +134,10 @@ public class LogFetcher implements Closeable {
         this.maxBucketFetchBytes =
                 (int)
                         conf.get(ConfigOptions.CLIENT_SCANNER_LOG_FETCH_MAX_BYTES_FOR_BUCKET)
+                                .getBytes();
+        this.maxBucketRemoteFetchBytes =
+                (int)
+                        conf.get(ConfigOptions.CLIENT_SCANNER_REMOTE_LOG_FETCH_MAX_BYTES_FOR_BUCKET)
                                 .getBytes();
         this.minFetchBytes =
                 (int) conf.get(ConfigOptions.CLIENT_SCANNER_LOG_FETCH_MIN_BYTES).getBytes();
@@ -427,7 +432,8 @@ public class LogFetcher implements Closeable {
                         new PbFetchLogReqForBucket()
                                 .setBucketId(tb.getBucket())
                                 .setFetchOffset(offset)
-                                .setMaxFetchBytes(maxBucketFetchBytes);
+                                .setMaxFetchBytes(maxBucketFetchBytes)
+                                .setMaxRemoteBytes(maxBucketRemoteFetchBytes);
                 if (tb.getPartitionId() != null) {
                     fetchLogReqForBucket.setPartitionId(tb.getPartitionId());
                 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -1001,6 +1001,16 @@ public class ConfigOptions {
                                     + "from client. Records are fetched in batches, the max bytes size is config by "
                                     + "this option.");
 
+    public static final ConfigOption<MemorySize>
+            CLIENT_SCANNER_REMOTE_LOG_FETCH_MAX_BYTES_FOR_BUCKET =
+                    key("client.scanner.remote-log.fetch.max-bytes-for-bucket")
+                            .memoryType()
+                            .defaultValue(LOG_SEGMENT_FILE_SIZE.defaultValue())
+                            .withDescription(
+                                    "The maximum amount of remote data the server should return for a table bucket in fetch request "
+                                            + "from client. Records are fetched in batches, the max bytes size of remote log is config by "
+                                            + "this option.");
+
     public static final ConfigOption<Duration> CLIENT_SCANNER_LOG_FETCH_WAIT_MAX_TIME =
             key("client.scanner.log.fetch.wait-max-time")
                     .durationType()

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -618,6 +618,7 @@ message PbFetchLogReqForBucket {
   // TODO leader epoch
   required int64 fetch_offset = 3;
   required int32 max_fetch_bytes = 4;
+  optional int64 max_remote_bytes = 5;
 }
 
 message PbFetchLogRespForTable {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/entity/FetchReqInfo.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/entity/FetchReqInfo.java
@@ -24,6 +24,8 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static com.alibaba.fluss.config.ConfigOptions.CLIENT_SCANNER_LOG_FETCH_MAX_BYTES_FOR_BUCKET;
+
 /** The structure of fetch data. */
 @Internal
 public final class FetchReqInfo {
@@ -31,17 +33,28 @@ public final class FetchReqInfo {
     private final long fetchOffset;
     @Nullable private final int[] projectFields;
 
-    private int maxBytes;
+    private final int maxBytes;
+    private final long maxRemoteBytes;
 
     public FetchReqInfo(long tableId, long fetchOffset, int maxBytes) {
-        this(tableId, fetchOffset, maxBytes, null);
+        this(
+                tableId,
+                fetchOffset,
+                maxBytes,
+                null,
+                CLIENT_SCANNER_LOG_FETCH_MAX_BYTES_FOR_BUCKET.defaultValue().getBytes());
     }
 
     public FetchReqInfo(
-            long tableId, long fetchOffset, int maxBytes, @Nullable int[] projectFields) {
+            long tableId,
+            long fetchOffset,
+            int maxBytes,
+            @Nullable int[] projectFields,
+            long maxRemoteBytes) {
         this.tableId = tableId;
         this.fetchOffset = fetchOffset;
         this.maxBytes = maxBytes;
+        this.maxRemoteBytes = maxRemoteBytes;
         this.projectFields = projectFields;
     }
 
@@ -53,8 +66,8 @@ public final class FetchReqInfo {
         return fetchOffset;
     }
 
-    public void setFetchMaxBytes(int maxBytes) {
-        this.maxBytes = maxBytes;
+    public long getMaxRemoteBytes() {
+        return maxRemoteBytes;
     }
 
     public int getMaxBytes() {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/RemoteLogManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/RemoteLogManager.java
@@ -237,8 +237,9 @@ public class RemoteLogManager implements Closeable {
      * whose remote log start offset higher that or equal to this offset, and including another one
      * segment whose remote log start offset smaller than this offset (floor key).
      */
-    public List<RemoteLogSegment> relevantRemoteLogSegments(TableBucket tableBucket, long offset) {
-        return remoteLogTablet(tableBucket).relevantRemoteLogSegments(offset);
+    public List<RemoteLogSegment> relevantRemoteLogSegments(
+            TableBucket tableBucket, long offset, long maxRemoteBytes) {
+        return remoteLogTablet(tableBucket).relevantRemoteLogSegments(offset, maxRemoteBytes);
     }
 
     private boolean remoteDisabled() {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
@@ -173,6 +173,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.alibaba.fluss.config.ConfigOptions.CLIENT_SCANNER_LOG_FETCH_MAX_BYTES_FOR_BUCKET;
 import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toByteBuffer;
 import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toPbAclInfo;
 import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
@@ -702,7 +703,12 @@ public class ServerRpcMessageUtils {
                                 tableId,
                                 fetchLogReqForBucket.getFetchOffset(),
                                 fetchLogReqForBucket.getMaxFetchBytes(),
-                                projectionFields));
+                                projectionFields,
+                                fetchLogReqForBucket.hasMaxRemoteBytes()
+                                        ? fetchLogReqForBucket.getMaxRemoteBytes()
+                                        : CLIENT_SCANNER_LOG_FETCH_MAX_BYTES_FOR_BUCKET
+                                                .defaultValue()
+                                                .getBytes()));
             }
         }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/log/remote/RemoteLogTTLTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/log/remote/RemoteLogTTLTest.java
@@ -60,7 +60,7 @@ final class RemoteLogTTLTest extends RemoteLogTestBase {
         // run RLMTask to copy local log segment to remote and commit snapshot.
         remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
         RemoteLogTablet remoteLog = remoteLogManager.remoteLogTablet(tb);
-        assertThat(remoteLog.relevantRemoteLogSegments(0L).size()).isEqualTo(4);
+        assertThat(remoteLog.relevantRemoteLogSegments(0L, Integer.MAX_VALUE).size()).isEqualTo(4);
         assertThat(remoteLog.allRemoteLogSegments().size()).isEqualTo(4);
         assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(0L);
 
@@ -68,7 +68,7 @@ final class RemoteLogTTLTest extends RemoteLogTestBase {
         // default 7 days TTL, this should expire all remote segments.
         manualClock.advanceTime(Duration.ofDays(7).plusHours(1));
         remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
-        assertThat(remoteLog.relevantRemoteLogSegments(0L).size()).isEqualTo(0);
+        assertThat(remoteLog.relevantRemoteLogSegments(0L, Integer.MAX_VALUE).size()).isEqualTo(0);
         assertThat(remoteLog.allRemoteLogSegments()).isEmpty();
         assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(Long.MAX_VALUE);
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/log/remote/RemoteLogTabletTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/log/remote/RemoteLogTabletTest.java
@@ -51,8 +51,10 @@ class RemoteLogTabletTest extends RemoteLogTestBase {
                 .hasSize(remoteLogSegmentList.size());
         assertThat(remoteLogTablet.allRemoteLogSegments())
                 .containsExactlyInAnyOrderElementsOf(remoteLogSegmentList);
-        assertThat(remoteLogTablet.relevantRemoteLogSegments(0L))
+        assertThat(remoteLogTablet.relevantRemoteLogSegments(0L, Integer.MAX_VALUE))
                 .containsExactlyInAnyOrderElementsOf(remoteLogSegmentList);
+        assertThat(remoteLogTablet.relevantRemoteLogSegments(0L, 1))
+                .containsExactlyInAnyOrder(remoteLogSegmentList.get(0));
     }
 
     @ParameterizedTest
@@ -135,24 +137,25 @@ class RemoteLogTabletTest extends RemoteLogTestBase {
         remoteLogTablet.addAndDeleteLogSegments(remoteLogSegmentList, Collections.emptyList());
 
         // Get offset from 0.
-        List<RemoteLogSegment> result = remoteLogTablet.relevantRemoteLogSegments(0L);
+        List<RemoteLogSegment> result =
+                remoteLogTablet.relevantRemoteLogSegments(0L, Integer.MAX_VALUE);
         assertThat(result.size()).isEqualTo(5);
         assertThat(result).containsExactlyInAnyOrderElementsOf(remoteLogSegmentList);
 
         // Get offset from 10, the remote log start offset of the second segment is 10, so the first
         // segment will not be included.
-        result = remoteLogTablet.relevantRemoteLogSegments(10L);
+        result = remoteLogTablet.relevantRemoteLogSegments(10L, Integer.MAX_VALUE);
         assertThat(result.size()).isEqualTo(4);
 
-        result = remoteLogTablet.relevantRemoteLogSegments(11L);
+        result = remoteLogTablet.relevantRemoteLogSegments(11L, Integer.MAX_VALUE);
         assertThat(result.size()).isEqualTo(4);
 
-        result = remoteLogTablet.relevantRemoteLogSegments(49L);
+        result = remoteLogTablet.relevantRemoteLogSegments(49L, Integer.MAX_VALUE);
         assertThat(result.size()).isEqualTo(1);
 
         // Get offset from 50, the remote start offset of the last segment is 40, the remote log end
         // offset is 50, no segment will be included.
-        result = remoteLogTablet.relevantRemoteLogSegments(50L);
+        result = remoteLogTablet.relevantRemoteLogSegments(50L, Integer.MAX_VALUE);
         assertThat(result.size()).isEqualTo(0);
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1421 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
