### PR TITLE
[server] Fix coordinator metrics not updated when no events arrive

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -222,7 +223,7 @@ public final class CoordinatorEventManager implements EventManager {
 
     private class CoordinatorEventThread extends ShutdownableThread {
 
-        private long lastMetricsUpdateTime = System.currentTimeMillis();
+        private long lastMetricsUpdateTime = 0;
 
         public CoordinatorEventThread(String name) {
             super(name, false);
@@ -237,7 +238,15 @@ public final class CoordinatorEventManager implements EventManager {
                 lastMetricsUpdateTime = currentTime;
             }
 
-            QueuedEvent queuedEvent = queue.take();
+            // Use poll with timeout instead of blocking take() so that the thread
+            // wakes up periodically to update metrics even when no events arrive
+            // (e.g., after coordinator restart with no client requests).
+            long elapsed = System.currentTimeMillis() - lastMetricsUpdateTime;
+            long pollTimeout = Math.max(METRICS_UPDATE_INTERVAL_MS - elapsed, 100);
+            QueuedEvent queuedEvent = queue.poll(pollTimeout, TimeUnit.MILLISECONDS);
+            if (queuedEvent == null) {
+                return;
+            }
             CoordinatorEvent coordinatorEvent = queuedEvent.event;
 
             long eventStartTimeMs = System.currentTimeMillis();

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManagerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator.event;
+
+import org.apache.fluss.cluster.Endpoint;
+import org.apache.fluss.cluster.ServerType;
+import org.apache.fluss.server.coordinator.CoordinatorContext;
+import org.apache.fluss.server.metadata.ServerInfo;
+import org.apache.fluss.server.metrics.group.TestingMetricGroups;
+import org.apache.fluss.server.zk.ZkEpoch;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link CoordinatorEventManager}. */
+class CoordinatorEventManagerTest {
+
+    /**
+     * Verifies that coordinator metrics are updated immediately after startup, even when no events
+     * arrive. This tests the fix for the issue where metrics like
+     * fluss_coordinator_activeTabletServerCount remained 0 after coordinator restart if no client
+     * requests came in.
+     *
+     * <p>The fix has two parts:
+     *
+     * <ul>
+     *   <li>lastMetricsUpdateTime initialized to 0 (triggers immediate first update)
+     *   <li>queue.poll(timeout) instead of queue.take() (thread wakes up periodically)
+     * </ul>
+     */
+    @Test
+    void testMetricsUpdatedImmediatelyOnStartup() {
+        CoordinatorContext context = new CoordinatorContext(ZkEpoch.INITIAL_EPOCH);
+        context.addLiveCoordinator("coordinator-0");
+        context.addLiveTabletServer(
+                new ServerInfo(
+                        0,
+                        "rack0",
+                        Endpoint.fromListenersString("CLIENT://host0:1000"),
+                        ServerType.TABLET_SERVER));
+        context.addLiveTabletServer(
+                new ServerInfo(
+                        1,
+                        "rack1",
+                        Endpoint.fromListenersString("CLIENT://host1:1000"),
+                        ServerType.TABLET_SERVER));
+
+        AtomicInteger metricsUpdateCount = new AtomicInteger(0);
+        EventProcessor testProcessor =
+                event -> {
+                    if (event instanceof AccessContextEvent) {
+                        processAccessContext((AccessContextEvent<?>) event, context);
+                        metricsUpdateCount.incrementAndGet();
+                    }
+                };
+
+        CoordinatorEventManager manager =
+                new CoordinatorEventManager(testProcessor, TestingMetricGroups.COORDINATOR_METRICS);
+        manager.start();
+
+        try {
+            // The first doWork() should trigger metrics update immediately
+            // (lastMetricsUpdateTime=0) without waiting for any events.
+            retry(
+                    Duration.ofMinutes(1),
+                    () -> assertThat(metricsUpdateCount.get()).isGreaterThan(0));
+        } finally {
+            manager.close();
+        }
+    }
+
+    private static <T> void processAccessContext(
+            AccessContextEvent<T> event, CoordinatorContext context) {
+        try {
+            T result = event.getAccessFunction().apply(context);
+            event.getResultFuture().complete(result);
+        } catch (Throwable t) {
+            event.getResultFuture().completeExceptionally(t);
+        }
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManagerTest.java
@@ -19,6 +19,8 @@ package org.apache.fluss.server.coordinator.event;
 
 import org.apache.fluss.cluster.Endpoint;
 import org.apache.fluss.cluster.ServerType;
+import org.apache.fluss.metrics.Gauge;
+import org.apache.fluss.metrics.MetricNames;
 import org.apache.fluss.server.coordinator.CoordinatorContext;
 import org.apache.fluss.server.metadata.ServerInfo;
 import org.apache.fluss.server.metrics.group.TestingMetricGroups;
@@ -84,8 +86,16 @@ class CoordinatorEventManagerTest {
             retry(
                     Duration.ofMinutes(1),
                     () -> assertThat(metricsUpdateCount.get()).isGreaterThan(0));
+
+            Gauge activeTabletServerCount =
+                    (Gauge)
+                            TestingMetricGroups.COORDINATOR_METRICS
+                                    .getMetrics()
+                                    .get(MetricNames.ACTIVE_TABLET_SERVER_COUNT);
+            assertThat(activeTabletServerCount.getValue()).isEqualTo(2);
         } finally {
             manager.close();
+            TestingMetricGroups.COORDINATOR_METRICS.close();
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3147 

<!-- What is the purpose of the change -->

After coordinator restart, if no client requests arrive, the
`CoordinatorEventThread `stays blocked on `queue.take()` and never
updates metrics gauges like activeTabletServerCount.

Fix by replacing `queue.take()` with `queue.poll(timeout)` so the
thread periodically wakes up to refresh metrics, and initializing
`lastMetricsUpdateTime` to 0 to trigger an immediate first update.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
