### PR TITLE
[lake/iceberg] Support snapshot expiration for lake tables

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -2220,6 +2220,34 @@ public class ConfigOptions {
                                     + ConfigOptions.TABLE_DATALAKE_AUTO_EXPIRE_SNAPSHOT
                                     + " is false.");
 
+    public static final ConfigOption<Long> LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_COMMITS =
+            key("lake.iceberg.expire-snapshot.min-interval-commits")
+                    .longType()
+                    .defaultValue(10L)
+                    .withDescription(
+                            "Minimum number of commits that must occur since the last snapshot expiration "
+                                    + "before expiration is eligible to run again for Iceberg tables. "
+                                    + "Works in conjunction with lake.iceberg.expire-snapshot.min-interval-ms: "
+                                    + "both thresholds must be satisfied (AND logic) before expiration is triggered. "
+                                    + "This prevents metadata and file-deletion storms on object stores in "
+                                    + "high-frequency streaming tiering scenarios. Only applies when "
+                                    + "lake.tiering.auto-expire-snapshot or "
+                                    + "table.datalake.auto-expire-snapshot is enabled.");
+
+    public static final ConfigOption<Duration> LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_MS =
+            key("lake.iceberg.expire-snapshot.min-interval-ms")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(10))
+                    .withDescription(
+                            "Minimum duration that must elapse since the last snapshot expiration "
+                                    + "before expiration is eligible to run again for Iceberg tables. "
+                                    + "Works in conjunction with lake.iceberg.expire-snapshot.min-interval-commits: "
+                                    + "both thresholds must be satisfied (AND logic) before expiration is triggered. "
+                                    + "This acts as the primary rate-limiter for high-frequency streaming tiering "
+                                    + "scenarios where many commits occur per minute. Only applies when "
+                                    + "lake.tiering.auto-expire-snapshot or "
+                                    + "table.datalake.auto-expire-snapshot is enabled.");
+
     // ------------------------------------------------------------------------
     //  ConfigOptions for fluss kafka
     // ------------------------------------------------------------------------

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
@@ -17,7 +17,9 @@
 
 package org.apache.fluss.lake.iceberg.tiering;
 
+import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.lake.committer.CommittedLakeSnapshot;
+import org.apache.fluss.lake.committer.CommitterInitContext;
 import org.apache.fluss.lake.committer.LakeCommitResult;
 import org.apache.fluss.lake.committer.LakeCommitter;
 import org.apache.fluss.lake.iceberg.maintenance.RewriteDataFileResult;
@@ -28,6 +30,7 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.ExpireSnapshots;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Snapshot;
@@ -61,12 +64,23 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
 
     private final Catalog icebergCatalog;
     private final Table icebergTable;
+    private final boolean isAutoSnapshotExpiration;
     private static final ThreadLocal<Long> currentCommitSnapshotId = new ThreadLocal<>();
 
-    public IcebergLakeCommitter(IcebergCatalogProvider icebergCatalogProvider, TablePath tablePath)
+    public IcebergLakeCommitter(
+            IcebergCatalogProvider icebergCatalogProvider,
+            CommitterInitContext committerInitContext)
             throws IOException {
         this.icebergCatalog = icebergCatalogProvider.get();
-        this.icebergTable = getTable(tablePath);
+        this.icebergTable = getTable(committerInitContext.tablePath());
+        this.isAutoSnapshotExpiration =
+                committerInitContext
+                                .tableInfo()
+                                .getTableConfig()
+                                .isDataLakeAutoExpireSnapshot()
+                        || committerInitContext
+                                .lakeTieringConfig()
+                                .get(ConfigOptions.LAKE_TIERING_AUTO_EXPIRE_SNAPSHOT);
         // register iceberg listener
         Listeners.register(new IcebergSnapshotCreateListener(), CreateSnapshotEvent.class);
     }
@@ -141,6 +155,12 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
                     snapshotId = rewriteCommitSnapshotId;
                 }
             }
+
+            // Expire old snapshots if auto-expire-snapshot is enabled
+            if (isAutoSnapshotExpiration) {
+                expireSnapshots();
+            }
+
             // Iceberg does not provide cumulative table stats API yet; leave stats as -1 (unknown).
             return LakeCommitResult.committedIsReadable(snapshotId);
         } catch (Exception e) {
@@ -259,6 +279,22 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
             }
         } catch (Exception e) {
             throw new IOException("Failed to close IcebergLakeCommitter.", e);
+        }
+    }
+
+    /**
+     * Expires old snapshots from the Iceberg table. Uses Iceberg's built-in snapshot expiration
+     * which respects table properties like {@code history.expire.max-snapshot-age-ms} and {@code
+     * history.expire.min-snapshots-to-keep}.
+     */
+    private void expireSnapshots() {
+        try {
+            ExpireSnapshots expireSnapshots =
+                    icebergTable.expireSnapshots().cleanExpiredFiles(true);
+            expireSnapshots.commit();
+            LOG.debug("Successfully expired old snapshots for Iceberg table.");
+        } catch (Exception e) {
+            LOG.warn("Failed to expire snapshots for Iceberg table, will retry on next commit.", e);
         }
     }
 

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
@@ -74,10 +74,7 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
         this.icebergCatalog = icebergCatalogProvider.get();
         this.icebergTable = getTable(committerInitContext.tablePath());
         this.isAutoSnapshotExpiration =
-                committerInitContext
-                                .tableInfo()
-                                .getTableConfig()
-                                .isDataLakeAutoExpireSnapshot()
+                committerInitContext.tableInfo().getTableConfig().isDataLakeAutoExpireSnapshot()
                         || committerInitContext
                                 .lakeTieringConfig()
                                 .get(ConfigOptions.LAKE_TIERING_AUTO_EXPIRE_SNAPSHOT);

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
@@ -246,15 +246,21 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
         if (latestLakeSnapshotIdOfFluss != null) {
             Snapshot latestLakeSnapshotOfFluss = icebergTable.snapshot(latestLakeSnapshotIdOfFluss);
             if (latestLakeSnapshotOfFluss == null) {
-                throw new IllegalStateException(
-                        "Referenced Fluss snapshot "
-                                + latestLakeSnapshotIdOfFluss
-                                + " not found in Iceberg table");
-            }
-            // note: we need to use sequence number to compare,
-            // we can't use snapshot id as the snapshot id is not ordered
-            if (latestLakeSnapshot.sequenceNumber() <= latestLakeSnapshotOfFluss.sequenceNumber()) {
-                return null;
+                // The referenced snapshot was expired from Iceberg. Since Iceberg never
+                // expires the current snapshot, the latest Fluss-committed snapshot we found
+                // above must be newer than the expired one — treat as a missing snapshot.
+                LOG.warn(
+                        "Referenced Fluss snapshot {} was expired from Iceberg table. "
+                                + "The latest Fluss-committed snapshot {} will be used for recovery.",
+                        latestLakeSnapshotIdOfFluss,
+                        latestLakeSnapshot.snapshotId());
+            } else {
+                // note: we need to use sequence number to compare,
+                // we can't use snapshot id as the snapshot id is not ordered
+                if (latestLakeSnapshot.sequenceNumber()
+                        <= latestLakeSnapshotOfFluss.sequenceNumber()) {
+                    return null;
+                }
             }
         }
 

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
@@ -17,6 +17,7 @@
 
 package org.apache.fluss.lake.iceberg.tiering;
 
+import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.lake.committer.CommittedLakeSnapshot;
 import org.apache.fluss.lake.committer.CommitterInitContext;
@@ -24,6 +25,8 @@ import org.apache.fluss.lake.committer.LakeCommitResult;
 import org.apache.fluss.lake.committer.LakeCommitter;
 import org.apache.fluss.lake.iceberg.maintenance.RewriteDataFileResult;
 import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.utils.clock.Clock;
+import org.apache.fluss.utils.clock.SystemClock;
 
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.CatalogUtil;
@@ -65,11 +68,25 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
     private final Catalog icebergCatalog;
     private final Table icebergTable;
     private final boolean isAutoSnapshotExpiration;
+    private final long minIntervalCommits;
+    private final long minIntervalMs;
+    private final Clock clock;
+    private long commitsSinceLastExpire = 0;
+    private long lastExpireTimestampMs = 0;
     private static final ThreadLocal<Long> currentCommitSnapshotId = new ThreadLocal<>();
 
     public IcebergLakeCommitter(
             IcebergCatalogProvider icebergCatalogProvider,
             CommitterInitContext committerInitContext)
+            throws IOException {
+        this(icebergCatalogProvider, committerInitContext, SystemClock.getInstance());
+    }
+
+    @VisibleForTesting
+    IcebergLakeCommitter(
+            IcebergCatalogProvider icebergCatalogProvider,
+            CommitterInitContext committerInitContext,
+            Clock clock)
             throws IOException {
         this.icebergCatalog = icebergCatalogProvider.get();
         this.icebergTable = getTable(committerInitContext.tablePath());
@@ -78,6 +95,16 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
                         || committerInitContext
                                 .lakeTieringConfig()
                                 .get(ConfigOptions.LAKE_TIERING_AUTO_EXPIRE_SNAPSHOT);
+        this.minIntervalCommits =
+                committerInitContext
+                        .lakeTieringConfig()
+                        .get(ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_COMMITS);
+        this.minIntervalMs =
+                committerInitContext
+                        .lakeTieringConfig()
+                        .get(ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_MS)
+                        .toMillis();
+        this.clock = clock;
         // register iceberg listener
         Listeners.register(new IcebergSnapshotCreateListener(), CreateSnapshotEvent.class);
     }
@@ -153,9 +180,14 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
                 }
             }
 
-            // Expire old snapshots if auto-expire-snapshot is enabled
+            // Expire old snapshots if auto-expire-snapshot is enabled, subject to throttle gates
             if (isAutoSnapshotExpiration) {
-                expireSnapshots();
+                commitsSinceLastExpire++;
+                if (shouldExpireSnapshots()) {
+                    expireSnapshots();
+                    commitsSinceLastExpire = 0;
+                    lastExpireTimestampMs = clock.milliseconds();
+                }
             }
 
             // Iceberg does not provide cumulative table stats API yet; leave stats as -1 (unknown).
@@ -283,6 +315,23 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
         } catch (Exception e) {
             throw new IOException("Failed to close IcebergLakeCommitter.", e);
         }
+    }
+
+    /**
+     * Returns true when both throttle gates are satisfied (AND logic):
+     *
+     * <ul>
+     *   <li>At least {@code minIntervalCommits} commits have occurred since the last expiration.
+     *   <li>At least {@code minIntervalMs} milliseconds have elapsed since the last expiration.
+     * </ul>
+     *
+     * <p>On the very first call {@code lastExpireTimestampMs} is 0, so the time gate is trivially
+     * satisfied and expiration fires as soon as the commit-count threshold is reached.
+     */
+    private boolean shouldExpireSnapshots() {
+        boolean countThresholdMet = commitsSinceLastExpire >= minIntervalCommits;
+        boolean timeThresholdMet = (clock.milliseconds() - lastExpireTimestampMs) >= minIntervalMs;
+        return countThresholdMet && timeThresholdMet;
     }
 
     /**

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeTieringFactory.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeTieringFactory.java
@@ -53,7 +53,7 @@ public class IcebergLakeTieringFactory
     @Override
     public LakeCommitter<IcebergWriteResult, IcebergCommittable> createLakeCommitter(
             CommitterInitContext committerInitContext) throws IOException {
-        return new IcebergLakeCommitter(icebergCatalogProvider, committerInitContext.tablePath());
+        return new IcebergLakeCommitter(icebergCatalogProvider, committerInitContext);
     }
 
     @Override

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
@@ -35,6 +35,7 @@ import org.apache.fluss.record.LogRecord;
 import org.apache.fluss.row.BinaryString;
 import org.apache.fluss.row.GenericRow;
 import org.apache.fluss.types.DataTypes;
+import org.apache.fluss.utils.clock.ManualClock;
 import org.apache.fluss.utils.types.Tuple2;
 
 import org.apache.iceberg.PartitionSpec;
@@ -90,19 +91,21 @@ class IcebergTieringTest {
     private static final int BUCKET_NUM = 3;
 
     private @TempDir File tempWarehouseDir;
+    private Configuration icebergConfiguration;
+    private IcebergCatalogProvider icebergCatalogProvider;
     private IcebergLakeTieringFactory icebergLakeTieringFactory;
     private Catalog icebergCatalog;
 
     @BeforeEach
     void beforeEach() {
-        Configuration configuration = new Configuration();
-        configuration.setString("warehouse", "file://" + tempWarehouseDir);
-        configuration.setString("type", "hadoop");
-        configuration.setString("name", "test");
-        IcebergCatalogProvider provider = new IcebergCatalogProvider(configuration);
-        icebergCatalog = provider.get();
+        icebergConfiguration = new Configuration();
+        icebergConfiguration.setString("warehouse", "file://" + tempWarehouseDir);
+        icebergConfiguration.setString("type", "hadoop");
+        icebergConfiguration.setString("name", "test");
+        icebergCatalogProvider = new IcebergCatalogProvider(icebergConfiguration);
+        icebergCatalog = icebergCatalogProvider.get();
 
-        icebergLakeTieringFactory = new IcebergLakeTieringFactory(configuration);
+        icebergLakeTieringFactory = new IcebergLakeTieringFactory(icebergConfiguration);
     }
 
     private static Stream<Arguments> tieringWriteArgs() {
@@ -328,6 +331,12 @@ class IcebergTieringTest {
         Configuration lakeTieringConfig = new Configuration();
         lakeTieringConfig.set(
                 ConfigOptions.LAKE_TIERING_AUTO_EXPIRE_SNAPSHOT, isLakeTieringExpireSnapshot);
+        // Disable throttle gates so expiration fires on every commit (testing enable/disable, not
+        // throttle behavior)
+        lakeTieringConfig.setLong(
+                ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_COMMITS.key(), 1L);
+        lakeTieringConfig.setString(
+                ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_MS.key(), "0ms");
 
         // Write data multiple times to generate snapshots
         for (int round = 0; round < 5; round++) {
@@ -390,6 +399,11 @@ class IcebergTieringTest {
 
         Configuration lakeTieringConfig = new Configuration();
         lakeTieringConfig.set(ConfigOptions.LAKE_TIERING_AUTO_EXPIRE_SNAPSHOT, false);
+        // Disable throttle gates so expiration fires on every commit
+        lakeTieringConfig.setLong(
+                ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_COMMITS.key(), 1L);
+        lakeTieringConfig.setString(
+                ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_MS.key(), "0ms");
 
         // Round 1: Write and commit, capture snapshot ID (simulating Flink checkpoint saving it)
         long firstSnapshotId;
@@ -455,6 +469,161 @@ class IcebergTieringTest {
         }
     }
 
+    /**
+     * Verifies that the count-based throttle gate prevents expiration from running on every commit.
+     * With {@code MIN_INTERVAL_COMMITS=3} and the time gate effectively disabled ({@code
+     * MIN_INTERVAL_MS=0}), expiration should fire every 3 commits instead of every commit.
+     */
+    @Test
+    void testSnapshotExpirationThrottlingCountGate() throws Exception {
+        int bucketNum = 1;
+        TablePath tablePath = TablePath.of("iceberg", "test_expire_throttle_count");
+
+        Map<String, String> tableProperties = new HashMap<>();
+        tableProperties.put(TableProperties.MIN_SNAPSHOTS_TO_KEEP, "1");
+        tableProperties.put(TableProperties.MAX_SNAPSHOT_AGE_MS, "1");
+        createTable(tablePath, false, false, tableProperties);
+
+        TableDescriptor descriptor =
+                TableDescriptor.builder()
+                        .schema(
+                                org.apache.fluss.metadata.Schema.newBuilder()
+                                        .column("c1", DataTypes.INT())
+                                        .column("c2", DataTypes.STRING())
+                                        .column("c3", DataTypes.STRING())
+                                        .build())
+                        .distributedBy(bucketNum)
+                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
+                        .property(ConfigOptions.TABLE_DATALAKE_AUTO_EXPIRE_SNAPSHOT, true)
+                        .build();
+        TableInfo tableInfo =
+                TableInfo.of(tablePath, 0, 1, descriptor, DEFAULT_REMOTE_DATA_DIR, 1L, 1L);
+
+        Configuration lakeTieringConfig = new Configuration();
+        // Require 3 commits before expiration is eligible (time gate disabled by setting to 0ms)
+        lakeTieringConfig.setLong(
+                ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_COMMITS.key(), 3L);
+        lakeTieringConfig.setString(
+                ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_MS.key(), "0ms");
+
+        // Use a ManualClock well past epoch so the time gate is always satisfied
+        ManualClock manualClock = new ManualClock(System.currentTimeMillis());
+
+        // Write 9 commits using a shared committer with the ManualClock
+        CommitterInitContext initContext =
+                buildCommitterInitContext(tablePath, tableInfo, lakeTieringConfig);
+        try (IcebergLakeCommitter committer =
+                new IcebergLakeCommitter(icebergCatalogProvider, initContext, manualClock)) {
+            for (int round = 0; round < 9; round++) {
+                List<IcebergWriteResult> writeResults = new ArrayList<>();
+                for (int bucket = 0; bucket < bucketNum; bucket++) {
+                    try (LakeWriter<IcebergWriteResult> writer =
+                            createLakeWriter(tablePath, bucket, null, null, tableInfo)) {
+                        for (LogRecord record : genLogTableRecords(null, bucket, 1).f0) {
+                            writer.write(record);
+                        }
+                        writeResults.add(writer.complete());
+                    }
+                }
+                IcebergCommittable committable = committer.toCommittable(writeResults);
+                committer.commit(committable, Collections.emptyMap());
+            }
+        }
+
+        // With MIN_SNAPSHOTS_TO_KEEP=1 and expiration every 3 commits,
+        // the last expiration should have happened on commit 9 (3rd multiple of 3).
+        // Only 1 snapshot should remain.
+        Table icebergTable = icebergCatalog.loadTable(toIceberg(tablePath));
+        icebergTable.refresh();
+        int snapshotCount = 0;
+        for (Snapshot ignored : icebergTable.snapshots()) {
+            snapshotCount++;
+        }
+        assertThat(snapshotCount)
+                .as("With count-throttle of 3 and 9 commits, expiration should have fired 3 times")
+                .isEqualTo(1);
+    }
+
+    /**
+     * Verifies that the time-based throttle gate blocks expiration until enough time has elapsed,
+     * and that expiration eventually fires once the time gate is satisfied. Uses {@link
+     * ManualClock} for deterministic time control — no {@link Thread#sleep} needed.
+     */
+    @Test
+    void testSnapshotExpirationThrottlingTimeGate() throws Exception {
+        int bucketNum = 1;
+        TablePath tablePath = TablePath.of("iceberg", "test_expire_throttle_time");
+
+        Map<String, String> tableProperties = new HashMap<>();
+        tableProperties.put(TableProperties.MIN_SNAPSHOTS_TO_KEEP, "1");
+        tableProperties.put(TableProperties.MAX_SNAPSHOT_AGE_MS, "1");
+        createTable(tablePath, false, false, tableProperties);
+
+        TableDescriptor descriptor =
+                TableDescriptor.builder()
+                        .schema(
+                                org.apache.fluss.metadata.Schema.newBuilder()
+                                        .column("c1", DataTypes.INT())
+                                        .column("c2", DataTypes.STRING())
+                                        .column("c3", DataTypes.STRING())
+                                        .build())
+                        .distributedBy(bucketNum)
+                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
+                        .property(ConfigOptions.TABLE_DATALAKE_AUTO_EXPIRE_SNAPSHOT, true)
+                        .build();
+        TableInfo tableInfo =
+                TableInfo.of(tablePath, 0, 1, descriptor, DEFAULT_REMOTE_DATA_DIR, 1L, 1L);
+
+        Configuration lakeTieringConfig = new Configuration();
+        // Count gate: 1 commit (always satisfied after first commit).
+        // Time gate: 10 minutes — must elapse before expiration fires.
+        lakeTieringConfig.setLong(
+                ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_COMMITS.key(), 1L);
+        lakeTieringConfig.setString(
+                ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_MS.key(), "10min");
+
+        // ManualClock at t=0 so the 10-minute time gate is not yet satisfied on first commits
+        ManualClock manualClock = new ManualClock(0);
+
+        CommitterInitContext initContext =
+                buildCommitterInitContext(tablePath, tableInfo, lakeTieringConfig);
+        try (IcebergLakeCommitter committer =
+                new IcebergLakeCommitter(icebergCatalogProvider, initContext, manualClock)) {
+
+            // Phase 1: write 3 commits at t=0 — time gate not satisfied, expiration blocked
+            for (int round = 0; round < 3; round++) {
+                writeRound(committer, tablePath, bucketNum, tableInfo);
+            }
+
+            Table icebergTable = icebergCatalog.loadTable(toIceberg(tablePath));
+            icebergTable.refresh();
+            int snapshotCountBefore = 0;
+            for (Snapshot ignored : icebergTable.snapshots()) {
+                snapshotCountBefore++;
+            }
+            assertThat(snapshotCountBefore)
+                    .as(
+                            "Time gate not yet elapsed: expiration should be blocked, all 3 snapshots kept")
+                    .isEqualTo(3);
+
+            // Phase 2: advance clock past the 10-minute time gate
+            manualClock.advanceTime(java.time.Duration.ofMinutes(11));
+
+            // Phase 3: one more commit — both gates now satisfied, expiration fires
+            writeRound(committer, tablePath, bucketNum, tableInfo);
+
+            icebergTable.refresh();
+            int snapshotCountAfter = 0;
+            for (Snapshot ignored : icebergTable.snapshots()) {
+                snapshotCountAfter++;
+            }
+            assertThat(snapshotCountAfter)
+                    .as(
+                            "After time gate elapses, expiration should fire and retain only 1 snapshot")
+                    .isEqualTo(1);
+        }
+    }
+
     private void writeData(
             TablePath tablePath,
             TableInfo tableInfo,
@@ -492,6 +661,48 @@ class IcebergTieringTest {
                             committableSerializer.getVersion(), serialized);
             lakeCommitter.commit(committable, Collections.emptyMap());
         }
+    }
+
+    private CommitterInitContext buildCommitterInitContext(
+            TablePath tablePath, TableInfo tableInfo, Configuration lakeTieringConfig) {
+        return new CommitterInitContext() {
+            @Override
+            public TablePath tablePath() {
+                return tablePath;
+            }
+
+            @Override
+            public TableInfo tableInfo() {
+                return tableInfo;
+            }
+
+            @Override
+            public Configuration lakeTieringConfig() {
+                return lakeTieringConfig;
+            }
+
+            @Override
+            public Configuration flussClientConfig() {
+                return new Configuration();
+            }
+        };
+    }
+
+    private void writeRound(
+            IcebergLakeCommitter committer, TablePath tablePath, int bucketNum, TableInfo tableInfo)
+            throws Exception {
+        List<IcebergWriteResult> writeResults = new ArrayList<>();
+        for (int bucket = 0; bucket < bucketNum; bucket++) {
+            try (LakeWriter<IcebergWriteResult> writer =
+                    createLakeWriter(tablePath, bucket, null, null, tableInfo)) {
+                for (LogRecord record : genLogTableRecords(null, bucket, 1).f0) {
+                    writer.write(record);
+                }
+                writeResults.add(writer.complete());
+            }
+        }
+        IcebergCommittable committable = committer.toCommittable(writeResults);
+        committer.commit(committable, Collections.emptyMap());
     }
 
     private Tuple2<List<LogRecord>, List<LogRecord>> genLogTableRecords(

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
@@ -19,6 +19,7 @@ package org.apache.fluss.lake.iceberg.tiering;
 
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.lake.committer.CommittedLakeSnapshot;
 import org.apache.fluss.lake.committer.CommitterInitContext;
 import org.apache.fluss.lake.committer.LakeCommitter;
 import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
@@ -49,6 +50,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -320,7 +322,8 @@ class IcebergTieringTest {
                                 ConfigOptions.TABLE_DATALAKE_AUTO_EXPIRE_SNAPSHOT,
                                 isTableAutoExpireSnapshot)
                         .build();
-        TableInfo tableInfo = TableInfo.of(tablePath, 0, 1, descriptor, 1L, 1L);
+        TableInfo tableInfo =
+                TableInfo.of(tablePath, 0, 1, descriptor, DEFAULT_REMOTE_DATA_DIR, 1L, 1L);
 
         Configuration lakeTieringConfig = new Configuration();
         lakeTieringConfig.set(
@@ -347,6 +350,108 @@ class IcebergTieringTest {
         } else {
             // if auto snapshot expiration is disabled, all snapshots should be retained
             assertThat(snapshotCount).isEqualTo(5);
+        }
+    }
+
+    /**
+     * Validates that snapshot expiration can cause recovery failure.
+     *
+     * <p>Scenario: The tiering service commits multiple snapshots with auto-expire enabled. With
+     * aggressive settings (MIN_SNAPSHOTS_TO_KEEP=1), only the latest snapshot is retained. If the
+     * Flink checkpoint references an earlier (now-expired) snapshot ID, then on recovery
+     * getMissingLakeSnapshot will fail because it calls icebergTable.snapshot(expiredSnapshotId)
+     * which returns null, throwing an IllegalStateException.
+     */
+    @Test
+    void testSnapshotExpirationDoesNotBreakRecovery() throws Exception {
+        int bucketNum = 1;
+        TablePath tablePath = TablePath.of("iceberg", "test_expire_recovery");
+
+        // Aggressive expiration: keep only 1 snapshot, expire after 1ms
+        Map<String, String> tableProperties = new HashMap<>();
+        tableProperties.put(TableProperties.MIN_SNAPSHOTS_TO_KEEP, "1");
+        tableProperties.put(TableProperties.MAX_SNAPSHOT_AGE_MS, "1");
+        createTable(tablePath, false, false, tableProperties);
+
+        TableDescriptor descriptor =
+                TableDescriptor.builder()
+                        .schema(
+                                org.apache.fluss.metadata.Schema.newBuilder()
+                                        .column("c1", DataTypes.INT())
+                                        .column("c2", DataTypes.STRING())
+                                        .column("c3", DataTypes.STRING())
+                                        .build())
+                        .distributedBy(bucketNum)
+                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
+                        .property(ConfigOptions.TABLE_DATALAKE_AUTO_EXPIRE_SNAPSHOT, true)
+                        .build();
+        TableInfo tableInfo =
+                TableInfo.of(tablePath, 0, 1, descriptor, DEFAULT_REMOTE_DATA_DIR, 1L, 1L);
+
+        Configuration lakeTieringConfig = new Configuration();
+        lakeTieringConfig.set(ConfigOptions.LAKE_TIERING_AUTO_EXPIRE_SNAPSHOT, false);
+
+        // Round 1: Write and commit, capture snapshot ID (simulating Flink checkpoint saving it)
+        long firstSnapshotId;
+        Map<String, String> snapshotProperties =
+                Collections.singletonMap(
+                        LakeCommitter.FLUSS_LAKE_SNAP_BUCKET_OFFSET_PROPERTY, "/path/to/offsets-1");
+        {
+            List<IcebergWriteResult> writeResults = new ArrayList<>();
+            for (int bucket = 0; bucket < bucketNum; bucket++) {
+                try (LakeWriter<IcebergWriteResult> writer =
+                        createLakeWriter(tablePath, bucket, null, null, tableInfo)) {
+                    for (LogRecord record : genLogTableRecords(null, bucket, 3).f0) {
+                        writer.write(record);
+                    }
+                    writeResults.add(writer.complete());
+                }
+            }
+            try (LakeCommitter<IcebergWriteResult, IcebergCommittable> lakeCommitter =
+                    createLakeCommitter(tablePath, tableInfo, lakeTieringConfig)) {
+                IcebergCommittable committable = lakeCommitter.toCommittable(writeResults);
+                firstSnapshotId =
+                        lakeCommitter
+                                .commit(committable, snapshotProperties)
+                                .getCommittedSnapshotId();
+            }
+        }
+
+        // Verify first snapshot exists
+        Table icebergTable = icebergCatalog.loadTable(toIceberg(tablePath));
+        assertThat(icebergTable.snapshot(firstSnapshotId)).isNotNull();
+
+        // Small delay to ensure snapshot age exceeds MAX_SNAPSHOT_AGE_MS=1ms
+        Thread.sleep(50);
+
+        // Round 2 & 3: Write more data with auto-expire enabled to trigger expiration
+        for (int round = 0; round < 2; round++) {
+            writeData(tablePath, tableInfo, lakeTieringConfig, bucketNum);
+            Thread.sleep(50);
+        }
+
+        // Verify the first snapshot has been expired
+        icebergTable.refresh();
+        assertThat(icebergTable.snapshot(firstSnapshotId))
+                .as("First snapshot should have been expired by aggressive expiration settings")
+                .isNull();
+
+        // Simulate recovery: Flink restarts from checkpoint which has firstSnapshotId
+        // This is what TieringCommitOperator.checkFlussNotMissingLakeSnapshot does.
+        // Even though firstSnapshotId was expired, getMissingLakeSnapshot should
+        // gracefully return the latest Fluss-committed snapshot (like Paimon's pickOrLatest).
+        try (LakeCommitter<IcebergWriteResult, IcebergCommittable> lakeCommitter =
+                createLakeCommitter(tablePath, tableInfo, lakeTieringConfig)) {
+            CommittedLakeSnapshot missingSnapshot =
+                    lakeCommitter.getMissingLakeSnapshot(firstSnapshotId);
+            assertThat(missingSnapshot)
+                    .as(
+                            "Recovery should succeed even when referenced snapshot is expired, "
+                                    + "returning the latest Fluss-committed snapshot")
+                    .isNotNull();
+            // The returned snapshot should be the latest one (from round 2 or 3), not the expired
+            // one
+            assertThat(missingSnapshot.getLakeSnapshotId()).isNotEqualTo(firstSnapshotId);
         }
     }
 

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
@@ -506,10 +506,7 @@ class IcebergTieringTest {
         lakeTieringConfig.setString(
                 ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_MS.key(), "0ms");
 
-        // Use a ManualClock well past epoch so the time gate is always satisfied
         ManualClock manualClock = new ManualClock(System.currentTimeMillis());
-
-        // Write 9 commits using a shared committer with the ManualClock
         CommitterInitContext initContext =
                 buildCommitterInitContext(tablePath, tableInfo, lakeTieringConfig);
         try (IcebergLakeCommitter committer =
@@ -546,8 +543,7 @@ class IcebergTieringTest {
 
     /**
      * Verifies that the time-based throttle gate blocks expiration until enough time has elapsed,
-     * and that expiration eventually fires once the time gate is satisfied. Uses {@link
-     * ManualClock} for deterministic time control — no {@link Thread#sleep} needed.
+     * and that expiration eventually fires once the time gate is satisfied.
      */
     @Test
     void testSnapshotExpirationThrottlingTimeGate() throws Exception {
@@ -582,7 +578,6 @@ class IcebergTieringTest {
         lakeTieringConfig.setString(
                 ConfigOptions.LAKE_ICEBERG_EXPIRE_SNAPSHOT_MIN_INTERVAL_MS.key(), "10min");
 
-        // ManualClock at t=0 so the 10-minute time gate is not yet satisfied on first commits
         ManualClock manualClock = new ManualClock(0);
 
         CommitterInitContext initContext =

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
@@ -39,6 +39,7 @@ import org.apache.fluss.utils.types.Tuple2;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -105,6 +106,15 @@ class IcebergTieringTest {
     private static Stream<Arguments> tieringWriteArgs() {
         return Stream.of(
                 // isPrimaryKeyTable, isPartitionedTable
+                Arguments.of(true, true),
+                Arguments.of(true, false),
+                Arguments.of(false, true),
+                Arguments.of(false, false));
+    }
+
+    private static Stream<Arguments> snapshotExpireArgs() {
+        return Stream.of(
+                // isTableAutoExpireSnapshot, isLakeTieringExpireSnapshot
                 Arguments.of(true, true),
                 Arguments.of(true, false),
                 Arguments.of(false, true),
@@ -188,7 +198,7 @@ class IcebergTieringTest {
 
         // second, commit data
         try (LakeCommitter<IcebergWriteResult, IcebergCommittable> lakeCommitter =
-                createLakeCommitter(tablePath, tableInfo)) {
+                createLakeCommitter(tablePath, tableInfo, new Configuration())) {
             // serialize/deserialize committable
             IcebergCommittable icebergCommittable =
                     lakeCommitter.toCommittable(icebergWriteResults);
@@ -251,7 +261,8 @@ class IcebergTieringTest {
     }
 
     private LakeCommitter<IcebergWriteResult, IcebergCommittable> createLakeCommitter(
-            TablePath tablePath, TableInfo tableInfo) throws IOException {
+            TablePath tablePath, TableInfo tableInfo, Configuration lakeTieringConfig)
+            throws IOException {
         return icebergLakeTieringFactory.createLakeCommitter(
                 new CommitterInitContext() {
                     @Override
@@ -266,7 +277,7 @@ class IcebergTieringTest {
 
                     @Override
                     public Configuration lakeTieringConfig() {
-                        return new Configuration();
+                        return lakeTieringConfig;
                     }
 
                     @Override
@@ -274,6 +285,108 @@ class IcebergTieringTest {
                         return new Configuration();
                     }
                 });
+    }
+
+    @ParameterizedTest
+    @MethodSource("snapshotExpireArgs")
+    void testSnapshotExpiration(
+            boolean isTableAutoExpireSnapshot, boolean isLakeTieringExpireSnapshot)
+            throws Exception {
+        int bucketNum = 3;
+        TablePath tablePath =
+                TablePath.of(
+                        "iceberg",
+                        String.format(
+                                "test_snapshot_expire_%s_%s",
+                                isTableAutoExpireSnapshot, isLakeTieringExpireSnapshot));
+
+        // Create Iceberg table with snapshot retention properties
+        Map<String, String> tableProperties = new HashMap<>();
+        tableProperties.put(TableProperties.MIN_SNAPSHOTS_TO_KEEP, "1");
+        tableProperties.put(TableProperties.MAX_SNAPSHOT_AGE_MS, "1");
+        createTable(tablePath, false, false, tableProperties);
+
+        TableDescriptor descriptor =
+                TableDescriptor.builder()
+                        .schema(
+                                org.apache.fluss.metadata.Schema.newBuilder()
+                                        .column("c1", DataTypes.INT())
+                                        .column("c2", DataTypes.STRING())
+                                        .column("c3", DataTypes.STRING())
+                                        .build())
+                        .distributedBy(bucketNum)
+                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
+                        .property(
+                                ConfigOptions.TABLE_DATALAKE_AUTO_EXPIRE_SNAPSHOT,
+                                isTableAutoExpireSnapshot)
+                        .build();
+        TableInfo tableInfo = TableInfo.of(tablePath, 0, 1, descriptor, 1L, 1L);
+
+        Configuration lakeTieringConfig = new Configuration();
+        lakeTieringConfig.set(
+                ConfigOptions.LAKE_TIERING_AUTO_EXPIRE_SNAPSHOT, isLakeTieringExpireSnapshot);
+
+        // Write data multiple times to generate snapshots
+        for (int round = 0; round < 5; round++) {
+            writeData(tablePath, tableInfo, lakeTieringConfig, bucketNum);
+            // Small delay to ensure snapshots are older than MAX_SNAPSHOT_AGE_MS=1ms
+            Thread.sleep(10);
+        }
+
+        // Verify snapshot count
+        Table icebergTable = icebergCatalog.loadTable(toIceberg(tablePath));
+        int snapshotCount = 0;
+        for (Snapshot ignored : icebergTable.snapshots()) {
+            snapshotCount++;
+        }
+
+        if (isTableAutoExpireSnapshot || isLakeTieringExpireSnapshot) {
+            // if auto snapshot expiration is enabled, old snapshots should be expired
+            // With MIN_SNAPSHOTS_TO_KEEP=1, only 1 snapshot should be retained
+            assertThat(snapshotCount).isEqualTo(1);
+        } else {
+            // if auto snapshot expiration is disabled, all snapshots should be retained
+            assertThat(snapshotCount).isEqualTo(5);
+        }
+    }
+
+    private void writeData(
+            TablePath tablePath,
+            TableInfo tableInfo,
+            Configuration lakeTieringConfig,
+            int bucketNum)
+            throws Exception {
+        List<IcebergWriteResult> icebergWriteResults = new ArrayList<>();
+        SimpleVersionedSerializer<IcebergWriteResult> writeResultSerializer =
+                icebergLakeTieringFactory.getWriteResultSerializer();
+        SimpleVersionedSerializer<IcebergCommittable> committableSerializer =
+                icebergLakeTieringFactory.getCommittableSerializer();
+
+        for (int bucket = 0; bucket < bucketNum; bucket++) {
+            try (LakeWriter<IcebergWriteResult> writer =
+                    createLakeWriter(tablePath, bucket, null, null, tableInfo)) {
+                Tuple2<List<LogRecord>, List<LogRecord>> writeAndExpectRecords =
+                        genLogTableRecords(null, bucket, 3);
+                for (LogRecord record : writeAndExpectRecords.f0) {
+                    writer.write(record);
+                }
+                IcebergWriteResult result = writer.complete();
+                byte[] serialized = writeResultSerializer.serialize(result);
+                icebergWriteResults.add(
+                        writeResultSerializer.deserialize(
+                                writeResultSerializer.getVersion(), serialized));
+            }
+        }
+
+        try (LakeCommitter<IcebergWriteResult, IcebergCommittable> lakeCommitter =
+                createLakeCommitter(tablePath, tableInfo, lakeTieringConfig)) {
+            IcebergCommittable committable = lakeCommitter.toCommittable(icebergWriteResults);
+            byte[] serialized = committableSerializer.serialize(committable);
+            committable =
+                    committableSerializer.deserialize(
+                            committableSerializer.getVersion(), serialized);
+            lakeCommitter.commit(committable, Collections.emptyMap());
+        }
     }
 
     private Tuple2<List<LogRecord>, List<LogRecord>> genLogTableRecords(
@@ -361,6 +474,14 @@ class IcebergTieringTest {
 
     private void createTable(
             TablePath tablePath, boolean isPrimaryTable, boolean isPartitionedTable) {
+        createTable(tablePath, isPrimaryTable, isPartitionedTable, Collections.emptyMap());
+    }
+
+    private void createTable(
+            TablePath tablePath,
+            boolean isPrimaryTable,
+            boolean isPartitionedTable,
+            Map<String, String> tableProperties) {
         Namespace namespace = Namespace.of(tablePath.getDatabaseName());
         if (icebergCatalog instanceof SupportsNamespaces) {
             SupportsNamespaces ns = (SupportsNamespaces) icebergCatalog;
@@ -406,7 +527,7 @@ class IcebergTieringTest {
 
         TableIdentifier tableId =
                 TableIdentifier.of(tablePath.getDatabaseName(), tablePath.getTableName());
-        icebergCatalog.createTable(tableId, schema, partitionSpec);
+        icebergCatalog.createTable(tableId, schema, partitionSpec, tableProperties);
     }
 
     private CloseableIterator<Record> getIcebergRows(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2213 

<!-- What is the purpose of the change -->

### Brief change log

Similar to https://github.com/apache/fluss/issues/2182, this PR adds support for snapshot expiration for Iceberg tables.


### Tests

fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java

### API and Format

N/A

### Documentation

The configs `table.datalake.auto-expire-snapshot`  and  `tiering service config lake.tiering.auto-expire-snapshot` already exist. This PR makes Iceberg implement it.

Added 2 new configs: `lake.iceberg.expire-snapshot.min-interval-commits` and `lake.iceberg.expire-snapshot.min-interval-ms` to throttle snapshotting.