### PR TITLE
[server] Validate Java version >= 11 in config.sh to prevent silent startup failures

### DIFF
--- a/fluss-dist/src/main/resources/bin/config.sh
+++ b/fluss-dist/src/main/resources/bin/config.sh
@@ -93,6 +93,20 @@ readFromConfig() {
     [ -z "$value" ] && echo "$defaultValue" || echo "$value"
 }
 
+is_jdk_version_ge_11() {
+  java_command=$1
+
+  # get the java version using the java command
+  java_version=$($java_command -version 2>&1 | grep 'version' | cut -d '"' -f 2)
+  major_version=$(echo "$java_version" | cut -d. -f1)
+
+  if [ "$major_version" -ge 11 ]; then
+      return 0 # for true
+  else
+      return 1 # for false
+  fi
+}
+
 is_jdk_version_ge_17() {
   java_command=$1
 
@@ -221,6 +235,13 @@ else
     fi
 fi
 
+# Verify that the Java version is at least 11
+if ! is_jdk_version_ge_11 ${JAVA_RUN}; then
+    java_version=$(${JAVA_RUN} -version 2>&1 | grep 'version' | head -n 1)
+    echo "[ERROR] Fluss requires Java 11 or higher. Current Java version: ${java_version}."
+    echo "[ERROR] Please set JAVA_HOME to a Java 11+ installation."
+    exit 1
+fi
 
 # Define HOSTNAME if it is not already set
 if [ -z "${HOSTNAME}" ]; then

--- a/fluss-dist/src/main/resources/bin/config.sh
+++ b/fluss-dist/src/main/resources/bin/config.sh
@@ -93,28 +93,15 @@ readFromConfig() {
     [ -z "$value" ] && echo "$defaultValue" || echo "$value"
 }
 
-is_jdk_version_ge_11() {
+is_jdk_version_ge() {
   java_command=$1
+  target_version=$2
 
   # get the java version using the java command
   java_version=$($java_command -version 2>&1 | grep 'version' | cut -d '"' -f 2)
   major_version=$(echo "$java_version" | cut -d. -f1)
 
-  if [ "$major_version" -ge 11 ]; then
-      return 0 # for true
-  else
-      return 1 # for false
-  fi
-}
-
-is_jdk_version_ge_17() {
-  java_command=$1
-
-  # get the java version using the java command
-  java_version=$($java_command -version 2>&1 | grep 'version' | cut -d '"' -f 2)
-  major_version=$(echo "$java_version" | cut -d. -f1)
-
-  if [ "$major_version" -ge 17 ]; then
+  if [ "$major_version" -ge "$target_version" ]; then
       return 0 # for true
   else
       return 1 # for false
@@ -236,7 +223,7 @@ else
 fi
 
 # Verify that the Java version is at least 11
-if ! is_jdk_version_ge_11 "$JAVA_RUN"; then
+if ! is_jdk_version_ge "$JAVA_RUN" 11; then
     java_version=$("$JAVA_RUN" -version 2>&1 | grep 'version' | head -n 1)
     echo "[ERROR] Fluss requires Java 11 or higher. Current Java version: ${java_version}."
     echo "[ERROR] Please set JAVA_HOME to a Java 11+ installation."

--- a/fluss-dist/src/main/resources/bin/config.sh
+++ b/fluss-dist/src/main/resources/bin/config.sh
@@ -236,8 +236,8 @@ else
 fi
 
 # Verify that the Java version is at least 11
-if ! is_jdk_version_ge_11 ${JAVA_RUN}; then
-    java_version=$(${JAVA_RUN} -version 2>&1 | grep 'version' | head -n 1)
+if ! is_jdk_version_ge_11 "$JAVA_RUN"; then
+    java_version=$("$JAVA_RUN" -version 2>&1 | grep 'version' | head -n 1)
     echo "[ERROR] Fluss requires Java 11 or higher. Current Java version: ${java_version}."
     echo "[ERROR] Please set JAVA_HOME to a Java 11+ installation."
     exit 1

--- a/fluss-dist/src/main/resources/bin/fluss-console.sh
+++ b/fluss-dist/src/main/resources/bin/fluss-console.sh
@@ -103,7 +103,7 @@ fi
 
 # when jdk version is 17 or above, need to add following option to make arrow works
 # see https://arrow.apache.org/docs/dev/java/install.html#java-compatibility
-if is_jdk_version_ge_17 "$JAVA_RUN" ; then
+if is_jdk_version_ge "$JAVA_RUN" 17 ; then
   JVM_ARGS="${JVM_ARGS} --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
 fi
 

--- a/fluss-dist/src/main/resources/bin/fluss-daemon.sh
+++ b/fluss-dist/src/main/resources/bin/fluss-daemon.sh
@@ -129,7 +129,7 @@ case $STARTSTOP in
 
         # when jdk version is 17 or above, need to add following option to make arrow works
         # see https://arrow.apache.org/docs/dev/java/install.html#java-compatibility
-        if is_jdk_version_ge_17 "$JAVA_RUN" ; then
+        if is_jdk_version_ge "$JAVA_RUN" 17 ; then
             JVM_ARGS="${JVM_ARGS} --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
         fi
 


### PR DESCRIPTION
## Summary
- Add `is_jdk_version_ge_11()` function in `config.sh` to validate Java version
- Insert version check after `JAVA_RUN` resolution, before any process startup
- When Java < 11, print clear error message and exit with code 1

## Test Plan
- `bash -n` syntax check passes on config.sh, coordinator-server.sh, tablet-server.sh, local-cluster.sh
- Integration test: Java 17 correctly passes version check; simulated Java 8 correctly blocked with error message

Fixes #3192