### PR TITLE
[server] make RemoteLogManifest sorted with startOffset

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogManifest.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogManifest.java
@@ -24,6 +24,7 @@ import org.apache.fluss.remote.RemoteLogSegment;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -73,6 +74,7 @@ public class RemoteLogManifest {
             }
         }
         newSegments.addAll(addedSegments);
+        newSegments.sort(Comparator.comparingLong(RemoteLogSegment::remoteLogStartOffset));
         return new RemoteLogManifest(physicalTablePath, tableBucket, newSegments);
     }
 


### PR DESCRIPTION
### Purpose

Without this PR, the segment metadata in the manifest file is not sorted, which makes it difficult to verify multiple offsets one by one.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
