### PR TITLE
[server] Fix ReplicaFetcherThread keeps throwing OutOfOrderSequenceException because of writer id expire

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/log/WriterStateManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/WriterStateManagerTest.java
@@ -126,14 +126,14 @@ public class WriterStateManagerTest {
     void testPrepareUpdateDoesNotMutate() {
         WriterAppendInfo appendInfo = stateManager.prepareUpdate(writerId);
         appendInfo.appendDataBatch(
-                0, new LogOffsetMetadata(15L), 20L, false, System.currentTimeMillis());
+                0, new LogOffsetMetadata(15L), 20L, false, true, System.currentTimeMillis());
         assertThat(stateManager.lastEntry(writerId)).isNotPresent();
         stateManager.update(appendInfo);
         assertThat(stateManager.lastEntry(writerId)).isPresent();
 
         WriterAppendInfo nextAppendInfo = stateManager.prepareUpdate(writerId);
         nextAppendInfo.appendDataBatch(
-                1, new LogOffsetMetadata(26L), 30L, false, System.currentTimeMillis());
+                1, new LogOffsetMetadata(26L), 30L, false, true, System.currentTimeMillis());
         assertThat(stateManager.lastEntry(writerId)).isPresent();
 
         WriterStateEntry lastEntry = stateManager.lastEntry(writerId).get();
@@ -521,6 +521,7 @@ public class WriterStateManagerTest {
                 new LogOffsetMetadata(offset),
                 offset,
                 isWriterInBatchExpired,
+                true,
                 lastTimestamp);
         stateManager.update(appendInfo);
         stateManager.updateMapEndOffset(offset + 1);

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
@@ -174,6 +174,8 @@ public class ReplicaTestBase {
         conf.set(ConfigOptions.CLIENT_WRITER_BUFFER_PAGE_SIZE, MemorySize.parse("512b"));
         conf.set(ConfigOptions.CLIENT_WRITER_BATCH_SIZE, MemorySize.parse("1kb"));
 
+        conf.set(ConfigOptions.WRITER_ID_EXPIRATION_TIME, Duration.ofHours(12));
+
         scheduler = new FlussScheduler(2);
         scheduler.startup();
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
@@ -401,7 +401,7 @@ public class ReplicaFetcherThreadTest {
                         conf,
                         zkClient,
                         scheduler,
-                        SystemClock.getInstance(),
+                        manualClock,
                         TestingMetricGroups.TABLET_SERVER_METRICS);
         logManager.startup();
         ReplicaManager replicaManager =

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
@@ -46,7 +46,7 @@ import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.server.zk.data.TableRegistration;
 import org.apache.fluss.testutils.common.AllCallbackWrapper;
 import org.apache.fluss.utils.clock.Clock;
-import org.apache.fluss.utils.clock.SystemClock;
+import org.apache.fluss.utils.clock.ManualClock;
 import org.apache.fluss.utils.concurrent.FlussScheduler;
 import org.apache.fluss.utils.concurrent.Scheduler;
 
@@ -86,6 +86,7 @@ public class ReplicaFetcherThreadTest {
             new AllCallbackWrapper<>(new ZooKeeperExtension());
 
     private static ZooKeeperClient zkClient;
+    private ManualClock manualClock;
     private @TempDir File tempDir;
     private TableBucket tb;
     private final int leaderServerId = 1;
@@ -106,6 +107,7 @@ public class ReplicaFetcherThreadTest {
     @BeforeEach
     public void setup() throws Exception {
         ZOO_KEEPER_EXTENSION_WRAPPER.getCustomExtension().cleanupRoot();
+        manualClock = new ManualClock(System.currentTimeMillis());
         Configuration conf = new Configuration();
         tb = new TableBucket(DATA1_TABLE_ID, 0);
         leaderRM = createReplicaManager(leaderServerId);
@@ -277,6 +279,77 @@ public class ReplicaFetcherThreadTest {
                 () -> assertThat(followerReplica.getLocalLogEndOffset()).isEqualTo(120L));
     }
 
+    @Test
+    void testAppendAsFollowerThrowOutOfOrderSequenceException() throws Exception {
+        Replica followerReplica = followerRM.getReplicaOrException(tb);
+
+        long writerId = 101;
+        CompletableFuture<List<ProduceLogResultForBucket>> future;
+
+        // 1. append 2 batches to leader with (writerId=101L, batchSequence=0 offset=0L)
+        future = new CompletableFuture<>();
+        leaderRM.appendRecordsToLog(
+                1000,
+                1,
+                Collections.singletonMap(
+                        tb, genMemoryLogRecordsWithWriterId(DATA1, writerId, 0, 0)),
+                future::complete);
+        assertThat(future.get()).containsOnly(new ProduceLogResultForBucket(tb, 0L, 10L));
+
+        // 2. append the first batch to follower with (writerId=101L, batchSequence=0 offset=0L) to
+        // mock
+        // follower have already fetched one batch.
+        followerReplica.appendRecordsToFollower(
+                genMemoryLogRecordsWithWriterId(DATA1, writerId, 0, 0));
+        assertThat(followerReplica.getLocalLogEndOffset()).isEqualTo(10L);
+
+        // advance time
+        manualClock.advanceTime(Duration.ofHours(13));
+
+        // 3. append the second batch to leader with (writerId=101L, batchSequence=1 offset=10L)
+        future = new CompletableFuture<>();
+        leaderRM.appendRecordsToLog(
+                1000,
+                1,
+                Collections.singletonMap(
+                        tb, genMemoryLogRecordsWithWriterId(DATA1, writerId, 1, 0)),
+                future::complete);
+        assertThat(future.get()).containsOnly(new ProduceLogResultForBucket(tb, 10L, 20L));
+
+        // 3. mock remove expired writer, writerId=101 will be removed.
+        assertThat(followerReplica.getLogTablet().writerStateManager().activeWriters().size())
+                .isEqualTo(1);
+        followerReplica.getLogTablet().removeExpiredWriter(manualClock.milliseconds());
+        assertThat(followerReplica.getLogTablet().writerStateManager().activeWriters().size())
+                .isEqualTo(0);
+
+        // 4. begin fetcher thread.
+        followerFetcher.addBuckets(
+                Collections.singletonMap(
+                        tb,
+                        new InitialFetchStatus(
+                                DATA1_TABLE_ID, DATA1_TABLE_PATH, leader.id(), 10L)));
+        followerFetcher.start();
+        // fetcher will force append the second batch to follower
+        retry(
+                Duration.ofSeconds(20),
+                () -> assertThat(followerReplica.getLocalLogEndOffset()).isEqualTo(20L));
+
+        // 5. mock new batch to leader with (writerId=101L, batchSequence=2 offset=20L)
+        future = new CompletableFuture<>();
+        leaderRM.appendRecordsToLog(
+                1000,
+                1,
+                Collections.singletonMap(
+                        tb, genMemoryLogRecordsWithWriterId(DATA1, writerId, 2, 0)),
+                future::complete);
+        assertThat(future.get()).containsOnly(new ProduceLogResultForBucket(tb, 20L, 30L));
+        // now fetcher will work well since the state of writerId=101 is established
+        retry(
+                Duration.ofSeconds(20),
+                () -> assertThat(followerReplica.getLocalLogEndOffset()).isEqualTo(30L));
+    }
+
     private void registerTableInZkClient() throws Exception {
         ZOO_KEEPER_EXTENSION_WRAPPER.getCustomExtension().cleanupRoot();
         zkClient.registerTable(
@@ -319,6 +392,7 @@ public class ReplicaFetcherThreadTest {
     private ReplicaManager createReplicaManager(int serverId) throws Exception {
         Configuration conf = new Configuration();
         conf.setString(ConfigOptions.DATA_DIR, tempDir.getAbsolutePath() + "/server-" + serverId);
+        conf.set(ConfigOptions.WRITER_ID_EXPIRATION_TIME, Duration.ofHours(12));
         Scheduler scheduler = new FlussScheduler(2);
         scheduler.startup();
 
@@ -341,7 +415,7 @@ public class ReplicaFetcherThreadTest {
                         new TabletServerMetadataCache(new MetadataManager(null, conf), null),
                         RpcClient.create(conf, TestingClientMetricGroup.newInstance(), false),
                         TestingMetricGroups.TABLET_SERVER_METRICS,
-                        SystemClock.getInstance());
+                        manualClock);
         replicaManager.startup();
         return replicaManager;
     }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1624 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
