### PR TITLE
[hotfix] Add bucket info for error info while loading the stored index file

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogIndexCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogIndexCache.java
@@ -476,8 +476,9 @@ public class RemoteLogIndexCache implements Closeable {
                 index = readIndex.apply(indexFile);
             } catch (CorruptIndexException ex) {
                 LOG.info(
-                        "Error occurred while loading the stored index file {}",
+                        "Error occurred while loading the stored index file {} for bucket {}",
                         indexFile.getPath(),
+                        remoteLogSegment.tableBucket(),
                         ex);
             }
         }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

Currently, when an error occurs while loading an index file, it is difficult to determine which table the file belongs to.
```
2025-09-17 10:36:20,114 INFO  com.alibaba.fluss.server.log.remote.RemoteLogIndexCache      [] - Error occurred while loading the stored index file /mnt/fluss/data/0/remote-log-index-cache/77878665_6c45b095-35dc-4202-8878-02e9121d92de.timeindex
com.alibaba.fluss.server.exception.CorruptIndexException: Corrupt time index found, time index file (/mnt/fluss/data/0/remote-log-index-cache/77878665_6c45b095-35dc-4202-8878-02e9121d92de.timeindex) has non-zero size but the last timestamp is 0 which is less than the first timestamp 1758020356382
	at com.alibaba.fluss.server.log.TimeIndex.lambda$sanityCheck$0(TimeIndex.java:105) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.utils.concurrent.LockUtils.inLock(LockUtils.java:32) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.utils.concurrent.LockUtils.inReadLock(LockUtils.java:50) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.TimeIndex.sanityCheck(TimeIndex.java:94) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.remote.RemoteLogIndexCache.lambda$createCacheEntry$7(RemoteLogIndexCache.java:270) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.remote.RemoteLogIndexCache.loadIndexFile(RemoteLogIndexCache.java:476) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.remote.RemoteLogIndexCache.createCacheEntry(RemoteLogIndexCache.java:254) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.remote.RemoteLogIndexCache.lambda$getIndexEntry$2(RemoteLogIndexCache.java:221) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$14(BoundedLocalCache.java:2406) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916) ~[?:?]
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2404) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2387) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:108) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.github.benmanes.caffeine.cache.LocalManualCache.get(LocalManualCache.java:62) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.remote.RemoteLogIndexCache.lambda$getIndexEntry$3(RemoteLogIndexCache.java:219) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.utils.concurrent.LockUtils.inLock(LockUtils.java:42) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.utils.concurrent.LockUtils.inReadLock(LockUtils.java:55) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.remote.RemoteLogIndexCache.getIndexEntry(RemoteLogIndexCache.java:208) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.remote.RemoteLogIndexCache.lambda$lookupPosition$0(RemoteLogIndexCache.java:186) ~[fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.utils.concurrent.LockUtils.inLock(LockUtils.java:42) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.utils.concurrent.LockUtils.inReadLock(LockUtils.java:55) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.remote.RemoteLogIndexCache.lookupPosition(RemoteLogIndexCache.java:185) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.log.remote.RemoteLogManager.lookupPositionForOffset(RemoteLogManager.java:215) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.replica.ReplicaManager.fetchLogFromRemote(ReplicaManager.java:1168) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.replica.ReplicaManager.handleFetchOutOfRangeException(ReplicaManager.java:1137) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.replica.ReplicaManager.readFromLog(ReplicaManager.java:1107) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.replica.ReplicaManager.fetchLogRecords(ReplicaManager.java:478) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.server.tablet.TabletService.fetchLog(TabletService.java:178) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at jdk.internal.reflect.GeneratedMethodAccessor10.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at com.alibaba.fluss.rpc.netty.server.FlussRequestHandler.processRequest(FlussRequestHandler.java:63) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.rpc.netty.server.FlussRequestHandler.processRequest(FlussRequestHandler.java:34) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.rpc.netty.server.RequestProcessor.processRequest(RequestProcessor.java:98) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at com.alibaba.fluss.rpc.netty.server.RequestProcessor.run(RequestProcessor.java:70) [fluss-server-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
