### PR TITLE
[common] Fix serverConnection that has already been set to disconnected is still processing requests error

### DIFF
--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/NettyClientTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/NettyClientTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -156,9 +157,9 @@ final class NettyClientTest {
                                 nettyClient
                                         .sendRequest(serverNode, ApiKeys.API_VERSIONS, request)
                                         .get())
-                .isInstanceOf(ExecutionException.class)
-                .hasMessageContaining("Disconnected from node")
-                .hasRootCauseMessage("finishConnect(..) failed: Connection refused");
+                .rootCause()
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("Connection refused");
         assertThat(nettyClient.connections().size()).isEqualTo(0);
 
         // restart the netty server.

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/ServerConnectionTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/ServerConnectionTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.rpc.netty.client;
+
+import org.apache.fluss.cluster.Endpoint;
+import org.apache.fluss.cluster.ServerNode;
+import org.apache.fluss.cluster.ServerType;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.DisconnectException;
+import org.apache.fluss.metrics.groups.MetricGroup;
+import org.apache.fluss.metrics.util.NOPMetricsGroup;
+import org.apache.fluss.rpc.TestingGatewayService;
+import org.apache.fluss.rpc.messages.GetTableSchemaRequest;
+import org.apache.fluss.rpc.messages.PbTablePath;
+import org.apache.fluss.rpc.metrics.TestingClientMetricGroup;
+import org.apache.fluss.rpc.netty.client.ServerConnection.ConnectionState;
+import org.apache.fluss.rpc.netty.server.NettyServer;
+import org.apache.fluss.rpc.netty.server.RequestsMetrics;
+import org.apache.fluss.rpc.protocol.ApiKeys;
+import org.apache.fluss.security.auth.AuthenticationFactory;
+import org.apache.fluss.security.auth.ClientAuthenticator;
+import org.apache.fluss.shaded.netty4.io.netty.bootstrap.Bootstrap;
+import org.apache.fluss.shaded.netty4.io.netty.channel.EventLoopGroup;
+import org.apache.fluss.utils.NetUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.fluss.rpc.netty.NettyUtils.getClientSocketChannelClass;
+import static org.apache.fluss.rpc.netty.NettyUtils.newEventLoopGroup;
+import static org.apache.fluss.utils.NetUtils.getAvailablePort;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link ServerConnection}. */
+public class ServerConnectionTest {
+
+    private EventLoopGroup eventLoopGroup;
+    private Bootstrap bootstrap;
+    private ClientAuthenticator clientAuthenticator;
+    private Configuration conf;
+    private NettyServer nettyServer;
+    private ServerNode serverNode;
+    private TestingGatewayService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        conf = new Configuration();
+        buildNettyServer(0);
+
+        eventLoopGroup = newEventLoopGroup(1, "fluss-netty-client-test");
+        bootstrap =
+                new Bootstrap()
+                        .group(eventLoopGroup)
+                        .channel(getClientSocketChannelClass(eventLoopGroup))
+                        .handler(new ClientChannelInitializer(5000));
+        clientAuthenticator =
+                AuthenticationFactory.loadClientAuthenticatorSupplier(new Configuration()).get();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (nettyServer != null) {
+            nettyServer.close();
+        }
+
+        if (eventLoopGroup != null) {
+            eventLoopGroup.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void testConnectionClose() {
+        ServerConnection connection =
+                new ServerConnection(
+                        bootstrap,
+                        serverNode,
+                        TestingClientMetricGroup.newInstance(),
+                        clientAuthenticator,
+                        false);
+        ConnectionState connectionState = connection.getConnectionState();
+        assertThat(connectionState).isEqualTo(ConnectionState.CONNECTING);
+
+        GetTableSchemaRequest request =
+                new GetTableSchemaRequest()
+                        .setTablePath(
+                                new PbTablePath().setDatabaseName("test").setTableName("test"))
+                        .setSchemaId(0);
+        connection.send(ApiKeys.GET_TABLE_SCHEMA, request);
+
+        CompletableFuture<Void> future = connection.close();
+        connectionState = connection.getConnectionState();
+        assertThat(connectionState).isEqualTo(ConnectionState.DISCONNECTED);
+        assertThat(future.isDone()).isTrue();
+
+        assertThatThrownBy(() -> connection.send(ApiKeys.GET_TABLE_SCHEMA, request).get())
+                .rootCause()
+                .isInstanceOf(DisconnectException.class)
+                .hasMessageContaining("Cannot send request to server");
+        future = connection.close();
+        assertThat(future.isDone()).isTrue();
+    }
+
+    private void buildNettyServer(int serverId) throws Exception {
+        try (NetUtils.Port availablePort = getAvailablePort()) {
+            serverNode =
+                    new ServerNode(
+                            serverId, "localhost", availablePort.getPort(), ServerType.COORDINATOR);
+            service = new TestingGatewayService();
+            MetricGroup metricGroup = NOPMetricsGroup.newInstance();
+            nettyServer =
+                    new NettyServer(
+                            conf,
+                            Collections.singleton(
+                                    new Endpoint(serverNode.host(), serverNode.port(), "INTERNAL")),
+                            service,
+                            metricGroup,
+                            RequestsMetrics.createCoordinatorServerRequestMetrics(metricGroup));
+            nettyServer.start();
+        }
+    }
+}


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1721 

<!-- What is the purpose of the change -->

Fix serverConnection that has already been set to disconnected is still processing requests error.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
