### PR TITLE
[docs] Add Upgrade Notes for 0.8

### DIFF
--- a/website/docs/maintenance/operations/racks.md
+++ b/website/docs/maintenance/operations/racks.md
@@ -1,5 +1,5 @@
 ---
-title: Racks
+title: Rack-Aware Deployment
 sidebar_position: 2
 ---
 

--- a/website/docs/maintenance/operations/upgrade-notes-0.8.md
+++ b/website/docs/maintenance/operations/upgrade-notes-0.8.md
@@ -1,0 +1,32 @@
+---
+title: Upgrade Notes
+sidebar_position: 3
+---
+
+# Upgrade Notes from v0.7 to v0.8
+
+These upgrade notes discuss important aspects, such as configuration, behavior, or dependencies, that changed between Fluss 0.7 and Fluss 0.8. Please read these notes carefully if you are planning to upgrade your Fluss version to 0.8.
+
+## Deprecation / End of Support
+
+### Java 8 is Deprecated
+Beginning with Fluss v0.8, we now only provide binary distributions built with Java 11.
+**Java 8 is deprecated** as of this release and will be fully removed in future versions.
+
+🔧 **For users still on Java 8**:
+You can continue building Fluss from source using Java 8 by running:
+```bash
+mvn install -DskipTests -Pjava8
+```
+However, we **strongly recommend upgrading to Java 11 or higher** to ensure compatibility, performance, and long-term support.
+
+🔁 **If you’re using Fluss with Apache Flink**:
+Please also upgrade your Flink deployment to **Java 11 or above**. All Flink versions currently supported by Fluss are fully compatible with Java 11.
+
+## Metrics Updates
+
+We have updated the report level for some metrics and also removed some metrics, this greatly reduces the metrics amount and improves the performance.
+
+The following metrics are removed: TODO
+
+The following metrics are changed: TODO

--- a/website/docs/maintenance/operations/upgrade-notes-0.9.md
+++ b/website/docs/maintenance/operations/upgrade-notes-0.9.md
@@ -1,0 +1,13 @@
+---
+title: Upgrade Notes
+sidebar_class_name: hidden
+---
+
+# Upgrade Notes from v0.8 to v0.9
+
+These upgrade notes discuss important aspects, such as configuration, behavior, or dependencies, that changed between Fluss 0.8 and Fluss 0.9. Please read these notes carefully if you are planning to upgrade your Fluss version to 0.9.
+
+
+## Deprecation / End of Support
+
+TODO

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -238,3 +238,7 @@
     text-align: center;
     width: 98%;
 }
+
+.hidden {
+    display: none !important;
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

This adds the Upgrade Notes page the new version (0.7 -> 0.8).

These upgrade notes discuss important aspects, such as configuration, behavior, or dependencies, that changed between Fluss 0.7 and Fluss 0.8. We provide these notes to users for users planning to upgrade Fluss version to 0.8.

<!-- Linking this pull request to the issue -->
Linked issue: close #1693

<!-- What is the purpose of the change -->

### Brief change log

- This is only a draft of upgrade notes of 0.8, more items should be added later
- There is a version number in the URL slug for the upgrade notes (e.g., `http://fluss.apache.org/docs/next/maintenance/operations/upgrade-notes-0.8/`), this is useful when the release announcement blog link the upgrade note, to have a static content of this version of upgrade notes. 
- Added another upgrade notes for the v0.9 as an example when we rolling versions, and the front-matter support to hide sepcific upgrade notes. (there is only one upgrade notes page for this version in the sidebar, old upgrade notes should be hidden from the sidebar but still accessible from links).

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
