### PR TITLE
[common] Change Cluster#getRandomTabletServer() to really random retrieve tabletServer

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/cluster/Cluster.java
+++ b/fluss-common/src/main/java/org/apache/fluss/cluster/Cluster.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * An immutable representation of a subset of the server nodes, tables, and buckets and schemas in
@@ -46,9 +45,6 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 @Internal
 public final class Cluster {
-
-    private static final AtomicLong RANDOM_SEED = new AtomicLong(System.nanoTime());
-
     @Nullable private final ServerNode coordinatorServer;
     private final Map<PhysicalTablePath, List<BucketLocation>> availableLocationsByPath;
     private final Map<TableBucket, BucketLocation> availableLocationByBucket;
@@ -218,8 +214,7 @@ public final class Cluster {
             return null;
         }
 
-        long seedMix = RANDOM_SEED.get() ^ ThreadLocalRandom.current().nextLong();
-        int index = (int) (Math.abs(seedMix) % serverNodes.size());
+        int index = ThreadLocalRandom.current().nextInt(serverNodes.size());
         return serverNodes.get(index);
     }
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1718 

<!-- What is the purpose of the change -->

`Cluster#getRandomTabletServer()` does not truly randomly retrieve a `TabletServer`. The current implementation of `getRandomTabletServer` always retrieves the first element from the map iterator, which results in consistently selecting `TabletServer-0`.

```java
public ServerNode getRandomTabletServer() {
        // TODO this method need to get one tablet server according to the load.
        List<ServerNode> serverNodes = new ArrayList<>(aliveTabletServersById.values());
        return !serverNodes.isEmpty() ? serverNodes.get(0) : null;
    }
```

This pr is aims to change `Cluster#getRandomTabletServer()` to really random retrieve `tabletServer`.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
