### PR TITLE
[flink] Fix batch query on empty datalake-enabled table to return 0 rows instead of failing

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -361,9 +361,22 @@ public class FlinkSourceEnumerator
             context.callAsync(
                     () -> {
                         List<SourceSplitBase> splits = generateHybridLakeFlussSplits();
+                        // No lake snapshot exists, fall back to Fluss-only splits
                         if (splits == null) {
-                            throw new UnsupportedOperationException(
-                                    "Currently, Batch mode can only be supported if one lake snapshot exists for the table.");
+                            if (isPartitioned) {
+                                Set<PartitionInfo> partitionInfos = listPartitions();
+                                Collection<Partition> partitions =
+                                        partitionInfos.stream()
+                                                .map(
+                                                        p ->
+                                                                new Partition(
+                                                                        p.getPartitionId(),
+                                                                        p.getPartitionName()))
+                                                .collect(Collectors.toList());
+                                splits = this.initPartitionedSplits(partitions);
+                            } else {
+                                splits = this.initNonPartitionedSplits();
+                            }
                         }
                         return splits;
                     },

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -363,6 +363,10 @@ public class FlinkSourceEnumerator
                         List<SourceSplitBase> splits = generateHybridLakeFlussSplits();
                         // No lake snapshot exists, fall back to Fluss-only splits
                         if (splits == null) {
+                            LOG.info(
+                                    "No lake snapshot found for table {},"
+                                            + " falling back to Fluss-only splits.",
+                                    tablePath);
                             if (isPartitioned) {
                                 Set<PartitionInfo> partitionInfos = listPartitions();
                                 Collection<Partition> partitions =


### PR DESCRIPTION
### Summary
- When a datalake-enabled table is empty (no lake snapshot), batch query via Flink SQL
  throws UnsupportedOperationException. This PR makes it return empty result
  (0 rows) instead, consistent with Spark connector behavior.

### Root Cause
In `FlinkSourceEnumerator.startInBatchMode()`, `generateHybridLakeFlussSplits()`
returns null when no lake snapshot exists. The stream mode code in the same
commit (79379968) correctly falls back to `initNonPartitionedSplits()`, but the
batch mode path was left to throw an exception.

### Change
- `FlinkSourceEnumerator.java`: Return `Collections.emptyList()` instead of
  throwing `UnsupportedOperationException` when splits is null.

### Verification
- Ran `mvnw test -pl fluss-flink/fluss-flink-common -Dtest="FlinkSourceEnumerator*"`
- All existing tests pass

Fixes #3207