### PR TITLE
[server] Add request queue size metric per processor

### DIFF
--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/RequestProcessorPool.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/RequestProcessorPool.java
@@ -38,6 +38,8 @@ import java.util.concurrent.Executors;
 final class RequestProcessorPool {
     private static final Logger LOG = LoggerFactory.getLogger(RequestProcessorPool.class);
 
+    private static final String PROCESSOR_INDEX = "processor_index";
+
     private final RequestChannel[] requestChannels;
     private final RequestProcessor[] processors;
 
@@ -54,10 +56,16 @@ final class RequestProcessorPool {
 
         RequestHandler<?>[] requestHandlers = initializeRequestHandlers(protocols, service);
         for (int i = 0; i < numProcessors; i++) {
-            requestChannels[i] = new RequestChannel(totalQueueCapacity / numProcessors);
+            RequestChannel requestChannel = new RequestChannel(totalQueueCapacity / numProcessors);
+            requestChannels[i] = requestChannel;
             // bind processor to a single channel to make requests from the
             // same channel processed serializable
-            processors[i] = new RequestProcessor(i, requestChannels[i], service, requestHandlers);
+            processors[i] = new RequestProcessor(i, requestChannel, service, requestHandlers);
+            requestsMetrics.gauge(
+                    PROCESSOR_INDEX,
+                    String.valueOf(i),
+                    MetricNames.REQUEST_QUEUE_SIZE,
+                    requestChannel::requestsCount);
         }
         // register requestQueueSize metrics
         requestsMetrics.gauge(MetricNames.REQUEST_QUEUE_SIZE, this::getRequestQueueSize);

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/RequestsMetrics.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/RequestsMetrics.java
@@ -85,6 +85,11 @@ public class RequestsMetrics {
         requestMetricGroup.gauge(name, gauge);
     }
 
+    /** Create a gauge metric in a child group of the request metric group. */
+    <T, G extends Gauge<T>> void gauge(String groupKey, String groupValue, String name, G gauge) {
+        requestMetricGroup.addGroup(groupKey, groupValue).gauge(name, gauge);
+    }
+
     /** Add a metric group for given request name. */
     private void addMetrics(MetricGroup parentMetricGroup, String requestName) {
         metricsByRequest.put(

--- a/website/docs/maintenance/observability/monitor-metrics.md
+++ b/website/docs/maintenance/observability/monitor-metrics.md
@@ -639,17 +639,29 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </thead>
   <tbody>
     <tr>
-      <th rowspan="1"><strong>coordinator</strong></th>
+      <th rowspan="2"><strong>coordinator</strong></th>
       <td rowspan="1">request</td>
       <td>requestQueueSize</td>
       <td>The CoordinatorServer node network waiting queue size.</td>
       <td>Gauge</td>
     </tr>
     <tr>
-      <th rowspan="8">tabletserver</th>
+      <td rowspan="1">request_processor_index</td>
+      <td>requestQueueSize</td>
+      <td>The CoordinatorServer node network waiting queue size labeled with <code>processor_index</code>.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="9">tabletserver</th>
       <td rowspan="1">request</td>
       <td>requestQueueSize</td>
       <td>The TabletServer node network waiting queue size.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td rowspan="1">request_processor_index</td>
+      <td>requestQueueSize</td>
+      <td>The TabletServer node network waiting queue size labeled with <code>processor_index</code>.</td>
       <td>Gauge</td>
     </tr>
     <tr>


### PR DESCRIPTION
### Purpose

Currently, each connection is bound to a dedicated RPC processor. Based on the aggregated RPC queue metrics, we cannot determine whether high latency is caused by a specific processor queue being blocked.
When latency is high, I want to identify whether a particular processor’s queue is congested or stuck.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
