### PR TITLE
[client] Fix race condition in RemoteLogDownloader causing flaky test…

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloader.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloader.java
@@ -142,15 +142,14 @@ public class RemoteLogDownloader implements Closeable {
      * to fetch.
      */
     void fetchOnce() throws Exception {
-        // blocks until there is capacity (the fetched file is consumed)
-        prefetchSemaphore.acquire();
-
         // wait until there is a remote fetch request
         RemoteLogDownloadRequest request = segmentsToFetch.poll(pollTimeout, TimeUnit.MILLISECONDS);
         if (request == null) {
-            prefetchSemaphore.release();
             return;
         }
+
+        // blocks until there is capacity (the fetched file is consumed)
+        prefetchSemaphore.acquire();
 
         TableBucket tableBucket = request.getTableBucket();
         try {

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
@@ -216,8 +216,11 @@ class RemoteLogDownloaderTest {
                     });
             // make sure 4 threads are used.
             assertThat(fileDownloader.threadNames.size()).isEqualTo(4);
-            // only 4 segments are pre-fetched.
-            assertThat(remoteLogDownloader.getSizeOfSegmentsToFetch()).isEqualTo(totalSegments - 4);
+            // only 4 segments are pre-fetched; the download thread may have polled one additional
+            // segment from the queue before blocking on the semaphore, so queue size is
+            // either totalSegments-4 (nothing extra polled) or totalSegments-5 (one extra polled).
+            assertThat(remoteLogDownloader.getSizeOfSegmentsToFetch())
+                    .isBetween(totalSegments - 4 - 1, totalSegments - 4);
 
             for (int i = 3; i < totalSegments; i++) {
                 RemoteLogSegment segment = remoteLogSegments.get(i);


### PR DESCRIPTION
…PrefetchNum

The prefetch semaphore was acquired before polling the work queue in fetchOnce(). When the queue was empty the download thread held a permit for the full pollTimeout (10 ms) before releasing it, creating a window where availablePermits() transiently returned 1 instead of 2 immediately after two recycleRemoteLog() calls in testPrefetchNum.

Fix: poll the queue first and only acquire the semaphore when there is actual work to do. The semaphore is never borrowed for null-polls, so availablePermits() accurately reflects true available capacity at all times.

Also updates testDownloadLogInParallelAndInPriority: with poll-first semantics the download thread polls one extra item before blocking on the semaphore, so the queue size is totalSegments-5 or totalSegments-4 (not strictly totalSegments-4 as before). The assertion is relaxed to isBetween() to cover both cases.

Fixes #3145

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
