### PR TITLE
[website] Allow Kapa AI Widget Resources on Fluss Website

### DIFF
--- a/website/.htaccess
+++ b/website/.htaccess
@@ -1,4 +1,7 @@
 # CSP permissions for fluss.apache.org - Additional allowances to be coordinated with privacy team
 # See the CSP request mail for allowing Fluss project to use Algolia, YouTube and Google Calendar:
 # https://lists.apache.org/thread/xt0ggzc7f4dj8g91b92w4tk5g8cdslwd
-SetEnv CSP_PROJECT_DOMAINS "https://www.youtube-nocookie.com https://www.youtube.com https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/ https://calendar.google.com"
+# Allow Kapa AI Widget (Ask AI button): the widget bundle is hosted on *.kapa.ai,
+# it loads Google reCAPTCHA Enterprise for anti-bot verification, and its chat-stream
+# backend proxy is hosted on Google Cloud Run (*.a.run.app).
+SetEnv CSP_PROJECT_DOMAINS "https://www.youtube-nocookie.com https://www.youtube.com https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/ https://calendar.google.com https://*.kapa.ai/ https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://*.a.run.app"

--- a/website/.htaccess
+++ b/website/.htaccess
@@ -1,7 +1,6 @@
 # CSP permissions for fluss.apache.org - Additional allowances to be coordinated with privacy team
 # See the CSP request mail for allowing Fluss project to use Algolia, YouTube and Google Calendar:
 # https://lists.apache.org/thread/xt0ggzc7f4dj8g91b92w4tk5g8cdslwd
-# Allow Kapa AI Widget (Ask AI button): the widget bundle is hosted on *.kapa.ai,
-# it loads Google reCAPTCHA Enterprise for anti-bot verification, and its chat-stream
-# backend proxy is hosted on Google Cloud Run (*.a.run.app).
-SetEnv CSP_PROJECT_DOMAINS "https://www.youtube-nocookie.com https://www.youtube.com https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/ https://calendar.google.com https://*.kapa.ai/ https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://*.a.run.app"
+# Kapa AI Widget ("Ask AI" button) — domains per Kapa's official CSP guide:
+# https://docs.kapa.ai/integrations/faq#how-do-i-fix-csp-errors
+SetEnv CSP_PROJECT_DOMAINS "https://www.youtube-nocookie.com https://www.youtube.com https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/ https://calendar.google.com https://widget.kapa.ai https://proxy.kapa.ai https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app https://metrics.kapa.ai https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://hcaptcha.com https://*.hcaptcha.com"


### PR DESCRIPTION

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3206 

<!-- What is the purpose of the change -->

### Brief change log

`website/.htaccess`: append to `CSP_PROJECT_DOMAINS` only the precise hosts listed in Kapa's documentation
(https://docs.kapa.ai/integrations/faq#how-do-i-fix-csp-errors), plus the two reCAPTCHA hosts the widget loads at runtime:

| Domain | Why it is needed | Source |
| --- | --- | --- |
| `https://widget.kapa.ai` | Widget bundle (`kapa-widget.bundle.js`) | Kapa CSP guide |
| `https://proxy.kapa.ai` | Primary chat / search backend | Kapa CSP guide |
| `https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app` | Cloud Run fallback (3 endpoints in the bundle) | Kapa CSP guide |
| `https://metrics.kapa.ai` | Widget telemetry | Kapa CSP guide |
| `https://www.google.com/recaptcha/` | reCAPTCHA Enterprise loader | Kapa CSP guide + verified in bundle |
| `https://www.gstatic.com/recaptcha/` | reCAPTCHA companion resources (`recaptcha__<lang>.js`) | Verified by `curl enterprise.js` (loaded transitively) |
| `https://hcaptcha.com` | hCaptcha challenge | Kapa CSP guide |
| `https://*.hcaptcha.com` | hCaptcha sub-resources (vendor apex only) | Kapa CSP guide |

No cross-tenant wildcard is used.
### Tests

<!-- List UT and IT cases to verify this change -->
This is an `.htaccess`-only change with no executable code path, so there is nothing to add to the JUnit suite.

### API and Format

<!-- Does this change affect API or storage format -->
No. Website / CSP configuration only.

### Documentation

<!-- Does this change introduce a new feature -->
No. User-visible behavior is that the existing "Ask AI" button starts working.
