### PR TITLE
[client] Fix IndexOutOfBoundsException in limit scan for log table with complex types

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/batch/LimitBatchScanner.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/batch/LimitBatchScanner.java
@@ -94,7 +94,7 @@ public class LimitBatchScanner implements BatchScanner {
         RowType rowType = tableInfo.getRowType();
         this.fieldGetters = new InternalRow.FieldGetter[rowType.getFieldCount()];
         for (int i = 0; i < rowType.getFieldCount(); i++) {
-            this.fieldGetters[i] = InternalRow.createFieldGetter(rowType.getTypeAt(i), i);
+            this.fieldGetters[i] = InternalRow.createDeepFieldGetter(rowType.getTypeAt(i), i);
         }
 
         LimitScanRequest limitScanRequest =

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceBatchITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceBatchITCase.java
@@ -320,11 +320,11 @@ abstract class FlinkTableSourceBatchITCase extends FlinkTestBase {
         List<String> collected = collectRowsWithTimeout(iterRows, 2);
         List<String> expected =
                 Arrays.asList(
-                        "+I[1, address1, name1]",
-                        "+I[2, address2, name2]",
-                        "+I[3, address3, name3]",
-                        "+I[4, address4, name4]",
-                        "+I[5, address5, name5]");
+                        "+I[1, address1, name1, [1, 2]]",
+                        "+I[2, address2, name2, [2, 3]]",
+                        "+I[3, address3, name3, [3, 4]]",
+                        "+I[4, address4, name4, [4, 5]]",
+                        "+I[5, address5, name5, [5, 6]]");
         assertThat(collected).isSubsetOf(expected);
         assertThat(collected).hasSize(2);
 
@@ -491,7 +491,8 @@ abstract class FlinkTableSourceBatchITCase extends FlinkTestBase {
                         "create table %s ("
                                 + "  id int not null,"
                                 + "  address varchar,"
-                                + "  name varchar)"
+                                + "  name varchar,"
+                                + "  int_array array<int>)"
                                 + " with ("
                                 + "  'bucket.num' = '4', "
                                 + "  'table.auto-partition.enabled' = 'false' "
@@ -504,7 +505,7 @@ abstract class FlinkTableSourceBatchITCase extends FlinkTestBase {
         try (Table table = conn.getTable(tablePath)) {
             AppendWriter appendWriter = table.newAppend().createWriter();
             for (int i = 1; i <= 5; i++) {
-                Object[] values = new Object[] {i, "address" + i, "name" + i};
+                Object[] values = new Object[] {i, "address" + i, "name" + i, new Integer[] {i, i + 1}};
                 appendWriter.append(row(values));
                 // make sure every bucket has records
                 appendWriter.flush();

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceBatchITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceBatchITCase.java
@@ -505,7 +505,8 @@ abstract class FlinkTableSourceBatchITCase extends FlinkTestBase {
         try (Table table = conn.getTable(tablePath)) {
             AppendWriter appendWriter = table.newAppend().createWriter();
             for (int i = 1; i <= 5; i++) {
-                Object[] values = new Object[] {i, "address" + i, "name" + i, new Integer[] {i, i + 1}};
+                Object[] values =
+                        new Object[] {i, "address" + i, "name" + i, new Integer[] {i, i + 1}};
                 appendWriter.append(row(values));
                 // make sure every bucket has records
                 appendWriter.flush();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3219

<!-- What is the purpose of the change -->

Fix `IndexOutOfBoundsException` when running `SELECT * FROM <log_table> LIMIT N` on a log table with complex type columns (ARRAY, MAP, nested ROW). 
   
**Root cause:** `LimitBatchScanner` uses `InternalRow.createFieldGetter` (shallow copy) to extract fields from Arrow-backed `ColumnarRow`. For complex types, the shallow getter returns `ColumnarArray`/`ColumnarMap` objects that still reference Arrow off-heap memory. After `collectRows()` calls `scanner.close()` → `chunkedFactory.close()`, the Arrow memory is freed, but the stale references in `GenericRow` are later accessed by `toFlinkRowData()`, causing the crash.
                                                                                          
**Fix:** Use `InternalRow.createDeepFieldGetter` instead of `createFieldGetter` in `LimitBatchScanner`. This method materializes complex types into `GenericArray`/`GenericMap`/`GenericRow` before Arrow memory is freed, and was specifically designed for this purpose (see its Javadoc).       
                                                                                          
Also adds `int_array array<int>` column to `prepareLogTable()` so that `testLimitLogTableScan` covers complex types by default.      
     
### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
