### PR TITLE
[client] Add validation for client.scanner.log.max-poll-records and client.connect-timeout

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/FlussConnection.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/FlussConnection.java
@@ -71,13 +71,13 @@ public final class FlussConnection implements Connection {
 
     FlussConnection(Configuration conf, MetricRegistry metricRegistry) {
         this.conf = conf;
+        FlussConfigUtils.validateClientConfigs(conf);
         // init Filesystem with configuration from FlussConnection,
         // only pass options with 'client.fs.' prefix
         FileSystem.initialize(
                 Configuration.fromMap(
                         extractPrefix(new HashMap<>(conf.toMap()), CLIENT_PREFIX + "fs.")),
                 null);
-        FlussConfigUtils.validateClientConfigs(conf);
         // for client metrics.
         setupClientMetricsConfiguration();
         String clientId = conf.getString(ConfigOptions.CLIENT_ID);

--- a/fluss-client/src/main/java/org/apache/fluss/client/FlussConnection.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/FlussConnection.java
@@ -32,6 +32,7 @@ import org.apache.fluss.client.write.WriterClient;
 import org.apache.fluss.cluster.ServerNode;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.FlussConfigUtils;
 import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.fs.FileSystem;
 import org.apache.fluss.metadata.TablePath;
@@ -76,6 +77,7 @@ public final class FlussConnection implements Connection {
                 Configuration.fromMap(
                         extractPrefix(new HashMap<>(conf.toMap()), CLIENT_PREFIX + "fs.")),
                 null);
+        FlussConfigUtils.validateClientConfigs(conf);
         // for client metrics.
         setupClientMetricsConfiguration();
         String clientId = conf.getString(ConfigOptions.CLIENT_ID);

--- a/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
@@ -225,4 +225,22 @@ public class FlussConfigUtils {
                             option.key(), minValue));
         }
     }
+
+    public static void validateClientConfigs(Configuration conf) {
+        int maxPollRecords = conf.getInt(ConfigOptions.CLIENT_SCANNER_LOG_MAX_POLL_RECORDS);
+        if (maxPollRecords <= 0) {
+            throw new IllegalConfigurationException(
+                    String.format(
+                            "Invalid configuration for %s, it must be greater than 0.",
+                            ConfigOptions.CLIENT_SCANNER_LOG_MAX_POLL_RECORDS.key()));
+        }
+
+        long connectTimeoutMs = conf.get(ConfigOptions.CLIENT_CONNECT_TIMEOUT).toMillis();
+        if (connectTimeoutMs <= 0) {
+            throw new IllegalConfigurationException(
+                    String.format(
+                            "Invalid configuration for %s, it must be greater than 0.",
+                            ConfigOptions.CLIENT_CONNECT_TIMEOUT.key()));
+        }
+    }
 }

--- a/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
@@ -23,6 +23,7 @@ import org.apache.fluss.exception.IllegalConfigurationException;
 import org.apache.fluss.fs.FsPath;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -227,20 +228,18 @@ public class FlussConfigUtils {
     }
 
     public static void validateClientConfigs(Configuration conf) {
-        int maxPollRecords = conf.getInt(ConfigOptions.CLIENT_SCANNER_LOG_MAX_POLL_RECORDS);
-        if (maxPollRecords <= 0) {
-            throw new IllegalConfigurationException(
-                    String.format(
-                            "Invalid configuration for %s, it must be greater than 0.",
-                            ConfigOptions.CLIENT_SCANNER_LOG_MAX_POLL_RECORDS.key()));
-        }
+        validMinValue(conf, ConfigOptions.CLIENT_SCANNER_LOG_MAX_POLL_RECORDS, 1);
+        validMinDuration(conf, ConfigOptions.CLIENT_CONNECT_TIMEOUT, 1);
+    }
 
-        long connectTimeoutMs = conf.get(ConfigOptions.CLIENT_CONNECT_TIMEOUT).toMillis();
-        if (connectTimeoutMs <= 0) {
+    private static void validMinDuration(
+            Configuration conf, ConfigOption<Duration> option, long minMillis) {
+        long millis = conf.get(option).toMillis();
+        if (millis < minMillis) {
             throw new IllegalConfigurationException(
                     String.format(
-                            "Invalid configuration for %s, it must be greater than 0.",
-                            ConfigOptions.CLIENT_CONNECT_TIMEOUT.key()));
+                            "Invalid configuration for %s, it must be greater than or equal %d ms.",
+                            option.key(), minMillis));
         }
     }
 }

--- a/fluss-common/src/test/java/org/apache/fluss/config/FlussConfigUtilsTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/config/FlussConfigUtilsTest.java
@@ -175,4 +175,27 @@ class FlussConfigUtilsTest {
                 .hasMessageContaining(ConfigOptions.TABLET_SERVER_ID.key())
                 .hasMessageContaining("it must be greater than or equal 0");
     }
+
+    @Test
+    void testValidateClientConfigs() {
+        // valid defaults should pass
+        Configuration validConf = new Configuration();
+        FlussConfigUtils.validateClientConfigs(validConf);
+
+        // max-poll-records = 0 should fail
+        Configuration zeroPollConf = new Configuration();
+        zeroPollConf.set(ConfigOptions.CLIENT_SCANNER_LOG_MAX_POLL_RECORDS, 0);
+        assertThatThrownBy(() -> FlussConfigUtils.validateClientConfigs(zeroPollConf))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining(ConfigOptions.CLIENT_SCANNER_LOG_MAX_POLL_RECORDS.key())
+                .hasMessageContaining("must be greater than 0");
+
+        // connect-timeout = 0 should fail
+        Configuration zeroTimeoutConf = new Configuration();
+        zeroTimeoutConf.set(ConfigOptions.CLIENT_CONNECT_TIMEOUT, java.time.Duration.ZERO);
+        assertThatThrownBy(() -> FlussConfigUtils.validateClientConfigs(zeroTimeoutConf))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining(ConfigOptions.CLIENT_CONNECT_TIMEOUT.key())
+                .hasMessageContaining("must be greater than 0");
+    }
 }

--- a/fluss-common/src/test/java/org/apache/fluss/config/FlussConfigUtilsTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/config/FlussConfigUtilsTest.java
@@ -21,6 +21,7 @@ import org.apache.fluss.exception.IllegalConfigurationException;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -188,14 +189,14 @@ class FlussConfigUtilsTest {
         assertThatThrownBy(() -> FlussConfigUtils.validateClientConfigs(zeroPollConf))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining(ConfigOptions.CLIENT_SCANNER_LOG_MAX_POLL_RECORDS.key())
-                .hasMessageContaining("must be greater than 0");
+                .hasMessageContaining("must be greater than or equal 1");
 
         // connect-timeout = 0 should fail
         Configuration zeroTimeoutConf = new Configuration();
-        zeroTimeoutConf.set(ConfigOptions.CLIENT_CONNECT_TIMEOUT, java.time.Duration.ZERO);
+        zeroTimeoutConf.set(ConfigOptions.CLIENT_CONNECT_TIMEOUT, Duration.ZERO);
         assertThatThrownBy(() -> FlussConfigUtils.validateClientConfigs(zeroTimeoutConf))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining(ConfigOptions.CLIENT_CONNECT_TIMEOUT.key())
-                .hasMessageContaining("must be greater than 0");
+                .hasMessageContaining("must be greater than or equal 1 ms");
     }
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3068

<!-- What is the purpose of the change -->
Add client config validation for `client.scanner.log.max-poll-records` and `client.connect-timeout` during `FlussConnection` initialization. Setting either of these to 0 or negative makes no practical sense — poll() would return nothing and TCP connect would time out immediately.
### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
- Added `validateClientConfigs()` in `FlussConfigUtils` covering `client.scanner.log.max-poll-records` (must be > 0) and `client.connect-timeout` (must be > 0)
- Called `validateClientConfigs()` in `FlussConnection` constructor
- Added unit tests in `FlussConfigUtilsTest`
### Tests

<!-- List UT and IT cases to verify this change -->
Existing `FlussConfigUtilsTest` extended with `testValidateClientConfigs()` covering default validity and each invalid case.
### API and Format

<!-- Does this change affect API or storage format -->
NO
### Documentation

<!-- Does this change introduce a new feature -->
NO