### PR TITLE
[spark] Fix empty projection issue in Spark batch read to avoid Arrow metadata errors with COUNT(*)/COUNT(1)

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/record/FileLogProjection.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/FileLogProjection.java
@@ -231,7 +231,9 @@ public class FileLogProjection {
                             currentProjection.bodyCompression);
             checkState(
                     headerMetadata.length == currentProjection.arrowMetadataLength,
-                    "Invalid metadata length");
+                    "Invalid Arrow metadata length: actual=%s, expected=%s",
+                    headerMetadata.length,
+                    currentProjection.arrowMetadataLength);
 
             // 4. update and copy log batch header
             logHeaderBuffer.position(LENGTH_OFFSET);

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussBatch.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussBatch.scala
@@ -53,12 +53,14 @@ abstract class FlussBatch(
 
   protected def projection: Array[Int] = {
     val columnNameToIndex = tableInfo.getSchema.getColumnNames.asScala.zipWithIndex.toMap
-    readSchema.fields.map {
+    val projectedColumns = readSchema.fields.map {
       field =>
         columnNameToIndex.getOrElse(
           field.name,
           throw new IllegalArgumentException(s"Invalid field name: ${field.name}"))
     }
+    // COUNT(*) may prune all columns; ensure at least one column to avoid Arrow metadata error.
+    if (projectedColumns.isEmpty) Array(0) else projectedColumns
   }
 
   override def close(): Unit = {

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkPrimaryKeyTableReadTest.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkPrimaryKeyTableReadTest.scala
@@ -75,6 +75,12 @@ class SparkPrimaryKeyTableReadTest extends FlussSparkTestBase {
           Row(1000L, 25L, 605, "addr5") :: Nil
       )
 
+      // Test COUNT(*) pushdown
+      checkAnswer(
+        sql(s"SELECT COUNT(*) FROM $DEFAULT_DATABASE.t"),
+        Row(5L) :: Nil
+      )
+
       // Trigger snapshot.
       flussServer.triggerAndWaitSnapshot(tablePath)
       inputPartitions = genInputPartition(tablePath, null)
@@ -131,6 +137,11 @@ class SparkPrimaryKeyTableReadTest extends FlussSparkTestBase {
           Row(700L, 220L, "addr2") ::
           Row(800L, 23L, "addr3") ::
           Nil
+      )
+
+      checkAnswer(
+        sql(s"SELECT COUNT(*) FROM $DEFAULT_DATABASE.t"),
+        Row(6L) :: Nil
       )
 
       // Only support FULL startup mode.
@@ -238,6 +249,11 @@ class SparkPrimaryKeyTableReadTest extends FlussSparkTestBase {
           Row(800L, 23L, 603, "addr3", "2026-01-02") ::
           Row(900L, 240L, 604, "addr4_updated", "2026-01-02") ::
           Nil
+      )
+
+      checkAnswer(
+        sql(s"SELECT COUNT(*) FROM $DEFAULT_DATABASE.t"),
+        Row(6L) :: Nil
       )
     }
   }


### PR DESCRIPTION
… metadata errors with COUNT(*)/COUNT(1)

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
