### PR TITLE
[client] Change the default value of 'netty.client.num-network-threads' to 3 to avoid netty channel congestion

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -739,10 +739,10 @@ public class ConfigOptions {
     public static final ConfigOption<Integer> NETTY_CLIENT_NUM_NETWORK_THREADS =
             key("netty.client.num-network-threads")
                     .intType()
-                    .defaultValue(1)
+                    .defaultValue(3)
                     .withDescription(
                             "The number of threads that the client uses for sending requests to the "
-                                    + "network and receiving responses from network. The default value is 1");
+                                    + "network and receiving responses from network. The default value is 3");
 
     // ------------------------------------------------------------------------
     //  Client Settings

--- a/website/docs/maintenance/configuration.md
+++ b/website/docs/maintenance/configuration.md
@@ -89,7 +89,7 @@ during the Fluss cluster working.
 | netty.server.num-worker-threads  | Integer  | 8       | The number of threads that the server uses for processing requests, which may include disk and remote I/O.                                  |
 | netty.server.max-queued-requests | Integer  | 500     | The number of queued requests allowed for worker threads, before blocking the I/O threads.                                                  |
 | netty.connection.max-idle-time   | Duration | 10min   | Close idle connections after the given time specified by this config.                                                                       |
-| netty.client.num-network-threads | Integer  | 1       | The number of threads that the client uses for sending requests to the network and receiving responses from network. The default value is 1 |
+| netty.client.num-network-threads | Integer  | 3       | The number of threads that the client uses for sending requests to the network and receiving responses from network. The default value is 3 |
 
 ## Log
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1641 

LogScanner's consumption latency keeps increasing during cluster upgrades. It appears the upgrade caused a Netty worker to hang. Fluss currently defaults to only 1 Netty worker thread (netty.client.num-network-threads=1), resulting in network channel congestion. The issue disappears when increasing netty.client.num-network-threads to 3.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
