### PR TITLE
[filesystem] fix the size of fluss-fs-s3 is too big

### DIFF
--- a/fluss-filesystems/fluss-fs-azure/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-azure/src/main/resources/META-INF/NOTICE
@@ -32,11 +32,11 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-configuration2:2.8.0
 - org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-text:1.10.0
-- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.2.0
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21:1.2.0
 - org.apache.hadoop:hadoop-annotations:3.4.0
 - org.apache.hadoop:hadoop-auth:3.4.0
-- org.apache.hadoop:hadoop-azure:3.4.0
+- org.apache.hadoop:hadoop-azure:3.3.4
 - org.apache.hadoop:hadoop-common:3.4.0
 - org.apache.kerby:kerb-core:2.0.3
 - org.apache.kerby:kerby-asn1:2.0.3
@@ -44,8 +44,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-util:2.0.3
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.13
+- org.codehaus.jackson:jackson-core-asl:1.9.13
+- org.codehaus.jackson:jackson-mapper-asl:1.9.13
 - org.codehaus.jettison:jettison:1.5.4
-- org.wildfly.openssl:wildfly-openssl:1.1.3.Final
+- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 - org.xerial.snappy:snappy-java:1.1.10.4
 
 This project bundles the following dependencies under the BSD license. See bundled license files for details.
@@ -76,5 +78,5 @@ This project bundles the following dependencies under the Eclipse Public License
 - EPL-2.0: https://www.eclipse.org/legal/epl-2.0/
 - Apache-2.0: http://www.apache.org/licenses/LICENSE-2.0.txt
 
-- org.eclipse.jetty:jetty-util-ajax:9.4.53.v20231009
-- org.eclipse.jetty:jetty-util:9.4.53.v20231009
+- org.eclipse.jetty:jetty-util-ajax:9.4.43.v20210629
+- org.eclipse.jetty:jetty-util:9.4.43.v20210629

--- a/fluss-filesystems/fluss-fs-gs/pom.xml
+++ b/fluss-filesystems/fluss-fs-gs/pom.xml
@@ -82,10 +82,6 @@
                     <artifactId>jersey-server</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.github.pjfanning</groupId>
-                    <artifactId>jersey-json</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>
                 </exclusion>

--- a/fluss-filesystems/fluss-fs-gs/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-gs/src/main/resources/META-INF/NOTICE
@@ -5,7 +5,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.15.3
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
-- com.fasterxml.woodstox:woodstox-core:5.4.0
+- com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.android:annotations:4.1.1.4
 - com.google.api-client:google-api-client-jackson2:2.0.1
 - com.google.api-client:google-api-client:2.2.0
@@ -45,9 +45,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.16.0
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.14.0
-- commons-logging:commons-logging:1.2
-- io.dropwizard.metrics:metrics-core:3.2.4
+- commons-io:commons-io:2.8.0
+- commons-logging:commons-logging:1.1.3
 - io.grpc:grpc-alts:1.59.1
 - io.grpc:grpc-api:1.59.1
 - io.grpc:grpc-auth:1.59.1
@@ -65,15 +64,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.grpc:grpc-stub:1.59.1
 - io.grpc:grpc-util:1.59.1
 - io.grpc:grpc-xds:1.59.1
-- io.netty:netty-buffer:4.1.100.Final
-- io.netty:netty-codec:4.1.100.Final
-- io.netty:netty-common:4.1.100.Final
-- io.netty:netty-handler:4.1.100.Final
-- io.netty:netty-resolver:4.1.100.Final
-- io.netty:netty-transport-classes-epoll:4.1.100.Final
-- io.netty:netty-transport-native-epoll:4.1.100.Final
-- io.netty:netty-transport-native-unix-common:4.1.100.Final
-- io.netty:netty-transport:4.1.100.Final
 - io.opencensus:opencensus-api:0.31.1
 - io.opencensus:opencensus-contrib-exemplar-util:0.31.0
 - io.opencensus:opencensus-contrib-grpc-metrics:0.31.0
@@ -85,23 +75,21 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.opencensus:opencensus-impl-core:0.31.0
 - io.opencensus:opencensus-proto:0.2.0
 - io.perfmark:perfmark-api:0.26.0
-- org.apache.commons:commons-compress:1.24.0
-- org.apache.commons:commons-configuration2:2.8.0
+- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.18.0
-- org.apache.commons:commons-text:1.10.0
-- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.2.0
-- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21:1.2.0
-- org.apache.hadoop:hadoop-annotations:3.4.0
-- org.apache.hadoop:hadoop-auth:3.4.0
-- org.apache.hadoop:hadoop-common:3.4.0
+- org.apache.commons:commons-text:1.4
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
+- org.apache.hadoop:hadoop-annotations:3.3.4
+- org.apache.hadoop:hadoop-auth:3.3.4
+- org.apache.hadoop:hadoop-common:3.3.4
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.13
-- org.apache.kerby:kerb-core:2.0.3
-- org.apache.kerby:kerby-asn1:2.0.3
-- org.apache.kerby:kerby-pkix:2.0.3
-- org.apache.kerby:kerby-util:2.0.3
-- org.bouncycastle:bcprov-jdk15on:1.70
-- org.codehaus.jettison:jettison:1.5.4
+- org.apache.kerby:kerb-core:1.0.1
+- org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
+- org.apache.kerby:kerby-util:1.0.1
 - org.conscrypt:conscrypt-openjdk-uber:2.5.2
 - org.xerial.snappy:snappy-java:1.1.10.4
 
@@ -113,7 +101,7 @@ See bundled license files for details.
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 See bundled license files for details.
 
-- dnsjava:dnsjava:3.4.0
+- dnsjava:dnsjava:2.1.7
 
 This project bundles the following dependencies under BSD-3 License (https://opensource.org/licenses/BSD-3-Clause).
 See bundled license files for details.

--- a/fluss-filesystems/fluss-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -9,40 +9,28 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.15.3
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
-- com.fasterxml.woodstox:woodstox-core:5.4.0
+- com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 - com.google.j2objc:j2objc-annotations:1.1
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.14.0
-- commons-logging:commons-logging:1.2
-- io.dropwizard.metrics:metrics-core:3.2.4
-- io.netty:netty-buffer:4.1.100.Final
-- io.netty:netty-codec:4.1.100.Final
-- io.netty:netty-common:4.1.100.Final
-- io.netty:netty-handler:4.1.100.Final
-- io.netty:netty-resolver:4.1.100.Final
-- io.netty:netty-transport-classes-epoll:4.1.100.Final
-- io.netty:netty-transport-native-epoll:4.1.100.Final
-- io.netty:netty-transport-native-unix-common:4.1.100.Final
-- io.netty:netty-transport:4.1.100.Final
-- org.apache.commons:commons-compress:1.24.0
-- org.apache.commons:commons-configuration2:2.8.0
+- commons-io:commons-io:2.8.0
+- commons-logging:commons-logging:1.1.3
+- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.18.0
-- org.apache.commons:commons-text:1.10.0
-- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.2.0
-- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21:1.2.0
-- org.apache.hadoop:hadoop-annotations:3.4.0
-- org.apache.hadoop:hadoop-auth:3.4.0
-- org.apache.hadoop:hadoop-common:3.4.0
-- org.apache.kerby:kerb-core:2.0.3
-- org.apache.kerby:kerby-asn1:2.0.3
-- org.apache.kerby:kerby-pkix:2.0.3
-- org.apache.kerby:kerby-util:2.0.3
-- org.bouncycastle:bcprov-jdk15on:1.70
-- org.codehaus.jettison:jettison:1.5.4
+- org.apache.commons:commons-text:1.4
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
+- org.apache.hadoop:hadoop-annotations:3.3.4
+- org.apache.hadoop:hadoop-auth:3.3.4
+- org.apache.hadoop:hadoop-common:3.3.4
+- org.apache.kerby:kerb-core:1.0.1
+- org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
+- org.apache.kerby:kerby-util:1.0.1
 - org.xerial.snappy:snappy-java:1.1.10.4
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
@@ -54,7 +42,7 @@ See bundled license files for details.
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 See bundled license files for details.
 
-- dnsjava:dnsjava:3.4.0
+- dnsjava:dnsjava:2.1.7
 
 This project bundles the following dependencies under the Go License (https://golang.org/LICENSE).
 See bundled license files for details.

--- a/fluss-filesystems/fluss-fs-hdfs/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-hdfs/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,11 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.15.3
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
-- org.apache.hadoop:hadoop-hdfs-client:3.4.0
+- com.squareup.okhttp3:okhttp:4.9.3
+- com.squareup.okio:okio:2.8.0
+- org.apache.hadoop:hadoop-hdfs-client:3.3.4
+- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10
+- org.jetbrains.kotlin:kotlin-stdlib:1.4.10
 
 This project bundles the following dependencies under BSD-3 License (https://opensource.org/licenses/BSD-3-Clause).
 See bundled license files for details.

--- a/fluss-filesystems/fluss-fs-oss/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-oss/src/main/resources/META-INF/NOTICE
@@ -40,7 +40,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.opentracing:opentracing-noop:0.33.0
 - io.opentracing:opentracing-util:0.33.0
 - jakarta.activation:jakarta.activation-api:1.2.1
-- org.apache.hadoop:hadoop-aliyun:3.4.0
+- org.apache.hadoop:hadoop-aliyun:3.3.4
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.2.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21:1.2.0
 - org.apache.httpcomponents:httpclient:4.5.13

--- a/fluss-filesystems/fluss-fs-s3/pom.xml
+++ b/fluss-filesystems/fluss-fs-s3/pom.xml
@@ -75,10 +75,6 @@
                     <artifactId>jersey-server</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.github.pjfanning</groupId>
-                    <artifactId>jersey-json</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>
                 </exclusion>

--- a/fluss-filesystems/fluss-fs-s3/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-s3/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.15.3
-- com.fasterxml.woodstox:woodstox-core:5.4.0
+- com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
@@ -21,46 +21,33 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.15
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.14.0
+- commons-io:commons-io:2.8.0
 - commons-logging:commons-logging:1.1.3
-- io.dropwizard.metrics:metrics-core:3.2.4
-- io.netty:netty-buffer:4.1.100.Final
-- io.netty:netty-codec:4.1.100.Final
-- io.netty:netty-common:4.1.100.Final
-- io.netty:netty-handler:4.1.100.Final
-- io.netty:netty-resolver:4.1.100.Final
-- io.netty:netty-transport-classes-epoll:4.1.100.Final
-- io.netty:netty-transport-native-epoll:4.1.100.Final
-- io.netty:netty-transport-native-unix-common:4.1.100.Final
-- io.netty:netty-transport:4.1.100.Final
 - joda-time:joda-time:2.8.1
-- org.apache.commons:commons-compress:1.24.0
-- org.apache.commons:commons-configuration2:2.8.0
+- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.18.0
-- org.apache.commons:commons-text:1.10.0
-- org.apache.hadoop:hadoop-annotations:3.4.0
-- org.apache.hadoop:hadoop-auth:3.4.0
-- org.apache.hadoop:hadoop-aws:3.4.0
-- org.apache.hadoop:hadoop-common:3.4.0
-- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.2.0
-- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21:1.2.0
+- org.apache.commons:commons-text:1.4
+- org.apache.hadoop:hadoop-annotations:3.3.4
+- org.apache.hadoop:hadoop-auth:3.3.4
+- org.apache.hadoop:hadoop-aws:3.3.4
+- org.apache.hadoop:hadoop-common:3.3.4
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.13
-- org.apache.kerby:kerb-core:2.0.3
-- org.apache.kerby:kerby-asn1:2.0.3
-- org.apache.kerby:kerby-pkix:2.0.3
-- org.apache.kerby:kerby-util:2.0.3
-- org.bouncycastle:bcprov-jdk15on:1.70
-- org.codehaus.jettison:jettison:1.5.4
-- org.wildfly.openssl:wildfly-openssl:1.1.3.Final
+- org.apache.kerby:kerb-core:1.0.1
+- org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
+- org.apache.kerby:kerby-util:1.0.1
+- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 - org.xerial.snappy:snappy-java:1.1.10.4
-- software.amazon.awssdk:bundle:2.23.19
 - software.amazon.ion:ion-java:1.0.2
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 See bundled license files for details.
 
-- dnsjava:dnsjava:3.4.0
+- dnsjava:dnsjava:2.1.7
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
 See bundled license files for details.

--- a/fluss-filesystems/pom.xml
+++ b/fluss-filesystems/pom.xml
@@ -41,7 +41,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <fs.hadoopshaded.version>3.4.0</fs.hadoopshaded.version>
+        <fs.hadoopshaded.version>3.3.4</fs.hadoopshaded.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
     </properties>
 

--- a/website/docs/maintenance/filesystems/hdfs.md
+++ b/website/docs/maintenance/filesystems/hdfs.md
@@ -56,7 +56,7 @@ fluss.hadoop.hadoop.security.kerberos.ticket.cache.path: /tmp/krb5cc_1000
 
 #### Use Machine Hadoop Environment Configuration
 
-Fluss includes bundled Hadoop libraries with version 3.4.0 for deploying Fluss in machine without Hadoop installed. 
+Fluss includes bundled Hadoop libraries with version 3.3.4 for deploying Fluss in machine without Hadoop installed. 
 For most use cases, these work perfectly. However, you should configure your machine's native Hadoop environment if:
 1. Your HDFS uses kerberos security
 2. You need to avoid version conflicts between Fluss's bundled hadoop libraries and your HDFS cluster


### PR DESCRIPTION
### Purpose

Linked issue: close https://github.com/apache/fluss/issues/2412


### Brief change log
Because [pr2009](https://github.com/apache/fluss/pull/2009) upgraded Hadoop to version 3.4.0, it became dependent on the   `aws-java-sdk-v2`'s bundle JAR, which is 500+M in size.
This pr downgrades the Hadoop version in the `fluss-filesystems` module to 3.3.4.
