### PR TITLE
[client] Ensure UPDATE_BEFORE and UPDATE_AFTER are never split across poll batches

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/CompletedFetch.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/CompletedFetch.java
@@ -22,6 +22,7 @@ import org.apache.fluss.client.table.scanner.ScanRecord;
 import org.apache.fluss.exception.CorruptRecordException;
 import org.apache.fluss.exception.FetchException;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.record.ChangeType;
 import org.apache.fluss.record.CompactedLogRecord;
 import org.apache.fluss.record.IndexedLogRecord;
 import org.apache.fluss.record.LogRecord;
@@ -211,24 +212,20 @@ abstract class CompletedFetch {
         List<ScanRecord> scanRecords = new ArrayList<>();
         try {
             for (int i = 0; i < maxRecords; i++) {
-                // Only move to next record if there was no exception in the last fetch.
-                if (cachedRecordException == null) {
-                    corruptLastRecord = true;
-                    lastRecord = nextFetchedRecord();
-                    corruptLastRecord = false;
-                }
-
+                fetchRecord(scanRecords);
                 if (lastRecord == null) {
                     break;
                 }
+            }
 
-                ScanRecord record = toScanRecord(lastRecord);
-                scanRecords.add(record);
-                recordsRead++;
-                // Per-record offset is a best-effort value; the authoritative offset
-                // comes from the batch's nextLogOffset once the batch is fully consumed.
-                nextFetchOffset = lastRecord.logOffset() + 1;
-                cachedRecordException = null;
+            // Guarantee that UPDATE_BEFORE (-U) and UPDATE_AFTER (+U) are never split
+            // across two consecutive poll batches. If the last fetched record is an
+            // UPDATE_BEFORE, fetch one more record so the matching UPDATE_AFTER is
+            // included in the same batch. This prevents downstream converters (e.g.,
+            // BinlogRowConverter) from seeing an orphaned -U when records from multiple
+            // buckets are interleaved across polls.
+            if (lastRecord != null && lastRecord.getChangeType() == ChangeType.UPDATE_BEFORE) {
+                fetchRecord(scanRecords);
             }
         } catch (Exception e) {
             cachedRecordException = e;
@@ -242,6 +239,27 @@ abstract class CompletedFetch {
         }
 
         return scanRecords;
+    }
+
+    private void fetchRecord(List<ScanRecord> scanRecords) throws Exception {
+        // Only move to next record if there was no exception in the last fetch.
+        if (cachedRecordException == null) {
+            corruptLastRecord = true;
+            lastRecord = nextFetchedRecord();
+            corruptLastRecord = false;
+        }
+
+        if (lastRecord == null) {
+            return;
+        }
+
+        ScanRecord record = toScanRecord(lastRecord);
+        scanRecords.add(record);
+        recordsRead++;
+        // Per-record offset is a best-effort value; the authoritative offset
+        // comes from the batch's nextLogOffset once the batch is fully consumed.
+        nextFetchOffset = lastRecord.logOffset() + 1;
+        cachedRecordException = null;
     }
 
     private LogRecord nextFetchedRecord() throws Exception {

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetchCollectorTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetchCollectorTest.java
@@ -20,9 +20,12 @@ package org.apache.fluss.client.table.scanner.log;
 import org.apache.fluss.client.metadata.MetadataUpdater;
 import org.apache.fluss.client.metadata.TestingMetadataUpdater;
 import org.apache.fluss.client.table.scanner.ScanRecord;
+import org.apache.fluss.compression.ArrowCompressionInfo;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.metadata.LogFormat;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.record.ChangeType;
 import org.apache.fluss.record.LogRecordBatch;
 import org.apache.fluss.record.LogRecordReadContext;
 import org.apache.fluss.record.MemoryLogRecords;
@@ -32,8 +35,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.fluss.record.TestData.DATA1;
@@ -43,6 +48,7 @@ import static org.apache.fluss.record.TestData.DATA1_TABLE_INFO;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_PATH;
 import static org.apache.fluss.record.TestData.DEFAULT_SCHEMA_ID;
 import static org.apache.fluss.record.TestData.TEST_SCHEMA_GETTER;
+import static org.apache.fluss.testutils.DataTestUtils.createBasicMemoryLogRecords;
 import static org.apache.fluss.testutils.DataTestUtils.genMemoryLogRecordsByObject;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -258,5 +264,64 @@ public class LogFetchCollectorTest {
             TableBucket tableBucket, FetchLogResultForBucket resultForBucket, long offset) {
         return new DefaultCompletedFetch(
                 tableBucket, resultForBucket, readContext, logScannerStatus, true, offset, null);
+    }
+
+    @Test
+    void testUpdateBeforeAndAfterNeverSplitAcrossPolls() throws Exception {
+        // Create records: INSERT, UPDATE_BEFORE, UPDATE_AFTER, INSERT
+        // With maxPollRecords=1, the fix should still return -U/+U together.
+        List<ChangeType> changeTypes =
+                Arrays.asList(
+                        ChangeType.INSERT,
+                        ChangeType.UPDATE_BEFORE,
+                        ChangeType.UPDATE_AFTER,
+                        ChangeType.INSERT);
+        List<Object[]> objects = DATA1.subList(0, 4);
+        MemoryLogRecords records =
+                createBasicMemoryLogRecords(
+                        DATA1_ROW_TYPE,
+                        DEFAULT_SCHEMA_ID,
+                        0L,
+                        System.currentTimeMillis(),
+                        LogRecordBatch.CURRENT_LOG_MAGIC_VALUE,
+                        org.apache.fluss.record.LogRecordBatchFormat.NO_WRITER_ID,
+                        org.apache.fluss.record.LogRecordBatchFormat.NO_BATCH_SEQUENCE,
+                        changeTypes,
+                        objects,
+                        LogFormat.ARROW,
+                        ArrowCompressionInfo.DEFAULT_COMPRESSION);
+
+        Configuration conf = new Configuration();
+        conf.setInt(ConfigOptions.CLIENT_SCANNER_LOG_MAX_POLL_RECORDS, 1);
+        MetadataUpdater metadataUpdater =
+                new TestingMetadataUpdater(
+                        Collections.singletonMap(DATA1_TABLE_PATH, DATA1_TABLE_INFO));
+        LogFetchCollector collector =
+                new LogFetchCollector(DATA1_TABLE_PATH, logScannerStatus, conf, metadataUpdater);
+
+        TableBucket tb = new TableBucket(DATA1_TABLE_ID, 0);
+        FetchLogResultForBucket result = new FetchLogResultForBucket(tb, records, 4L);
+        CompletedFetch completedFetch = makeCompletedFetch(tb, result, 0L);
+        logFetchBuffer.add(completedFetch);
+
+        // Poll 1: should get 1 INSERT record (maxPollRecords=1)
+        ScanRecords poll1 = collector.collectFetch(logFetchBuffer);
+        List<ScanRecord> records1 = poll1.records(tb);
+        assertThat(records1).hasSize(1);
+        assertThat(records1.get(0).getChangeType()).isEqualTo(ChangeType.INSERT);
+
+        // Poll 2: should get 2 records (-U and +U together) even though maxPollRecords=1,
+        // because -U/+U must never be split.
+        ScanRecords poll2 = collector.collectFetch(logFetchBuffer);
+        List<ScanRecord> records2 = poll2.records(tb);
+        assertThat(records2).hasSize(2);
+        assertThat(records2.get(0).getChangeType()).isEqualTo(ChangeType.UPDATE_BEFORE);
+        assertThat(records2.get(1).getChangeType()).isEqualTo(ChangeType.UPDATE_AFTER);
+
+        // Poll 3: should get the last INSERT record
+        ScanRecords poll3 = collector.collectFetch(logFetchBuffer);
+        List<ScanRecord> records3 = poll3.records(tb);
+        assertThat(records3).hasSize(1);
+        assertThat(records3.get(0).getChangeType()).isEqualTo(ChangeType.INSERT);
     }
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2880 

<!-- What is the purpose of the change -->

### Brief change log


When CompletedFetch.fetchRecords() hits maxRecords, it may cut between a -U (UPDATE_BEFORE) and +U (UPDATE_AFTER) pair. If the next poll returns records from multiple buckets, downstream stateful converters (e.g., BinlogRowConverter) can see an orphaned -U whose pendingUpdateBefore state gets corrupted by interleaved records from other buckets.

Fix: after the fetch loop, if the last record is UPDATE_BEFORE, fetch one additional record to include the matching UPDATE_AFTER in the same batch. Extract the per-record fetch logic into a reusable fetchRecord() method.


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
