### PR TITLE
[test]  Fixing flaky test CoordinatorEventManagerTest.testMetricsUpdatedImmediatelyOnStartup

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManagerTest.java
@@ -92,7 +92,14 @@ class CoordinatorEventManagerTest {
                             TestingMetricGroups.COORDINATOR_METRICS
                                     .getMetrics()
                                     .get(MetricNames.ACTIVE_TABLET_SERVER_COUNT);
-            assertThat(activeTabletServerCount.getValue()).isEqualTo(2);
+            // The gauge reads the volatile tabletServerCount field which is updated
+            // after the AccessContextEvent future completes. Use retry to handle
+            // the brief window between metricsUpdateCount increment (inside the
+            // event processor) and the volatile field assignment (after
+            // getResultFuture().get() in updateMetricsViaAccessContext).
+            retry(
+                    Duration.ofMinutes(1),
+                    () -> assertThat(activeTabletServerCount.getValue()).isEqualTo(2));
         } finally {
             manager.close();
             TestingMetricGroups.COORDINATOR_METRICS.close();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3188

<!-- What is the purpose of the change -->

### Brief change log
Fixes unstable test CoordinatorEventManagerTest.testMetricsUpdatedImmediatelyOnStartup by adding a retry to handle the brief window between metricsUpdateCount increment (inside the event processor) and the volatile field assignment (after
getResultFuture().get() in updateMetricsViaAccessContext).

I ran the tests 5 times once and 10 times the other time and the test passed on all 15 occasions.

### Tests

N/A
