### PR TITLE
Change default path to store rocksdb related logs

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/rocksdb/RocksDBResourceContainer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/rocksdb/RocksDBResourceContainer.java
@@ -284,9 +284,21 @@ public class RocksDBResourceContainer implements AutoCloseable {
         String logFilePath = System.getProperty("log.file");
         if (logFilePath != null) {
             File logFile = resolveFileLocation(logFilePath);
-            if (logFile != null && resolveFileLocation(logFile.getParent()) != null) {
-                dbOptions.setDbLogDir(logFile.getParent());
+            String rocksDbLogDir = logFile.getParent() + "/rocksdb";
+            File rocksDbLogDirFile = new File(rocksDbLogDir);
+            if (!rocksDbLogDirFile.exists()) {
+                try {
+                    if (!rocksDbLogDirFile.mkdirs()) {
+                        LOG.warn("Failed to create RocksDB log directory: {}", rocksDbLogDir);
+                        return;
+                    }
+                } catch (SecurityException e) {
+                    LOG.warn("Failed to create RocksDB log directory due to security restrictions: {}", 
+                            rocksDbLogDir, e);
+                    return;
+                }
             }
+            dbOptions.setDbLogDir(rocksDbLogDir);
         }
     }
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/rocksdb/RocksDBResourceContainer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/rocksdb/RocksDBResourceContainer.java
@@ -293,8 +293,7 @@ public class RocksDBResourceContainer implements AutoCloseable {
                         return;
                     }
                 } catch (SecurityException e) {
-                    LOG.warn("Failed to create RocksDB log directory due to security restrictions: {}", 
-                            rocksDbLogDir, e);
+                    LOG.warn("Failed to create RocksDB log directory due to security restrictions: {}", rocksDbLogDir, e);
                     return;
                 }
             }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/rocksdb/RocksDBResourceContainerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/rocksdb/RocksDBResourceContainerTest.java
@@ -108,7 +108,7 @@ class RocksDBResourceContainerTest {
         System.setProperty("log.file", logFile.getPath());
         try (RocksDBResourceContainer container = new RocksDBResourceContainer()) {
             assertThat(container.getDbOptions().infoLogLevel()).isEqualTo(InfoLogLevel.INFO_LEVEL);
-            assertThat(container.getDbOptions().dbLogDir()).isEqualTo(logFile.getParent());
+            assertThat(container.getDbOptions().dbLogDir()).isEqualTo(logFile.getParent() + "/rocksdb");
         } finally {
             logFile.delete();
         }


### PR DESCRIPTION
### Purpose

Linked issue: close #1542 

### Brief change log

fix(server): create dedicated directory for RocksDB logs
- Add separate directory for RocksDB logs to prevent important server logs from being difficult to locate
- Create the directory if it doesn't exist and handle potential errors
- Update unit tests to reflect the new log directory path