### PR TITLE
[spark] Add numRowsRead custom metric and improve Spark UI operator name for FlussScan

### DIFF
--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/catalog/AbstractSparkTable.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/catalog/AbstractSparkTable.scala
@@ -38,7 +38,7 @@ abstract class AbstractSparkTable(val admin: Admin, val tableInfo: TableInfo) ex
   protected lazy val _partitionSchema = new StructType(
     _schema.fields.filter(e => tableInfo.getPartitionKeys.contains(e.name)))
 
-  override def name(): String = tableInfo.toString
+  override def name(): String = tableInfo.getTablePath.toString
 
   override def schema(): StructType = _schema
 

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussAppendPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussAppendPartitionReader.scala
@@ -58,7 +58,7 @@ class FlussAppendPartitionReader(
     currentRecords = scanRecords.records(tableBucket).iterator()
   }
 
-  override def next(): Boolean = {
+  override def next0(): Boolean = {
     if (closed || currentOffset >= flussPartition.stopOffset) {
       return false
     }
@@ -71,7 +71,6 @@ class FlussAppendPartitionReader(
     if (currentRecords.hasNext) {
       val scanRecord = currentRecords.next()
       currentRow = convertToSparkRow(scanRecord)
-      numRowsRead += 1
       currentOffset = scanRecord.logOffset() + 1
       true
     } else if (currentOffset < flussPartition.stopOffset) {

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussAppendPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussAppendPartitionReader.scala
@@ -71,6 +71,7 @@ class FlussAppendPartitionReader(
     if (currentRecords.hasNext) {
       val scanRecord = currentRecords.next()
       currentRow = convertToSparkRow(scanRecord)
+      numRowsRead += 1
       currentOffset = scanRecord.logOffset() + 1
       true
     } else if (currentOffset < flussPartition.stopOffset) {

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMetrics.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussMetrics.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.spark.read
+
+import org.apache.spark.sql.connector.metric.{CustomSumMetric, CustomTaskMetric}
+
+object FlussMetrics {
+  val NUM_ROWS_READ = "numRowsRead"
+}
+
+// ---------------------------------------------------------------------------
+// CustomMetric classes — driver-side aggregation (must have 0-arg constructor)
+// ---------------------------------------------------------------------------
+
+/** Base trait for Fluss sum metrics. */
+sealed trait FlussSumMetric extends CustomSumMetric {
+  override def aggregateTaskMetrics(taskMetrics: Array[Long]): String = {
+    var sum = 0L
+    for (v <- taskMetrics) { sum += v }
+    String.valueOf(sum)
+  }
+}
+
+/** Aggregates total rows read across all tasks. */
+case class FlussNumRowsReadMetric() extends FlussSumMetric {
+  override def name(): String = FlussMetrics.NUM_ROWS_READ
+  override def description(): String = "number of rows read from Fluss"
+}
+
+// ---------------------------------------------------------------------------
+// CustomTaskMetric classes — executor-side reporting
+// ---------------------------------------------------------------------------
+
+/** Base trait for Fluss task metrics. */
+sealed trait FlussTaskMetric extends CustomTaskMetric
+
+/** Reports the number of rows read in a single task. */
+case class FlussNumRowsReadTaskMetric(override val value: Long) extends FlussTaskMetric {
+  override def name(): String = FlussMetrics.NUM_ROWS_READ
+}

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussPartitionReader.scala
@@ -29,6 +29,7 @@ import org.apache.fluss.types.RowType
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.metric.CustomTaskMetric
 import org.apache.spark.sql.connector.read.PartitionReader
 
 import java.time.Duration
@@ -46,8 +47,12 @@ abstract class FlussPartitionReader(tablePath: TablePath, flussConfig: Configura
 
   protected var currentRow: InternalRow = _
   protected var closed = false
+  protected var numRowsRead: Long = 0L
 
   override def get(): InternalRow = currentRow
+
+  override def currentMetricsValues(): Array[CustomTaskMetric] =
+    Array(FlussNumRowsReadTaskMetric(numRowsRead))
 
   def close0(): Unit
 

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussPartitionReader.scala
@@ -54,6 +54,16 @@ abstract class FlussPartitionReader(tablePath: TablePath, flussConfig: Configura
   override def currentMetricsValues(): Array[CustomTaskMetric] =
     Array(FlussNumRowsReadTaskMetric(numRowsRead))
 
+  def next0(): Boolean
+
+  override def next(): Boolean = {
+    val hasNext = next0()
+    if (hasNext) {
+      numRowsRead += 1
+    }
+    hasNext
+  }
+
   def close0(): Unit
 
   override def close(): Unit = {

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussScan.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussScan.scala
@@ -24,6 +24,7 @@ import org.apache.fluss.spark.SparkConversions
 import org.apache.fluss.spark.read.lake.{FlussLakeAppendBatch, FlussLakeUpsertBatch}
 
 import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.read.{Batch, Scan}
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream
 import org.apache.spark.sql.types.StructType
@@ -33,11 +34,21 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 trait FlussScan extends Scan {
   def tableInfo: TableInfo
 
+  def tablePath: TablePath
+
   def requiredSchema: Option[StructType]
+
+  protected def scanType: String
 
   override def readSchema(): StructType = {
     requiredSchema.getOrElse(SparkConversions.toSparkDataType(tableInfo.getRowType))
   }
+
+  override def description(): String =
+    s"FlussScan: [$tablePath], Type: [$scanType]"
+
+  override def supportedCustomMetrics(): Array[CustomMetric] =
+    Array(FlussNumRowsReadMetric())
 }
 
 /** Fluss Append Scan. */
@@ -50,6 +61,8 @@ case class FlussAppendScan(
     options: CaseInsensitiveStringMap,
     flussConfig: Configuration)
   extends FlussScan {
+
+  override protected val scanType: String = "Append"
 
   override def toBatch: Batch = {
     new FlussAppendBatch(tablePath, tableInfo, readSchema, pushedPredicate, options, flussConfig)
@@ -81,6 +94,8 @@ case class FlussLakeAppendScan(
     flussConfig: Configuration)
   extends FlussScan {
 
+  override protected val scanType: String = "LakeAppend"
+
   override def toBatch: Batch = {
     new FlussLakeAppendBatch(tablePath, tableInfo, readSchema, options, flussConfig)
   }
@@ -105,6 +120,8 @@ case class FlussUpsertScan(
     flussConfig: Configuration)
   extends FlussScan {
 
+  override protected val scanType: String = "Upsert"
+
   override def toBatch: Batch = {
     new FlussUpsertBatch(tablePath, tableInfo, readSchema, options, flussConfig)
   }
@@ -128,6 +145,8 @@ case class FlussLakeUpsertScan(
     options: CaseInsensitiveStringMap,
     flussConfig: Configuration)
   extends FlussScan {
+
+  override protected val scanType: String = "LakeUpsert"
 
   override def toBatch: Batch = {
     new FlussLakeUpsertBatch(tablePath, tableInfo, readSchema, options, flussConfig)

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussUpsertPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussUpsertPartitionReader.scala
@@ -86,14 +86,13 @@ class FlussUpsertPartitionReader(
   // initialize scanners
   initialize()
 
-  override def next(): Boolean = {
+  override def next0(): Boolean = {
     if (closed) {
       return false
     }
 
     if (mergedIterator.hasNext) {
       currentRow = convertToSparkRow(mergedIterator.next())
-      numRowsRead += 1
       true
     } else {
       false

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussUpsertPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussUpsertPartitionReader.scala
@@ -93,6 +93,7 @@ class FlussUpsertPartitionReader(
 
     if (mergedIterator.hasNext) {
       currentRow = convertToSparkRow(mergedIterator.next())
+      numRowsRead += 1
       true
     } else {
       false

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/lake/FlussLakeAppendPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/lake/FlussLakeAppendPartitionReader.scala
@@ -51,7 +51,7 @@ class FlussLakeAppendPartitionReader(
 
   override lazy val projectedRowType: RowType = rowType.project(projection)
 
-  override def next(): Boolean = {
+  override def next0(): Boolean = {
     if (closed || recordIterator == null) {
       return false
     }

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/lake/FlussLakeUpsertPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/lake/FlussLakeUpsertPartitionReader.scala
@@ -69,6 +69,7 @@ class FlussLakeUpsertPartitionReader(
     while (true) {
       if (mergedIterator.hasNext) {
         currentRow = convertToSparkRow(mergedIterator.next())
+        numRowsRead += 1
         return true
       }
 

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/lake/FlussLakeUpsertPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/lake/FlussLakeUpsertPartitionReader.scala
@@ -60,7 +60,7 @@ class FlussLakeUpsertPartitionReader(
 
   override lazy val projectedRowType: RowType = rowType.project(projection)
 
-  override def next(): Boolean = {
+  override def next0(): Boolean = {
     if (closed || scanFinished) {
       return false
     }
@@ -69,7 +69,6 @@ class FlussLakeUpsertPartitionReader(
     while (true) {
       if (mergedIterator.hasNext) {
         currentRow = convertToSparkRow(mergedIterator.next())
-        numRowsRead += 1
         return true
       }
 

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkLogTableReadTest.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkLogTableReadTest.scala
@@ -18,12 +18,10 @@
 package org.apache.fluss.spark
 
 import org.apache.fluss.spark.read.{FlussMetrics, FlussScan}
-
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation}
 import org.apache.fluss.spark.read.FlussAppendScan
 
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation}
 import org.assertj.core.api.Assertions.assertThat

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkLogTableReadTest.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkLogTableReadTest.scala
@@ -17,6 +17,10 @@
 
 package org.apache.fluss.spark
 
+import org.apache.fluss.spark.read.{FlussMetrics, FlussScan}
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation}
 import org.apache.fluss.spark.read.FlussAppendScan
 
 import org.apache.spark.sql.{DataFrame, Row}
@@ -485,5 +489,41 @@ class SparkLogTableReadTest extends FlussSparkTestBase {
     assert(
       expected.exists(pushed.contains),
       s"Expected any of $expected in pushed predicates, got $pushed")
+  }
+
+  test("Spark Read: log table scan metrics") {
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE $DEFAULT_DATABASE.t (id INT, name STRING)
+             |""".stripMargin)
+
+      sql(s"""
+             |INSERT INTO $DEFAULT_DATABASE.t VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')
+             |""".stripMargin)
+
+      val df = sql(s"SELECT * FROM $DEFAULT_DATABASE.t")
+
+      // Verify scan description and supportedCustomMetrics before execution
+      val scan = df.queryExecution.optimizedPlan
+        .collectFirst { case r: DataSourceV2ScanRelation => r }
+        .get
+        .scan
+        .asInstanceOf[FlussScan]
+
+      assert(scan.description().contains("FlussScan"))
+      assert(scan.description().contains("Append"))
+      assert(scan.supportedCustomMetrics().exists(_.name() == FlussMetrics.NUM_ROWS_READ))
+
+      // Execute the query to trigger metric accumulation
+      df.collect()
+
+      // Verify numRowsRead is accumulated in BatchScanExec after execution
+      val batchScanExec = df.queryExecution.executedPlan.collectFirst {
+        case b: BatchScanExec => b
+      }.get
+
+      val numRowsRead = batchScanExec.metrics(FlussMetrics.NUM_ROWS_READ).value
+      assert(numRowsRead == 5L, s"Expected 5 rows read, got $numRowsRead")
+    }
   }
 }

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkPrimaryKeyTableReadTest.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkPrimaryKeyTableReadTest.scala
@@ -20,9 +20,10 @@ package org.apache.fluss.spark
 import org.apache.fluss.client.initializer.{BucketOffsetsRetrieverImpl, OffsetsInitializer}
 import org.apache.fluss.config.{ConfigOptions, Configuration}
 import org.apache.fluss.metadata.{TableBucket, TablePath}
-import org.apache.fluss.spark.read.FlussUpsertInputPartition
+import org.apache.fluss.spark.read.{FlussMetrics, FlussScan, FlussUpsertInputPartition}
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation}
 import org.assertj.core.api.Assertions.assertThat
 
 import scala.collection.JavaConverters._
@@ -334,5 +335,45 @@ class SparkPrimaryKeyTableReadTest extends FlussSparkTestBase {
 
   private def hasSnapshotData(inputPartition: FlussUpsertInputPartition): Boolean = {
     inputPartition.snapshotId >= 0
+  }
+
+  test("Spark Read: primary key table scan metrics") {
+    withTable("t") {
+      val tablePath = createTablePath("t")
+      sql(s"""
+             |CREATE TABLE $DEFAULT_DATABASE.t (id INT, name STRING)
+             |TBLPROPERTIES("primary.key" = "id", "bucket.num" = 1)
+             |""".stripMargin)
+
+      sql(s"""
+             |INSERT INTO $DEFAULT_DATABASE.t VALUES (1, 'a'), (2, 'b'), (3, 'c')
+             |""".stripMargin)
+
+      flussServer.triggerAndWaitSnapshot(tablePath)
+
+      val df = sql(s"SELECT * FROM $DEFAULT_DATABASE.t")
+
+      // Verify scan description and supportedCustomMetrics before execution
+      val scan = df.queryExecution.optimizedPlan
+        .collectFirst { case r: DataSourceV2ScanRelation => r }
+        .get
+        .scan
+        .asInstanceOf[FlussScan]
+
+      assert(scan.description().contains("FlussScan"))
+      assert(scan.description().contains("Upsert"))
+      assert(scan.supportedCustomMetrics().exists(_.name() == FlussMetrics.NUM_ROWS_READ))
+
+      // Execute the query to trigger metric accumulation
+      df.collect()
+
+      // Verify numRowsRead is accumulated in BatchScanExec after execution
+      val batchScanExec = df.queryExecution.executedPlan.collectFirst {
+        case b: BatchScanExec => b
+      }.get
+
+      val numRowsRead = batchScanExec.metrics(FlussMetrics.NUM_ROWS_READ).value
+      assert(numRowsRead == 3L, s"Expected 3 rows read, got $numRowsRead")
+    }
   }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3160

<!-- What is the purpose of the change -->

### Brief change log

This PR adds custom metrics support to the Spark connector for Fluss table scans, enabling users to monitor
row read counts via Spark UI. It also fixes `AbstractSparkTable.name()` to return the correct table path.

- **Add `numRowsRead` custom metric**: Introduces `FlussMetrics` with custom metric classes (`FlussNumRowsReadMetric`, `FlussNumRowsReadTaskMetric`) for driver-side aggregation and executor-side reporting
- **Fix Spark UI operator name**: `AbstractSparkTable.name()` now returns  `tableInfo.getTablePath.toString` (e.g. `db.table`) instead of the verbose `TableInfo.toString`.
- **Refactor `next()` → `next0()`**: Moves scan logic to `next0()` in concrete readers so the
  base class can centrally maintain the row counter.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

- `SparkLogTableReadTest, Spark Read: log table scan metrics`
- `SparkPrimaryKeyTableReadTest, Spark Read: primary key table scan metrics`


### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
