### PR TITLE
[client] Fix corruption after zero-copy lazy parse ByteBuf

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/batch/LimitBatchScanner.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/batch/LimitBatchScanner.java
@@ -94,7 +94,9 @@ public class LimitBatchScanner implements BatchScanner {
         RowType rowType = tableInfo.getRowType();
         this.fieldGetters = new InternalRow.FieldGetter[rowType.getFieldCount()];
         for (int i = 0; i < rowType.getFieldCount(); i++) {
-            this.fieldGetters[i] = InternalRow.createDeepFieldGetter(rowType.getTypeAt(i), i);
+            // getRecords() returns a heap copy, so rows don't reference the released buffer.
+            this.fieldGetters[i] =
+                    InternalRow.createDeepFieldGetter(rowType.getTypeAt(i), i, false);
         }
 
         LimitScanRequest limitScanRequest =

--- a/fluss-common/src/main/java/org/apache/fluss/record/LogRecordReadContext.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/LogRecordReadContext.java
@@ -148,7 +148,8 @@ public class LogRecordReadContext implements LogRecordBatch.ReadContext, AutoClo
         // TODO: use a more reasonable memory limit
         BufferAllocator allocator =
                 BufferAllocatorUtil.createBufferAllocator(allocationManagerFactory);
-        FieldGetter[] fieldGetters = buildProjectedFieldGetters(dataRowType, selectedFields);
+        FieldGetter[] fieldGetters =
+                buildProjectedFieldGetters(dataRowType, selectedFields, LogFormat.ARROW);
         return new LogRecordReadContext(
                 LogFormat.ARROW,
                 dataRowType,
@@ -234,7 +235,8 @@ public class LogRecordReadContext implements LogRecordBatch.ReadContext, AutoClo
      */
     public static LogRecordReadContext createIndexedReadContext(
             RowType rowType, int schemaId, int[] selectedFields, SchemaGetter schemaGetter) {
-        FieldGetter[] fieldGetters = buildProjectedFieldGetters(rowType, selectedFields);
+        FieldGetter[] fieldGetters =
+                buildProjectedFieldGetters(rowType, selectedFields, LogFormat.INDEXED);
         // for INDEXED log format, the projection is NEVER push downed to the server side
         return new LogRecordReadContext(
                 LogFormat.INDEXED, rowType, schemaId, null, fieldGetters, false, schemaGetter);
@@ -265,7 +267,8 @@ public class LogRecordReadContext implements LogRecordBatch.ReadContext, AutoClo
             int schemaId,
             int[] selectedFields,
             @Nullable SchemaGetter schemaGetter) {
-        FieldGetter[] fieldGetters = buildProjectedFieldGetters(rowType, selectedFields);
+        FieldGetter[] fieldGetters =
+                buildProjectedFieldGetters(rowType, selectedFields, LogFormat.COMPACTED);
         // for COMPACTED log format, the projection is NEVER push downed to the server side
         return new LogRecordReadContext(
                 LogFormat.COMPACTED, rowType, schemaId, null, fieldGetters, false, schemaGetter);
@@ -368,14 +371,17 @@ public class LogRecordReadContext implements LogRecordBatch.ReadContext, AutoClo
         return targetSchemaId == schemaId || isProjectionPushDowned();
     }
 
-    private static FieldGetter[] buildProjectedFieldGetters(RowType rowType, int[] selectedFields) {
+    private static FieldGetter[] buildProjectedFieldGetters(
+            RowType rowType, int[] selectedFields, LogFormat logFormat) {
+        // ARROW already copies strings during deserialization;
+        // other formats reference pooled network buffers and need explicit copying.
+        boolean copyStrings = logFormat != LogFormat.ARROW;
         List<DataType> dataTypeList = rowType.getChildren();
         FieldGetter[] fieldGetters = new FieldGetter[selectedFields.length];
         for (int i = 0; i < fieldGetters.length; i++) {
-            // build deep field getter to support nested types
             fieldGetters[i] =
                     InternalRow.createDeepFieldGetter(
-                            dataTypeList.get(selectedFields[i]), selectedFields[i]);
+                            dataTypeList.get(selectedFields[i]), selectedFields[i], copyStrings);
         }
         return fieldGetters;
     }

--- a/fluss-common/src/main/java/org/apache/fluss/row/InternalArray.java
+++ b/fluss-common/src/main/java/org/apache/fluss/row/InternalArray.java
@@ -19,8 +19,6 @@
 package org.apache.fluss.row;
 
 import org.apache.fluss.annotation.PublicEvolving;
-import org.apache.fluss.row.columnar.ColumnarRow;
-import org.apache.fluss.row.columnar.VectorizedColumnBatch;
 import org.apache.fluss.types.ArrayType;
 import org.apache.fluss.types.DataType;
 import org.apache.fluss.types.MapType;
@@ -161,23 +159,26 @@ public interface InternalArray extends DataGetters {
         };
     }
 
-    /**
-     * Creates a deep accessor for getting elements in an internal array data structure at the given
-     * position. It returns new objects (GenericArray/GenericMap/GenericMap) for nested
-     * array/map/row types.
-     *
-     * <p>NOTE: Currently, it is only used for deep copying {@link ColumnarRow} for Arrow which
-     * avoid the arrow buffer is released before accessing elements. It doesn't deep copy STRING and
-     * BYTES types, because {@link ColumnarRow} already deep copies the bytes, see {@link
-     * VectorizedColumnBatch#getString(int, int)}. This can be removed once we supports object reuse
-     * for Arrow {@link ColumnarRow}, see {@code CompletedFetch#toScanRecord(LogRecord)}.
-     */
-    static ElementGetter createDeepElementGetter(DataType fieldType) {
+    /** Same as InternalRow.createDeepFieldGetter but for array elements. */
+    static ElementGetter createDeepElementGetter(DataType fieldType, boolean copyStrings) {
         final ElementGetter elementGetter;
         switch (fieldType.getTypeRoot()) {
+            case CHAR:
+                final int charLen = getLength(fieldType);
+                elementGetter =
+                        copyStrings
+                                ? (array, pos) -> array.getChar(pos, charLen).copy()
+                                : (array, pos) -> array.getChar(pos, charLen);
+                break;
+            case STRING:
+                elementGetter =
+                        copyStrings
+                                ? (array, pos) -> array.getString(pos).copy()
+                                : InternalArray::getString;
+                break;
             case ARRAY:
                 DataType nestedType = ((ArrayType) fieldType).getElementType();
-                ElementGetter nestedGetter = createDeepElementGetter(nestedType);
+                ElementGetter nestedGetter = createDeepElementGetter(nestedType, copyStrings);
                 elementGetter =
                         (array, pos) -> {
                             InternalArray inner = array.getArray(pos);
@@ -191,8 +192,8 @@ public interface InternalArray extends DataGetters {
             case MAP:
                 DataType keyType = ((MapType) fieldType).getKeyType();
                 DataType valueType = ((MapType) fieldType).getValueType();
-                ElementGetter keyGetter = createDeepElementGetter(keyType);
-                ElementGetter valueGetter = createDeepElementGetter(valueType);
+                ElementGetter keyGetter = createDeepElementGetter(keyType, copyStrings);
+                ElementGetter valueGetter = createDeepElementGetter(valueType, copyStrings);
                 elementGetter =
                         (array, pos) -> {
                             InternalMap inner = array.getMap(pos);
@@ -212,7 +213,8 @@ public interface InternalArray extends DataGetters {
                 int numFields = rowType.getFieldCount();
                 InternalRow.FieldGetter[] fieldGetters = new InternalRow.FieldGetter[numFields];
                 for (int i = 0; i < numFields; i++) {
-                    fieldGetters[i] = InternalRow.createDeepFieldGetter(rowType.getTypeAt(i), i);
+                    fieldGetters[i] =
+                            InternalRow.createDeepFieldGetter(rowType.getTypeAt(i), i, copyStrings);
                 }
                 elementGetter =
                         (array, pos) -> {

--- a/fluss-common/src/main/java/org/apache/fluss/row/InternalRow.java
+++ b/fluss-common/src/main/java/org/apache/fluss/row/InternalRow.java
@@ -19,8 +19,6 @@ package org.apache.fluss.row;
 
 import org.apache.fluss.annotation.PublicEvolving;
 import org.apache.fluss.record.ChangeType;
-import org.apache.fluss.row.columnar.ColumnarRow;
-import org.apache.fluss.row.columnar.VectorizedColumnBatch;
 import org.apache.fluss.types.ArrayType;
 import org.apache.fluss.types.DataType;
 import org.apache.fluss.types.MapType;
@@ -32,7 +30,6 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.fluss.row.InternalArray.createDeepElementGetter;
 import static org.apache.fluss.types.DataTypeChecks.getLength;
 import static org.apache.fluss.types.DataTypeChecks.getPrecision;
 import static org.apache.fluss.types.DataTypeChecks.getScale;
@@ -239,22 +236,35 @@ public interface InternalRow extends DataGetters {
     }
 
     /**
-     * Creates a deep accessor for getting elements in an internal array data structure at the given
-     * position. It returns new objects (GenericArray/GenericMap/GenericMap) for nested
-     * array/map/row types.
+     * Creates a deep accessor for getting elements in an internal row data structure at the given
+     * position. Returns new objects (GenericArray/GenericMap/GenericRow) for nested array/map/row
+     * types to prevent use-after-free when the underlying buffer is released.
      *
-     * <p>NOTE: Currently, it is only used for deep copying {@link ColumnarRow} for Arrow which
-     * avoid the arrow buffer is released before accessing elements. It doesn't deep copy STRING and
-     * BYTES types, because {@link ColumnarRow} already deep copies the bytes, see {@link
-     * VectorizedColumnBatch#getString(int, int)}. This can be removed once we supports object reuse
-     * for Arrow {@link ColumnarRow}, see {@code CompletedFetch#toScanRecord(LogRecord)}.
+     * <p>ARROW already deep copies strings in VectorizedColumnBatch, so copyStrings should be
+     * false. INDEXED and COMPACTED rows reference pooled network buffers, so copyStrings should be
+     * true to copy STRING/CHAR via BinaryString.copy().
      */
-    static FieldGetter createDeepFieldGetter(DataType fieldType, int fieldPos) {
+    static FieldGetter createDeepFieldGetter(
+            DataType fieldType, int fieldPos, boolean copyStrings) {
         final FieldGetter fieldGetter;
         switch (fieldType.getTypeRoot()) {
+            case CHAR:
+                final int charLen = getLength(fieldType);
+                fieldGetter =
+                        copyStrings
+                                ? row -> row.getChar(fieldPos, charLen).copy()
+                                : row -> row.getChar(fieldPos, charLen);
+                break;
+            case STRING:
+                fieldGetter =
+                        copyStrings
+                                ? row -> row.getString(fieldPos).copy()
+                                : row -> row.getString(fieldPos);
+                break;
             case ARRAY:
                 DataType elementType = ((ArrayType) fieldType).getElementType();
-                InternalArray.ElementGetter nestedGetter = createDeepElementGetter(elementType);
+                InternalArray.ElementGetter nestedGetter =
+                        InternalArray.createDeepElementGetter(elementType, copyStrings);
                 fieldGetter =
                         row -> {
                             InternalArray array = row.getArray(fieldPos);
@@ -268,9 +278,9 @@ public interface InternalRow extends DataGetters {
             case MAP:
                 MapType mapType = (MapType) fieldType;
                 InternalArray.ElementGetter keyGetter =
-                        createDeepElementGetter(mapType.getKeyType());
+                        InternalArray.createDeepElementGetter(mapType.getKeyType(), copyStrings);
                 InternalArray.ElementGetter valueGetter =
-                        createDeepElementGetter(mapType.getValueType());
+                        InternalArray.createDeepElementGetter(mapType.getValueType(), copyStrings);
                 fieldGetter =
                         row -> {
                             InternalMap map = row.getMap(fieldPos);
@@ -288,7 +298,8 @@ public interface InternalRow extends DataGetters {
                 int numFields = rowType.getFieldCount();
                 FieldGetter[] nestedFieldGetters = new FieldGetter[numFields];
                 for (int i = 0; i < numFields; i++) {
-                    nestedFieldGetters[i] = createDeepFieldGetter(rowType.getTypeAt(i), i);
+                    nestedFieldGetters[i] =
+                            createDeepFieldGetter(rowType.getTypeAt(i), i, copyStrings);
                 }
                 fieldGetter =
                         row -> {

--- a/fluss-common/src/main/java/org/apache/fluss/row/InternalRow.java
+++ b/fluss-common/src/main/java/org/apache/fluss/row/InternalRow.java
@@ -19,6 +19,7 @@ package org.apache.fluss.row;
 
 import org.apache.fluss.annotation.PublicEvolving;
 import org.apache.fluss.record.ChangeType;
+import org.apache.fluss.row.columnar.VectorizedColumnBatch;
 import org.apache.fluss.types.ArrayType;
 import org.apache.fluss.types.DataType;
 import org.apache.fluss.types.MapType;
@@ -240,9 +241,9 @@ public interface InternalRow extends DataGetters {
      * position. Returns new objects (GenericArray/GenericMap/GenericRow) for nested array/map/row
      * types to prevent use-after-free when the underlying buffer is released.
      *
-     * <p>ARROW already deep copies strings in VectorizedColumnBatch, so copyStrings should be
-     * false. INDEXED and COMPACTED rows reference pooled network buffers, so copyStrings should be
-     * true to copy STRING/CHAR via BinaryString.copy().
+     * <p>For ARROW, pass copyStrings=false since {@link VectorizedColumnBatch} already copies
+     * strings. For INDEXED and COMPACTED, pass copyStrings=true to copy STRING/CHAR out of the
+     * pooled buffer they reference.
      */
     static FieldGetter createDeepFieldGetter(
             DataType fieldType, int fieldPos, boolean copyStrings) {

--- a/fluss-common/src/test/java/org/apache/fluss/row/InternalRowTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/row/InternalRowTest.java
@@ -17,11 +17,17 @@
 
 package org.apache.fluss.row;
 
+import org.apache.fluss.memory.MemorySegment;
+import org.apache.fluss.row.indexed.IndexedRow;
+import org.apache.fluss.row.indexed.IndexedRowWriter;
 import org.apache.fluss.types.DataField;
+import org.apache.fluss.types.DataType;
 import org.apache.fluss.types.DataTypes;
 
 import org.junit.jupiter.api.Test;
 
+import static org.apache.fluss.row.BinaryRow.BinaryRowFormat.INDEXED;
+import static org.apache.fluss.row.BinaryString.fromString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test of {@link org.apache.fluss.row.InternalRow}. */
@@ -52,5 +58,59 @@ public class InternalRowTest {
                 .isEqualTo(InternalMap.class);
         assertThat(InternalRow.getDataClass(DataTypes.ROW(new DataField("a", DataTypes.INT()))))
                 .isEqualTo(InternalRow.class);
+    }
+
+    /** copyStrings=true copies STRING/CHAR (including nested) so values survive buffer release. */
+    @Test
+    void testDeepFieldGetterCopiesStringsAfterBufferRelease() {
+        DataType[] dataTypes = {
+            DataTypes.STRING(),
+            DataTypes.CHAR(2),
+            DataTypes.ARRAY(DataTypes.STRING()),
+            DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()),
+            DataTypes.ROW(new DataField("nested", DataTypes.STRING()))
+        };
+
+        IndexedRowWriter writer = new IndexedRowWriter(dataTypes);
+        BinaryWriter.ValueWriter[] writers = new BinaryWriter.ValueWriter[dataTypes.length];
+        for (int i = 0; i < dataTypes.length; i++) {
+            writers[i] = BinaryWriter.createValueWriter(dataTypes[i], INDEXED);
+        }
+        writers[0].writeValue(writer, 0, fromString("hello"));
+        writers[1].writeValue(writer, 1, fromString("ab"));
+        writers[2].writeValue(writer, 2, GenericArray.of(fromString("x"), fromString("y")));
+        writers[3].writeValue(writer, 3, GenericMap.of(1, fromString("one")));
+        writers[4].writeValue(writer, 4, GenericRow.of(fromString("nested")));
+
+        IndexedRow row = new IndexedRow(dataTypes);
+        row.pointTo(writer.segment(), 0, writer.position());
+
+        Object copiedString = deepGetter(dataTypes[0], 0, true).getFieldOrNull(row);
+        Object copiedChar = deepGetter(dataTypes[1], 1, true).getFieldOrNull(row);
+        InternalArray copiedArray =
+                (InternalArray) deepGetter(dataTypes[2], 2, true).getFieldOrNull(row);
+        InternalMap copiedMap = (InternalMap) deepGetter(dataTypes[3], 3, true).getFieldOrNull(row);
+        InternalRow copiedRow = (InternalRow) deepGetter(dataTypes[4], 4, true).getFieldOrNull(row);
+
+        // A copyStrings=false view stays un-materialized so it reflects later overwrites.
+        Object viewString = deepGetter(dataTypes[0], 0, false).getFieldOrNull(row);
+
+        MemorySegment segment = writer.segment();
+        for (int i = 0; i < writer.position(); i++) {
+            segment.put(i, (byte) 0);
+        }
+
+        assertThat(copiedString).isEqualTo(fromString("hello"));
+        assertThat(copiedChar).isEqualTo(fromString("ab"));
+        assertThat(copiedArray.getString(0)).isEqualTo(fromString("x"));
+        assertThat(copiedArray.getString(1)).isEqualTo(fromString("y"));
+        assertThat(copiedMap.valueArray().getString(0)).isEqualTo(fromString("one"));
+        assertThat(copiedRow.getString(0)).isEqualTo(fromString("nested"));
+        assertThat(viewString).isNotEqualTo(fromString("hello"));
+    }
+
+    private static InternalRow.FieldGetter deepGetter(
+            DataType dataType, int pos, boolean copyStrings) {
+        return InternalRow.createDeepFieldGetter(dataType, pos, copyStrings);
     }
 }


### PR DESCRIPTION
## Summary

After #2948, INDEXED/COMPACTED rows reference pooled Netty ByteBuf memory. When DefaultCompletedFetch.drain() releases the buffer, BinaryString fields in returned ScanRecords become dangling references — causing corruption like in https://github.com/apache/fluss/actions/runs/24007394419/job/70013234004?pr=3004

Fix: when building field getters for log record projection, defensively copy STRING/CHAR fields via BinaryString.copy() for formats that reference pooled buffers. ARROW is excluded since VectorizedColumnBatch already produces independent      string copies.
The copy flag propagates through nested types (ARRAY, MAP, ROW) so structures like ARRAY<STRING> are also safe.