### PR TITLE
[hotfix] Fix unstable test IcebergTieringITCase

### DIFF
--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -55,6 +56,7 @@ import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
 /** Implementation of {@link LakeCommitter} for Iceberg. */
 public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, IcebergCommittable> {
+    private static final String COMMITTER_USER = "commit-user";
 
     private final Catalog icebergCatalog;
     private final Table icebergTable;
@@ -139,7 +141,7 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
 
     private void addFlussProperties(
             SnapshotUpdate<?> operation, Map<String, String> snapshotProperties) {
-        operation.set("commit-user", FLUSS_LAKE_TIERING_COMMIT_USER);
+        operation.set(COMMITTER_USER, FLUSS_LAKE_TIERING_COMMIT_USER);
         for (Map.Entry<String, String> entry : snapshotProperties.entrySet()) {
             operation.set(entry.getKey(), entry.getValue());
         }
@@ -173,9 +175,13 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
         }
 
         // Check if there's a gap between Fluss and Iceberg snapshots
-        if (latestLakeSnapshotIdOfFluss != null
-                && latestLakeSnapshot.snapshotId() <= latestLakeSnapshotIdOfFluss) {
-            return null;
+        if (latestLakeSnapshotIdOfFluss != null) {
+            // note: we need to use sequence number to compare,
+            // we can't use snapshot id as the snapshot id is not ordered
+            Snapshot latestLakeSnapshotOfFluss = icebergTable.snapshot(latestLakeSnapshotIdOfFluss);
+            if (latestLakeSnapshot.sequenceNumber() <= latestLakeSnapshotOfFluss.sequenceNumber()) {
+                return null;
+            }
         }
 
         CommittedLakeSnapshot committedLakeSnapshot =
@@ -237,20 +243,15 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
         icebergTable.refresh();
 
         // Find the latest snapshot committed by Fluss
-        Iterable<Snapshot> snapshots = icebergTable.snapshots();
-        Snapshot latestFlussSnapshot = null;
-
+        List<Snapshot> snapshots = (List<Snapshot>) icebergTable.snapshots();
+        Collections.reverse(snapshots);
         for (Snapshot snapshot : snapshots) {
             Map<String, String> summary = snapshot.summary();
-            if (summary != null && commitUser.equals(summary.get("commit-user"))) {
-                if (latestFlussSnapshot == null
-                        || snapshot.snapshotId() > latestFlussSnapshot.snapshotId()) {
-                    latestFlussSnapshot = snapshot;
-                }
+            if (summary != null && commitUser.equals(summary.get(COMMITTER_USER))) {
+                return snapshot;
             }
         }
-
-        return latestFlussSnapshot;
+        return null;
     }
 
     /** A {@link Listener} to listen the iceberg create snapshot event. */


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1580 

<!-- What is the purpose of the change -->
FIx unstable Iceberg TieringITCase

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

Note such error log 

```
com.alibaba.fluss.flink.tiering.source.enumerator.TieringSourceEnumerator [] - Tiering table 1 is failed, fail reason is java.lang.IllegalStateException: The current Fluss's lake snapshot 5402285830333994804 is less than lake actual snapshot 8732241012020816263 committed by Fluss for table: {tablePath=fluss.logTable, tableId=1}, missing snapshot: CommittedLakeSnapshot{lakeSnapshotId=8732241012020816263, logEndOffsets={(null,0)=6}, partitionNameById={}}.

```
But actaully,  snapshot `8732241012020816263` is the parent of snapshot `5402285830333994804`  which means snapshot `8732241012020816263` is actally an older snapshot than snapshot `5402285830333994804`.

So, not compare with icberge snapshot id since the snapshot id is not incremental. Use the sequence number since sequence number is incremental. 



### Tests

<!-- List UT and IT cases to verify this change -->
Run IT for mutiple(over 10) times, all passed. 
Before this fix, run around 5 times will cause test fail

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
