### PR TITLE
[flink] Support delta join on Flink 2.1

### DIFF
--- a/fluss-flink/fluss-flink-2.1/src/main/java/org/apache/fluss/flink/catalog/Flink21Catalog.java
+++ b/fluss-flink/fluss-flink-2.1/src/main/java/org/apache/fluss/flink/catalog/Flink21Catalog.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.catalog;
+
+import org.apache.fluss.metadata.TableInfo;
+
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** A {@link FlinkCatalog} used for Flink 2.1. */
+public class Flink21Catalog extends FlinkCatalog {
+
+    public Flink21Catalog(
+            String name,
+            String defaultDatabase,
+            String bootstrapServers,
+            ClassLoader classLoader,
+            Map<String, String> securityConfigs) {
+        super(name, defaultDatabase, bootstrapServers, classLoader, securityConfigs);
+    }
+
+    @Override
+    public CatalogBaseTable getTable(ObjectPath objectPath)
+            throws TableNotExistException, CatalogException {
+        CatalogBaseTable catalogBaseTable = super.getTable(objectPath);
+        if (!(catalogBaseTable instanceof CatalogTable)) {
+            return catalogBaseTable;
+        }
+
+        CatalogTable table = (CatalogTable) catalogBaseTable;
+        Optional<Schema.UnresolvedPrimaryKey> pkOp = table.getUnresolvedSchema().getPrimaryKey();
+        // If there is no pk, return directly.
+        if (pkOp.isEmpty()) {
+            return table;
+        }
+
+        Schema.Builder newSchemaBuilder =
+                Schema.newBuilder().fromSchema(table.getUnresolvedSchema());
+        // Pk is always an index.
+        newSchemaBuilder.index(pkOp.get().getColumnNames());
+
+        // Judge whether we can do prefix lookup.
+        TableInfo tableInfo = connection.getTable(toTablePath(objectPath)).getTableInfo();
+        List<String> bucketKeys = tableInfo.getBucketKeys();
+        // For partition table, the physical primary key is the primary key that excludes the
+        // partition key
+        List<String> physicalPrimaryKeys = tableInfo.getPhysicalPrimaryKeys();
+        List<String> indexKeys = new ArrayList<>();
+        if (isPrefixList(physicalPrimaryKeys, bucketKeys)) {
+            indexKeys.addAll(bucketKeys);
+            if (tableInfo.isPartitioned()) {
+                indexKeys.addAll(tableInfo.getPartitionKeys());
+            }
+        }
+
+        if (!indexKeys.isEmpty()) {
+            newSchemaBuilder.index(indexKeys);
+        }
+        return CatalogTable.newBuilder()
+                .schema(newSchemaBuilder.build())
+                .comment(table.getComment())
+                .partitionKeys(table.getPartitionKeys())
+                .options(table.getOptions())
+                .snapshot(table.getSnapshot().orElse(null))
+                .distribution(table.getDistribution().orElse(null))
+                .build();
+    }
+
+    private static boolean isPrefixList(List<String> fullList, List<String> prefixList) {
+        if (fullList.size() <= prefixList.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < prefixList.size(); i++) {
+            if (!fullList.get(i).equals(prefixList.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/fluss-flink/fluss-flink-2.1/src/main/java/org/apache/fluss/flink/catalog/Flink21CatalogFactory.java
+++ b/fluss-flink/fluss-flink-2.1/src/main/java/org/apache/fluss/flink/catalog/Flink21CatalogFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.catalog;
+
+/** A {@link FlinkCatalogFactory} used for Flink 2.1. */
+public class Flink21CatalogFactory extends FlinkCatalogFactory {
+
+    @Override
+    public FlinkCatalog createCatalog(Context context) {
+        FlinkCatalog catalog = super.createCatalog(context);
+        return new Flink21Catalog(
+                catalog.catalogName,
+                catalog.defaultDatabase,
+                catalog.bootstrapServers,
+                catalog.classLoader,
+                catalog.securityConfigs);
+    }
+}

--- a/fluss-flink/fluss-flink-2.1/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/fluss-flink/fluss-flink-2.1/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-org.apache.fluss.flink.catalog.FlinkCatalogFactory
+org.apache.fluss.flink.catalog.Flink21CatalogFactory

--- a/fluss-flink/fluss-flink-2.1/src/test/java/org/apache/fluss/flink/catalog/Flink21CatalogITCase.java
+++ b/fluss-flink/fluss-flink-2.1/src/test/java/org/apache/fluss/flink/catalog/Flink21CatalogITCase.java
@@ -17,5 +17,267 @@
 
 package org.apache.fluss.flink.catalog;
 
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.fluss.flink.FlinkConnectorOptions.BUCKET_KEY;
+import static org.apache.fluss.flink.FlinkConnectorOptions.BUCKET_NUMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** IT case for catalog in Flink 2.1. */
-public class Flink21CatalogITCase extends FlinkCatalogITCase {}
+public class Flink21CatalogITCase extends FlinkCatalogITCase {
+
+    @BeforeAll
+    static void beforeAll() {
+        FlinkCatalogITCase.beforeAll();
+
+        // close the old one and open a new one later
+        catalog.close();
+
+        catalog =
+                new Flink21Catalog(
+                        catalog.catalogName,
+                        catalog.defaultDatabase,
+                        catalog.bootstrapServers,
+                        catalog.classLoader,
+                        catalog.securityConfigs);
+        catalog.open();
+    }
+
+    @Test
+    @Override
+    void testCreateTable() throws Exception {
+        // create a table will all supported data types
+        tEnv.executeSql(
+                "create table test_table "
+                        + "(a int not null primary key not enforced,"
+                        + " b CHAR(3),"
+                        + " c STRING not null COMMENT 'STRING COMMENT',"
+                        + " d STRING,"
+                        + " e BOOLEAN,"
+                        + " f BINARY(2),"
+                        + " g BYTES COMMENT 'BYTES',"
+                        + " h BYTES,"
+                        + " i DECIMAL(12, 2),"
+                        + " j TINYINT,"
+                        + " k SMALLINT,"
+                        + " l BIGINT,"
+                        + " m FLOAT,"
+                        + " n DOUBLE,"
+                        + " o DATE,"
+                        + " p TIME,"
+                        + " q TIMESTAMP,"
+                        + " r TIMESTAMP_LTZ,"
+                        + " s ROW<a INT>) COMMENT 'a test table'");
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder
+                .column("a", DataTypes.INT().notNull())
+                .column("b", DataTypes.CHAR(3))
+                .column("c", DataTypes.STRING().notNull())
+                .withComment("STRING COMMENT")
+                .column("d", DataTypes.STRING())
+                .column("e", DataTypes.BOOLEAN())
+                .column("f", DataTypes.BINARY(2))
+                .column("g", DataTypes.BYTES())
+                .withComment("BYTES")
+                .column("h", DataTypes.BYTES())
+                .column("i", DataTypes.DECIMAL(12, 2))
+                .column("j", DataTypes.TINYINT())
+                .column("k", DataTypes.SMALLINT())
+                .column("l", DataTypes.BIGINT())
+                .column("m", DataTypes.FLOAT())
+                .column("n", DataTypes.DOUBLE())
+                .column("o", DataTypes.DATE())
+                .column("p", DataTypes.TIME())
+                .column("q", DataTypes.TIMESTAMP())
+                .column("r", DataTypes.TIMESTAMP_LTZ())
+                .column("s", DataTypes.ROW(DataTypes.FIELD("a", DataTypes.INT())))
+                .primaryKey("a")
+                .index("a");
+        Schema expectedSchema = schemaBuilder.build();
+        CatalogTable table =
+                (CatalogTable) catalog.getTable(new ObjectPath(DEFAULT_DB, "test_table"));
+        assertThat(table.getUnresolvedSchema()).isEqualTo(expectedSchema);
+    }
+
+    @Test
+    @Override
+    void testTableWithExpression() throws Exception {
+        // create a table with watermark and computed column
+        tEnv.executeSql(
+                "CREATE TABLE expression_test (\n"
+                        + "    `user` BIGINT not null primary key not enforced,\n"
+                        + "    product STRING COMMENT 'comment1',\n"
+                        + "    price DOUBLE,\n"
+                        + "    quantity DOUBLE,\n"
+                        + "    cost AS price * quantity,\n"
+                        + "    order_time TIMESTAMP(3),\n"
+                        + "    WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND\n"
+                        + ") with ('k1' = 'v1')");
+        CatalogTable table =
+                (CatalogTable) catalog.getTable(new ObjectPath(DEFAULT_DB, "expression_test"));
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder
+                .column("user", DataTypes.BIGINT().notNull())
+                .column("product", DataTypes.STRING())
+                .withComment("comment1")
+                .column("price", DataTypes.DOUBLE())
+                .column("quantity", DataTypes.DOUBLE())
+                .columnByExpression("cost", "`price` * `quantity`")
+                .column("order_time", DataTypes.TIMESTAMP(3))
+                .watermark("order_time", "`order_time` - INTERVAL '5' SECOND")
+                .primaryKey("user")
+                .index("user");
+        Schema expectedSchema = schemaBuilder.build();
+        assertThat(table.getUnresolvedSchema()).isEqualTo(expectedSchema);
+        Map<String, String> expectedOptions = new HashMap<>();
+        expectedOptions.put("k1", "v1");
+        expectedOptions.put(BUCKET_KEY.key(), "user");
+        expectedOptions.put(BUCKET_NUMBER.key(), "1");
+        assertOptionsEqual(table.getOptions(), expectedOptions);
+    }
+
+    @Test
+    void testGetTableWithIndex() throws Exception {
+        String tableName = "table_with_pk_only";
+        tEnv.executeSql(
+                String.format(
+                        "create table %s ( "
+                                + " a int, "
+                                + " b varchar, "
+                                + " c bigint, "
+                                + " primary key (a, b) NOT ENFORCED"
+                                + ") with ( "
+                                + " 'connector' = 'fluss' "
+                                + ")",
+                        tableName));
+        CatalogTable table = (CatalogTable) catalog.getTable(new ObjectPath(DEFAULT_DB, tableName));
+        Schema expectedSchema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT().notNull())
+                        .column("b", DataTypes.STRING().notNull())
+                        .column("c", DataTypes.BIGINT())
+                        .primaryKey("a", "b")
+                        .index("a", "b")
+                        .build();
+        assertThat(table.getUnresolvedSchema()).isEqualTo(expectedSchema);
+
+        tableName = "table_with_prefix_bucket_key";
+        tEnv.executeSql(
+                String.format(
+                        "create table %s ( "
+                                + " a int, "
+                                + " b varchar, "
+                                + " c bigint, "
+                                + " primary key (a, b) NOT ENFORCED"
+                                + ") with ( "
+                                + " 'connector' = 'fluss', "
+                                + " 'bucket.key' = 'a'"
+                                + ")",
+                        tableName));
+
+        table = (CatalogTable) catalog.getTable(new ObjectPath(DEFAULT_DB, tableName));
+        expectedSchema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT().notNull())
+                        .column("b", DataTypes.STRING().notNull())
+                        .column("c", DataTypes.BIGINT())
+                        .primaryKey("a", "b")
+                        .index("a", "b")
+                        .index("a")
+                        .build();
+        assertThat(table.getUnresolvedSchema()).isEqualTo(expectedSchema);
+
+        tableName = "table_with_bucket_key_is_not_prefix_pk";
+        tEnv.executeSql(
+                String.format(
+                        "create table %s ( "
+                                + " a int, "
+                                + " b varchar, "
+                                + " c bigint, "
+                                + " primary key (a, b) NOT ENFORCED"
+                                + ") with ( "
+                                + " 'connector' = 'fluss', "
+                                + " 'bucket.key' = 'b'"
+                                + ")",
+                        tableName));
+
+        table = (CatalogTable) catalog.getTable(new ObjectPath(DEFAULT_DB, tableName));
+        expectedSchema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT().notNull())
+                        .column("b", DataTypes.STRING().notNull())
+                        .column("c", DataTypes.BIGINT())
+                        .primaryKey("a", "b")
+                        .index("a", "b")
+                        .build();
+        assertThat(table.getUnresolvedSchema()).isEqualTo(expectedSchema);
+
+        tableName = "table_with_partition_1";
+        tEnv.executeSql(
+                String.format(
+                        "create table %s ( "
+                                + " a int, "
+                                + " b varchar, "
+                                + " c bigint, "
+                                + " dt varchar, "
+                                + " primary key (a, b, dt) NOT ENFORCED "
+                                + ") "
+                                + " partitioned by (dt) "
+                                + " with ( "
+                                + " 'connector' = 'fluss', "
+                                + " 'bucket.key' = 'a'"
+                                + ")",
+                        tableName));
+
+        table = (CatalogTable) catalog.getTable(new ObjectPath(DEFAULT_DB, tableName));
+        expectedSchema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT().notNull())
+                        .column("b", DataTypes.STRING().notNull())
+                        .column("c", DataTypes.BIGINT())
+                        .column("dt", DataTypes.STRING().notNull())
+                        .primaryKey("a", "b", "dt")
+                        .index("a", "b", "dt")
+                        .index("a", "dt")
+                        .build();
+        assertThat(table.getUnresolvedSchema()).isEqualTo(expectedSchema);
+
+        tableName = "table_with_partition_2";
+        tEnv.executeSql(
+                String.format(
+                        "create table %s ( "
+                                + " a int, "
+                                + " b varchar, "
+                                + " c bigint, "
+                                + " dt varchar, "
+                                + " primary key (dt, a, b) NOT ENFORCED "
+                                + ") "
+                                + " partitioned by (dt) "
+                                + " with ( "
+                                + " 'connector' = 'fluss', "
+                                + " 'bucket.key' = 'a'"
+                                + ")",
+                        tableName));
+
+        table = (CatalogTable) catalog.getTable(new ObjectPath(DEFAULT_DB, tableName));
+        expectedSchema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT().notNull())
+                        .column("b", DataTypes.STRING().notNull())
+                        .column("c", DataTypes.BIGINT())
+                        .column("dt", DataTypes.STRING().notNull())
+                        .primaryKey("dt", "a", "b")
+                        .index("dt", "a", "b")
+                        .index("a", "dt")
+                        .build();
+        assertThat(table.getUnresolvedSchema()).isEqualTo(expectedSchema);
+    }
+}

--- a/fluss-flink/fluss-flink-2.1/src/test/java/org/apache/fluss/flink/source/Flink21TableSourceITCase.java
+++ b/fluss-flink/fluss-flink-2.1/src/test/java/org/apache/fluss/flink/source/Flink21TableSourceITCase.java
@@ -17,5 +17,127 @@
 
 package org.apache.fluss.flink.source;
 
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.row.InternalRow;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertResultsIgnoreOrder;
+import static org.apache.fluss.flink.utils.FlinkTestBase.writeRows;
+import static org.apache.fluss.testutils.DataTestUtils.row;
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** IT case for {@link FlinkTableSource} in Flink 2.1. */
-public class Flink21TableSourceITCase extends FlinkTableSourceITCase {}
+public class Flink21TableSourceITCase extends FlinkTableSourceITCase {
+
+    @Test
+    void testDeltaJoin() throws Exception {
+        tEnv.getConfig().set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 2);
+
+        String leftTableName = "left_table";
+        tEnv.executeSql(
+                String.format(
+                        "create table %s ( "
+                                + " a1 int, "
+                                + " b1 varchar, "
+                                + " c1 bigint, "
+                                + " d1 int, "
+                                + " e1 bigint, "
+                                + " primary key (c1, d1) NOT ENFORCED"
+                                + ") with ("
+                                + " 'connector' = 'fluss', "
+                                + " 'bucket.key' = 'c1', "
+                                // currently, delta join only support append-only source
+                                + " 'table.merge-engine' = 'first_row' "
+                                + ")",
+                        leftTableName));
+        List<InternalRow> rows1 =
+                Arrays.asList(
+                        row(1, "v1", 100L, 1, 10000L),
+                        row(2, "v2", 200L, 2, 20000L),
+                        // dropped because of first row
+                        row(3, "v1", 300L, 3, 30000L),
+                        row(4, "v4", 400L, 4, 40000L));
+        // write records and wait generate snapshot.
+        TablePath leftTablePath = TablePath.of(DEFAULT_DB, leftTableName);
+        writeRows(conn, leftTablePath, rows1, false);
+
+        String rightTableName = "right_table";
+        tEnv.executeSql(
+                String.format(
+                        "create table %s ("
+                                + " a2 int, "
+                                + " b2 varchar, "
+                                + " c2 bigint, "
+                                + " d2 int, "
+                                + " e2 bigint, "
+                                + " primary key (c2, d2) NOT ENFORCED"
+                                + ") with ("
+                                + " 'connector' = 'fluss', "
+                                + " 'bucket.key' = 'c2', "
+                                // currently, delta join only support append-only source
+                                + " 'table.merge-engine' = 'first_row' "
+                                + ")",
+                        rightTableName));
+        List<InternalRow> rows2 =
+                Arrays.asList(
+                        row(1, "v1", 100L, 1, 10000L),
+                        row(2, "v3", 200L, 2, 20000L),
+                        row(3, "v4", 300L, 4, 30000L),
+                        // dropped because of first row
+                        row(4, "v4", 500L, 4, 50000L));
+        // write records
+        TablePath rightTablePath = TablePath.of(DEFAULT_DB, rightTableName);
+        writeRows(conn, rightTablePath, rows2, false);
+
+        String sinkTableName = "sink_table";
+        tEnv.executeSql(
+                String.format(
+                        "create table %s ( "
+                                + " a1 int, "
+                                + " b1 varchar, "
+                                + " c1 bigint, "
+                                + " d1 int, "
+                                + " e1 bigint, "
+                                + " a2 int, "
+                                + " b2 varchar, "
+                                + " c2 bigint, "
+                                + " d2 int, "
+                                + " e2 bigint, "
+                                + " primary key (c1, d1, c2, d2) NOT ENFORCED"
+                                + ") with ("
+                                + " 'connector' = 'fluss' "
+                                + ")",
+                        sinkTableName));
+
+        tEnv.getConfig()
+                .set(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY,
+                        OptimizerConfigOptions.DeltaJoinStrategy.FORCE);
+
+        String sql =
+                String.format(
+                        "INSERT INTO %s SELECT * FROM %s INNER JOIN %s ON c1 = c2 AND d1 = d2",
+                        sinkTableName, leftTableName, rightTableName);
+
+        assertThat(tEnv.explainSql(sql))
+                .contains("DeltaJoin(joinType=[InnerJoin], where=[((c1 = c2) AND (d1 = d2))]");
+
+        tEnv.executeSql(sql);
+
+        CloseableIterator<Row> collected =
+                tEnv.executeSql(String.format("select * from %s", sinkTableName)).collect();
+        List<String> expected =
+                Arrays.asList(
+                        "+I[1, v1, 100, 1, 10000, 1, v1, 100, 1, 10000]",
+                        "+I[2, v2, 200, 2, 20000, 2, v3, 200, 2, 20000]");
+        assertResultsIgnoreOrder(collected, expected, true);
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -17,27 +17,6 @@
 
 package org.apache.fluss.flink.catalog;
 
-import org.apache.fluss.client.Connection;
-import org.apache.fluss.client.ConnectionFactory;
-import org.apache.fluss.client.admin.Admin;
-import org.apache.fluss.config.ConfigOptions;
-import org.apache.fluss.config.Configuration;
-import org.apache.fluss.exception.FlussRuntimeException;
-import org.apache.fluss.exception.InvalidTableException;
-import org.apache.fluss.flink.lake.LakeCatalog;
-import org.apache.fluss.flink.procedure.ProcedureManager;
-import org.apache.fluss.flink.utils.CatalogExceptionUtils;
-import org.apache.fluss.flink.utils.DataLakeUtils;
-import org.apache.fluss.flink.utils.FlinkConversions;
-import org.apache.fluss.metadata.DatabaseDescriptor;
-import org.apache.fluss.metadata.PartitionInfo;
-import org.apache.fluss.metadata.PartitionSpec;
-import org.apache.fluss.metadata.TableDescriptor;
-import org.apache.fluss.metadata.TableInfo;
-import org.apache.fluss.metadata.TablePath;
-import org.apache.fluss.utils.ExceptionUtils;
-import org.apache.fluss.utils.IOUtils;
-
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
@@ -69,6 +48,27 @@ import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.procedures.Procedure;
+
+import org.apache.fluss.client.Connection;
+import org.apache.fluss.client.ConnectionFactory;
+import org.apache.fluss.client.admin.Admin;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.FlussRuntimeException;
+import org.apache.fluss.exception.InvalidTableException;
+import org.apache.fluss.flink.lake.LakeCatalog;
+import org.apache.fluss.flink.procedure.ProcedureManager;
+import org.apache.fluss.flink.utils.CatalogExceptionUtils;
+import org.apache.fluss.flink.utils.DataLakeUtils;
+import org.apache.fluss.flink.utils.FlinkConversions;
+import org.apache.fluss.metadata.DatabaseDescriptor;
+import org.apache.fluss.metadata.PartitionInfo;
+import org.apache.fluss.metadata.PartitionSpec;
+import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.metadata.TableInfo;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.utils.ExceptionUtils;
+import org.apache.fluss.utils.IOUtils;
 
 import javax.annotation.Nullable;
 
@@ -110,7 +110,7 @@ public class FlinkCatalog extends AbstractCatalog {
     protected final String catalogName;
     protected final String defaultDatabase;
     protected final String bootstrapServers;
-    private final Map<String, String> securityConfigs;
+    protected final Map<String, String> securityConfigs;
     protected Connection connection;
     protected Admin admin;
     private volatile @Nullable LakeCatalog lakeCatalog;

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/FlinkConversions.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/FlinkConversions.java
@@ -17,6 +17,15 @@
 
 package org.apache.fluss.flink.utils;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.types.RowKind;
+
 import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.config.ConfigOption;
 import org.apache.fluss.config.FlussConfigUtils;
@@ -34,15 +43,6 @@ import org.apache.fluss.types.DataType;
 import org.apache.fluss.types.RowType;
 import org.apache.fluss.utils.StringUtils;
 import org.apache.fluss.utils.TimeUtils;
-
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.table.catalog.CatalogDatabase;
-import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.Column;
-import org.apache.flink.table.catalog.ResolvedCatalogTable;
-import org.apache.flink.table.catalog.ResolvedSchema;
-import org.apache.flink.table.catalog.exceptions.CatalogException;
-import org.apache.flink.types.RowKind;
 
 import java.time.Duration;
 import java.util.ArrayList;

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -17,13 +17,6 @@
 
 package org.apache.fluss.flink.catalog;
 
-import org.apache.fluss.cluster.ServerNode;
-import org.apache.fluss.config.ConfigOptions;
-import org.apache.fluss.config.Configuration;
-import org.apache.fluss.exception.InvalidTableException;
-import org.apache.fluss.metadata.TablePath;
-import org.apache.fluss.server.testutils.FlussClusterExtension;
-
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
@@ -37,6 +30,13 @@ import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
+
+import org.apache.fluss.cluster.ServerNode;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.InvalidTableException;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.server.testutils.FlussClusterExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -82,7 +82,7 @@ abstract class FlinkCatalogITCase {
 
     static final String CATALOG_NAME = "testcatalog";
     static final String DEFAULT_DB = FlinkCatalogOptions.DEFAULT_DATABASE.defaultValue();
-    static Catalog catalog;
+    static FlinkCatalog catalog;
 
     protected TableEnvironment tEnv;
 
@@ -673,7 +673,7 @@ abstract class FlinkCatalogITCase {
                         "The configured default-database 'non-exist' does not exist in the Fluss cluster.");
     }
 
-    private static void assertOptionsEqual(
+    protected static void assertOptionsEqual(
             Map<String, String> actualOptions, Map<String, String> expectedOptions) {
         actualOptions.remove(ConfigOptions.BOOTSTRAP_SERVERS.key());
         actualOptions.remove(ConfigOptions.TABLE_REPLICATION_FACTOR.key());

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceITCase.java
@@ -17,21 +17,6 @@
 
 package org.apache.fluss.flink.source;
 
-import org.apache.fluss.client.Connection;
-import org.apache.fluss.client.ConnectionFactory;
-import org.apache.fluss.client.admin.Admin;
-import org.apache.fluss.client.metadata.KvSnapshots;
-import org.apache.fluss.client.table.Table;
-import org.apache.fluss.client.table.writer.UpsertWriter;
-import org.apache.fluss.config.ConfigOptions;
-import org.apache.fluss.config.Configuration;
-import org.apache.fluss.metadata.TablePath;
-import org.apache.fluss.row.GenericRow;
-import org.apache.fluss.row.InternalRow;
-import org.apache.fluss.server.testutils.FlussClusterExtension;
-import org.apache.fluss.utils.clock.ManualClock;
-
-import org.apache.commons.lang3.RandomUtils;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
@@ -45,6 +30,21 @@ import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.fluss.client.Connection;
+import org.apache.fluss.client.ConnectionFactory;
+import org.apache.fluss.client.admin.Admin;
+import org.apache.fluss.client.metadata.KvSnapshots;
+import org.apache.fluss.client.table.Table;
+import org.apache.fluss.client.table.writer.UpsertWriter;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.row.GenericRow;
+import org.apache.fluss.row.InternalRow;
+import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.utils.clock.ManualClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
### Purpose

Linked issue: close #1143

Support delta join on Flink 2.1.

### Brief change log

- Introduce a specific Catalog for Flink 2.1 and override the `getTable` method.
- Treat pk as an index in the schema.
- Treat bucket keys and partition keys that serve as primary key prefixes as an index in the schema.
- Add tests for Catalog#getTable and Delta Join

### Tests

- Flink21CatalogITCase 
- Flink21TableSourceITCase

### API and Format

None.

### Documentation

None.
