### PR TITLE
[hotfix] Add debug log for NettyServerHandler to trace the request process time

### DIFF
--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/NettyServerHandler.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/NettyServerHandler.java
@@ -240,6 +240,14 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
             send.writeTo(ctx);
             ctx.flush();
             long requestEndTimeMs = System.currentTimeMillis();
+            LOG.debug(
+                    "Finished process request type: {}, inQueueTime: {}, processTime: {}, "
+                            + "responseSendToClientTime: {}, request from: {}",
+                    request.getApiMethod().getApiKey(),
+                    request.getRequestDequeTimeMs() - request.getStartTimeMs(),
+                    request.getRequestCompletedTimeMs() - request.getRequestDequeTimeMs(),
+                    requestEndTimeMs - request.getRequestCompletedTimeMs(),
+                    request.getAddress());
             updateRequestMetrics(request, requestEndTimeMs);
         } catch (Throwable t) {
             LOG.error("Failed to send response to client.", t);


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

Add debug log for `NettyServerHandler` to trace the request process time. This is very useful when there is a bottleneck in cluster network request processing, as it can quickly identify slow requests.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
