### PR TITLE
[flink] Push down lake filters for non-partitioned scans

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -572,7 +572,19 @@ public class FlinkTableSource
             acceptedFilters.addAll(recordBatchResult.getAcceptedFilters());
         }
 
-        pushdownLakeFilters(filters, acceptedFilters);
+        if (lakeSource != null) {
+            // Lake pushdown only contributes extra accepted filters.
+            // We intentionally do not mutate remainingFilters here:
+            // 1. partition/record-batch pushdown has already established the Fluss-side scan
+            //    behavior;
+            // 2. FLINK-38635 requires returning the original filters as remaining so Flink keeps
+            //    applying them as a correctness safety net;
+            // 3. LakeSource reports accepted predicates in converted Predicate form rather than the
+            //    original ResolvedExpression instances, so adjusting remainingFilters here would
+            //    add bookkeeping complexity without changing runtime behavior.
+            pushdownLakeFilters(filters, acceptedFilters);
+        }
+
         // FLINK-38635 We cannot determine whether this source will ultimately be used as a
         // scan source or a lookup source. If used as a lookup source, the accepted filters
         // (partition filters, record batch filters) are not enforced in the lookup path.
@@ -624,10 +636,6 @@ public class FlinkTableSource
 
     private void pushdownLakeFilters(
             List<ResolvedExpression> filters, List<ResolvedExpression> acceptedFilters) {
-        if (lakeSource == null) {
-            return;
-        }
-
         List<Predicate> lakePredicates = new ArrayList<>();
         List<ResolvedExpression> convertedFilters = new ArrayList<>();
         for (ResolvedExpression filter : filters) {
@@ -644,18 +652,18 @@ public class FlinkTableSource
         }
 
         LakeSource.FilterPushDownResult filterPushDownResult =
-                lakeSource.withFilters(lakePredicates);
+                checkNotNull(lakeSource).withFilters(lakePredicates);
+        // acceptedFilters tracks which original Flink expressions are confirmed as pushed down to
+        // at least one backend. For lake pushdown we append the corresponding source expressions
+        // here, but we intentionally leave remainingFilters unchanged; applyFilters() still returns
+        // the full original filter list as remaining so Flink re-applies all predicates after the
+        // source read.
         List<Predicate> acceptedLakePredicates = filterPushDownResult.acceptedPredicates();
         for (int i = 0; i < lakePredicates.size(); i++) {
             if (acceptedLakePredicates.contains(lakePredicates.get(i))
                     && !acceptedFilters.contains(convertedFilters.get(i))) {
                 acceptedFilters.add(convertedFilters.get(i));
             }
-        }
-
-        if (acceptedLakePredicates.size() != lakePredicates.size()) {
-            LOG.info(
-                    "LakeSource rejected some filters. Keep Flink-side filtering as the safety net.");
         }
     }
 

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -628,20 +628,6 @@ public class FlinkTableSource
         return Result.of(acceptedFilters, remainingFilters);
     }
 
-    /**
-     * Adds lake-accepted predicates into {@code acceptedFilters}.
-     *
-     * <p>This method intentionally does not mutate {@code remainingFilters}:
-     *
-     * <p>1. partition/record-batch pushdown has already established the Fluss-side scan behavior;
-     *
-     * <p>2. FLINK-38635 requires returning the original filters as remaining so Flink keeps
-     * applying them as a correctness safety net;
-     *
-     * <p>3. {@link LakeSource.FilterPushDownResult} reports accepted predicates in converted {@link
-     * Predicate} form rather than original {@link ResolvedExpression} instances, so adjusting
-     * remainingFilters here would add bookkeeping complexity without changing runtime behavior.
-     */
     private void pushdownLakeFilters(
             List<ResolvedExpression> filters, List<ResolvedExpression> acceptedFilters) {
         List<Predicate> lakePredicates = new ArrayList<>();

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -563,11 +563,6 @@ public class FlinkTableSource
             partitionFilters = converted.isEmpty() ? null : PredicateBuilder.and(converted);
         }
 
-        Result lakeFilterPushDownResult = pushdownLakeFilters(filters);
-        if (lakeFilterPushDownResult != null) {
-            return lakeFilterPushDownResult;
-        }
-
         if (acceptedFilters.isEmpty() && remainingFilters.isEmpty()) {
             remainingFilters.addAll(filters);
         }
@@ -576,6 +571,8 @@ public class FlinkTableSource
             Result recordBatchResult = pushdownRecordBatchFilter(remainingFilters);
             acceptedFilters.addAll(recordBatchResult.getAcceptedFilters());
         }
+
+        pushdownLakeFilters(filters, acceptedFilters);
         // FLINK-38635 We cannot determine whether this source will ultimately be used as a
         // scan source or a lookup source. If used as a lookup source, the accepted filters
         // (partition filters, record batch filters) are not enforced in the lookup path.
@@ -625,32 +622,41 @@ public class FlinkTableSource
         return Result.of(acceptedFilters, remainingFilters);
     }
 
-    @Nullable
-    private Result pushdownLakeFilters(List<ResolvedExpression> filters) {
+    private void pushdownLakeFilters(
+            List<ResolvedExpression> filters, List<ResolvedExpression> acceptedFilters) {
         if (lakeSource == null) {
-            return null;
+            return;
         }
 
         List<Predicate> lakePredicates = new ArrayList<>();
+        List<ResolvedExpression> convertedFilters = new ArrayList<>();
         for (ResolvedExpression filter : filters) {
             Optional<Predicate> predicateOptional =
                     convertToFlussPredicate(tableOutputType, filter);
-            predicateOptional.ifPresent(lakePredicates::add);
+            if (predicateOptional.isPresent()) {
+                lakePredicates.add(predicateOptional.get());
+                convertedFilters.add(filter);
+            }
         }
 
         if (lakePredicates.isEmpty()) {
-            return null;
+            return;
         }
 
         LakeSource.FilterPushDownResult filterPushDownResult =
                 lakeSource.withFilters(lakePredicates);
-        if (filterPushDownResult.acceptedPredicates().size() != lakePredicates.size()) {
-            LOG.info("LakeSource rejected some filters. Falling back to Flink-side filtering.");
-            // Flink will apply all filters to preserve correctness.
-            return Result.of(Collections.<ResolvedExpression>emptyList(), filters);
+        List<Predicate> acceptedLakePredicates = filterPushDownResult.acceptedPredicates();
+        for (int i = 0; i < lakePredicates.size(); i++) {
+            if (acceptedLakePredicates.contains(lakePredicates.get(i))
+                    && !acceptedFilters.contains(convertedFilters.get(i))) {
+                acceptedFilters.add(convertedFilters.get(i));
+            }
         }
 
-        return null;
+        if (acceptedLakePredicates.size() != lakePredicates.size()) {
+            LOG.info(
+                    "LakeSource rejected some filters. Keep Flink-side filtering as the safety net.");
+        }
     }
 
     /**

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -91,6 +91,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -573,15 +574,8 @@ public class FlinkTableSource
         }
 
         if (lakeSource != null) {
-            // Lake pushdown only contributes extra accepted filters.
-            // We intentionally do not mutate remainingFilters here:
-            // 1. partition/record-batch pushdown has already established the Fluss-side scan
-            //    behavior;
-            // 2. FLINK-38635 requires returning the original filters as remaining so Flink keeps
-            //    applying them as a correctness safety net;
-            // 3. LakeSource reports accepted predicates in converted Predicate form rather than the
-            //    original ResolvedExpression instances, so adjusting remainingFilters here would
-            //    add bookkeeping complexity without changing runtime behavior.
+            // Lake pushdown only contributes extra accepted filters; see
+            // pushdownLakeFilters(...) for why remainingFilters must stay unchanged.
             pushdownLakeFilters(filters, acceptedFilters);
         }
 
@@ -634,6 +628,20 @@ public class FlinkTableSource
         return Result.of(acceptedFilters, remainingFilters);
     }
 
+    /**
+     * Adds lake-accepted predicates into {@code acceptedFilters}.
+     *
+     * <p>This method intentionally does not mutate {@code remainingFilters}:
+     *
+     * <p>1. partition/record-batch pushdown has already established the Fluss-side scan behavior;
+     *
+     * <p>2. FLINK-38635 requires returning the original filters as remaining so Flink keeps
+     * applying them as a correctness safety net;
+     *
+     * <p>3. {@link LakeSource.FilterPushDownResult} reports accepted predicates in converted {@link
+     * Predicate} form rather than original {@link ResolvedExpression} instances, so adjusting
+     * remainingFilters here would add bookkeeping complexity without changing runtime behavior.
+     */
     private void pushdownLakeFilters(
             List<ResolvedExpression> filters, List<ResolvedExpression> acceptedFilters) {
         List<Predicate> lakePredicates = new ArrayList<>();
@@ -653,12 +661,9 @@ public class FlinkTableSource
 
         LakeSource.FilterPushDownResult filterPushDownResult =
                 checkNotNull(lakeSource).withFilters(lakePredicates);
-        // acceptedFilters tracks which original Flink expressions are confirmed as pushed down to
-        // at least one backend. For lake pushdown we append the corresponding source expressions
-        // here, but we intentionally leave remainingFilters unchanged; applyFilters() still returns
-        // the full original filter list as remaining so Flink re-applies all predicates after the
-        // source read.
-        List<Predicate> acceptedLakePredicates = filterPushDownResult.acceptedPredicates();
+        Set<Predicate> acceptedLakePredicates =
+                Collections.newSetFromMap(new IdentityHashMap<Predicate, Boolean>());
+        acceptedLakePredicates.addAll(filterPushDownResult.acceptedPredicates());
         for (int i = 0; i < lakePredicates.size(); i++) {
             if (acceptedLakePredicates.contains(lakePredicates.get(i))
                     && !acceptedFilters.contains(convertedFilters.get(i))) {

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -561,27 +561,11 @@ public class FlinkTableSource
                 }
             }
             partitionFilters = converted.isEmpty() ? null : PredicateBuilder.and(converted);
+        }
 
-            // lake source is not null
-            if (lakeSource != null) {
-                List<Predicate> lakePredicates = new ArrayList<>();
-                for (ResolvedExpression filter : filters) {
-                    Optional<Predicate> predicateOptional =
-                            convertToFlussPredicate(tableOutputType, filter);
-                    predicateOptional.ifPresent(lakePredicates::add);
-                }
-
-                if (!lakePredicates.isEmpty()) {
-                    final LakeSource.FilterPushDownResult filterPushDownResult =
-                            lakeSource.withFilters(lakePredicates);
-                    if (filterPushDownResult.acceptedPredicates().size() != lakePredicates.size()) {
-                        LOG.info(
-                                "LakeSource rejected some partition filters. Falling back to Flink-side filtering.");
-                        // Flink will apply all filters to preserve correctness
-                        return Result.of(Collections.emptyList(), filters);
-                    }
-                }
-            }
+        Result lakeFilterPushDownResult = pushdownLakeFilters(filters);
+        if (lakeFilterPushDownResult != null) {
+            return lakeFilterPushDownResult;
         }
 
         if (acceptedFilters.isEmpty() && remainingFilters.isEmpty()) {
@@ -639,6 +623,34 @@ public class FlinkTableSource
             this.logRecordBatchFilter = null;
         }
         return Result.of(acceptedFilters, remainingFilters);
+    }
+
+    @Nullable
+    private Result pushdownLakeFilters(List<ResolvedExpression> filters) {
+        if (lakeSource == null) {
+            return null;
+        }
+
+        List<Predicate> lakePredicates = new ArrayList<>();
+        for (ResolvedExpression filter : filters) {
+            Optional<Predicate> predicateOptional =
+                    convertToFlussPredicate(tableOutputType, filter);
+            predicateOptional.ifPresent(lakePredicates::add);
+        }
+
+        if (lakePredicates.isEmpty()) {
+            return null;
+        }
+
+        LakeSource.FilterPushDownResult filterPushDownResult =
+                lakeSource.withFilters(lakePredicates);
+        if (filterPushDownResult.acceptedPredicates().size() != lakePredicates.size()) {
+            LOG.info("LakeSource rejected some filters. Falling back to Flink-side filtering.");
+            // Flink will apply all filters to preserve correctness.
+            return Result.of(Collections.<ResolvedExpression>emptyList(), filters);
+        }
+
+        return null;
     }
 
     /**

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFilterPushDownTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFilterPushDownTest.java
@@ -22,6 +22,11 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.TableConfig;
 import org.apache.fluss.flink.FlinkConnectorOptions;
 import org.apache.fluss.flink.utils.FlinkConnectorOptionsUtils;
+import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
+import org.apache.fluss.lake.source.LakeSource;
+import org.apache.fluss.lake.source.LakeSplit;
+import org.apache.fluss.lake.source.Planner;
+import org.apache.fluss.lake.source.RecordReader;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.predicate.Predicate;
 import org.apache.fluss.row.BinaryString;
@@ -40,6 +45,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -352,6 +359,111 @@ public class FlinkTableSourceFilterPushDownTest {
             // No filters should be accepted or remain
             assertThat(result.getAcceptedFilters()).isEmpty();
             assertThat(result.getRemainingFilters()).isEmpty();
+            assertThat(tableSource.getLogRecordBatchFilter()).isNull();
+        }
+    }
+
+    @Nested
+    class NonPartitionedLakeSourceTests {
+        private FlinkTableSource tableSource;
+        private TrackingLakeSource lakeSource;
+
+        @BeforeEach
+        void setUp() {
+            RowType tableOutputType =
+                    (RowType)
+                            DataTypes.ROW(
+                                            DataTypes.FIELD("id", DataTypes.INT()),
+                                            DataTypes.FIELD("name", DataTypes.STRING()),
+                                            DataTypes.FIELD("value", DataTypes.BIGINT()),
+                                            DataTypes.FIELD("region", DataTypes.STRING()))
+                                    .getLogicalType();
+
+            TablePath tablePath = TablePath.of("test_db", "test_lake_log_table");
+            Configuration flussConfig = new Configuration();
+            flussConfig.setString(FlinkConnectorOptions.BOOTSTRAP_SERVERS.key(), "localhost:9092");
+
+            Configuration tableConfig = new Configuration();
+            tableConfig.set(ConfigOptions.TABLE_STATISTICS_COLUMNS, "*");
+
+            FlinkConnectorOptionsUtils.StartupOptions startupOptions =
+                    new FlinkConnectorOptionsUtils.StartupOptions();
+            startupOptions.startupMode = FlinkConnectorOptions.ScanStartupMode.FULL;
+
+            tableSource =
+                    new FlinkTableSource(
+                            tablePath,
+                            flussConfig,
+                            new TableConfig(tableConfig),
+                            tableOutputType,
+                            new int[] {}, // no primary key indexes
+                            new int[] {}, // bucket key indexes
+                            new int[] {}, // partition key indexes
+                            false, // batch mode
+                            startupOptions,
+                            false, // lookup async
+                            false, // insert if not exists
+                            null, // cache
+                            1000L, // scan partition discovery interval
+                            false, // is data lake enabled
+                            null, // merge engine type
+                            Maps.newHashMap(),
+                            null); // lease context
+        }
+
+        @Test
+        void testNonPartitionedLakeSourcePushesDownFilters() {
+            lakeSource = new TrackingLakeSource(false);
+            setLakeSource(tableSource, lakeSource);
+
+            FieldReferenceExpression regionFieldRef =
+                    new FieldReferenceExpression("region", DataTypes.STRING(), 0, 3);
+            FieldReferenceExpression valueFieldRef =
+                    new FieldReferenceExpression("value", DataTypes.BIGINT(), 0, 2);
+
+            CallExpression regionEqualCall =
+                    new CallExpression(
+                            BuiltInFunctionDefinitions.EQUALS,
+                            Arrays.asList(regionFieldRef, new ValueLiteralExpression("HangZhou")),
+                            DataTypes.BOOLEAN());
+            CallExpression valueRangeCall =
+                    new CallExpression(
+                            BuiltInFunctionDefinitions.GREATER_THAN,
+                            Arrays.asList(valueFieldRef, new ValueLiteralExpression(1000L)),
+                            DataTypes.BOOLEAN());
+
+            List<ResolvedExpression> filters = Arrays.asList(regionEqualCall, valueRangeCall);
+
+            FlinkTableSource.Result result = tableSource.applyFilters(filters);
+
+            assertThat(lakeSource.getWithFiltersCalls()).isEqualTo(1);
+            assertThat(lakeSource.getReceivedPredicates()).hasSize(2);
+            assertThat(result.getAcceptedFilters()).hasSize(2);
+            assertThat(result.getRemainingFilters()).hasSize(2);
+            assertThat(tableSource.getLogRecordBatchFilter()).isNotNull();
+        }
+
+        @Test
+        void testRejectedLakeFiltersFallbackToFlinkSideFiltering() {
+            lakeSource = new TrackingLakeSource(true);
+            setLakeSource(tableSource, lakeSource);
+
+            FieldReferenceExpression fieldRef =
+                    new FieldReferenceExpression("region", DataTypes.STRING(), 0, 3);
+            CallExpression equalCall =
+                    new CallExpression(
+                            BuiltInFunctionDefinitions.EQUALS,
+                            Arrays.asList(fieldRef, new ValueLiteralExpression("HangZhou")),
+                            DataTypes.BOOLEAN());
+
+            List<ResolvedExpression> filters =
+                    Collections.<ResolvedExpression>singletonList(equalCall);
+
+            FlinkTableSource.Result result = tableSource.applyFilters(filters);
+
+            assertThat(lakeSource.getWithFiltersCalls()).isEqualTo(1);
+            assertThat(result.getAcceptedFilters()).isEmpty();
+            assertThat(result.getRemainingFilters()).hasSize(1);
             assertThat(tableSource.getLogRecordBatchFilter()).isNull();
         }
     }
@@ -1057,6 +1169,71 @@ public class FlinkTableSourceFilterPushDownTest {
             assertThat(result.getAcceptedFilters()).isEmpty();
             assertThat(result.getRemainingFilters()).hasSize(1);
             assertThat(nonFullStartupTableSource.getSingleRowFilter()).isNull();
+        }
+    }
+
+    private static void setLakeSource(
+            FlinkTableSource tableSource, LakeSource<LakeSplit> trackingLakeSource) {
+        try {
+            Field lakeSourceField = FlinkTableSource.class.getDeclaredField("lakeSource");
+            lakeSourceField.setAccessible(true);
+            lakeSourceField.set(tableSource, trackingLakeSource);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to inject LakeSource for test.", e);
+        }
+    }
+
+    private static final class TrackingLakeSource implements LakeSource<LakeSplit> {
+        private final boolean rejectLastPredicate;
+        private final List<Predicate> receivedPredicates = new ArrayList<>();
+        private int withFiltersCalls;
+
+        private TrackingLakeSource(boolean rejectLastPredicate) {
+            this.rejectLastPredicate = rejectLastPredicate;
+        }
+
+        @Override
+        public void withProject(int[][] project) {}
+
+        @Override
+        public void withLimit(int limit) {}
+
+        @Override
+        public FilterPushDownResult withFilters(List<Predicate> predicates) {
+            withFiltersCalls++;
+            receivedPredicates.clear();
+            receivedPredicates.addAll(predicates);
+
+            if (rejectLastPredicate && !predicates.isEmpty()) {
+                return FilterPushDownResult.of(
+                        predicates.subList(0, predicates.size() - 1),
+                        predicates.subList(predicates.size() - 1, predicates.size()));
+            }
+
+            return FilterPushDownResult.of(predicates, Collections.<Predicate>emptyList());
+        }
+
+        @Override
+        public Planner<LakeSplit> createPlanner(PlannerContext context) {
+            throw new UnsupportedOperationException("Not needed for this test.");
+        }
+
+        @Override
+        public RecordReader createRecordReader(ReaderContext<LakeSplit> context) {
+            throw new UnsupportedOperationException("Not needed for this test.");
+        }
+
+        @Override
+        public SimpleVersionedSerializer<LakeSplit> getSplitSerializer() {
+            throw new UnsupportedOperationException("Not needed for this test.");
+        }
+
+        private int getWithFiltersCalls() {
+            return withFiltersCalls;
+        }
+
+        private List<Predicate> getReceivedPredicates() {
+            return receivedPredicates;
         }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFilterPushDownTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFilterPushDownTest.java
@@ -22,11 +22,6 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.TableConfig;
 import org.apache.fluss.flink.FlinkConnectorOptions;
 import org.apache.fluss.flink.utils.FlinkConnectorOptionsUtils;
-import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
-import org.apache.fluss.lake.source.LakeSource;
-import org.apache.fluss.lake.source.LakeSplit;
-import org.apache.fluss.lake.source.Planner;
-import org.apache.fluss.lake.source.RecordReader;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.predicate.Predicate;
 import org.apache.fluss.row.BinaryString;
@@ -45,8 +40,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -364,111 +357,6 @@ public class FlinkTableSourceFilterPushDownTest {
     }
 
     @Nested
-    class NonPartitionedLakeSourceTests {
-        private FlinkTableSource tableSource;
-        private TrackingLakeSource lakeSource;
-
-        @BeforeEach
-        void setUp() {
-            RowType tableOutputType =
-                    (RowType)
-                            DataTypes.ROW(
-                                            DataTypes.FIELD("id", DataTypes.INT()),
-                                            DataTypes.FIELD("name", DataTypes.STRING()),
-                                            DataTypes.FIELD("value", DataTypes.BIGINT()),
-                                            DataTypes.FIELD("region", DataTypes.STRING()))
-                                    .getLogicalType();
-
-            TablePath tablePath = TablePath.of("test_db", "test_lake_log_table");
-            Configuration flussConfig = new Configuration();
-            flussConfig.setString(FlinkConnectorOptions.BOOTSTRAP_SERVERS.key(), "localhost:9092");
-
-            Configuration tableConfig = new Configuration();
-            tableConfig.set(ConfigOptions.TABLE_STATISTICS_COLUMNS, "*");
-
-            FlinkConnectorOptionsUtils.StartupOptions startupOptions =
-                    new FlinkConnectorOptionsUtils.StartupOptions();
-            startupOptions.startupMode = FlinkConnectorOptions.ScanStartupMode.FULL;
-
-            tableSource =
-                    new FlinkTableSource(
-                            tablePath,
-                            flussConfig,
-                            new TableConfig(tableConfig),
-                            tableOutputType,
-                            new int[] {}, // no primary key indexes
-                            new int[] {}, // bucket key indexes
-                            new int[] {}, // partition key indexes
-                            false, // batch mode
-                            startupOptions,
-                            false, // lookup async
-                            false, // insert if not exists
-                            null, // cache
-                            1000L, // scan partition discovery interval
-                            false, // is data lake enabled
-                            null, // merge engine type
-                            Maps.newHashMap(),
-                            null); // lease context
-        }
-
-        @Test
-        void testNonPartitionedLakeSourcePushesDownFilters() {
-            lakeSource = new TrackingLakeSource(false);
-            setLakeSource(tableSource, lakeSource);
-
-            FieldReferenceExpression regionFieldRef =
-                    new FieldReferenceExpression("region", DataTypes.STRING(), 0, 3);
-            FieldReferenceExpression valueFieldRef =
-                    new FieldReferenceExpression("value", DataTypes.BIGINT(), 0, 2);
-
-            CallExpression regionEqualCall =
-                    new CallExpression(
-                            BuiltInFunctionDefinitions.EQUALS,
-                            Arrays.asList(regionFieldRef, new ValueLiteralExpression("HangZhou")),
-                            DataTypes.BOOLEAN());
-            CallExpression valueRangeCall =
-                    new CallExpression(
-                            BuiltInFunctionDefinitions.GREATER_THAN,
-                            Arrays.asList(valueFieldRef, new ValueLiteralExpression(1000L)),
-                            DataTypes.BOOLEAN());
-
-            List<ResolvedExpression> filters = Arrays.asList(regionEqualCall, valueRangeCall);
-
-            FlinkTableSource.Result result = tableSource.applyFilters(filters);
-
-            assertThat(lakeSource.getWithFiltersCalls()).isEqualTo(1);
-            assertThat(lakeSource.getReceivedPredicates()).hasSize(2);
-            assertThat(result.getAcceptedFilters()).hasSize(2);
-            assertThat(result.getRemainingFilters()).hasSize(2);
-            assertThat(tableSource.getLogRecordBatchFilter()).isNotNull();
-        }
-
-        @Test
-        void testRejectedLakeFiltersDoNotBlockFlussPushdown() {
-            lakeSource = new TrackingLakeSource(true);
-            setLakeSource(tableSource, lakeSource);
-
-            FieldReferenceExpression fieldRef =
-                    new FieldReferenceExpression("region", DataTypes.STRING(), 0, 3);
-            CallExpression equalCall =
-                    new CallExpression(
-                            BuiltInFunctionDefinitions.EQUALS,
-                            Arrays.asList(fieldRef, new ValueLiteralExpression("HangZhou")),
-                            DataTypes.BOOLEAN());
-
-            List<ResolvedExpression> filters =
-                    Collections.<ResolvedExpression>singletonList(equalCall);
-
-            FlinkTableSource.Result result = tableSource.applyFilters(filters);
-
-            assertThat(lakeSource.getWithFiltersCalls()).isEqualTo(1);
-            assertThat(result.getAcceptedFilters()).hasSize(1);
-            assertThat(result.getRemainingFilters()).hasSize(1);
-            assertThat(tableSource.getLogRecordBatchFilter()).isNotNull();
-        }
-    }
-
-    @Nested
     class PartitionedKvTableTests {
         private FlinkTableSource tableSource;
 
@@ -759,39 +647,6 @@ public class FlinkTableSourceFilterPushDownTest {
             assertThat(tableSource.getLogRecordBatchFilter())
                     .isNotNull(); // Record batch filter pushed down for non-PK partitioned log
             // table
-        }
-
-        @Test
-        void testPartitionedLakeSourcePushdownDoesNotBlockFlussPushdown() {
-            TrackingLakeSource lakeSource = new TrackingLakeSource(true);
-            setLakeSource(tableSource, lakeSource);
-
-            FieldReferenceExpression regionFieldRef =
-                    new FieldReferenceExpression("region", DataTypes.STRING(), 0, 3);
-            FieldReferenceExpression idFieldRef =
-                    new FieldReferenceExpression("id", DataTypes.INT(), 0, 0);
-
-            CallExpression regionEqualCall =
-                    new CallExpression(
-                            BuiltInFunctionDefinitions.EQUALS,
-                            Arrays.asList(regionFieldRef, new ValueLiteralExpression("us-east")),
-                            DataTypes.BOOLEAN());
-            CallExpression idEqualCall =
-                    new CallExpression(
-                            BuiltInFunctionDefinitions.EQUALS,
-                            Arrays.asList(idFieldRef, new ValueLiteralExpression(5)),
-                            DataTypes.BOOLEAN());
-
-            List<ResolvedExpression> filters = Arrays.asList(regionEqualCall, idEqualCall);
-
-            FlinkTableSource.Result result = tableSource.applyFilters(filters);
-
-            assertThat(lakeSource.getWithFiltersCalls()).isEqualTo(1);
-            assertThat(lakeSource.getReceivedPredicates()).hasSize(2);
-            assertThat(result.getAcceptedFilters()).hasSize(2);
-            assertThat(result.getRemainingFilters()).hasSize(2);
-            assertThat(tableSource.getPartitionFilters()).isNotNull();
-            assertThat(tableSource.getLogRecordBatchFilter()).isNotNull();
         }
     }
 
@@ -1202,71 +1057,6 @@ public class FlinkTableSourceFilterPushDownTest {
             assertThat(result.getAcceptedFilters()).isEmpty();
             assertThat(result.getRemainingFilters()).hasSize(1);
             assertThat(nonFullStartupTableSource.getSingleRowFilter()).isNull();
-        }
-    }
-
-    private static void setLakeSource(
-            FlinkTableSource tableSource, LakeSource<LakeSplit> trackingLakeSource) {
-        try {
-            Field lakeSourceField = FlinkTableSource.class.getDeclaredField("lakeSource");
-            lakeSourceField.setAccessible(true);
-            lakeSourceField.set(tableSource, trackingLakeSource);
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException("Failed to inject LakeSource for test.", e);
-        }
-    }
-
-    private static final class TrackingLakeSource implements LakeSource<LakeSplit> {
-        private final boolean rejectLastPredicate;
-        private final List<Predicate> receivedPredicates = new ArrayList<>();
-        private int withFiltersCalls;
-
-        private TrackingLakeSource(boolean rejectLastPredicate) {
-            this.rejectLastPredicate = rejectLastPredicate;
-        }
-
-        @Override
-        public void withProject(int[][] project) {}
-
-        @Override
-        public void withLimit(int limit) {}
-
-        @Override
-        public FilterPushDownResult withFilters(List<Predicate> predicates) {
-            withFiltersCalls++;
-            receivedPredicates.clear();
-            receivedPredicates.addAll(predicates);
-
-            if (rejectLastPredicate && !predicates.isEmpty()) {
-                return FilterPushDownResult.of(
-                        predicates.subList(0, predicates.size() - 1),
-                        predicates.subList(predicates.size() - 1, predicates.size()));
-            }
-
-            return FilterPushDownResult.of(predicates, Collections.<Predicate>emptyList());
-        }
-
-        @Override
-        public Planner<LakeSplit> createPlanner(PlannerContext context) {
-            throw new UnsupportedOperationException("Not needed for this test.");
-        }
-
-        @Override
-        public RecordReader createRecordReader(ReaderContext<LakeSplit> context) {
-            throw new UnsupportedOperationException("Not needed for this test.");
-        }
-
-        @Override
-        public SimpleVersionedSerializer<LakeSplit> getSplitSerializer() {
-            throw new UnsupportedOperationException("Not needed for this test.");
-        }
-
-        private int getWithFiltersCalls() {
-            return withFiltersCalls;
-        }
-
-        private List<Predicate> getReceivedPredicates() {
-            return receivedPredicates;
         }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFilterPushDownTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFilterPushDownTest.java
@@ -444,7 +444,7 @@ public class FlinkTableSourceFilterPushDownTest {
         }
 
         @Test
-        void testRejectedLakeFiltersFallbackToFlinkSideFiltering() {
+        void testRejectedLakeFiltersDoNotBlockFlussPushdown() {
             lakeSource = new TrackingLakeSource(true);
             setLakeSource(tableSource, lakeSource);
 
@@ -462,9 +462,9 @@ public class FlinkTableSourceFilterPushDownTest {
             FlinkTableSource.Result result = tableSource.applyFilters(filters);
 
             assertThat(lakeSource.getWithFiltersCalls()).isEqualTo(1);
-            assertThat(result.getAcceptedFilters()).isEmpty();
+            assertThat(result.getAcceptedFilters()).hasSize(1);
             assertThat(result.getRemainingFilters()).hasSize(1);
-            assertThat(tableSource.getLogRecordBatchFilter()).isNull();
+            assertThat(tableSource.getLogRecordBatchFilter()).isNotNull();
         }
     }
 
@@ -759,6 +759,39 @@ public class FlinkTableSourceFilterPushDownTest {
             assertThat(tableSource.getLogRecordBatchFilter())
                     .isNotNull(); // Record batch filter pushed down for non-PK partitioned log
             // table
+        }
+
+        @Test
+        void testPartitionedLakeSourcePushdownDoesNotBlockFlussPushdown() {
+            TrackingLakeSource lakeSource = new TrackingLakeSource(true);
+            setLakeSource(tableSource, lakeSource);
+
+            FieldReferenceExpression regionFieldRef =
+                    new FieldReferenceExpression("region", DataTypes.STRING(), 0, 3);
+            FieldReferenceExpression idFieldRef =
+                    new FieldReferenceExpression("id", DataTypes.INT(), 0, 0);
+
+            CallExpression regionEqualCall =
+                    new CallExpression(
+                            BuiltInFunctionDefinitions.EQUALS,
+                            Arrays.asList(regionFieldRef, new ValueLiteralExpression("us-east")),
+                            DataTypes.BOOLEAN());
+            CallExpression idEqualCall =
+                    new CallExpression(
+                            BuiltInFunctionDefinitions.EQUALS,
+                            Arrays.asList(idFieldRef, new ValueLiteralExpression(5)),
+                            DataTypes.BOOLEAN());
+
+            List<ResolvedExpression> filters = Arrays.asList(regionEqualCall, idEqualCall);
+
+            FlinkTableSource.Result result = tableSource.applyFilters(filters);
+
+            assertThat(lakeSource.getWithFiltersCalls()).isEqualTo(1);
+            assertThat(lakeSource.getReceivedPredicates()).hasSize(2);
+            assertThat(result.getAcceptedFilters()).hasSize(2);
+            assertThat(result.getRemainingFilters()).hasSize(2);
+            assertThat(tableSource.getPartitionFilters()).isNotNull();
+            assertThat(tableSource.getLogRecordBatchFilter()).isNotNull();
         }
     }
 


### PR DESCRIPTION
<!--
Generated-by: Codex (GPT-5) following https://github.com/apache/fluss/blob/main/AGENTS.md
-->

### Purpose

Linked issue: close #3168

Allow `FlinkTableSource` to push filters into `LakeSource` for non-partitioned table scans. Before this change, lake filter pushdown was nested under `isPartitioned()`, so non-partitioned scans in lake-backed `FULL` reads always fell back to Flink-side filtering for historical data.

### Brief change log

- keep lake filter pushdown enabled for partitioned tables and extend the same path to non-partitioned tables
- make lake pushdown only contribute accepted filter metadata so it does not bypass Fluss-side partition pruning or record-batch filtering
- document why `pushdownLakeFilters(...)` updates `acceptedFilters` but intentionally does not rewrite `remainingFilters`
- existing union-read ITs already exercise both partitioned and non-partitioned log tables through `FlinkUnionReadLogTableITCase#testReadLogTableFullType(boolean isPartitioned)` in both Iceberg and Paimon modules

### Tests

- `./mvnw -pl fluss-flink/fluss-flink-common -DskipITs test`
- `./mvnw -pl fluss-flink/fluss-flink-common spotless:check -Dspotless.check.skip=false`
- Existing IT note: `FlinkUnionReadLogTableITCase#testReadLogTableFullType` runs with `isPartitioned = false` and `true`; the partitioned branch additionally asserts partition filter pushdown in the plan

### API and Format

No API or storage format changes.

### Documentation

No documentation changes.
