### PR TITLE
[tiering] Fix Paimon IOManager leak in MergeTreeWriter

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/mergetree/MergeTreeWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/mergetree/MergeTreeWriter.java
@@ -46,23 +46,42 @@ public class MergeTreeWriter extends RecordWriter<KeyValue> {
 
     private final RowKeyExtractor rowKeyExtractor;
 
+    private final IOManager ioManager;
+
     public MergeTreeWriter(
             FileStoreTable fileStoreTable,
             TableBucket tableBucket,
             @Nullable String partition,
             List<String> partitionKeys,
             RowType flussRowType) {
+        this(
+                fileStoreTable,
+                createIOManager(fileStoreTable),
+                tableBucket,
+                partition,
+                partitionKeys,
+                flussRowType);
+    }
+
+    MergeTreeWriter(
+            FileStoreTable fileStoreTable,
+            IOManager ioManager,
+            TableBucket tableBucket,
+            @Nullable String partition,
+            List<String> partitionKeys,
+            RowType flussRowType) {
         super(
-                createTableWrite(fileStoreTable),
+                createTableWrite(fileStoreTable, ioManager),
                 fileStoreTable.rowType(),
                 tableBucket,
                 partition,
                 partitionKeys,
                 flussRowType);
         this.rowKeyExtractor = fileStoreTable.createRowKeyExtractor();
+        this.ioManager = ioManager;
     }
 
-    private static TableWriteImpl<KeyValue> createTableWrite(FileStoreTable fileStoreTable) {
+    private static IOManager createIOManager(FileStoreTable fileStoreTable) {
         // we allow users to configure the temporary directory used by fluss tiering
         // since the default java.io.tmpdir may not be suitable.
         // currently, we don't expose the option, as a workaround way, maybe in the future we can
@@ -70,11 +89,23 @@ public class MergeTreeWriter extends RecordWriter<KeyValue> {
         Map<String, String> props = fileStoreTable.options();
         String tmpDir =
                 props.getOrDefault(FLUSS_TIERING_TMP_DIR_KEY, System.getProperty("java.io.tmpdir"));
+        return IOManager.create(tmpDir);
+    }
+
+    private static TableWriteImpl<KeyValue> createTableWrite(
+            FileStoreTable fileStoreTable, IOManager ioManager) {
         //noinspection unchecked
         return (TableWriteImpl<KeyValue>)
-                fileStoreTable
-                        .newWrite(FLUSS_LAKE_TIERING_COMMIT_USER)
-                        .withIOManager(IOManager.create(tmpDir));
+                fileStoreTable.newWrite(FLUSS_LAKE_TIERING_COMMIT_USER).withIOManager(ioManager);
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            super.close();
+        } finally {
+            ioManager.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
<!--
Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

- [x] Yes (Claude Code - Claude Opus 4.6)

### Purpose

<!-- Linking this pull request to the issue -->

Fix Paimon IOManager resource leak in `MergeTreeWriter` that causes `paimon-io-<UUID>` temp directories to accumulate in `/tmp` and eventually exhaust disk space when tiering service is running.

### Brief change log

The `IOManager` created in `MergeTreeWriter.createTableWrite()` was passed inline to `withIOManager()` without keeping a reference. Since Paimon's `TableWriteImpl` does not own the IOManager lifecycle, the IOManager was never closed when the writer was closed, leaving `paimon-io-<UUID>` directories behind in `/tmp` after each tiering task.

- Store the `IOManager` as a field in `MergeTreeWriter`
- Override `close()` to explicitly close the `IOManager` in a finally block, ensuring temp directories are cleaned up even if `tableWrite.close()` throws

### Tests

- Existing tiering-related integration tests cover the write/close flow
- Manual verification: start tiering service with PK tables and confirm `paimon-io-*` directories in `/tmp` are cleaned up after writer closes

### API and Format

No API or storage format changes.

### Documentation

No documentation changes needed.