### PR TITLE
[spark] Fix flaky SparkStreamingTest by handling interruption when close streaming execution

### DIFF
--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
@@ -52,6 +52,8 @@ abstract class FlussMicroBatchStream(
   with Logging
   with AutoCloseable {
 
+  @volatile private var stopped = false
+
   lazy val conn: Connection = ConnectionFactory.createConnection(flussConfig)
 
   lazy val admin: Admin = conn.getAdmin
@@ -107,6 +109,10 @@ abstract class FlussMicroBatchStream(
       throw new UnsupportedOperationException(s"Only ReadAllAvailable is supported, but $readLimit")
     }
 
+    if (stopped) {
+      return start
+    }
+
     val latestTableBucketOffsets = if (allDataForTriggerAvailableNow.isDefined) {
       allDataForTriggerAvailableNow.get
     } else {
@@ -116,6 +122,9 @@ abstract class FlussMicroBatchStream(
   }
 
   override def prepareForTriggerAvailableNow(): Unit = {
+    if (stopped) {
+      return
+    }
     allDataForTriggerAvailableNow = fetchLatestOffsets()
   }
 
@@ -145,7 +154,10 @@ abstract class FlussMicroBatchStream(
   // No need to notify fluss server
   override def commit(end: Offset): Unit = {}
 
-  override def stop(): Unit = close()
+  override def stop(): Unit = {
+    stopped = true
+    close()
+  }
 
   override def deserializeOffset(json: String): Offset = {
     FlussSourceOffset(TableBucketOffsets.fromJsonBytes(json.getBytes("utf-8")))

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
@@ -21,6 +21,7 @@ import org.apache.fluss.client.{Connection, ConnectionFactory}
 import org.apache.fluss.client.admin.Admin
 import org.apache.fluss.client.initializer.{BucketOffsetsRetrieverImpl, OffsetsInitializer}
 import org.apache.fluss.config.Configuration
+import org.apache.fluss.exception.FlussRuntimeException
 import org.apache.fluss.metadata.{PartitionInfo, TableBucket, TableInfo, TablePath}
 import org.apache.fluss.utils.json.TableBucketOffsets
 
@@ -51,8 +52,6 @@ abstract class FlussMicroBatchStream(
   with MicroBatchStream
   with Logging
   with AutoCloseable {
-
-  @volatile private var stopped = false
 
   lazy val conn: Connection = ConnectionFactory.createConnection(flussConfig)
 
@@ -109,10 +108,6 @@ abstract class FlussMicroBatchStream(
       throw new UnsupportedOperationException(s"Only ReadAllAvailable is supported, but $readLimit")
     }
 
-    if (stopped) {
-      return start
-    }
-
     val latestTableBucketOffsets = if (allDataForTriggerAvailableNow.isDefined) {
       allDataForTriggerAvailableNow.get
     } else {
@@ -122,40 +117,47 @@ abstract class FlussMicroBatchStream(
   }
 
   override def prepareForTriggerAvailableNow(): Unit = {
-    if (stopped) {
-      return
-    }
     allDataForTriggerAvailableNow = fetchLatestOffsets()
   }
 
   private def fetchLatestOffsets(): Option[TableBucketOffsets] = {
-    val buckets = (0 until tableInfo.getNumBuckets).toSeq
-    val offsetsInitializer = OffsetsInitializer.latest()
-    if (tableInfo.isPartitioned) {
-      val partitionOffsets = partitionInfos.asScala.map(
-        partitionInfo =>
-          FlussMicroBatchStream.getLatestOffsets(
-            tableInfo,
-            offsetsInitializer,
-            bucketOffsetsRetriever,
-            buckets,
-            Some(partitionInfo)))
-      val mergedOffsets = partitionOffsets
-        .map(_.getOffsets)
-        .reduce((l, r) => (l.asScala ++ r.asScala).asJava)
-      Some(new TableBucketOffsets(tableInfo.getTableId, mergedOffsets))
-    } else {
-      Some(
-        FlussMicroBatchStream
-          .getLatestOffsets(tableInfo, offsetsInitializer, bucketOffsetsRetriever, buckets, None))
+    try {
+      val buckets = (0 until tableInfo.getNumBuckets).toSeq
+      val offsetsInitializer = OffsetsInitializer.latest()
+      if (tableInfo.isPartitioned) {
+        val partitionOffsets = partitionInfos.asScala.map(
+          partitionInfo =>
+            FlussMicroBatchStream.getLatestOffsets(
+              tableInfo,
+              offsetsInitializer,
+              bucketOffsetsRetriever,
+              buckets,
+              Some(partitionInfo)))
+        val mergedOffsets = partitionOffsets
+          .map(_.getOffsets)
+          .reduce((l, r) => (l.asScala ++ r.asScala).asJava)
+        Some(new TableBucketOffsets(tableInfo.getTableId, mergedOffsets))
+      } else {
+        Some(
+          FlussMicroBatchStream
+            .getLatestOffsets(tableInfo, offsetsInitializer, bucketOffsetsRetriever, buckets, None))
+      }
+    } catch {
+      case e: FlussRuntimeException =>
+        if (e.getCause != null && e.getCause.isInstanceOf[InterruptedException]) {
+          logWarning(s"Streaming execution thread be interrupted.")
+          None
+        } else {
+          throw e
+        }
     }
+
   }
 
   // No need to notify fluss server
   override def commit(end: Offset): Unit = {}
 
   override def stop(): Unit = {
-    stopped = true
     close()
   }
 
@@ -354,5 +356,23 @@ class FlussUpsertMicroBatchStream(
 
   override def createReaderFactory(): PartitionReaderFactory = {
     new FlussUpsertPartitionReaderFactory(tablePath, projection, options, flussConfig)
+  }
+
+  /**
+   * Check if an exception is caused by thread interruption during stream shutdown. This mirrors
+   * Spark's isInterruptionException logic to distinguish between intentional interruption (stop()
+   * called) and real errors.
+   */
+  private def isInterruptionException(e: Throwable): Boolean = e match {
+    case _: InterruptedException => true
+    case _: java.io.InterruptedIOException => true
+    case _: java.nio.channels.ClosedByInterruptException => true
+    case e: java.util.concurrent.ExecutionException =>
+      isInterruptionException(e.getCause)
+    case e: Exception =>
+      // Fluss wraps InterruptedException in FlussRuntimeException
+      if (e.getCause != null) isInterruptionException(e.getCause)
+      else false
+    case _ => false
   }
 }

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
@@ -157,9 +157,7 @@ abstract class FlussMicroBatchStream(
   // No need to notify fluss server
   override def commit(end: Offset): Unit = {}
 
-  override def stop(): Unit = {
-    close()
-  }
+  override def stop(): Unit = close()
 
   override def deserializeOffset(json: String): Offset = {
     FlussSourceOffset(TableBucketOffsets.fromJsonBytes(json.getBytes("utf-8")))

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
@@ -145,13 +145,12 @@ abstract class FlussMicroBatchStream(
     } catch {
       case e: FlussRuntimeException =>
         if (e.getCause != null && e.getCause.isInstanceOf[InterruptedException]) {
-          logWarning(s"Streaming execution thread be interrupted.")
-          None
+          logWarning(s"Streaming execution thread was interrupted.")
+          throw e.getCause
         } else {
           throw e
         }
     }
-
   }
 
   // No need to notify fluss server

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMicroBatchStream.scala
@@ -357,22 +357,4 @@ class FlussUpsertMicroBatchStream(
   override def createReaderFactory(): PartitionReaderFactory = {
     new FlussUpsertPartitionReaderFactory(tablePath, projection, options, flussConfig)
   }
-
-  /**
-   * Check if an exception is caused by thread interruption during stream shutdown. This mirrors
-   * Spark's isInterruptionException logic to distinguish between intentional interruption (stop()
-   * called) and real errors.
-   */
-  private def isInterruptionException(e: Throwable): Boolean = e match {
-    case _: InterruptedException => true
-    case _: java.io.InterruptedIOException => true
-    case _: java.nio.channels.ClosedByInterruptException => true
-    case e: java.util.concurrent.ExecutionException =>
-      isInterruptionException(e.getCause)
-    case e: Exception =>
-      // Fluss wraps InterruptedException in FlussRuntimeException
-      if (e.getCause != null) isInterruptionException(e.getCause)
-      else false
-    case _ => false
-  }
 }

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/FlussSparkTestBase.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/FlussSparkTestBase.scala
@@ -63,7 +63,6 @@ class FlussSparkTestBase extends QueryTest with SharedSparkSession {
 
     super.beforeAll()
     sql(s"USE $DEFAULT_DATABASE")
-    sparkContext.setLogLevel("INFO")
   }
 
   override protected def afterAll(): Unit = {

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/FlussSparkTestBase.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/FlussSparkTestBase.scala
@@ -63,6 +63,7 @@ class FlussSparkTestBase extends QueryTest with SharedSparkSession {
 
     super.beforeAll()
     sql(s"USE $DEFAULT_DATABASE")
+    sparkContext.setLogLevel("INFO")
   }
 
   override protected def afterAll(): Unit = {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3129

<!-- What is the purpose of the change -->

### Brief change log

Spark's `isInterruptedByStop()` only recognizes:
- `InterruptedException`
- `InterruptedIOException`
- `ClosedByInterruptException`
- `ExecutionException` (with interrupt cause)
- `SparkException` (with "cancelled" message)

Fluss wraps `InterruptedException` in `FlussRuntimeException`, which Spark treats as a real error.


<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

manually run 10 rounds full spark ut in local.
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
