### PR TITLE
[tiering] Fix Paimon IOManager leak in MergeTreeWriter causing /tmp disk exhaustion

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/mergetree/MergeTreeWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/mergetree/MergeTreeWriter.java
@@ -45,21 +45,38 @@ public class MergeTreeWriter extends RecordWriter<KeyValue> {
 
     private final RowKeyExtractor rowKeyExtractor;
 
+    private final IOManager ioManager;
+
     public MergeTreeWriter(
             FileStoreTable fileStoreTable,
             TableBucket tableBucket,
             @Nullable String partition,
             List<String> partitionKeys) {
+        this(
+                fileStoreTable,
+                createIOManager(fileStoreTable),
+                tableBucket,
+                partition,
+                partitionKeys);
+    }
+
+    MergeTreeWriter(
+            FileStoreTable fileStoreTable,
+            IOManager ioManager,
+            TableBucket tableBucket,
+            @Nullable String partition,
+            List<String> partitionKeys) {
         super(
-                createTableWrite(fileStoreTable),
+                createTableWrite(fileStoreTable, ioManager),
                 fileStoreTable.rowType(),
                 tableBucket,
                 partition,
                 partitionKeys);
         this.rowKeyExtractor = fileStoreTable.createRowKeyExtractor();
+        this.ioManager = ioManager;
     }
 
-    private static TableWriteImpl<KeyValue> createTableWrite(FileStoreTable fileStoreTable) {
+    private static IOManager createIOManager(FileStoreTable fileStoreTable) {
         // we allow users to configure the temporary directory used by fluss tiering
         // since the default java.io.tmpdir may not be suitable.
         // currently, we don't expose the option, as a workaround way, maybe in the future we can
@@ -67,11 +84,23 @@ public class MergeTreeWriter extends RecordWriter<KeyValue> {
         Map<String, String> props = fileStoreTable.options();
         String tmpDir =
                 props.getOrDefault(FLUSS_TIERING_TMP_DIR_KEY, System.getProperty("java.io.tmpdir"));
+        return IOManager.create(tmpDir);
+    }
+
+    private static TableWriteImpl<KeyValue> createTableWrite(
+            FileStoreTable fileStoreTable, IOManager ioManager) {
         //noinspection unchecked
         return (TableWriteImpl<KeyValue>)
-                fileStoreTable
-                        .newWrite(FLUSS_LAKE_TIERING_COMMIT_USER)
-                        .withIOManager(IOManager.create(tmpDir));
+                fileStoreTable.newWrite(FLUSS_LAKE_TIERING_COMMIT_USER).withIOManager(ioManager);
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            super.close();
+        } finally {
+            ioManager.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
The IOManager created in MergeTreeWriter.createTableWrite() was passed inline to withIOManager() without keeping a reference. Since Paimon's TableWriteImpl does not own the IOManager lifecycle, it was never closed, leaving paimon-io-<UUID> directories in /tmp after each tiering task.

This fix stores the IOManager as a field and explicitly closes it in close() via a finally block, ensuring temp directories are cleaned up.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
