### PR TITLE
[test] Fix flaky CoordinatorEventManagerTest by isolating metric group instance

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManagerTest.java
@@ -21,9 +21,10 @@ import org.apache.fluss.cluster.Endpoint;
 import org.apache.fluss.cluster.ServerType;
 import org.apache.fluss.metrics.Gauge;
 import org.apache.fluss.metrics.MetricNames;
+import org.apache.fluss.metrics.registry.NOPMetricRegistry;
 import org.apache.fluss.server.coordinator.CoordinatorContext;
 import org.apache.fluss.server.metadata.ServerInfo;
-import org.apache.fluss.server.metrics.group.TestingMetricGroups;
+import org.apache.fluss.server.metrics.group.CoordinatorMetricGroup;
 import org.apache.fluss.server.zk.ZkEpoch;
 
 import org.junit.jupiter.api.Test;
@@ -76,8 +77,15 @@ class CoordinatorEventManagerTest {
                     }
                 };
 
-        CoordinatorEventManager manager =
-                new CoordinatorEventManager(testProcessor, TestingMetricGroups.COORDINATOR_METRICS);
+        // Create a fresh metric group per test to avoid gauge name collisions with other
+        // tests that share the static TestingMetricGroups.COORDINATOR_METRICS instance.
+        // AbstractMetricGroup.addMetric() rejects new gauges when a same-name gauge already
+        // exists (keeps the old one), which causes this test to read a stale gauge bound to
+        // a different CoordinatorEventManager instance.
+        CoordinatorMetricGroup metricGroup =
+                new CoordinatorMetricGroup(NOPMetricRegistry.INSTANCE, "cluster1", "host", "0");
+
+        CoordinatorEventManager manager = new CoordinatorEventManager(testProcessor, metricGroup);
         manager.start();
 
         try {
@@ -88,10 +96,7 @@ class CoordinatorEventManagerTest {
                     () -> assertThat(metricsUpdateCount.get()).isGreaterThan(0));
 
             Gauge activeTabletServerCount =
-                    (Gauge)
-                            TestingMetricGroups.COORDINATOR_METRICS
-                                    .getMetrics()
-                                    .get(MetricNames.ACTIVE_TABLET_SERVER_COUNT);
+                    (Gauge) metricGroup.getMetrics().get(MetricNames.ACTIVE_TABLET_SERVER_COUNT);
             // The gauge reads the volatile tabletServerCount field which is updated
             // after the AccessContextEvent future completes. Use retry to handle
             // the brief window between metricsUpdateCount increment (inside the
@@ -102,7 +107,7 @@ class CoordinatorEventManagerTest {
                     () -> assertThat(activeTabletServerCount.getValue()).isEqualTo(2));
         } finally {
             manager.close();
-            TestingMetricGroups.COORDINATOR_METRICS.close();
+            metricGroup.close();
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3245 

<!-- What is the purpose of the change -->

Shared static `TestingMetricGroups.COORDINATOR_METRICS` instance causes gauge name collision across tests: `AbstractMetricGroup.addMetric()` rejects new gauges when a same-name gauge already exists (keeps the old one), so the test reads a stale gauge bound to a different `CoordinatorEventManager` instance.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
