### PR TITLE
[server] Fix ReplicaFetcherThread keeps throwing UnknownServerException because of corrupt index file

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -176,7 +176,7 @@ public class ReplicaManager {
     private final SnapshotContext kvSnapshotContext;
 
     // remote log manager for remote log storage.
-    private final RemoteLogManager remoteLogManager;
+    protected final RemoteLogManager remoteLogManager;
 
     // for metrics
     private final TabletServerMetricGroup serverMetricGroup;
@@ -217,7 +217,7 @@ public class ReplicaManager {
     }
 
     @VisibleForTesting
-    ReplicaManager(
+    protected ReplicaManager(
             Configuration conf,
             Scheduler scheduler,
             LogManager logManager,
@@ -1101,7 +1101,9 @@ public class ReplicaManager {
 
                 FetchLogResultForBucket result;
                 if (replica != null && e instanceof LogOffsetOutOfRangeException) {
-                    result = handleFetchOutOfRangeException(replica, fetchOffset, e);
+                    result =
+                            handleFetchOutOfRangeException(
+                                    replica, fetchOffset, fetchParams.isFromFollower(), e);
                 } else {
                     result = new FetchLogResultForBucket(tb, ApiError.fromThrowable(e));
                 }
@@ -1113,7 +1115,7 @@ public class ReplicaManager {
     }
 
     private FetchLogResultForBucket handleFetchOutOfRangeException(
-            Replica replica, long fetchOffset, Exception e) {
+            Replica replica, long fetchOffset, boolean isFromFollower, Exception e) {
         TableBucket tb = replica.getTableBucket();
         if (fetchOffset == FetchParams.FETCH_FROM_EARLIEST_OFFSET) {
             fetchOffset = replica.getLogStartOffset();
@@ -1131,7 +1133,8 @@ public class ReplicaManager {
         // of RemoteLogSegment. For client fetcher, it will fetch the log from remote in client.
         // For follower, it can update its local metadata to adjust the next fetch offset.
         else if (canFetchFromRemoteLog(replica, fetchOffset)) {
-            RemoteLogFetchInfo remoteLogFetchInfo = fetchLogFromRemote(replica, fetchOffset);
+            RemoteLogFetchInfo remoteLogFetchInfo =
+                    fetchLogFromRemote(replica, fetchOffset, isFromFollower);
             if (remoteLogFetchInfo != null) {
                 return new FetchLogResultForBucket(
                         tb, remoteLogFetchInfo, replica.getLogHighWatermark());
@@ -1157,13 +1160,20 @@ public class ReplicaManager {
         return replica.getLogTablet().canFetchFromRemoteLog(fetchOffset);
     }
 
-    private @Nullable RemoteLogFetchInfo fetchLogFromRemote(Replica replica, long fetchOffset) {
+    private @Nullable RemoteLogFetchInfo fetchLogFromRemote(
+            Replica replica, long fetchOffset, boolean isFromFollower) {
         List<RemoteLogSegment> remoteLogSegmentList =
                 remoteLogManager.relevantRemoteLogSegments(replica.getTableBucket(), fetchOffset);
         if (!remoteLogSegmentList.isEmpty()) {
-            int firstStartPos =
-                    remoteLogManager.lookupPositionForOffset(
-                            remoteLogSegmentList.get(0), fetchOffset);
+            // follower does not require firstStartPos, so we do not look up this value.
+            // On one hand, this reduces query overhead, and on the other hand,
+            // it helps prevent unexpected issues caused by corrupted index files.
+            int firstStartPos = -1;
+            if (!isFromFollower) {
+                firstStartPos =
+                        remoteLogManager.lookupPositionForOffset(
+                                remoteLogSegmentList.get(0), fetchOffset);
+            }
             PhysicalTablePath physicalTablePath = replica.getPhysicalTablePath();
             FsPath remoteLogTabletDir =
                     FlussPaths.remoteLogTabletDir(

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
@@ -21,49 +21,61 @@ import org.apache.fluss.cluster.ServerNode;
 import org.apache.fluss.cluster.ServerType;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.MemorySize;
 import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.remote.RemoteLogSegment;
 import org.apache.fluss.rpc.RpcClient;
+import org.apache.fluss.rpc.entity.FetchLogResultForBucket;
 import org.apache.fluss.rpc.entity.ProduceLogResultForBucket;
+import org.apache.fluss.rpc.gateway.CoordinatorGateway;
 import org.apache.fluss.rpc.metrics.TestingClientMetricGroup;
 import org.apache.fluss.server.coordinator.MetadataManager;
 import org.apache.fluss.server.coordinator.TestCoordinatorGateway;
+import org.apache.fluss.server.entity.FetchReqInfo;
 import org.apache.fluss.server.entity.NotifyLeaderAndIsrData;
 import org.apache.fluss.server.entity.NotifyLeaderAndIsrResultForBucket;
+import org.apache.fluss.server.exception.CorruptIndexException;
 import org.apache.fluss.server.kv.KvManager;
 import org.apache.fluss.server.kv.snapshot.TestingCompletedKvSnapshotCommitter;
+import org.apache.fluss.server.log.FetchParams;
 import org.apache.fluss.server.log.LogManager;
+import org.apache.fluss.server.log.LogTablet;
+import org.apache.fluss.server.log.remote.RemoteLogManager;
+import org.apache.fluss.server.log.remote.RemoteLogStorage;
+import org.apache.fluss.server.log.remote.TestingRemoteLogStorage;
 import org.apache.fluss.server.metadata.TabletServerMetadataCache;
 import org.apache.fluss.server.metrics.group.TabletServerMetricGroup;
 import org.apache.fluss.server.metrics.group.TestingMetricGroups;
 import org.apache.fluss.server.replica.Replica;
 import org.apache.fluss.server.replica.ReplicaManager;
+import org.apache.fluss.server.replica.ReplicaTestBase;
 import org.apache.fluss.server.zk.NOPErrorHandler;
 import org.apache.fluss.server.zk.ZooKeeperClient;
-import org.apache.fluss.server.zk.ZooKeeperExtension;
 import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.server.zk.data.TableRegistration;
-import org.apache.fluss.testutils.common.AllCallbackWrapper;
+import org.apache.fluss.testutils.common.ManuallyTriggeredScheduledExecutorService;
 import org.apache.fluss.utils.clock.Clock;
-import org.apache.fluss.utils.clock.ManualClock;
 import org.apache.fluss.utils.concurrent.FlussScheduler;
 import org.apache.fluss.utils.concurrent.Scheduler;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
 import static org.apache.fluss.record.TestData.DATA1;
@@ -78,16 +90,11 @@ import static org.apache.fluss.testutils.DataTestUtils.genMemoryLogRecordsByObje
 import static org.apache.fluss.testutils.DataTestUtils.genMemoryLogRecordsWithWriterId;
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link ReplicaFetcherThread}. */
-public class ReplicaFetcherThreadTest {
-    @RegisterExtension
-    public static final AllCallbackWrapper<ZooKeeperExtension> ZOO_KEEPER_EXTENSION_WRAPPER =
-            new AllCallbackWrapper<>(new ZooKeeperExtension());
+public class ReplicaFetcherThreadTest extends ReplicaTestBase {
 
-    private static ZooKeeperClient zkClient;
-    private ManualClock manualClock;
-    private @TempDir File tempDir;
     private TableBucket tb;
     private final int leaderServerId = 1;
     private final int followerServerId = 2;
@@ -95,23 +102,19 @@ public class ReplicaFetcherThreadTest {
     private ServerNode leader;
     private ReplicaManager followerRM;
     private ReplicaFetcherThread followerFetcher;
-
-    @BeforeAll
-    static void baseBeforeAll() {
-        zkClient =
-                ZOO_KEEPER_EXTENSION_WRAPPER
-                        .getCustomExtension()
-                        .getZooKeeperClient(NOPErrorHandler.INSTANCE);
-    }
+    private ManuallyTriggeredScheduledExecutorService leaderRemoteLogTaskScheduler;
 
     @BeforeEach
     public void setup() throws Exception {
+        super.setup();
         ZOO_KEEPER_EXTENSION_WRAPPER.getCustomExtension().cleanupRoot();
-        manualClock = new ManualClock(System.currentTimeMillis());
         Configuration conf = new Configuration();
         tb = new TableBucket(DATA1_TABLE_ID, 0);
-        leaderRM = createReplicaManager(leaderServerId);
-        followerRM = createReplicaManager(followerServerId);
+        leaderRemoteLogTaskScheduler = new ManuallyTriggeredScheduledExecutorService();
+        leaderRM = createReplicaManager(leaderServerId, leaderRemoteLogTaskScheduler);
+        followerRM =
+                createReplicaManager(
+                        followerServerId, new ManuallyTriggeredScheduledExecutorService());
         // with local test leader end point.
         leader =
                 new ServerNode(
@@ -169,6 +172,59 @@ public class ReplicaFetcherThreadTest {
                 () ->
                         assertThat(followerRM.getReplicaOrException(tb).getLocalLogEndOffset())
                                 .isEqualTo(20L));
+    }
+
+    @Test
+    void testFetchRemoteWithCorruptIndex() throws Exception {
+        LogTablet logTablet = leaderRM.getReplicaOrException(tb).getLogTablet();
+        addMultiSegmentsToLogTablet(logTablet, 5);
+
+        File file = logTablet.getSegments().get(0).timeIndex().file();
+        // mock corrupt index
+        try (FileChannel fileChannel = FileChannel.open(file.toPath(), StandardOpenOption.APPEND)) {
+            for (int i = 0; i < 12; i++) {
+                fileChannel.write(ByteBuffer.wrap(new byte[] {0}));
+            }
+        }
+
+        // trigger RLMTask copy local log segment to remote and update metadata.
+        leaderRemoteLogTaskScheduler.triggerPeriodicScheduledTasks();
+        List<RemoteLogSegment> remoteLogSegmentList =
+                leaderRM.getRemoteLogManager().relevantRemoteLogSegments(tb, 0L);
+        assertThat(remoteLogSegmentList.size()).isEqualTo(4);
+
+        logTablet.updateRemoteLogEndOffset(40L);
+
+        // mock fetch by client, should throw CorruptIndexException, since we have a corrupt index.
+        CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> future =
+                new CompletableFuture<>();
+        assertThatThrownBy(
+                        () ->
+                                leaderRM.fetchLogRecords(
+                                        new FetchParams(-1, Integer.MAX_VALUE),
+                                        Collections.singletonMap(
+                                                tb,
+                                                new FetchReqInfo(tb.getTableId(), 0L, 1024 * 1024)),
+                                        future::complete))
+                .isInstanceOf(CorruptIndexException.class);
+
+        // begin fetcher thread.
+        followerFetcher.addBuckets(
+                Collections.singletonMap(
+                        tb,
+                        new InitialFetchStatus(DATA1_TABLE_ID, DATA1_TABLE_PATH, leader.id(), 0L)));
+        followerFetcher.start();
+        // fetcher should succeed in spite of corrupt index.
+        retry(
+                Duration.ofSeconds(20),
+                () ->
+                        assertThat(followerRM.getReplicaOrException(tb).getLocalLogStartOffset())
+                                .isEqualTo(40L));
+        retry(
+                Duration.ofSeconds(20),
+                () ->
+                        assertThat(followerRM.getReplicaOrException(tb).getLocalLogEndOffset())
+                                .isEqualTo(50L));
     }
 
     @Test
@@ -389,10 +445,15 @@ public class ReplicaFetcherThreadTest {
                 result -> {});
     }
 
-    private ReplicaManager createReplicaManager(int serverId) throws Exception {
+    private ReplicaManager createReplicaManager(
+            int serverId, ScheduledExecutorService remoteLogTaskScheduler) throws Exception {
         Configuration conf = new Configuration();
         conf.setString(ConfigOptions.DATA_DIR, tempDir.getAbsolutePath() + "/server-" + serverId);
+        conf.set(ConfigOptions.REMOTE_DATA_DIR, tempDir.getAbsolutePath() + "/remote_data_dir");
         conf.set(ConfigOptions.WRITER_ID_EXPIRATION_TIME, Duration.ofHours(12));
+        conf.set(ConfigOptions.LOG_SEGMENT_FILE_SIZE, MemorySize.parse("10kb"));
+        conf.set(ConfigOptions.LOG_INDEX_INTERVAL_SIZE, MemorySize.parse("1b"));
+        conf.set(ConfigOptions.REMOTE_LOG_TASK_INTERVAL_DURATION, Duration.ofSeconds(10));
         Scheduler scheduler = new FlussScheduler(2);
         scheduler.startup();
 
@@ -404,6 +465,18 @@ public class ReplicaFetcherThreadTest {
                         manualClock,
                         TestingMetricGroups.TABLET_SERVER_METRICS);
         logManager.startup();
+
+        CoordinatorGateway coordinatorGateway = new TestCoordinatorGateway(zkClient);
+        RemoteLogStorage remoteLogStorage = new TestingRemoteLogStorage(conf);
+        RemoteLogManager remoteLogManager =
+                new RemoteLogManager(
+                        conf,
+                        zkClient,
+                        coordinatorGateway,
+                        remoteLogStorage,
+                        remoteLogTaskScheduler,
+                        manualClock);
+
         ReplicaManager replicaManager =
                 new TestingReplicaManager(
                         conf,
@@ -413,8 +486,10 @@ public class ReplicaFetcherThreadTest {
                         zkClient,
                         serverId,
                         new TabletServerMetadataCache(new MetadataManager(null, conf), null),
+                        coordinatorGateway,
                         RpcClient.create(conf, TestingClientMetricGroup.newInstance(), false),
                         TestingMetricGroups.TABLET_SERVER_METRICS,
+                        remoteLogManager,
                         manualClock);
         replicaManager.startup();
         return replicaManager;
@@ -433,8 +508,10 @@ public class ReplicaFetcherThreadTest {
                 ZooKeeperClient zkClient,
                 int serverId,
                 TabletServerMetadataCache metadataCache,
+                CoordinatorGateway coordinatorGateway,
                 RpcClient rpcClient,
                 TabletServerMetricGroup serverMetricGroup,
+                RemoteLogManager remoteLogManager,
                 Clock clock)
                 throws IOException {
             super(
@@ -446,10 +523,11 @@ public class ReplicaFetcherThreadTest {
                     serverId,
                     metadataCache,
                     rpcClient,
-                    new TestCoordinatorGateway(),
+                    coordinatorGateway,
                     new TestingCompletedKvSnapshotCommitter(),
                     NOPErrorHandler.INSTANCE,
                     serverMetricGroup,
+                    remoteLogManager,
                     clock);
         }
 
@@ -466,11 +544,13 @@ public class ReplicaFetcherThreadTest {
                     if (leaderId == serverId) {
                         try {
                             replica.makeLeader(data);
-                        } catch (IOException e) {
+                            remoteLogManager.startLogTiering(replica);
+                        } catch (Exception e) {
                             throw new FlussRuntimeException(e);
                         }
                     } else {
                         replica.makeFollower(data);
+                        remoteLogManager.stopLogTiering(replica);
                     }
                 }
             }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1716 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
