### PR TITLE
git commit -m "[FLUSS-1571] [metrics] Add partition count metrics for tables and cluster monitoring"

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -41,6 +41,8 @@ public class MetricNames {
     public static final String TABLE_COUNT = "tableCount";
     public static final String BUCKET_COUNT = "bucketCount";
     public static final String REPLICAS_TO_DELETE_COUNT = "replicasToDeleteCount";
+    public static final String PARTITION_COUNT = "partitionCount";
+    public static final String TOTAL_PARTITION_COUNT = "totalPartitionCount";
 
     // for coordinator event processor
     public static final String EVENT_QUEUE_SIZE = "eventQueueSize";

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
@@ -104,6 +104,8 @@ public class CoordinatorContext {
     private ServerInfo coordinatorServerInfo = null;
     private int coordinatorEpoch = INITIAL_COORDINATOR_EPOCH;
 
+    private Runnable partitionCountUpdateCallback = null;
+
     public CoordinatorContext() {}
 
     public int getCoordinatorEpoch() {
@@ -232,6 +234,17 @@ public class CoordinatorContext {
     public void putPartition(long partitionId, PhysicalTablePath physicalTablePath) {
         this.pathByPartitionId.put(partitionId, physicalTablePath);
         this.partitionIdByPath.put(physicalTablePath, partitionId);
+        updatePartitionCountMetrics();
+    }
+
+    public void setPartitionCountUpdateCallback(Runnable callback) {
+        this.partitionCountUpdateCallback = callback;
+    }
+
+    private void updatePartitionCountMetrics() {
+        if (partitionCountUpdateCallback != null) {
+            partitionCountUpdateCallback.run();
+        }
     }
 
     public TableInfo getTableInfoById(long tableId) {
@@ -551,6 +564,25 @@ public class CoordinatorContext {
         return partitionsToBeDeleted;
     }
 
+    public int getTotalPartitionCount() {
+        return partitionAssignments.size();
+    }
+
+
+    public int getPartitionCountForTable(long tableId) {
+        return (int)
+                partitionAssignments.keySet().stream()
+                        .filter(partition -> partition.getTableId() == tableId)
+                        .count();
+    }
+
+
+    public Set<TablePartition> getPartitionsForTable(long tableId) {
+        return partitionAssignments.keySet().stream()
+                .filter(partition -> partition.getTableId() == tableId)
+                .collect(Collectors.toSet());
+    }
+
     public boolean isToBeDeleted(TableBucket tableBucket) {
         if (tableBucket.getPartitionId() == null) {
             return isTableQueuedForDeletion(tableBucket.getTableId());
@@ -614,6 +646,8 @@ public class CoordinatorContext {
         if (physicalTablePath != null) {
             partitionIdByPath.remove(physicalTablePath);
         }
+        // Update partition count metrics when partition is removed
+        updatePartitionCountMetrics();
     }
 
     private void clearTablesState() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorServer.java
@@ -176,6 +176,16 @@ public class CoordinatorServer extends ServerBase {
             this.coordinatorContext = new CoordinatorContext();
             this.metadataCache = new CoordinatorMetadataCache();
 
+            coordinatorContext.setPartitionCountUpdateCallback(
+                    () -> {
+                        if (serverMetricGroup != null) {
+                            int totalPartitionCount = coordinatorContext.getTotalPartitionCount();
+                            ((CoordinatorMetricGroup.MutableGauge<Integer>)
+                                            serverMetricGroup.totalPartitionCount())
+                                    .setValue(totalPartitionCount);
+                        }
+                    });
+
             this.authorizer = AuthorizerLoader.createAuthorizer(conf, zkClient, pluginManager);
             if (authorizer != null) {
                 authorizer.startup();

--- a/fluss-server/src/main/java/org/apache/fluss/server/metadata/TabletServerMetadataCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metadata/TabletServerMetadataCache.java
@@ -25,6 +25,8 @@ import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.server.coordinator.MetadataManager;
+import org.apache.fluss.server.metrics.group.PhysicalTableMetricGroup;
+import org.apache.fluss.server.metrics.group.TabletServerMetricGroup;
 import org.apache.fluss.server.tablet.TabletServer;
 import org.apache.fluss.server.zk.ZooKeeperClient;
 
@@ -68,11 +70,16 @@ public class TabletServerMetadataCache implements ServerMetadataCache {
 
     private final MetadataManager metadataManager;
     private final ZooKeeperClient zkClient;
+    private final TabletServerMetricGroup metricGroup;
 
-    public TabletServerMetadataCache(MetadataManager metadataManager, ZooKeeperClient zkClient) {
+    public TabletServerMetadataCache(
+            MetadataManager metadataManager,
+            ZooKeeperClient zkClient,
+            TabletServerMetricGroup metricGroup) {
         this.serverMetadataSnapshot = ServerMetadataSnapshot.empty();
         this.metadataManager = metadataManager;
         this.zkClient = zkClient;
+        this.metricGroup = metricGroup;
     }
 
     @Override
@@ -269,7 +276,34 @@ public class TabletServerMetadataCache implements ServerMetadataCache {
                                     partitionIdByPath,
                                     bucketMetadataMapForTables,
                                     bucketMetadataMapForPartitions);
+
+                    // Update partition count metrics
+                    updatePartitionCountMetrics(partitionIdByPath);
                 });
+    }
+
+    private void updatePartitionCountMetrics(Map<PhysicalTablePath, Long> partitionIdByPath) {
+        if (metricGroup != null) {
+            Map<TablePath, Integer> partitionCountByTable = new HashMap<>();
+            for (PhysicalTablePath physicalTablePath : partitionIdByPath.keySet()) {
+                TablePath tablePath = physicalTablePath.getTablePath();
+                partitionCountByTable.merge(tablePath, 1, Integer::sum);
+            }
+
+            for (Map.Entry<TablePath, Integer> entry : partitionCountByTable.entrySet()) {
+                TablePath tablePath = entry.getKey();
+                int partitionCount = entry.getValue();
+
+                PhysicalTablePath physicalTablePath = PhysicalTablePath.of(tablePath, null);
+                PhysicalTableMetricGroup tableMetricGroup =
+                        metricGroup.getPhysicalTableMetricGroup(physicalTablePath);
+                if (tableMetricGroup != null) {
+                    ((PhysicalTableMetricGroup.MutableGauge<Integer>)
+                                    tableMetricGroup.partitionCount())
+                            .setValue(partitionCount);
+                }
+            }
+        }
     }
 
     @VisibleForTesting

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/CoordinatorMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/CoordinatorMetricGroup.java
@@ -18,6 +18,8 @@
 package org.apache.fluss.server.metrics.group;
 
 import org.apache.fluss.metrics.CharacterFilter;
+import org.apache.fluss.metrics.Gauge;
+import org.apache.fluss.metrics.MetricNames;
 import org.apache.fluss.metrics.groups.AbstractMetricGroup;
 import org.apache.fluss.metrics.registry.MetricRegistry;
 
@@ -32,12 +34,17 @@ public class CoordinatorMetricGroup extends AbstractMetricGroup {
     protected final String hostname;
     protected final String serverId;
 
+    private final MutableGauge<Integer> totalPartitionCount;
+
     public CoordinatorMetricGroup(
             MetricRegistry registry, String clusterId, String hostname, String serverId) {
         super(registry, new String[] {clusterId, hostname, NAME}, null);
         this.clusterId = clusterId;
         this.hostname = hostname;
         this.serverId = serverId;
+
+        this.totalPartitionCount = new MutableGauge<>(0);
+        gauge(MetricNames.TOTAL_PARTITION_COUNT, totalPartitionCount);
     }
 
     @Override
@@ -50,5 +57,26 @@ public class CoordinatorMetricGroup extends AbstractMetricGroup {
         variables.put("cluster_id", clusterId);
         variables.put("host", hostname);
         variables.put("server_id", serverId);
+    }
+
+    public Gauge<Integer> totalPartitionCount() {
+        return totalPartitionCount;
+    }
+
+    public static class MutableGauge<T> implements Gauge<T> {
+        private volatile T value;
+
+        public MutableGauge(T initialValue) {
+            this.value = initialValue;
+        }
+
+        @Override
+        public T getValue() {
+            return value;
+        }
+
+        public void setValue(T value) {
+            this.value = value;
+        }
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/PhysicalTableMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/PhysicalTableMetricGroup.java
@@ -20,6 +20,7 @@ package org.apache.fluss.server.metrics.group;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metrics.CharacterFilter;
 import org.apache.fluss.metrics.Counter;
+import org.apache.fluss.metrics.Gauge;
 import org.apache.fluss.metrics.MeterView;
 import org.apache.fluss.metrics.MetricNames;
 import org.apache.fluss.metrics.NoOpCounter;
@@ -50,6 +51,9 @@ public class PhysicalTableMetricGroup extends AbstractMetricGroup {
     // ---- metrics for kv, will be null if the table isn't a kv table ----
     private final @Nullable KvMetricGroup kvMetrics;
 
+    // ---- partition metrics ----
+    private final MutableGauge<Integer> partitionCount;
+
     public PhysicalTableMetricGroup(
             MetricRegistry registry,
             PhysicalTablePath physicalTablePath,
@@ -63,6 +67,10 @@ public class PhysicalTableMetricGroup extends AbstractMetricGroup {
                         physicalTablePath.getTableName()),
                 serverMetricGroup);
         this.physicalTablePath = physicalTablePath;
+
+        // Initialize partition count gauge
+        this.partitionCount = new MutableGauge<>(0);
+        gauge(MetricNames.PARTITION_COUNT, partitionCount);
 
         // if is kv table, create kv metrics
         if (isKvTable) {
@@ -237,6 +245,28 @@ public class PhysicalTableMetricGroup extends AbstractMetricGroup {
 
     public int bucketGroupsCount() {
         return buckets.size();
+    }
+
+    public MutableGauge<Integer> partitionCount() {
+        return partitionCount;
+    }
+
+
+    public static class MutableGauge<T> implements Gauge<T> {
+        private volatile T value;
+
+        public MutableGauge(T initialValue) {
+            this.value = initialValue;
+        }
+
+        @Override
+        public T getValue() {
+            return value;
+        }
+
+        public void setValue(T value) {
+            this.value = value;
+        }
     }
 
     /** Metric group for specific kind of tablet of a table. */

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
@@ -142,4 +142,13 @@ public class TabletServerMetricGroup extends AbstractMetricGroup {
             }
         }
     }
+
+    public PhysicalTableMetricGroup getPhysicalTableMetricGroup(
+            PhysicalTablePath physicalTablePath) {
+        return metricGroupByPhysicalTable.get(physicalTablePath);
+    }
+
+    public MetricRegistry getRegistry() {
+        return super.registry;
+    }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
@@ -184,7 +184,9 @@ public class TabletServer extends ServerBase {
             this.zkClient = ZooKeeperUtils.startZookeeperClient(conf, this);
 
             MetadataManager metadataManager = new MetadataManager(zkClient, conf);
-            this.metadataCache = new TabletServerMetadataCache(metadataManager, zkClient);
+            this.metadataCache =
+                    new TabletServerMetadataCache(
+                            metadataManager, zkClient, tabletServerMetricGroup);
 
             this.scheduler = new FlussScheduler(conf.get(BACKGROUND_THREADS));
             scheduler.startup();


### PR DESCRIPTION
### Purpose

Linked issue: close #1571

This PR adds partition count metrics to help users monitor partition distribution across tables and the entire cluster. This addresses the issue where users create many unexpected partitions that can cause cluster instability, making it difficult to locate such problems without proper metrics.

### Brief change log

- **Added metric names**: `PARTITION_COUNT` for table-level and `TOTAL_PARTITION_COUNT` for cluster-level monitoring
- **Implemented MutableGauge**: A thread-safe, updatable gauge implementation for dynamic partition count tracking
- **Enhanced CoordinatorMetricGroup**: Added cluster-wide total partition count metric
- **Enhanced PhysicalTableMetricGroup**: Added per-table partition count metric  
- **Real-time updates**: Implemented event-driven metric updates when partitions are added/removed
- **Updated CoordinatorContext**: Added methods to retrieve partition counts and callback mechanism for real-time updates
- **Updated TabletServerMetadataCache**: Added partition count metric updates when metadata changes


### API and Format

- **New Metrics**: 
  - `partitionCount`: Per-table partition count (Integer gauge)
  - `totalPartitionCount`: Cluster-wide partition count (Integer gauge)
- **No breaking changes**: All changes are additive and backward compatible

### Documentation

This change introduces new monitoring capabilities:
- **Table-level monitoring**: Track partition count per table to identify tables with excessive partitions
- **Cluster-level monitoring**: Track total partition count across the cluster to prevent cluster instability
- **Real-time updates**: Metrics reflect partition changes immediately without polling delays