### PR TITLE
[FLUSS-2686] Add COS filesystem support

### DIFF
--- a/fluss-filesystems/fluss-fs-cos/pom.xml
+++ b/fluss-filesystems/fluss-fs-cos/pom.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.fluss</groupId>
+        <artifactId>fluss-filesystems</artifactId>
+        <version>0.10-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>fluss-fs-cos</artifactId>
+    <name>Fluss : FileSystems : COS FS</name>
+
+    <properties>
+        <fs.cosn.sdk.version>3.3.5</fs.cosn.sdk.version>
+        <fs.cos.api.version>5.6.139</fs.cos.api.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-fs-hadoop-shaded</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-fs-hadoop</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-cos</artifactId>
+            <version>${fs.cosn.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.qcloud</groupId>
+                    <artifactId>cos_api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.qcloud</groupId>
+            <artifactId>cos_api</artifactId>
+            <version>${fs.cos.api.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <!-- Hadoop requires jaxb-api for javax.xml.bind.JAXBException -->
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.api.version}</version>
+            <!-- packaged as an optional dependency that is only accessible on Java 11+ -->
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-test-utils</artifactId>
+        </dependency>
+        <!-- for the behavior test suite -->
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <!-- jaxb-api is packaged as an optional dependency that is only accessible on Java 11 -->
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-javax-jars</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactItems>
+                        <artifactItem>
+                            <groupId>javax.xml.bind</groupId>
+                            <artifactId>jaxb-api</artifactId>
+                            <version>${jaxb.api.version}</version>
+                            <type>jar</type>
+                            <overWrite>true</overWrite>
+                        </artifactItem>
+                    </artifactItems>
+                    <outputDirectory>${project.build.directory}/temporary</outputDirectory>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-javax-libraries</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <echo message="unpacking javax jars"/>
+                                <unzip dest="${project.build.directory}/classes/META-INF/versions/11">
+                                    <fileset dir="${project.build.directory}/temporary">
+                                        <include name="*"/>
+                                    </fileset>
+                                </unzip>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-fluss</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>*:*</include>
+                                </includes>
+                                <excludes>
+                                    <exclude>javax.servlet:servlet-api</exclude>
+                                    <exclude>xmlenc:xmlenc</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*</artifact>
+                                    <excludes>
+                                        <exclude>.gitkeep</exclude>
+                                        <exclude>mime.types</exclude>
+                                        <exclude>mozilla/**</exclude>
+                                        <exclude>LICENSE.txt</exclude>
+                                        <exclude>license/LICENSE*</exclude>
+                                        <exclude>okhttp3/internal/publicsuffix/NOTICE</exclude>
+                                        <exclude>NOTICE</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.fluss:fluss-fs-hadoop</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/fluss-filesystems/fluss-fs-cos/pom.xml
+++ b/fluss-filesystems/fluss-fs-cos/pom.xml
@@ -121,8 +121,15 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>default-jar</id>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -237,17 +244,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/fluss-filesystems/fluss-fs-cos/pom.xml
+++ b/fluss-filesystems/fluss-fs-cos/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.fluss</groupId>
         <artifactId>fluss-filesystems</artifactId>
-        <version>0.10-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>fluss-fs-cos</artifactId>

--- a/fluss-filesystems/fluss-fs-cos/pom.xml
+++ b/fluss-filesystems/fluss-fs-cos/pom.xml
@@ -65,6 +65,16 @@
                     <groupId>com.qcloud</groupId>
                     <artifactId>cos_api</artifactId>
                 </exclusion>
+                <!--
+                  Exclude the bundled COS SDK shipped by hadoop-cos to avoid having two
+                  COS SDK variants on the classpath (cos_api-bundle:5.6.69 and the directly
+                  declared cos_api:${fs.cos.api.version}), which produces hundreds of
+                  overlapping com.qcloud.cos.* classes during shading.
+                -->
+                <exclusion>
+                    <groupId>com.qcloud</groupId>
+                    <artifactId>cos_api-bundle</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-common</artifactId>

--- a/fluss-filesystems/fluss-fs-cos/pom.xml
+++ b/fluss-filesystems/fluss-fs-cos/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <fs.cosn.sdk.version>3.3.5</fs.cosn.sdk.version>
         <fs.cos.api.version>5.6.139</fs.cos.api.version>
+        <fs.cos.sts.sdk.version>3.1.678</fs.cos.sts.sdk.version>
     </properties>
 
     <dependencies>
@@ -83,6 +84,18 @@
             <groupId>com.qcloud</groupId>
             <artifactId>cos_api</artifactId>
             <version>${fs.cos.api.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.tencentcloudapi</groupId>
+            <artifactId>tencentcloud-sdk-java-sts</artifactId>
+            <version>${fs.cos.sts.sdk.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>

--- a/fluss-filesystems/fluss-fs-cos/pom.xml
+++ b/fluss-filesystems/fluss-fs-cos/pom.xml
@@ -31,7 +31,7 @@
     <name>Fluss : FileSystems : COS FS</name>
 
     <properties>
-        <fs.cosn.sdk.version>3.3.5</fs.cosn.sdk.version>
+        <fs.hadoop.cos.version>3.3.5</fs.hadoop.cos.version>
         <fs.cos.api.version>5.6.139</fs.cos.api.version>
         <fs.cos.sts.sdk.version>3.1.678</fs.cos.sts.sdk.version>
     </properties>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-cos</artifactId>
-            <version>${fs.cosn.sdk.version}</version>
+            <version>${fs.hadoop.cos.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.qcloud</groupId>

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystem.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystem.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos;
+
+import org.apache.fluss.fs.cos.token.COSSecurityTokenProvider;
+import org.apache.fluss.fs.hdfs.HadoopFileSystem;
+import org.apache.fluss.fs.token.ObtainedSecurityToken;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+
+import java.io.IOException;
+
+/**
+ * A {@link FileSystem} for Tencent Cloud COS that wraps an {@link HadoopFileSystem}, but overwrite
+ * method to generate access security token.
+ */
+class COSFileSystem extends HadoopFileSystem {
+
+    private final Configuration conf;
+    private volatile COSSecurityTokenProvider cosSecurityTokenProvider;
+    private final String scheme;
+
+    COSFileSystem(FileSystem hadoopFileSystem, String scheme, Configuration conf) {
+        super(hadoopFileSystem);
+        this.scheme = scheme;
+        this.conf = conf;
+    }
+
+    @Override
+    public ObtainedSecurityToken obtainSecurityToken() throws IOException {
+        try {
+            mayCreateSecurityTokenProvider();
+            return cosSecurityTokenProvider.obtainSecurityToken(scheme);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    private void mayCreateSecurityTokenProvider() throws IOException {
+        if (cosSecurityTokenProvider == null) {
+            synchronized (this) {
+                if (cosSecurityTokenProvider == null) {
+                    cosSecurityTokenProvider = new COSSecurityTokenProvider(conf);
+                }
+            }
+        }
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystem.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystem.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
 import java.io.IOException;
+import java.net.URI;
 
 /**
  * A {@link FileSystem} for Tencent Cloud COS that wraps an {@link HadoopFileSystem}, but overwrite
@@ -35,10 +36,12 @@ class COSFileSystem extends HadoopFileSystem {
     private final Configuration conf;
     private volatile COSSecurityTokenProvider cosSecurityTokenProvider;
     private final String scheme;
+    private final URI fsUri;
 
-    COSFileSystem(FileSystem hadoopFileSystem, String scheme, Configuration conf) {
+    COSFileSystem(FileSystem hadoopFileSystem, String scheme, URI fsUri, Configuration conf) {
         super(hadoopFileSystem);
         this.scheme = scheme;
+        this.fsUri = fsUri;
         this.conf = conf;
     }
 
@@ -56,7 +59,7 @@ class COSFileSystem extends HadoopFileSystem {
         if (cosSecurityTokenProvider == null) {
             synchronized (this) {
                 if (cosSecurityTokenProvider == null) {
-                    cosSecurityTokenProvider = new COSSecurityTokenProvider(conf);
+                    cosSecurityTokenProvider = new COSSecurityTokenProvider(fsUri, conf);
                 }
             }
         }

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos;
+
+import org.apache.fluss.annotation.VisibleForTesting;
+import org.apache.fluss.config.ConfigBuilder;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.fs.FileSystem;
+import org.apache.fluss.fs.FileSystemPlugin;
+import org.apache.fluss.fs.cos.token.COSSecurityTokenReceiver;
+
+import org.apache.hadoop.fs.cosn.CosNFileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+
+/** Simple factory for the Tencent Cloud COS file system. */
+public class COSFileSystemPlugin implements FileSystemPlugin {
+
+    private static final Logger LOG = LoggerFactory.getLogger(COSFileSystemPlugin.class);
+
+    public static final String SCHEME = "cosn";
+
+    /**
+     * In order to simplify, we make fluss cos configuration keys same with hadoop cos module. So,
+     * we add all configuration key with prefix `fs.cosn` in fluss conf to hadoop conf.
+     */
+    private static final String[] FLUSS_CONFIG_PREFIXES = {"fs.cosn."};
+
+    private static final String SECRET_ID = "fs.cosn.userinfo.secretId";
+    public static final String CREDENTIALS_PROVIDER = "fs.cosn.credentials.provider";
+
+    public static final String ENDPOINT_KEY = "fs.cosn.endpoint";
+
+    @Override
+    public String getScheme() {
+        return SCHEME;
+    }
+
+    @Override
+    public FileSystem create(URI fsUri, Configuration flussConfig) throws IOException {
+        org.apache.hadoop.conf.Configuration hadoopConfig = getHadoopConfiguration(flussConfig);
+
+        // set credential provider
+        if (hadoopConfig.get(SECRET_ID) == null) {
+            String credentialsProvider = hadoopConfig.get(CREDENTIALS_PROVIDER);
+            if (credentialsProvider != null) {
+                LOG.info(
+                        "{} is not set, but {} is set, using credential provider {}.",
+                        SECRET_ID,
+                        CREDENTIALS_PROVIDER,
+                        credentialsProvider);
+            } else {
+                // no secretId, no credentialsProvider,
+                // set default credential provider which will get token from
+                // COSSecurityTokenReceiver
+                setDefaultCredentialProvider(hadoopConfig);
+            }
+        } else {
+            LOG.info("{} is set, using provided secret id and secret key.", SECRET_ID);
+        }
+
+        final String scheme = fsUri.getScheme();
+        final String authority = fsUri.getAuthority();
+
+        if (scheme == null && authority == null) {
+            fsUri = org.apache.hadoop.fs.FileSystem.getDefaultUri(hadoopConfig);
+        } else if (scheme != null && authority == null) {
+            URI defaultUri = org.apache.hadoop.fs.FileSystem.getDefaultUri(hadoopConfig);
+            if (scheme.equals(defaultUri.getScheme()) && defaultUri.getAuthority() != null) {
+                fsUri = defaultUri;
+            }
+        }
+
+        org.apache.hadoop.fs.FileSystem fileSystem = initFileSystem(fsUri, hadoopConfig);
+        return new COSFileSystem(fileSystem, getScheme(), hadoopConfig);
+    }
+
+    protected org.apache.hadoop.fs.FileSystem initFileSystem(
+            URI fsUri, org.apache.hadoop.conf.Configuration hadoopConfig) throws IOException {
+        CosNFileSystem fileSystem = new CosNFileSystem();
+        fileSystem.initialize(fsUri, hadoopConfig);
+        return fileSystem;
+    }
+
+    protected void setDefaultCredentialProvider(org.apache.hadoop.conf.Configuration hadoopConfig) {
+        // use COSSecurityTokenReceiver to update hadoop config to set credentialsProvider
+        COSSecurityTokenReceiver.updateHadoopConfig(hadoopConfig);
+    }
+
+    @VisibleForTesting
+    org.apache.hadoop.conf.Configuration getHadoopConfiguration(Configuration flussConfig) {
+        org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
+        if (flussConfig == null) {
+            return conf;
+        }
+
+        // read all configuration with prefix 'FLUSS_CONFIG_PREFIXES'
+        for (String key : flussConfig.keySet()) {
+            for (String prefix : FLUSS_CONFIG_PREFIXES) {
+                if (key.startsWith(prefix)) {
+                    String value =
+                            flussConfig.getString(
+                                    ConfigBuilder.key(key).stringType().noDefaultValue(), null);
+                    conf.set(key, value);
+
+                    LOG.debug(
+                            "Adding Fluss config entry for {} as {} to Hadoop config",
+                            key,
+                            conf.get(key));
+                }
+            }
+        }
+        return conf;
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
@@ -44,7 +44,8 @@ public class COSFileSystemPlugin implements FileSystemPlugin {
      */
     private static final String[] FLUSS_CONFIG_PREFIXES = {"fs.cosn."};
 
-    private static final String SECRET_ID = "fs.cosn.userinfo.secretId";
+    public static final String SECRET_ID = "fs.cosn.userinfo.secretId";
+    public static final String SECRET_KEY = "fs.cosn.userinfo.secretKey";
     public static final String CREDENTIALS_PROVIDER = "fs.cosn.credentials.provider";
 
     public static final String ENDPOINT_KEY = "fs.cosn.endpoint";

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
@@ -48,7 +48,7 @@ public class COSFileSystemPlugin implements FileSystemPlugin {
     public static final String SECRET_KEY = "fs.cosn.userinfo.secretKey";
     public static final String CREDENTIALS_PROVIDER = "fs.cosn.credentials.provider";
 
-    public static final String ENDPOINT_KEY = "fs.cosn.endpoint";
+    public static final String ENDPOINT_KEY = "fs.cosn.bucket.endpoint_suffix";
 
     @Override
     public String getScheme() {

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
@@ -48,6 +48,8 @@ public class COSFileSystemPlugin implements FileSystemPlugin {
     public static final String SECRET_KEY = "fs.cosn.userinfo.secretKey";
     public static final String CREDENTIALS_PROVIDER = "fs.cosn.credentials.provider";
 
+    public static final String REGION = "fs.cosn.userinfo.region";
+
     public static final String ENDPOINT_KEY = "fs.cosn.bucket.endpoint_suffix";
 
     @Override

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/COSFileSystemPlugin.java
@@ -52,6 +52,14 @@ public class COSFileSystemPlugin implements FileSystemPlugin {
 
     public static final String ENDPOINT_KEY = "fs.cosn.bucket.endpoint_suffix";
 
+    /**
+     * Optional user-provided STS access policy (a JSON string) applied when calling {@code
+     * GetFederationToken}. When unset, Fluss will derive a default policy that scopes the temporary
+     * credential to the bucket configured in {@code remote.data.dir} so that the token cannot
+     * access other COS resources.
+     */
+    public static final String SECURITY_TOKEN_POLICY = "fs.cosn.security.token.policy";
+
     @Override
     public String getScheme() {
         return SCHEME;
@@ -93,7 +101,7 @@ public class COSFileSystemPlugin implements FileSystemPlugin {
         }
 
         org.apache.hadoop.fs.FileSystem fileSystem = initFileSystem(fsUri, hadoopConfig);
-        return new COSFileSystem(fileSystem, getScheme(), hadoopConfig);
+        return new COSFileSystem(fileSystem, getScheme(), fsUri, hadoopConfig);
     }
 
     protected org.apache.hadoop.fs.FileSystem initFileSystem(

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
@@ -27,12 +27,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.ENDPOINT_KEY;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_ID;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_KEY;
 
 /** A provider to provide Tencent Cloud COS security token. */
 public class COSSecurityTokenProvider {
-
-    private static final String SECRET_ID = "fs.cosn.userinfo.secretId";
-    private static final String SECRET_KEY = "fs.cosn.userinfo.secretKey";
 
     private final String endpoint;
     private final String secretId;

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos.token;
+
+import org.apache.fluss.fs.token.Credentials;
+import org.apache.fluss.fs.token.CredentialsJsonSerde;
+import org.apache.fluss.fs.token.ObtainedSecurityToken;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.ENDPOINT_KEY;
+
+/** A provider to provide Tencent Cloud COS security token. */
+public class COSSecurityTokenProvider {
+
+    private static final String SECRET_ID = "fs.cosn.userinfo.secretId";
+    private static final String SECRET_KEY = "fs.cosn.userinfo.secretKey";
+
+    private final String endpoint;
+    private final String secretId;
+    private final String secretKey;
+
+    public COSSecurityTokenProvider(Configuration conf) {
+        endpoint = conf.get(ENDPOINT_KEY);
+        secretId = conf.get(SECRET_ID);
+        secretKey = conf.get(SECRET_KEY);
+    }
+
+    public ObtainedSecurityToken obtainSecurityToken(String scheme) {
+        // For COS, we directly use the configured secret id and secret key as the token.
+        // If STS temporary credentials are needed in the future, this can be extended
+        // to call Tencent Cloud STS API to get temporary credentials.
+        Map<String, String> additionInfo = new HashMap<>();
+        // we need to put endpoint as addition info
+        if (endpoint != null) {
+            additionInfo.put(ENDPOINT_KEY, endpoint);
+        }
+
+        Credentials credentials = new Credentials(secretId, secretKey, null);
+        byte[] tokenBytes = CredentialsJsonSerde.toJson(credentials);
+
+        // token does not expire when using static credentials
+        return new ObtainedSecurityToken(scheme, tokenBytes, Long.MAX_VALUE, additionInfo);
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
@@ -21,42 +21,108 @@ import org.apache.fluss.fs.token.Credentials;
 import org.apache.fluss.fs.token.CredentialsJsonSerde;
 import org.apache.fluss.fs.token.ObtainedSecurityToken;
 
+import com.tencentcloudapi.common.Credential;
+import com.tencentcloudapi.common.exception.TencentCloudSDKException;
+import com.tencentcloudapi.sts.v20180813.StsClient;
+import com.tencentcloudapi.sts.v20180813.models.GetFederationTokenRequest;
+import com.tencentcloudapi.sts.v20180813.models.GetFederationTokenResponse;
 import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.ENDPOINT_KEY;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.REGION;
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_ID;
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_KEY;
+import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
-/** A provider to provide Tencent Cloud COS security token. */
+/**
+ * A provider to provide Tencent Cloud COS security token by calling STS GetFederationToken API to
+ * obtain temporary credentials.
+ */
 public class COSSecurityTokenProvider {
 
-    private final String endpoint;
+    private static final Logger LOG = LoggerFactory.getLogger(COSSecurityTokenProvider.class);
+
+    /** Default federation token name. */
+    private static final String FEDERATION_TOKEN_NAME = "fluss-cos-federation";
+
+    /** Default duration seconds for temporary credentials, 1800s = 30min. */
+    private static final long DEFAULT_DURATION_SECONDS = 1800L;
+
+    /**
+     * Default COS full read-write policy that allows all COS operations. See <a
+     * href="https://cloud.tencent.com/document/product/436/6884">Tencent Cloud COS doc</a>.
+     */
+    private static final String DEFAULT_POLICY =
+            "{"
+                    + "\"version\": \"2.0\","
+                    + "\"statement\": [{"
+                    + "\"action\": [\"name/cos:*\"],"
+                    + "\"effect\": \"allow\","
+                    + "\"resource\": [\"*\"]"
+                    + "}]"
+                    + "}";
+
+    private final String region;
     private final String secretId;
     private final String secretKey;
+    private final Map<String, String> additionInfos;
 
     public COSSecurityTokenProvider(Configuration conf) {
-        endpoint = conf.get(ENDPOINT_KEY);
-        secretId = conf.get(SECRET_ID);
-        secretKey = conf.get(SECRET_KEY);
+        this.region = conf.get(REGION);
+        checkNotNull(region, "Region is not set. Please set " + REGION);
+        this.secretId = conf.get(SECRET_ID);
+        checkNotNull(secretId, "Secret ID is not set. Please set " + SECRET_ID);
+        this.secretKey = conf.get(SECRET_KEY);
+        checkNotNull(secretKey, "Secret Key is not set. Please set " + SECRET_KEY);
+
+        this.additionInfos = new HashMap<>();
+        for (String key : Arrays.asList(REGION, ENDPOINT_KEY)) {
+            if (conf.get(key) != null) {
+                additionInfos.put(key, conf.get(key));
+            }
+        }
     }
 
-    public ObtainedSecurityToken obtainSecurityToken(String scheme) {
-        // For COS, we directly use the configured secret id and secret key as the token.
-        // If STS temporary credentials are needed in the future, this can be extended
-        // to call Tencent Cloud STS API to get temporary credentials.
-        Map<String, String> additionInfo = new HashMap<>();
-        // we need to put endpoint as addition info
-        if (endpoint != null) {
-            additionInfo.put(ENDPOINT_KEY, endpoint);
-        }
+    public ObtainedSecurityToken obtainSecurityToken(String scheme)
+            throws TencentCloudSDKException {
+        LOG.info("Obtaining session credentials token with secret id: {}", secretId);
 
-        Credentials credentials = new Credentials(secretId, secretKey, null);
-        byte[] tokenBytes = CredentialsJsonSerde.toJson(credentials);
+        Credential cred = new Credential(secretId, secretKey);
+        StsClient stsClient = new StsClient(cred, region);
 
-        // token does not expire when using static credentials
-        return new ObtainedSecurityToken(scheme, tokenBytes, Long.MAX_VALUE, additionInfo);
+        GetFederationTokenRequest request = new GetFederationTokenRequest();
+        request.setName(FEDERATION_TOKEN_NAME);
+        request.setDurationSeconds(DEFAULT_DURATION_SECONDS);
+        request.setPolicy(DEFAULT_POLICY);
+
+        GetFederationTokenResponse response = stsClient.GetFederationToken(request);
+        com.tencentcloudapi.sts.v20180813.models.Credentials stsCredentials =
+                response.getCredentials();
+
+        // ExpiredTime is a Unix timestamp in seconds, convert to milliseconds
+        long expiredTimeMillis = response.getExpiredTime() * 1000L;
+
+        LOG.info(
+                "Session credentials obtained successfully with tmp secret id: {}, expiration: {}",
+                stsCredentials.getTmpSecretId(),
+                response.getExpiration());
+
+        return new ObtainedSecurityToken(
+                scheme, toJson(stsCredentials), expiredTimeMillis, additionInfos);
+    }
+
+    private byte[] toJson(com.tencentcloudapi.sts.v20180813.models.Credentials stsCredentials) {
+        Credentials credentials =
+                new Credentials(
+                        stsCredentials.getTmpSecretId(),
+                        stsCredentials.getTmpSecretKey(),
+                        stsCredentials.getToken());
+        return CredentialsJsonSerde.toJson(credentials);
     }
 }

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +39,7 @@ import static org.apache.fluss.fs.cos.COSFileSystemPlugin.ENDPOINT_KEY;
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.REGION;
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_ID;
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_KEY;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECURITY_TOKEN_POLICY;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
 /**
@@ -54,32 +56,21 @@ public class COSSecurityTokenProvider {
     /** Default duration seconds for temporary credentials, 3600s = 1h. */
     private static final long DEFAULT_DURATION_SECONDS = 3600L;
 
-    /**
-     * Default COS full read-write policy that allows all COS operations. See <a
-     * href="https://cloud.tencent.com/document/product/436/6884">Tencent Cloud COS doc</a>.
-     */
-    private static final String DEFAULT_POLICY =
-            "{"
-                    + "\"version\": \"2.0\","
-                    + "\"statement\": [{"
-                    + "\"action\": [\"name/cos:*\"],"
-                    + "\"effect\": \"allow\","
-                    + "\"resource\": [\"*\"]"
-                    + "}]"
-                    + "}";
-
     private final String region;
     private final String secretId;
     private final String secretKey;
+    private final String policy;
     private final Map<String, String> additionInfos;
 
-    public COSSecurityTokenProvider(Configuration conf) {
+    public COSSecurityTokenProvider(URI fsUri, Configuration conf) {
+        checkNotNull(fsUri, "fsUri must not be null");
         this.region = conf.get(REGION);
         checkNotNull(region, "Region is not set. Please set " + REGION);
         this.secretId = conf.get(SECRET_ID);
         checkNotNull(secretId, "Secret ID is not set. Please set " + SECRET_ID);
         this.secretKey = conf.get(SECRET_KEY);
         checkNotNull(secretKey, "Secret Key is not set. Please set " + SECRET_KEY);
+        this.policy = resolvePolicy(conf, fsUri, region);
 
         this.additionInfos = new HashMap<>();
         for (String key : Arrays.asList(REGION, ENDPOINT_KEY)) {
@@ -99,7 +90,7 @@ public class COSSecurityTokenProvider {
         GetFederationTokenRequest request = new GetFederationTokenRequest();
         request.setName(FEDERATION_TOKEN_NAME);
         request.setDurationSeconds(DEFAULT_DURATION_SECONDS);
-        request.setPolicy(DEFAULT_POLICY);
+        request.setPolicy(policy);
 
         GetFederationTokenResponse response = stsClient.GetFederationToken(request);
         com.tencentcloudapi.sts.v20180813.models.Credentials stsCredentials =
@@ -115,6 +106,80 @@ public class COSSecurityTokenProvider {
 
         return new ObtainedSecurityToken(
                 scheme, toJson(stsCredentials), expiredTimeMillis, additionInfos);
+    }
+
+    /**
+     * Resolves the STS policy to apply when calling {@code GetFederationToken}.
+     *
+     * <p>If the user has explicitly configured {@link
+     * org.apache.fluss.fs.cos.COSFileSystemPlugin#SECURITY_TOKEN_POLICY}, that value is used as-is.
+     * Otherwise a default policy is built that scopes the temporary credential to the bucket and
+     * (optional) prefix derived from the fsUri (i.e. {@code remote.data.dir}), so the token cannot
+     * be used to access other COS resources.
+     */
+    private static String resolvePolicy(Configuration conf, URI fsUri, String region) {
+        String userPolicy = conf.get(SECURITY_TOKEN_POLICY);
+        if (userPolicy != null && !userPolicy.trim().isEmpty()) {
+            LOG.info(
+                    "Using user-provided STS policy from {} for COS federation token.",
+                    SECURITY_TOKEN_POLICY);
+            return userPolicy;
+        }
+        return buildBucketScopedPolicy(fsUri, region);
+    }
+
+    /**
+     * Builds a default STS policy that grants {@code name/cos:*} only on the bucket (and optional
+     * key prefix) referenced by the given fsUri.
+     *
+     * <p>COS resource format used here: {@code qcs::cos:<region>:uid/*:<bucket>/<prefix>*}. The
+     * wildcard owner uid keeps the policy independent of the account uin while still restricting
+     * access to a specific bucket.
+     */
+    private static String buildBucketScopedPolicy(URI fsUri, String region) {
+        String bucket = fsUri.getAuthority();
+        if (bucket == null || bucket.isEmpty()) {
+            // Fall back to all-resources policy if we cannot derive the bucket from fsUri.
+            LOG.warn(
+                    "Unable to derive bucket from fsUri {}. Falling back to a wildcard COS resource"
+                            + " policy. Consider explicitly configuring {} to a least-privilege"
+                            + " policy.",
+                    fsUri,
+                    SECURITY_TOKEN_POLICY);
+            return "{"
+                    + "\"version\": \"2.0\","
+                    + "\"statement\": [{"
+                    + "\"action\": [\"name/cos:*\"],"
+                    + "\"effect\": \"allow\","
+                    + "\"resource\": [\"*\"]"
+                    + "}]"
+                    + "}";
+        }
+
+        String path = fsUri.getPath();
+        String prefix;
+        if (path == null || path.isEmpty() || "/".equals(path)) {
+            prefix = "";
+        } else {
+            // Strip leading '/' so the resource pattern looks like "<bucket>/sub/dir/*".
+            prefix = path.startsWith("/") ? path.substring(1) : path;
+            if (!prefix.endsWith("/")) {
+                prefix = prefix + "/";
+            }
+        }
+
+        String resource = "qcs::cos:" + region + ":uid/*:" + bucket + "/" + prefix + "*";
+        LOG.info("Using bucket-scoped STS policy with resource: {}", resource);
+        return "{"
+                + "\"version\": \"2.0\","
+                + "\"statement\": [{"
+                + "\"action\": [\"name/cos:*\"],"
+                + "\"effect\": \"allow\","
+                + "\"resource\": [\""
+                + resource
+                + "\"]"
+                + "}]"
+                + "}";
     }
 
     private byte[] toJson(com.tencentcloudapi.sts.v20180813.models.Credentials stsCredentials) {

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
@@ -51,8 +51,8 @@ public class COSSecurityTokenProvider {
     /** Default federation token name. */
     private static final String FEDERATION_TOKEN_NAME = "fluss-cos-federation";
 
-    /** Default duration seconds for temporary credentials, 1800s = 30min. */
-    private static final long DEFAULT_DURATION_SECONDS = 1800L;
+    /** Default duration seconds for temporary credentials, 3600s = 1h. */
+    private static final long DEFAULT_DURATION_SECONDS = 3600L;
 
     /**
      * Default COS full read-write policy that allows all COS operations. See <a

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenReceiver.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenReceiver.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos.token;
+
+import org.apache.fluss.fs.cos.COSFileSystemPlugin;
+import org.apache.fluss.fs.token.CredentialsJsonSerde;
+import org.apache.fluss.fs.token.ObtainedSecurityToken;
+import org.apache.fluss.fs.token.SecurityTokenReceiver;
+
+import com.qcloud.cos.auth.BasicSessionCredentials;
+import com.qcloud.cos.auth.COSCredentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.CREDENTIALS_PROVIDER;
+
+/** Security token receiver for Tencent Cloud COS filesystem. */
+public class COSSecurityTokenReceiver implements SecurityTokenReceiver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(COSSecurityTokenReceiver.class);
+
+    static volatile COSCredentials credentials;
+    static volatile Map<String, String> additionInfos;
+
+    public static void updateHadoopConfig(org.apache.hadoop.conf.Configuration hadoopConfig) {
+        updateHadoopConfig(hadoopConfig, DynamicTemporaryCOSCredentialsProvider.NAME);
+    }
+
+    protected static void updateHadoopConfig(
+            org.apache.hadoop.conf.Configuration hadoopConfig, String credentialsProviderName) {
+        LOG.info("Updating Hadoop configuration");
+
+        String providers = hadoopConfig.get(CREDENTIALS_PROVIDER, "");
+
+        if (!providers.contains(credentialsProviderName)) {
+            if (providers.isEmpty()) {
+                LOG.debug("Setting provider");
+                providers = credentialsProviderName;
+            } else {
+                providers = credentialsProviderName + "," + providers;
+                LOG.debug("Prepending provider, new providers value: {}", providers);
+            }
+            hadoopConfig.set(CREDENTIALS_PROVIDER, providers);
+        } else {
+            LOG.debug("Provider already exists");
+        }
+
+        // then, set addition info
+        if (additionInfos == null) {
+            // if addition info is null, it also means we have not received any token,
+            throw new RuntimeException("Credentials is not ready.");
+        } else {
+            for (Map.Entry<String, String> entry : additionInfos.entrySet()) {
+                hadoopConfig.set(entry.getKey(), entry.getValue());
+            }
+        }
+
+        LOG.info("Updated Hadoop configuration successfully");
+    }
+
+    @Override
+    public String scheme() {
+        return COSFileSystemPlugin.SCHEME;
+    }
+
+    @Override
+    public void onNewTokensObtained(ObtainedSecurityToken token) {
+        LOG.info("Updating session credentials");
+
+        byte[] tokenBytes = token.getToken();
+
+        org.apache.fluss.fs.token.Credentials flussCredentials =
+                CredentialsJsonSerde.fromJson(tokenBytes);
+
+        // Create Credential from fluss credentials
+        credentials =
+                new BasicSessionCredentials(
+                        flussCredentials.getAccessKeyId(),
+                        flussCredentials.getSecretAccessKey(),
+                        flussCredentials.getSecurityToken());
+        additionInfos = token.getAdditionInfos();
+
+        LOG.info(
+                "Session credentials updated successfully with access key: {}.",
+                credentials.getCOSAccessKeyId());
+    }
+
+    public static COSCredentials getCredentials() {
+        return credentials;
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenReceiver.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenReceiver.java
@@ -22,6 +22,7 @@ import org.apache.fluss.fs.token.CredentialsJsonSerde;
 import org.apache.fluss.fs.token.ObtainedSecurityToken;
 import org.apache.fluss.fs.token.SecurityTokenReceiver;
 
+import com.qcloud.cos.auth.BasicCOSCredentials;
 import com.qcloud.cos.auth.BasicSessionCredentials;
 import com.qcloud.cos.auth.COSCredentials;
 import org.slf4j.Logger;
@@ -65,7 +66,10 @@ public class COSSecurityTokenReceiver implements SecurityTokenReceiver {
         // then, set addition info
         if (additionInfos == null) {
             // if addition info is null, it also means we have not received any token,
-            throw new RuntimeException("Credentials is not ready.");
+            throw new RuntimeException(
+                    "COS credentials have not been received yet. "
+                            + "Ensure onNewTokensObtained() has been called with valid tokens "
+                            + "before invoking COSSecurityTokenReceiver.updateHadoopConfig().");
         } else {
             for (Map.Entry<String, String> entry : additionInfos.entrySet()) {
                 hadoopConfig.set(entry.getKey(), entry.getValue());
@@ -89,14 +93,23 @@ public class COSSecurityTokenReceiver implements SecurityTokenReceiver {
         org.apache.fluss.fs.token.Credentials flussCredentials =
                 CredentialsJsonSerde.fromJson(tokenBytes);
 
-        // Create Credential from fluss credentials
-        credentials =
-                new BasicSessionCredentials(
-                        flussCredentials.getAccessKeyId(),
-                        flussCredentials.getSecretAccessKey(),
-                        flussCredentials.getSecurityToken());
+        // Create COSCredentials from fluss credentials, distinguishing between
+        // static credentials (no session token) and temporary session credentials
+        if (flussCredentials.getSecurityToken() != null) {
+            credentials =
+                    new BasicSessionCredentials(
+                            flussCredentials.getAccessKeyId(),
+                            flussCredentials.getSecretAccessKey(),
+                            flussCredentials.getSecurityToken());
+        } else {
+            credentials =
+                    new BasicCOSCredentials(
+                            flussCredentials.getAccessKeyId(),
+                            flussCredentials.getSecretAccessKey());
+        }
         additionInfos = token.getAdditionInfos();
 
+        // Consistent with S3DelegationTokenReceiver, logging access key at INFO level
         LOG.info(
                 "Session credentials updated successfully with access key: {}.",
                 credentials.getCOSAccessKeyId());

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenReceiver.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenReceiver.java
@@ -22,7 +22,6 @@ import org.apache.fluss.fs.token.CredentialsJsonSerde;
 import org.apache.fluss.fs.token.ObtainedSecurityToken;
 import org.apache.fluss.fs.token.SecurityTokenReceiver;
 
-import com.qcloud.cos.auth.BasicCOSCredentials;
 import com.qcloud.cos.auth.BasicSessionCredentials;
 import com.qcloud.cos.auth.COSCredentials;
 import org.slf4j.Logger;
@@ -93,20 +92,12 @@ public class COSSecurityTokenReceiver implements SecurityTokenReceiver {
         org.apache.fluss.fs.token.Credentials flussCredentials =
                 CredentialsJsonSerde.fromJson(tokenBytes);
 
-        // Create COSCredentials from fluss credentials, distinguishing between
-        // static credentials (no session token) and temporary session credentials
-        if (flussCredentials.getSecurityToken() != null) {
-            credentials =
-                    new BasicSessionCredentials(
-                            flussCredentials.getAccessKeyId(),
-                            flussCredentials.getSecretAccessKey(),
-                            flussCredentials.getSecurityToken());
-        } else {
-            credentials =
-                    new BasicCOSCredentials(
-                            flussCredentials.getAccessKeyId(),
-                            flussCredentials.getSecretAccessKey());
-        }
+        // STS always returns temporary credentials with a session token
+        credentials =
+                new BasicSessionCredentials(
+                        flussCredentials.getAccessKeyId(),
+                        flussCredentials.getSecretAccessKey(),
+                        flussCredentials.getSecurityToken());
         additionInfos = token.getAdditionInfos();
 
         // Consistent with S3DelegationTokenReceiver, logging access key at INFO level

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/DynamicTemporaryCOSCredentialsProvider.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/DynamicTemporaryCOSCredentialsProvider.java
@@ -26,9 +26,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Support dynamic session credentials for authenticating with Tencent Cloud COS. It'll get
- * credentials from {@link COSSecurityTokenReceiver}. It implements COS native {@link
- * COSCredentialsProvider} to work with CosNFileSystem.
+ * Support dynamic credentials for authenticating with Tencent Cloud COS. It'll get credentials from
+ * {@link COSSecurityTokenReceiver}. It implements COS native {@link COSCredentialsProvider} to work
+ * with CosNFileSystem.
+ *
+ * <p>This provider supports both static credentials (secretId/secretKey) and temporary session
+ * credentials (secretId/secretKey/sessionToken).
  */
 @Internal
 public class DynamicTemporaryCOSCredentialsProvider implements COSCredentialsProvider {
@@ -42,13 +45,21 @@ public class DynamicTemporaryCOSCredentialsProvider implements COSCredentialsPro
     public COSCredentials getCredentials() {
         COSCredentials credentials = COSSecurityTokenReceiver.getCredentials();
         if (credentials == null) {
-            throw new RuntimeException("Credentials is not ready.");
+            throw new RuntimeException(
+                    "COS credentials have not been received yet. "
+                            + "Ensure COSSecurityTokenReceiver has received valid tokens.");
         }
-        LOG.debug("Providing session credentials");
-        return new BasicSessionCredentials(
-                credentials.getCOSAccessKeyId(),
-                credentials.getCOSSecretKey(),
-                ((BasicSessionCredentials) credentials).getSessionToken());
+        if (credentials instanceof BasicSessionCredentials) {
+            BasicSessionCredentials sessionCredentials = (BasicSessionCredentials) credentials;
+            LOG.debug("Providing session credentials");
+            return new BasicSessionCredentials(
+                    sessionCredentials.getCOSAccessKeyId(),
+                    sessionCredentials.getCOSSecretKey(),
+                    sessionCredentials.getSessionToken());
+        } else {
+            LOG.debug("Providing non-session COS credentials");
+            return credentials;
+        }
     }
 
     @Override

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/DynamicTemporaryCOSCredentialsProvider.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/DynamicTemporaryCOSCredentialsProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos.token;
+
+import org.apache.fluss.annotation.Internal;
+
+import com.qcloud.cos.auth.BasicSessionCredentials;
+import com.qcloud.cos.auth.COSCredentials;
+import com.qcloud.cos.auth.COSCredentialsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Support dynamic session credentials for authenticating with Tencent Cloud COS. It'll get
+ * credentials from {@link COSSecurityTokenReceiver}. It implements COS native {@link
+ * COSCredentialsProvider} to work with CosNFileSystem.
+ */
+@Internal
+public class DynamicTemporaryCOSCredentialsProvider implements COSCredentialsProvider {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DynamicTemporaryCOSCredentialsProvider.class);
+
+    public static final String NAME = DynamicTemporaryCOSCredentialsProvider.class.getName();
+
+    @Override
+    public COSCredentials getCredentials() {
+        COSCredentials credentials = COSSecurityTokenReceiver.getCredentials();
+        if (credentials == null) {
+            throw new RuntimeException("Credentials is not ready.");
+        }
+        LOG.debug("Providing session credentials");
+        return new BasicSessionCredentials(
+                credentials.getCOSAccessKeyId(),
+                credentials.getCOSSecretKey(),
+                ((BasicSessionCredentials) credentials).getSessionToken());
+    }
+
+    @Override
+    public void refresh() {
+        // do nothing, credentials are updated by COSSecurityTokenReceiver
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,70 @@
+fluss-fs-cos
+Copyright 2025-2026 The Apache Software Foundation
+
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.fasterxml.jackson.core:jackson-annotations:2.15.3
+- com.fasterxml.jackson.core:jackson-core:2.15.3
+- com.fasterxml.jackson.core:jackson-databind:2.15.3
+- com.fasterxml.woodstox:woodstox-core:5.4.0
+- com.google.code.gson:gson:2.2.4
+- com.google.guava:failureaccess:1.0
+- com.google.guava:guava:27.0-jre
+- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+- com.google.j2objc:j2objc-annotations:1.1
+- com.google.re2j:re2j:1.1
+- com.qcloud:cos_api:5.6.139
+- com.qcloud:cos_api-bundle:5.6.69
+- com.squareup.okhttp:logging-interceptor:2.7.5
+- com.squareup.okhttp:okhttp:2.7.5
+- com.squareup.okio:okio:1.12.0
+- com.tencentcloudapi:tencentcloud-sdk-java-common:3.1.213
+- com.tencentcloudapi:tencentcloud-sdk-java-kms:3.1.213
+- commons-beanutils:commons-beanutils:1.9.4
+- commons-codec:commons-codec:1.13
+- commons-collections:commons-collections:3.2.2
+- commons-io:commons-io:2.14.0
+- commons-logging:commons-logging:1.2
+- dnsjava:dnsjava:3.4.0
+- io.dropwizard.metrics:metrics-core:3.2.4
+- io.netty:netty-buffer:4.1.100.Final
+- io.netty:netty-codec:4.1.100.Final
+- io.netty:netty-common:4.1.100.Final
+- io.netty:netty-handler:4.1.100.Final
+- io.netty:netty-resolver:4.1.100.Final
+- io.netty:netty-transport-classes-epoll:4.1.100.Final
+- io.netty:netty-transport-native-epoll:4.1.100.Final
+- io.netty:netty-transport-native-unix-common:4.1.100.Final
+- io.netty:netty-transport:4.1.100.Final
+- jakarta.activation:jakarta.activation-api:1.2.1
+- joda-time:joda-time:2.9.9
+- org.apache.commons:commons-compress:1.24.0
+- org.apache.commons:commons-configuration2:2.8.0
+- org.apache.commons:commons-lang3:3.18.0
+- org.apache.commons:commons-text:1.10.0
+- org.apache.hadoop:hadoop-annotations:3.4.0
+- org.apache.hadoop:hadoop-auth:3.4.0
+- org.apache.hadoop:hadoop-common:3.4.0
+- org.apache.hadoop:hadoop-cos:3.3.5
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.2.0
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21:1.2.0
+- org.apache.httpcomponents:httpclient:4.5.13
+- org.apache.httpcomponents:httpcore:4.4.13
+- org.apache.kerby:kerb-core:2.0.3
+- org.apache.kerby:kerby-asn1:2.0.3
+- org.apache.kerby:kerby-pkix:2.0.3
+- org.apache.kerby:kerby-util:2.0.3
+- org.bouncycastle:bcprov-jdk15on:1.67
+- org.checkerframework:checker-qual:2.5.2
+- org.codehaus.jettison:jettison:1.5.4
+- org.codehaus.mojo:animal-sniffer-annotations:1.17
+- org.codehaus.woodstox:stax2-api:4.2.1
+- org.xerial.snappy:snappy-java:1.1.10.4
+
+This project bundles the following dependencies under the CDDL 1.1 license.
+See bundled license files for details.
+
+- javax.xml.bind:jaxb-api:2.3.1

--- a/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
 - com.fasterxml.woodstox:woodstox-core:5.4.0
-- com.google.code.gson:gson:2.2.4
+- com.google.code.gson:gson:2.8.9
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
@@ -18,9 +18,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.re2j:re2j:1.1
 - com.qcloud:cos_api:5.6.139
 - com.qcloud:cos_api-bundle:5.6.69
-- com.squareup.okhttp:logging-interceptor:2.7.5
-- com.squareup.okhttp:okhttp:2.7.5
-- com.squareup.okio:okio:1.12.0
+- com.squareup.okhttp3:logging-interceptor:4.10.0
+- com.squareup.okhttp3:okhttp:4.10.0
+- com.squareup.okio:okio-jvm:3.2.0
+- com.squareup.okio:okio:3.2.0
 - com.tencentcloudapi:tencentcloud-sdk-java-common:3.1.678
 - com.tencentcloudapi:tencentcloud-sdk-java-kms:3.1.213
 - com.tencentcloudapi:tencentcloud-sdk-java-sts:3.1.678
@@ -42,6 +43,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.netty:netty-transport:4.1.100.Final
 - jakarta.activation:jakarta.activation-api:1.2.1
 - joda-time:joda-time:2.9.9
+- org.ini4j:ini4j:0.5.4
 - org.apache.commons:commons-compress:1.24.0
 - org.apache.commons:commons-configuration2:2.8.0
 - org.apache.commons:commons-lang3:3.18.0
@@ -60,6 +62,11 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-util:2.0.3
 - org.bouncycastle:bcprov-jdk15on:1.67
 - org.checkerframework:checker-qual:2.5.2
+- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.20
+- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10
+- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10
+- org.jetbrains.kotlin:kotlin-stdlib:1.6.20
+- org.jetbrains:annotations:13.0
 - org.codehaus.jettison:jettison:1.5.4
 - org.codehaus.mojo:animal-sniffer-annotations:1.17
 - org.codehaus.woodstox:stax2-api:4.2.1

--- a/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/NOTICE
@@ -17,7 +17,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.j2objc:j2objc-annotations:1.1
 - com.google.re2j:re2j:1.1
 - com.qcloud:cos_api:5.6.139
-- com.qcloud:cos_api-bundle:5.6.69
 - com.squareup.okhttp3:logging-interceptor:4.10.0
 - com.squareup.okhttp3:okhttp:4.10.0
 - com.squareup.okio:okio-jvm:3.2.0

--- a/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/NOTICE
@@ -21,8 +21,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.squareup.okhttp:logging-interceptor:2.7.5
 - com.squareup.okhttp:okhttp:2.7.5
 - com.squareup.okio:okio:1.12.0
-- com.tencentcloudapi:tencentcloud-sdk-java-common:3.1.213
+- com.tencentcloudapi:tencentcloud-sdk-java-common:3.1.678
 - com.tencentcloudapi:tencentcloud-sdk-java-kms:3.1.213
+- com.tencentcloudapi:tencentcloud-sdk-java-sts:3.1.678
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2

--- a/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/licenses/LICENSE.jaxb
+++ b/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/licenses/LICENSE.jaxb
@@ -1,0 +1,135 @@
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)Version 1.1
+
+1. Definitions.
+
+     1.1. "Contributor" means each individual or entity that creates or contributes to the creation of Modifications.
+
+     1.2. "Contributor Version" means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.
+
+     1.3. "Covered Software" means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.
+
+     1.4. "Executable" means the Covered Software in any form other than Source Code.
+
+     1.5. "Initial Developer" means the individual or entity that first makes Original Software available under this License.
+
+     1.6. "Larger Work" means a work which combines Covered Software or portions thereof with code not governed by the terms of this License.
+
+     1.7. "License" means this document.
+
+     1.8. "Licensable" means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.
+
+     1.9. "Modifications" means the Source Code and Executable form of any of the following:
+
+     A. Any file that results from an addition to, deletion from or modification of the contents of a file containing Original Software or previous Modifications;
+
+     B. Any new file that contains any part of the Original Software or previous Modification; or
+
+     C. Any new file that is contributed or otherwise made available under the terms of this License.
+
+     1.10. "Original Software" means the Source Code and Executable form of computer software code that is originally released under this License.
+
+     1.11. "Patent Claims" means any patent claim(s), now owned or hereafter acquired, including without limitation, method, process, and apparatus claims, in any patent Licensable by grantor.
+
+     1.12. "Source Code" means (a) the common form of computer software code in which modifications are made and (b) associated documentation included in or with such code.
+
+     1.13. "You" (or "Your") means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, "You" includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. License Grants.
+
+     2.1. The Initial Developer Grant.
+
+     Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, the Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+     (a) under intellectual property rights (other than patent or trademark) Licensable by Initial Developer, to use, reproduce, modify, display, perform, sublicense and distribute the Original Software (or portions thereof), with or without Modifications, and/or as part of a Larger Work; and
+
+     (b) under Patent Claims infringed by the making, using or selling of Original Software, to make, have made, use, practice, sell, and offer for sale, and/or otherwise dispose of the Original Software (or portions thereof).
+
+     (c) The licenses granted in Sections 2.1(a) and (b) are effective on the date Initial Developer first distributes or otherwise makes the Original Software available to a third party under the terms of this License.
+
+     (d) Notwithstanding Section 2.1(b) above, no patent license is granted: (1) for code that You delete from the Original Software, or (2) for infringements caused by: (i) the modification of the Original Software, or (ii) the combination of the Original Software with other software or devices.
+
+     2.2. Contributor Grant.
+
+     Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+     (a) under intellectual property rights (other than patent or trademark) Licensable by Contributor to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof), either on an unmodified basis, with other Modifications, as Covered Software and/or as part of a Larger Work; and
+
+     (b) under Patent Claims infringed by the making, using, or selling of Modifications made by that Contributor either alone and/or in combination with its Contributor Version (or portions of such combination), to make, use, sell, offer for sale, have made, and/or otherwise dispose of: (1) Modifications made by that Contributor (or portions thereof); and (2) the combination of Modifications made by that Contributor with its Contributor Version (or portions of such combination).
+
+     (c) The licenses granted in Sections 2.2(a) and 2.2(b) are effective on the date Contributor first distributes or otherwise makes the Modifications available to a third party.
+
+     (d) Notwithstanding Section 2.2(b) above, no patent license is granted: (1) for any code that Contributor has deleted from the Contributor Version; (2) for infringements caused by: (i) third party modifications of Contributor Version, or (ii) the combination of Modifications made by that Contributor with other software (except as part of the Contributor Version) or other devices; or (3) under Patent Claims infringed by Covered Software in the absence of Modifications made by that Contributor.
+
+3. Distribution Obligations.
+
+     3.1. Availability of Source Code.
+
+     Any Covered Software that You distribute or otherwise make available in Executable form must also be made available in Source Code form and that Source Code form must be distributed only under the terms of this License. You must include a copy of this License with every copy of the Source Code form of the Covered Software You distribute or otherwise make available. You must inform recipients of any such Covered Software in Executable form as to how they can obtain such Covered Software in Source Code form in a reasonable manner on or through a medium customarily used for software exchange.
+
+     3.2. Modifications.
+
+     The Modifications that You create or to which You contribute are governed by the terms of this License. You represent that You believe Your Modifications are Your original creation(s) and/or You have sufficient rights to grant the rights conveyed by this License.
+
+     3.3. Required Notices.
+
+     You must include a notice in each of Your Modifications that identifies You as the Contributor of the Modification. You may not remove or alter any copyright, patent or trademark notices contained within the Covered Software, or any notices of licensing or any descriptive text giving attribution to any Contributor or the Initial Developer.
+
+     3.4. Application of Additional Terms.
+
+     You may not offer or impose any terms on any Covered Software in Source Code form that alters or restricts the applicable version of this License or the recipients' rights hereunder. You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, you may do so only on Your own behalf, and not on behalf of the Initial Developer or any Contributor. You must make it absolutely clear that any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
+
+     3.5. Distribution of Executable Versions.
+
+     You may distribute the Executable form of the Covered Software under the terms of this License or under the terms of a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable form does not attempt to limit or alter the recipient's rights in the Source Code form from the rights set forth in this License. If You distribute the Covered Software in Executable form under a different license, You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.
+
+     3.6. Larger Works.
+
+     You may create a Larger Work by combining Covered Software with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Software.
+
+4. Versions of the License.
+
+     4.1. New Versions.
+
+     Oracle is the initial license steward and may publish revised and/or new versions of this License from time to time. Each version will be given a distinguishing version number. Except as provided in Section 4.3, no one other than the license steward has the right to modify this License.
+
+     4.2. Effect of New Versions.
+
+     You may always continue to use, distribute or otherwise make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. If the Initial Developer includes a notice in the Original Software prohibiting it from being distributed or otherwise made available under any subsequent version of the License, You must distribute and make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. Otherwise, You may also choose to use, distribute or otherwise make the Covered Software available under the terms of any subsequent version of the License published by the license steward.
+
+     4.3. Modified Versions.
+
+     When You are an Initial Developer and You want to create a new license for Your Original Software, You may create and use a modified version of this License if You: (a) rename the license and remove any references to the name of the license steward (except to note that the license differs from this License); and (b) otherwise make it clear that the license contains terms which differ from this License.
+
+5. DISCLAIMER OF WARRANTY.
+
+     COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+6. TERMINATION.
+
+     6.1. This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
+
+     6.2. If You assert a patent infringement claim (excluding declaratory judgment actions) against Initial Developer or a Contributor (the Initial Developer or Contributor against whom You assert such claim is referred to as "Participant") alleging that the Participant Software (meaning the Contributor Version where the Participant is a Contributor or the Original Software where the Participant is the Initial Developer) directly or indirectly infringes any patent, then any and all rights granted directly or indirectly to You by such Participant, the Initial Developer (if the Initial Developer is not the Participant) and all Contributors under Sections 2.1 and/or 2.2 of this License shall, upon 60 days notice from Participant terminate prospectively and automatically at the expiration of such 60 day notice period, unless if within such 60 day period You withdraw Your claim with respect to the Participant Software against such Participant either unilaterally or pursuant to a written agreement with Participant.
+
+     6.3. If You assert a patent infringement claim against Participant alleging that the Participant Software directly or indirectly infringes any patent where such claim is resolved (such as by license or settlement) prior to the initiation of patent infringement litigation, then the reasonable value of the licenses granted by such Participant under Sections 2.1 or 2.2 shall be taken into account in determining the amount or value of any payment or license.
+
+     6.4. In the event of termination under Sections 6.1 or 6.2 above, all end user licenses that have been validly granted by You or any distributor hereunder prior to termination (excluding licenses granted to You by any distributor) shall survive termination.
+
+7. LIMITATION OF LIABILITY.
+
+     UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+8. U.S. GOVERNMENT END USERS.
+
+     The Covered Software is a "commercial item," as that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial computer software" (as that term is defined at 48 C.F.R. ? 252.227-7014(a)(1)) and "commercial computer software documentation" as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Software with only those rights set forth herein. This U.S. Government Rights clause is in lieu of, and supersedes, any other FAR, DFAR, or other clause or provision that addresses Government rights in computer software under this License.
+
+9. MISCELLANEOUS.
+
+     This License represents the complete agreement concerning subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. This License shall be governed by the law of the jurisdiction specified in a notice contained within the Original Software (except to the extent applicable law, if any, provides otherwise), excluding such jurisdiction's conflict-of-law provisions. Any litigation relating to this License shall be subject to the jurisdiction of the courts located in the jurisdiction and venue specified in a notice contained within the Original Software, with the losing party responsible for costs, including, without limitation, court costs and reasonable attorneys' fees and expenses. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not apply to this License. You agree that You alone are responsible for compliance with the United States export administration regulations (and the export control laws and regulation of any other countries) when You use, distribute or otherwise make available any Covered Software.
+
+10. RESPONSIBILITY FOR CLAIMS.
+
+     As between Initial Developer and the Contributors, each party is responsible for claims and damages arising, directly or indirectly, out of its utilization of rights under this License and You agree to work with Initial Developer and Contributors to distribute such responsibility on an equitable basis. Nothing herein is intended or shall be deemed to constitute any admission of liability.
+
+----------
+NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)
+The code released under the CDDL shall be governed by the laws of the State of California (excluding conflict-of-law provisions). Any litigation relating to this License shall be subject to the jurisdiction of the Federal Courts of the Northern District of California and the state courts of the State of California, with venue lying in Santa Clara County, California.

--- a/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/services/org.apache.fluss.fs.FileSystemPlugin
+++ b/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/services/org.apache.fluss.fs.FileSystemPlugin
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.fluss.fs.cos.COSFileSystemPlugin

--- a/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/services/org.apache.fluss.fs.token.SecurityTokenReceiver
+++ b/fluss-filesystems/fluss-fs-cos/src/main/resources/META-INF/services/org.apache.fluss.fs.token.SecurityTokenReceiver
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.fluss.fs.cos.token.COSSecurityTokenReceiver

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSFileSystemBehaviorITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSFileSystemBehaviorITCase.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos;
+
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.fs.FileSystem;
+import org.apache.fluss.fs.FileSystemBehaviorTestSuite;
+import org.apache.fluss.fs.FsPath;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.UUID;
+
+/**
+ * An implementation of the {@link FileSystemBehaviorTestSuite} for the COS file system with Hadoop
+ * cos sdk.
+ */
+class COSFileSystemBehaviorITCase extends FileSystemBehaviorTestSuite {
+
+    private static final String TEST_DATA_DIR = "tests-" + UUID.randomUUID();
+
+    @BeforeAll
+    static void setup() {
+        COSTestCredentials.assumeCredentialsAvailable();
+
+        final Configuration conf = new Configuration();
+        conf.setString("fs.cosn.endpoint", COSTestCredentials.getCOSEndpoint());
+        conf.setString("fs.cosn.userinfo.secretId", COSTestCredentials.getCOSSecretId());
+        conf.setString("fs.cosn.userinfo.secretKey", COSTestCredentials.getCOSSecretKey());
+        FileSystem.initialize(conf, null);
+    }
+
+    @Override
+    protected FileSystem getFileSystem() throws Exception {
+        return getBasePath().getFileSystem();
+    }
+
+    @Override
+    protected FsPath getBasePath() {
+        return new FsPath(COSTestCredentials.getTestBucketUri() + TEST_DATA_DIR);
+    }
+
+    @AfterAll
+    static void clearFsConfig() {
+        FileSystem.initialize(new Configuration(), null);
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSFileSystemBehaviorITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSFileSystemBehaviorITCase.java
@@ -27,6 +27,10 @@ import org.junit.jupiter.api.BeforeAll;
 
 import java.util.UUID;
 
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.ENDPOINT_KEY;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_ID;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_KEY;
+
 /**
  * An implementation of the {@link FileSystemBehaviorTestSuite} for the COS file system with Hadoop
  * cos sdk.
@@ -40,9 +44,9 @@ class COSFileSystemBehaviorITCase extends FileSystemBehaviorTestSuite {
         COSTestCredentials.assumeCredentialsAvailable();
 
         final Configuration conf = new Configuration();
-        conf.setString("fs.cosn.endpoint", COSTestCredentials.getCOSEndpoint());
-        conf.setString("fs.cosn.userinfo.secretId", COSTestCredentials.getCOSSecretId());
-        conf.setString("fs.cosn.userinfo.secretKey", COSTestCredentials.getCOSSecretKey());
+        conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpoint());
+        conf.setString(SECRET_ID, COSTestCredentials.getCOSSecretId());
+        conf.setString(SECRET_KEY, COSTestCredentials.getCOSSecretKey());
         FileSystem.initialize(conf, null);
     }
 

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSFileSystemBehaviorITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSFileSystemBehaviorITCase.java
@@ -44,7 +44,7 @@ class COSFileSystemBehaviorITCase extends FileSystemBehaviorTestSuite {
         COSTestCredentials.assumeCredentialsAvailable();
 
         final Configuration conf = new Configuration();
-        conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpoint());
+        conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpointSuffix());
         conf.setString(SECRET_ID, COSTestCredentials.getCOSSecretId());
         conf.setString(SECRET_KEY, COSTestCredentials.getCOSSecretKey());
         FileSystem.initialize(conf, null);

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSTestCredentials.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSTestCredentials.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos;
+
+import javax.annotation.Nullable;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** Access to credentials to access COS buckets during integration tests. */
+public class COSTestCredentials {
+    @Nullable private static final String ENDPOINT = System.getenv("COSN_ENDPOINT");
+
+    @Nullable private static final String BUCKET = System.getenv("COSN_BUCKET");
+
+    @Nullable private static final String SECRET_ID = System.getenv("COSN_SECRET_ID");
+
+    @Nullable private static final String SECRET_KEY = System.getenv("COSN_SECRET_KEY");
+
+    // ------------------------------------------------------------------------
+
+    public static boolean credentialsAvailable() {
+        return isNotEmpty(ENDPOINT)
+                && isNotEmpty(BUCKET)
+                && isNotEmpty(SECRET_ID)
+                && isNotEmpty(SECRET_KEY);
+    }
+
+    /** Checks if a String is not null and not empty. */
+    private static boolean isNotEmpty(@Nullable String str) {
+        return str != null && !str.isEmpty();
+    }
+
+    public static void assumeCredentialsAvailable() {
+        assumeTrue(
+                credentialsAvailable(), "No COS credentials available in this test's environment");
+    }
+
+    /**
+     * Get COS endpoint used to connect.
+     *
+     * @return COS endpoint
+     */
+    public static String getCOSEndpoint() {
+        if (ENDPOINT != null) {
+            return ENDPOINT;
+        } else {
+            throw new IllegalStateException("COS endpoint is not available");
+        }
+    }
+
+    /**
+     * Get COS secret id.
+     *
+     * @return COS secret id
+     */
+    public static String getCOSSecretId() {
+        if (SECRET_ID != null) {
+            return SECRET_ID;
+        } else {
+            throw new IllegalStateException("COS secret id is not available");
+        }
+    }
+
+    /**
+     * Get COS secret key.
+     *
+     * @return COS secret key
+     */
+    public static String getCOSSecretKey() {
+        if (SECRET_KEY != null) {
+            return SECRET_KEY;
+        } else {
+            throw new IllegalStateException("COS secret key is not available");
+        }
+    }
+
+    public static String getTestBucketUri() {
+        return getTestBucketUriWithScheme("cosn");
+    }
+
+    public static String getTestBucketUriWithScheme(String scheme) {
+        if (BUCKET != null) {
+            return scheme + "://" + BUCKET + "/";
+        } else {
+            throw new IllegalStateException("COS test bucket is not available");
+        }
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSTestCredentials.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSTestCredentials.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** Access to credentials to access COS buckets during integration tests. */
 public class COSTestCredentials {
-    @Nullable private static final String ENDPOINT = System.getenv("COSN_ENDPOINT");
+    @Nullable private static final String ENDPOINT_SUFFIX = System.getenv("COSN_ENDPOINT_SUFFIX");
 
     @Nullable private static final String BUCKET = System.getenv("COSN_BUCKET");
 
@@ -36,7 +36,7 @@ public class COSTestCredentials {
     // ------------------------------------------------------------------------
 
     public static boolean credentialsAvailable() {
-        return isNotEmpty(ENDPOINT)
+        return isNotEmpty(ENDPOINT_SUFFIX)
                 && isNotEmpty(BUCKET)
                 && isNotEmpty(SECRET_ID)
                 && isNotEmpty(SECRET_KEY)
@@ -54,15 +54,15 @@ public class COSTestCredentials {
     }
 
     /**
-     * Get COS endpoint used to connect.
+     * Get COS endpoint suffix used to connect.
      *
-     * @return COS endpoint
+     * @return COS endpoint suffix
      */
-    public static String getCOSEndpoint() {
-        if (ENDPOINT != null) {
-            return ENDPOINT;
+    public static String getCOSEndpointSuffix() {
+        if (ENDPOINT_SUFFIX != null) {
+            return ENDPOINT_SUFFIX;
         } else {
-            throw new IllegalStateException("COS endpoint is not available");
+            throw new IllegalStateException("COS endpoint suffix is not available");
         }
     }
 

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSTestCredentials.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSTestCredentials.java
@@ -31,13 +31,16 @@ public class COSTestCredentials {
 
     @Nullable private static final String SECRET_KEY = System.getenv("COSN_SECRET_KEY");
 
+    @Nullable private static final String REGION = System.getenv("COSN_REGION");
+
     // ------------------------------------------------------------------------
 
     public static boolean credentialsAvailable() {
         return isNotEmpty(ENDPOINT)
                 && isNotEmpty(BUCKET)
                 && isNotEmpty(SECRET_ID)
-                && isNotEmpty(SECRET_KEY);
+                && isNotEmpty(SECRET_KEY)
+                && isNotEmpty(REGION);
     }
 
     /** Checks if a String is not null and not empty. */
@@ -86,6 +89,19 @@ public class COSTestCredentials {
             return SECRET_KEY;
         } else {
             throw new IllegalStateException("COS secret key is not available");
+        }
+    }
+
+    /**
+     * Get COS region.
+     *
+     * @return COS region
+     */
+    public static String getCOSRegion() {
+        if (REGION != null) {
+            return REGION;
+        } else {
+            throw new IllegalStateException("COS region is not available");
         }
     }
 

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithCredentialsProviderFileSystemBehaviorITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithCredentialsProviderFileSystemBehaviorITCase.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos;
+
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.fs.FileSystem;
+import org.apache.fluss.fs.FileSystemBehaviorTestSuite;
+import org.apache.fluss.fs.FsPath;
+
+import com.qcloud.cos.auth.COSCredentialsProvider;
+import org.apache.hadoop.fs.cosn.auth.EnvironmentVariableCredentialsProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.UUID;
+
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.CREDENTIALS_PROVIDER;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.ENDPOINT_KEY;
+
+/** IT case for access cos via set {@link COSCredentialsProvider}. */
+class COSWithCredentialsProviderFileSystemBehaviorITCase extends FileSystemBehaviorTestSuite {
+
+    private static final String TEST_DATA_DIR = "tests-" + UUID.randomUUID();
+
+    @BeforeAll
+    static void setup() {
+        COSTestCredentials.assumeCredentialsAvailable();
+
+        // Use EnvironmentVariableCredentialsProvider shipped with hadoop-cos, which reads
+        // credentials from the COSN_SECRET_ID / COSN_SECRET_KEY environment variables
+        // (the same ones already required by COSTestCredentials).
+        final Configuration conf = new Configuration();
+        conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpoint());
+        conf.setString(
+                CREDENTIALS_PROVIDER, EnvironmentVariableCredentialsProvider.class.getName());
+        FileSystem.initialize(conf, null);
+    }
+
+    @Override
+    protected FileSystem getFileSystem() throws Exception {
+        return getBasePath().getFileSystem();
+    }
+
+    @Override
+    protected FsPath getBasePath() {
+        return new FsPath(COSTestCredentials.getTestBucketUri() + TEST_DATA_DIR);
+    }
+
+    @AfterAll
+    static void clearFsConfig() {
+        FileSystem.initialize(new Configuration(), null);
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithCredentialsProviderFileSystemBehaviorITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithCredentialsProviderFileSystemBehaviorITCase.java
@@ -45,7 +45,7 @@ class COSWithCredentialsProviderFileSystemBehaviorITCase extends FileSystemBehav
         // credentials from the COSN_SECRET_ID / COSN_SECRET_KEY environment variables
         // (the same ones already required by COSTestCredentials).
         final Configuration conf = new Configuration();
-        conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpoint());
+        conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpointSuffix());
         conf.setString(
                 CREDENTIALS_PROVIDER, EnvironmentVariableCredentialsProvider.class.getName());
         FileSystem.initialize(conf, null);

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorBaseITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorBaseITCase.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos;
+
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.fs.FileSystem;
+import org.apache.fluss.fs.FileSystemBehaviorTestSuite;
+
+/** Base IT case for access COS with temporary credentials in hadoop sdk as COS FileSystem. */
+abstract class COSWithTokenFileSystemBehaviorBaseITCase extends FileSystemBehaviorTestSuite {
+
+    static void initFileSystemWithSecretKey() {
+        COSTestCredentials.assumeCredentialsAvailable();
+
+        // first init filesystem with secretId/secretKey
+        final Configuration conf = new Configuration();
+        conf.setString("fs.cosn.endpoint", COSTestCredentials.getCOSEndpoint());
+        conf.setString("fs.cosn.userinfo.secretId", COSTestCredentials.getCOSSecretId());
+        conf.setString("fs.cosn.userinfo.secretKey", COSTestCredentials.getCOSSecretKey());
+        FileSystem.initialize(conf, null);
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorBaseITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorBaseITCase.java
@@ -21,6 +21,10 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.fs.FileSystem;
 import org.apache.fluss.fs.FileSystemBehaviorTestSuite;
 
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.ENDPOINT_KEY;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_ID;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_KEY;
+
 /** Base IT case for access COS with temporary credentials in hadoop sdk as COS FileSystem. */
 abstract class COSWithTokenFileSystemBehaviorBaseITCase extends FileSystemBehaviorTestSuite {
 
@@ -29,9 +33,9 @@ abstract class COSWithTokenFileSystemBehaviorBaseITCase extends FileSystemBehavi
 
         // first init filesystem with secretId/secretKey
         final Configuration conf = new Configuration();
-        conf.setString("fs.cosn.endpoint", COSTestCredentials.getCOSEndpoint());
-        conf.setString("fs.cosn.userinfo.secretId", COSTestCredentials.getCOSSecretId());
-        conf.setString("fs.cosn.userinfo.secretKey", COSTestCredentials.getCOSSecretKey());
+        conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpoint());
+        conf.setString(SECRET_ID, COSTestCredentials.getCOSSecretId());
+        conf.setString(SECRET_KEY, COSTestCredentials.getCOSSecretKey());
         FileSystem.initialize(conf, null);
     }
 }

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorBaseITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorBaseITCase.java
@@ -34,7 +34,7 @@ abstract class COSWithTokenFileSystemBehaviorBaseITCase extends FileSystemBehavi
 
         // first init filesystem with secretId/secretKey
         final Configuration conf = new Configuration();
-        conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpoint());
+        conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpointSuffix());
         conf.setString(REGION, COSTestCredentials.getCOSRegion());
         conf.setString(SECRET_ID, COSTestCredentials.getCOSSecretId());
         conf.setString(SECRET_KEY, COSTestCredentials.getCOSSecretKey());

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorBaseITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorBaseITCase.java
@@ -22,6 +22,7 @@ import org.apache.fluss.fs.FileSystem;
 import org.apache.fluss.fs.FileSystemBehaviorTestSuite;
 
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.ENDPOINT_KEY;
+import static org.apache.fluss.fs.cos.COSFileSystemPlugin.REGION;
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_ID;
 import static org.apache.fluss.fs.cos.COSFileSystemPlugin.SECRET_KEY;
 
@@ -34,6 +35,7 @@ abstract class COSWithTokenFileSystemBehaviorBaseITCase extends FileSystemBehavi
         // first init filesystem with secretId/secretKey
         final Configuration conf = new Configuration();
         conf.setString(ENDPOINT_KEY, COSTestCredentials.getCOSEndpoint());
+        conf.setString(REGION, COSTestCredentials.getCOSRegion());
         conf.setString(SECRET_ID, COSTestCredentials.getCOSSecretId());
         conf.setString(SECRET_KEY, COSTestCredentials.getCOSSecretKey());
         FileSystem.initialize(conf, null);

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorITCase.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/COSWithTokenFileSystemBehaviorITCase.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos;
+
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.fs.FileSystem;
+import org.apache.fluss.fs.FsPath;
+import org.apache.fluss.fs.cos.token.COSSecurityTokenReceiver;
+import org.apache.fluss.fs.token.ObtainedSecurityToken;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.UUID;
+
+/** IT case for access COS with security token in hadoop sdk as FileSystem. */
+class COSWithTokenFileSystemBehaviorITCase extends COSWithTokenFileSystemBehaviorBaseITCase {
+
+    private static final String TEST_DATA_DIR = "tests-" + UUID.randomUUID();
+
+    @BeforeAll
+    static void setup() throws Exception {
+        // init a filesystem with secretId/secretKey so that it can generate token
+        initFileSystemWithSecretKey();
+        // now, we can init with token
+        initFileSystemWithToken(getFsPath());
+    }
+
+    @Override
+    protected FileSystem getFileSystem() throws Exception {
+        return getFsPath().getFileSystem();
+    }
+
+    @Override
+    protected FsPath getBasePath() {
+        return getFsPath();
+    }
+
+    protected static FsPath getFsPath() {
+        return new FsPath(COSTestCredentials.getTestBucketUri() + TEST_DATA_DIR);
+    }
+
+    @AfterAll
+    static void clearFsConfig() {
+        FileSystem.initialize(new Configuration(), null);
+    }
+
+    private static void initFileSystemWithToken(FsPath fsPath) throws Exception {
+        Configuration configuration = new Configuration();
+        // obtain a security token and call onNewTokensObtained
+        ObtainedSecurityToken obtainedSecurityToken = fsPath.getFileSystem().obtainSecurityToken();
+        COSSecurityTokenReceiver cosSecurityTokenReceiver = new COSSecurityTokenReceiver();
+        cosSecurityTokenReceiver.onNewTokensObtained(obtainedSecurityToken);
+
+        FileSystem.initialize(configuration, null);
+    }
+}

--- a/fluss-filesystems/pom.xml
+++ b/fluss-filesystems/pom.xml
@@ -36,6 +36,7 @@
         <module>fluss-fs-gs</module>
         <module>fluss-fs-azure</module>
         <module>fluss-fs-obs</module>
+        <module>fluss-fs-cos</module>
         <module>fluss-fs-hdfs</module>
     </modules>
     <packaging>pom</packaging>

--- a/fluss-test-coverage/pom.xml
+++ b/fluss-test-coverage/pom.xml
@@ -418,6 +418,7 @@
                                         </exclude>
                                         <exclude>org.apache.fluss.fs.hdfs.HdfsSecurityTokenReceiver</exclude>
                                         <exclude>org.apache.fluss.fs.oss.*</exclude>
+                                        <exclude>org.apache.fluss.fs.cos.*</exclude>
                                         <exclude>org.apache.fluss.fs.s3.*</exclude>
                                         <exclude>org.apache.fluss.fs.obs.*</exclude>
                                         <exclude>com.amazonaws.services.s3.model.transform.XmlResponsesSaxParser*

--- a/website/docs/maintenance/filesystems/cos.md
+++ b/website/docs/maintenance/filesystems/cos.md
@@ -11,10 +11,10 @@ sidebar_position: 7
 
 Tencent Cloud COS support is not included in the default Fluss distribution. To enable COS support, you need to manually install the filesystem plugin into Fluss.
 
-1. **Prepare the plugin JAR**: 
+1. **Prepare the plugin JAR**:
 
    - Download the `fluss-fs-cos-$FLUSS_VERSION$.jar` from the [Maven Repository](https://repo1.maven.org/maven2/org/apache/fluss/fluss-fs-cos/$FLUSS_VERSION$/fluss-fs-cos-$FLUSS_VERSION$.jar).
-   
+
 2. **Place the plugin**: Place the plugin JAR file in the `${FLUSS_HOME}/plugins/cos/` directory:
    ```bash
    mkdir -p ${FLUSS_HOME}/plugins/cos/
@@ -50,12 +50,12 @@ To avoid exposing sensitive access key information directly in the `server.yaml`
 
 For example, to use environment variables for credential management:
 ```yaml
-fs.cosn.credentials.provider: org.apache.hadoop.fs.cosn.auth.EnvironmentVariableCredentialProvider
+fs.cosn.credentials.provider: org.apache.hadoop.fs.cosn.auth.EnvironmentVariableCredentialsProvider
 ```
 Then, set the following environment variables before starting the Fluss service:
 ```bash
-export COS_SECRET_ID=<your-secret-id>
-export COS_SECRET_KEY=<your-secret-key>
+export COSN_SECRET_ID=<your-secret-id>
+export COSN_SECRET_KEY=<your-secret-key>
 ```
 This approach enhances security by keeping sensitive credentials out of configuration files.
 
@@ -73,7 +73,7 @@ find different regions in [Tencent Cloud COS Regions](https://cloud.tencent.com/
 ### How it works
 
 1. The Fluss server calls `GetFederationToken` with the configured permanent credentials to obtain a temporary credential consisting of a temporary secret id, a temporary secret key, and a session token.
-2. By default, the temporary credential is granted **full COS read-write permission** (`name/cos:*` on all resources) and has a **validity period of 30 minutes**.
+2. By default, the temporary credential is granted **full COS read-write permission** (`name/cos:*`) scoped to the bucket configured via `remote.data.dir`, and has a **validity period of 1 hour**. You can override this default policy by setting `fs.cosn.security.token.policy` to a custom STS policy JSON.
 3. The temporary credential is distributed to clients, which use it to access COS directly.
 4. Fluss automatically refreshes the credential before it expires.
 

--- a/website/docs/maintenance/filesystems/cos.md
+++ b/website/docs/maintenance/filesystems/cos.md
@@ -1,0 +1,89 @@
+---
+title: Tencent Cloud COS
+sidebar_position: 7
+---
+
+# Tencent Cloud COS
+
+[Tencent Cloud Object Storage](https://cloud.tencent.com/product/cos) (Tencent Cloud COS) is a distributed storage service offered by Tencent Cloud for storing massive amounts of data. It provides high scalability, low cost, reliability, and security.
+
+## Install COS Plugin Manually
+
+Tencent Cloud COS support is not included in the default Fluss distribution. To enable COS support, you need to manually install the filesystem plugin into Fluss.
+
+1. **Prepare the plugin JAR**: 
+
+   - Download the `fluss-fs-cos-$FLUSS_VERSION$.jar` from the [Maven Repository](https://repo1.maven.org/maven2/org/apache/fluss/fluss-fs-cos/$FLUSS_VERSION$/fluss-fs-cos-$FLUSS_VERSION$.jar).
+   
+2. **Place the plugin**: Place the plugin JAR file in the `${FLUSS_HOME}/plugins/cos/` directory:
+   ```bash
+   mkdir -p ${FLUSS_HOME}/plugins/cos/
+   cp fluss-fs-cos-$FLUSS_VERSION$.jar ${FLUSS_HOME}/plugins/cos/
+   ```
+
+3. Restart Fluss if the cluster is already running to ensure the new plugin is loaded.
+
+## Configurations setup
+
+To enable Tencent Cloud COS as remote storage, there are some required configurations that must be added to Fluss' `server.yaml`:
+
+```yaml
+# The dir that used to be as the remote storage of Fluss
+remote.data.dir: cosn://<your-bucket>/path/to/remote/storage
+# COS endpoint suffix, such as: cos.ap-guangzhou.myqcloud.com
+fs.cosn.bucket.endpoint_suffix: <your-endpoint-suffix>
+# COS region, such as: ap-guangzhou
+fs.cosn.userinfo.region: <your-cos-region>
+
+# Authentication (choose one option below)
+
+# Option 1: Direct credentials
+# Tencent Cloud secret id
+fs.cosn.userinfo.secretId: <your-secret-id>
+# Tencent Cloud secret key
+fs.cosn.userinfo.secretKey: <your-secret-key>
+
+# Option 2: Secure credential provider
+fs.cosn.credentials.provider: <your-credentials-provider>
+```
+To avoid exposing sensitive access key information directly in the `server.yaml`, you can choose option2 to use a credential provider by setting the `fs.cosn.credentials.provider` property.
+
+For example, to use environment variables for credential management:
+```yaml
+fs.cosn.credentials.provider: org.apache.hadoop.fs.cosn.auth.EnvironmentVariableCredentialProvider
+```
+Then, set the following environment variables before starting the Fluss service:
+```bash
+export COS_SECRET_ID=<your-secret-id>
+export COS_SECRET_KEY=<your-secret-key>
+```
+This approach enhances security by keeping sensitive credentials out of configuration files.
+
+## Token-based Authentication
+
+For client to access the remote storage such as reading snapshot or tiered log, client must obtain a temporary credential (STS token) from Fluss cluster.
+
+Fluss uses Tencent Cloud STS [GetFederationToken](https://cloud.tencent.com/document/product/1312/48195) API to obtain temporary credentials.
+Unlike `AssumeRole`, `GetFederationToken` does not require a role ARN — it generates temporary credentials directly from the caller's permanent credentials (`secretId` / `secretKey`).
+
+To enable this, you must configure `fs.cosn.userinfo.region` which is required for calling the STS API.
+The `fs.cosn.userinfo.region` specifies the COS region where your bucket is located, such as `ap-guangzhou`, `ap-beijing`, etc. You can
+find different regions in [Tencent Cloud COS Regions](https://cloud.tencent.com/document/product/436/6224).
+
+### How it works
+
+1. The Fluss server calls `GetFederationToken` with the configured permanent credentials to obtain a temporary credential consisting of a temporary secret id, a temporary secret key, and a session token.
+2. By default, the temporary credential is granted **full COS read-write permission** (`name/cos:*` on all resources) and has a **validity period of 30 minutes**.
+3. The temporary credential is distributed to clients, which use it to access COS directly.
+4. Fluss automatically refreshes the credential before it expires.
+
+:::note
+The effective permission of the temporary credential is the **intersection** of the permanent credential's permission and the policy specified in the `GetFederationToken` request.
+So the permanent credential (the `secretId` / `secretKey` configured in `server.yaml`) must have sufficient COS permissions.
+See more details in [Tencent Cloud COS Access Policy](https://cloud.tencent.com/document/product/436/6884).
+:::
+
+## Advanced Configurations
+
+Apart from the above configurations, you can also define the configuration keys mentioned in the [Hadoop-COS documentation](https://hadoop.apache.org/docs/current/hadoop-cos/cloud-storage/index.html)
+in the Fluss' `server.yaml`. These configurations defined in Hadoop-COS documentation are advanced configurations which are usually used by performance tuning.

--- a/website/docs/maintenance/filesystems/overview.md
+++ b/website/docs/maintenance/filesystems/overview.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 # File Systems
 
 Fluss uses file systems as remote storage to store snapshots for Primary-Key Table and store tiered log segments for Log Table. These
-are some of the file systems that Fluss supports currently, including *local*, *hadoop*, *Aliyun OSS*.
+are some of the file systems that Fluss supports currently, including *local*, *hadoop*, *Aliyun OSS*, *Tencent Cloud COS*.
 
 The file system used for a particular file is determined by its URI scheme. For example, `file:///home/user/text.txt` refers to a file in the local file system,
 while `hdfs://namenode:50010/data/user/text.txt` is a file in a specific HDFS cluster.
@@ -39,5 +39,7 @@ The Fluss project supports the following file systems:
 - **[Azure Blob Storage](azure.md)** is supported by `fluss-fs-azure` and registered under the `abfs://`,`abfss://`,`wasb://`,`wasbs://`, URI schemes.
 
 - **[HuaweiCloud OBS](obs.md)** is supported by `fluss-fs-obs` and registered under the `obs://` URI scheme. Please make sure to [manually install the OBS plugin](obs.md#install-obs-plugin-manually).
+
+- **[Tencent Cloud COS](cos.md)** is supported by `fluss-fs-cos` and registered under the `cosn://` URI scheme. Please make sure to [manually install the COS plugin](cos.md#install-cos-plugin-manually).
 
 The implementation is based on [Hadoop Project](https://hadoop.apache.org/) but is self-contained with no dependency footprint.


### PR DESCRIPTION
### Purpose

Linked issue: close #2686

This PR adds support for Tencent Cloud Object Storage (COS) as a remote filesystem for Fluss. COS is one of the most widely used cloud storage services in China and this integration enables users to store Fluss remote data on COS, similar to the existing OSS, OBS, S3, and GCS filesystem integrations.

### Brief change log

- **`fluss-fs-cos/pom.xml`**: Add module configuration with dependencies on `hadoop-cos` (3.3.5), `cos_api` (5.6.139), and `fluss-fs-hadoop` for Hadoop filesystem abstraction.
- **`COSFileSystem`**: Extends `HadoopFileSystem` to wrap Hadoop's `CosNFileSystem`, with lazy-initialized security token provider support for obtaining temporary credentials.
- **`COSFileSystemPlugin`**: Implements `FileSystemPlugin` SPI for the `cosn` scheme. Handles Hadoop configuration translation from Fluss config (prefix `fs.cosn.*`), supports three credential modes: static secret key, custom credentials provider, and dynamic security token via `COSSecurityTokenReceiver`.
- **`COSSecurityTokenProvider`**: Generates temporary security tokens using Tencent Cloud STS (Security Token Service) based on existing `secretId`/`secretKey` configuration.
- **`COSSecurityTokenReceiver`**: Implements `SecurityTokenReceiver` SPI to receive and apply security tokens, configuring `DynamicTemporaryCOSCredentialsProvider` as the Hadoop credentials provider.
- **`DynamicTemporaryCOSCredentialsProvider`**: Implements COS SDK's `COSCredentialsProvider` interface, providing `BasicSessionCredentials` from tokens received via `COSSecurityTokenReceiver`.
- **`fluss-filesystems/pom.xml`**: Register `fluss-fs-cos` as a sub-module.

### Tests

- `COSFileSystemBehaviorITCase`: Integration test for basic COS filesystem behavior (create, read, write, delete) using static credentials (`secretId`/`secretKey`).
- `COSWithTokenFileSystemBehaviorITCase`: Integration test for COS filesystem behavior using dynamic security tokens obtained via STS.
- `COSWithTokenFileSystemBehaviorBaseITCase`: Base class for token-based filesystem tests, handling filesystem initialization with both static credentials and security tokens.
- `COSTestCredentials`: Test utility that reads COS credentials and endpoint from environment variables (`COSN_SECRET_ID`, `COSN_SECRET_KEY`, `COSN_ENDPOINT`, `COSN_BUCKET`).

> Note: These are IT (integration tests) that require actual COS credentials and bucket access. They are skipped automatically when credentials are not available via `Assumptions.assumeTrue`.

### API and Format

No existing API or storage format changes. This PR only adds a new filesystem plugin that registers via SPI (`META-INF/services/org.apache.fluss.fs.FileSystemPlugin`).

New configuration keys introduced (all following standard Hadoop COS conventions):
- `fs.cosn.endpoint` — COS region endpoint (e.g., `ap-guangzhou`)
- `fs.cosn.userinfo.secretId` — Tencent Cloud secret ID
- `fs.cosn.userinfo.secretKey` — Tencent Cloud secret key
- `fs.cosn.credentials.provider` — Custom credentials provider class

### Documentation

This PR introduces a new feature. Documentation for COS filesystem configuration should be added to the Fluss documentation site in a follow-up. Usage example:

```yaml
remote.data.dir: cosn://bucket-name/fluss-data
fs.cosn.endpoint: ap-guangzhou
fs.cosn.userinfo.secretId: <your-secret-id>
fs.cosn.userinfo.secretKey: <your-secret-key>
