### PR TITLE
[server] Add metrics of log startOffset

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -229,6 +229,7 @@ public class MetricNames {
 
     // for log tablet
     public static final String LOG_NUM_SEGMENTS = "numSegments";
+    public static final String LOG_START_OFFSET = "startOffset";
     public static final String LOG_END_OFFSET = "endOffset";
     public static final String REMOTE_LOG_SIZE = "size";
     public static final String LOG_LAKE_TIMESTAMP_LAG = "timestampLag";

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -355,6 +355,7 @@ public final class LogTablet {
         MetricGroup metricGroup = bucketMetricGroup.addGroup("log");
         metricGroup.gauge(
                 MetricNames.LOG_NUM_SEGMENTS, () -> localLog.getSegments().numberOfSegments());
+        metricGroup.gauge(MetricNames.LOG_START_OFFSET, localLog::getLocalLogStartOffset);
         metricGroup.gauge(MetricNames.LOG_END_OFFSET, localLog::getLocalLogEndOffset);
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogTablet.java
@@ -121,6 +121,7 @@ public class RemoteLogTablet {
                     }
                     MetricGroup metricGroup = bucketMetricGroup.addGroup("remoteLog");
                     metricGroup.gauge(MetricNames.LOG_NUM_SEGMENTS, () -> numRemoteLogSegments);
+                    metricGroup.gauge(MetricNames.LOG_START_OFFSET, () -> remoteLogStartOffset);
                     metricGroup.gauge(MetricNames.LOG_END_OFFSET, () -> remoteLogEndOffset);
                     metricGroup.gauge(MetricNames.REMOTE_LOG_SIZE, this::getRemoteSizeInBytes);
                     remoteLogMetrics = metricGroup;

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogTablet.java
@@ -121,11 +121,19 @@ public class RemoteLogTablet {
                     }
                     MetricGroup metricGroup = bucketMetricGroup.addGroup("remoteLog");
                     metricGroup.gauge(MetricNames.LOG_NUM_SEGMENTS, () -> numRemoteLogSegments);
-                    metricGroup.gauge(MetricNames.LOG_START_OFFSET, () -> remoteLogStartOffset);
+                    metricGroup.gauge(MetricNames.LOG_START_OFFSET, this::getRemoteLogStartOffsetForMetric);
                     metricGroup.gauge(MetricNames.LOG_END_OFFSET, () -> remoteLogEndOffset);
                     metricGroup.gauge(MetricNames.REMOTE_LOG_SIZE, this::getRemoteSizeInBytes);
                     remoteLogMetrics = metricGroup;
                 });
+    }
+
+    public long getRemoteLogStartOffsetForMetric() {
+        // return -1 if no segments exist to make the metric more intuitive.
+        if (remoteLogStartOffset == INIT_REMOTE_LOG_START_OFFSET) {
+            return -1L;
+        }
+        return remoteLogStartOffset;
     }
 
     public long getRemoteSizeInBytes() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogTablet.java
@@ -121,19 +121,18 @@ public class RemoteLogTablet {
                     }
                     MetricGroup metricGroup = bucketMetricGroup.addGroup("remoteLog");
                     metricGroup.gauge(MetricNames.LOG_NUM_SEGMENTS, () -> numRemoteLogSegments);
-                    metricGroup.gauge(MetricNames.LOG_START_OFFSET, this::getRemoteLogStartOffsetForMetric);
+                    metricGroup.gauge(
+                            MetricNames.LOG_START_OFFSET,
+                            () -> {
+                                if (remoteLogStartOffset == INIT_REMOTE_LOG_START_OFFSET) {
+                                    return -1L;
+                                }
+                                return remoteLogStartOffset;
+                            });
                     metricGroup.gauge(MetricNames.LOG_END_OFFSET, () -> remoteLogEndOffset);
                     metricGroup.gauge(MetricNames.REMOTE_LOG_SIZE, this::getRemoteSizeInBytes);
                     remoteLogMetrics = metricGroup;
                 });
-    }
-
-    public long getRemoteLogStartOffsetForMetric() {
-        // return -1 if no segments exist to make the metric more intuitive.
-        if (remoteLogStartOffset == INIT_REMOTE_LOG_START_OFFSET) {
-            return -1L;
-        }
-        return remoteLogStartOffset;
     }
 
     public long getRemoteSizeInBytes() {

--- a/website/docs/maintenance/observability/monitor-metrics.md
+++ b/website/docs/maintenance/observability/monitor-metrics.md
@@ -853,6 +853,11 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>Gauge</td>
     </tr>
      <tr>
+      <td>startOffset</td>
+      <td>The start offset in local storage for this table bucket.</td>
+      <td>Gauge</td>
+    </tr>
+     <tr>
       <td>endOffset</td>
       <td>The end offset in local storage for this table bucket.</td>
       <td>Gauge</td>
@@ -872,6 +877,11 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td rowspan="3">table_bucket_remoteLog</td>
       <td>numSegments</td>
       <td>The number of segments in remote storage for this table bucket.</td>
+      <td>Gauge</td>
+    </tr>
+     <tr>
+      <td>startOffset</td>
+      <td>The start offset in remote storage for this table bucket.</td>
       <td>Gauge</td>
     </tr>
      <tr>


### PR DESCRIPTION
### Purpose

Linked issue: #3228 .

When the outOfRange exception, I hope I can find the tablet log startOffset from the metric system.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
