### PR TITLE
[s3] Propagate path-style-access config from server to client via delegation token

### DIFF
--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
@@ -52,6 +52,7 @@ public class S3DelegationTokenProvider {
 
     private static final String REGION_KEY = "fs.s3a.region";
     private static final String ENDPOINT_KEY = "fs.s3a.endpoint";
+    private static final String PATH_STYLE_ACCESS_KEY = "fs.s3a.path.style.access";
 
     private static final String ROLE_ARN_KEY = "fs.s3a.assumed.role.arn";
     private static final String STS_ENDPOINT_KEY = "fs.s3a.assumed.role.sts.endpoint";
@@ -83,7 +84,7 @@ public class S3DelegationTokenProvider {
         }
 
         this.additionInfos = new HashMap<>();
-        for (String key : Arrays.asList(REGION_KEY, ENDPOINT_KEY)) {
+        for (String key : Arrays.asList(REGION_KEY, ENDPOINT_KEY, PATH_STYLE_ACCESS_KEY)) {
             if (conf.get(key) != null) {
                 additionInfos.put(key, conf.get(key));
             }


### PR DESCRIPTION
## Summary
- `S3DelegationTokenProvider` only forwarded `region` and `endpoint` to the client via `additionInfos` in delegation tokens. The `path.style.access` setting was missing.
- This caused the Fluss client (e.g., running in Flink TaskManager) to use virtual-hosted-style addressing (`bucket.host`) instead of path-style (`host/bucket`), resulting in `UnknownHostException` when using S3-compatible stores (MinIO/RustFS) in Docker environments.
- Fix: Add `fs.s3a.path.style.access` to the forwarded config keys.

## Test plan
- [x] Verified with Fluss quickstart-flink Docker setup using RustFS as S3-compatible storage