### PR TITLE
[lake/hudi] Introduce fluss-lake-hudi module and HudiLakeStorage

### DIFF
--- a/docker/quickstart-flink/prepare_build.sh
+++ b/docker/quickstart-flink/prepare_build.sh
@@ -115,6 +115,7 @@ check_prerequisites() {
         "$PROJECT_ROOT/fluss-filesystems/fluss-fs-s3/target"
         "$PROJECT_ROOT/fluss-lake/fluss-lake-paimon/target"
         "$PROJECT_ROOT/fluss-lake/fluss-lake-iceberg/target"
+        "$PROJECT_ROOT/fluss-lake/fluss-lake-hudi/target"
         "$PROJECT_ROOT/fluss-flink/fluss-flink-tiering/target"
     )
 

--- a/fluss-dist/pom.xml
+++ b/fluss-dist/pom.xml
@@ -96,6 +96,13 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-lake-hudi</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
       
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/fluss-dist/src/main/assemblies/plugins.xml
+++ b/fluss-dist/src/main/assemblies/plugins.xml
@@ -98,6 +98,12 @@
             <outputDirectory>plugins/lance/</outputDirectory>
             <destName>fluss-lake-lance-${project.version}.jar</destName>
         </file>
+        <file>
+            <source>../fluss-lake/fluss-lake-hudi/target/fluss-lake-hudi-${project.version}.jar</source>
+            <outputDirectory>plugins/hudi/</outputDirectory>
+            <destName>fluss-lake-hudi-${project.version}.jar</destName>
+            <fileMode>0644</fileMode>
+        </file>
   </files>
 
 </assembly>

--- a/fluss-flink/fluss-flink-common/pom.xml
+++ b/fluss-flink/fluss-flink-common/pom.xml
@@ -95,25 +95,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Hudi -->
-        <dependency>
-            <groupId>org.apache.hudi</groupId>
-            <artifactId>hudi-flink${flink.major.version}-bundle</artifactId>
-            <version>${hudi.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-reload4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>ch.qos.reload4j</groupId>
-                    <artifactId>reload4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-
         <!-- test dependency -->
         <dependency>
             <groupId>org.apache.fluss</groupId>

--- a/fluss-flink/fluss-flink-common/pom.xml
+++ b/fluss-flink/fluss-flink-common/pom.xml
@@ -95,6 +95,24 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Hudi -->
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-flink${flink.major.version}-bundle</artifactId>
+            <version>${hudi.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
 
         <!-- test dependency -->
         <dependency>

--- a/fluss-lake/fluss-lake-hudi/pom.xml
+++ b/fluss-lake/fluss-lake-hudi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.fluss</groupId>
         <artifactId>fluss-lake</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>fluss-lake-hudi</artifactId>
@@ -36,21 +36,7 @@
             <groupId>org.apache.fluss</groupId>
             <artifactId>fluss-common</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/fluss-lake/fluss-lake-hudi/pom.xml
+++ b/fluss-lake/fluss-lake-hudi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.fluss</groupId>
         <artifactId>fluss-lake</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>fluss-lake-hudi</artifactId>

--- a/fluss-lake/fluss-lake-hudi/pom.xml
+++ b/fluss-lake/fluss-lake-hudi/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.fluss</groupId>
+        <artifactId>fluss-lake</artifactId>
+        <version>0.9-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>fluss-lake-hudi</artifactId>
+    <name>Fluss : Lake : Hudi</name>
+
+    <packaging>jar</packaging>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-common</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStorage.java
+++ b/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStorage.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.hudi;
+
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.lake.lakestorage.LakeCatalog;
+import org.apache.fluss.lake.lakestorage.LakeStorage;
+import org.apache.fluss.lake.source.LakeSource;
+import org.apache.fluss.lake.writer.LakeTieringFactory;
+import org.apache.fluss.metadata.TablePath;
+
+/** Implement of Hudi Lake Source. */
+public class HudiLakeStorage implements LakeStorage {
+
+    protected final Configuration hudiConfig;
+
+    public HudiLakeStorage(Configuration configuration) {
+        this.hudiConfig = configuration;
+    }
+
+    @Override
+    public LakeTieringFactory<?, ?> createLakeTieringFactory() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public LakeCatalog createLakeCatalog() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public LakeSource<?> createLakeSource(TablePath tablePath) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStorage.java
+++ b/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStorage.java
@@ -24,10 +24,10 @@ import org.apache.fluss.lake.source.LakeSource;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
 import org.apache.fluss.metadata.TablePath;
 
-/** Implementation of Hudi lake storage. */
+/** Hudi Implementation of {@link LakeStorage}. */
 public class HudiLakeStorage implements LakeStorage {
 
-    protected final Configuration hudiConfig;
+    private final Configuration hudiConfig;
 
     public HudiLakeStorage(Configuration configuration) {
         this.hudiConfig = configuration;
@@ -36,26 +36,26 @@ public class HudiLakeStorage implements LakeStorage {
     @Override
     public LakeTieringFactory<?, ?> createLakeTieringFactory() {
         throw new UnsupportedOperationException(
-            "HudiLakeStorage is currently a scaffold and does not support creating a "
-                + "LakeTieringFactory yet. Verify that Hudi lake storage was selected "
-                + "intentionally and that the required Hudi support/module is available.");
+                "HudiLakeStorage is currently a scaffold and does not support creating a "
+                        + "LakeTieringFactory yet. Verify that Hudi lake storage was selected "
+                        + "intentionally and that the required Hudi support/module is available.");
     }
 
     @Override
     public LakeCatalog createLakeCatalog() {
         throw new UnsupportedOperationException(
-            "HudiLakeStorage is currently a scaffold and does not support creating a "
-                + "LakeCatalog yet. Verify that Hudi lake storage was selected "
-                + "intentionally and that the required Hudi support/module is available.");
+                "HudiLakeStorage is currently a scaffold and does not support creating a "
+                        + "LakeCatalog yet. Verify that Hudi lake storage was selected "
+                        + "intentionally and that the required Hudi support/module is available.");
     }
 
     @Override
     public LakeSource<?> createLakeSource(TablePath tablePath) {
         throw new UnsupportedOperationException(
-            "HudiLakeStorage is currently a scaffold and does not support creating a "
-                + "LakeSource for table '"
-                + tablePath
-                + "' yet. Verify that Hudi lake storage was selected intentionally "
-                + "and that the required Hudi support/module is available.");
+                "HudiLakeStorage is currently a scaffold and does not support creating a "
+                        + "LakeSource for table '"
+                        + tablePath
+                        + "' yet. Verify that Hudi lake storage was selected intentionally "
+                        + "and that the required Hudi support/module is available.");
     }
 }

--- a/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStorage.java
+++ b/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStorage.java
@@ -24,7 +24,7 @@ import org.apache.fluss.lake.source.LakeSource;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
 import org.apache.fluss.metadata.TablePath;
 
-/** Implement of Hudi Lake Source. */
+/** Implementation of Hudi lake storage. */
 public class HudiLakeStorage implements LakeStorage {
 
     protected final Configuration hudiConfig;
@@ -35,16 +35,27 @@ public class HudiLakeStorage implements LakeStorage {
 
     @Override
     public LakeTieringFactory<?, ?> createLakeTieringFactory() {
-        throw new UnsupportedOperationException("Not implemented");
+        throw new UnsupportedOperationException(
+            "HudiLakeStorage is currently a scaffold and does not support creating a "
+                + "LakeTieringFactory yet. Verify that Hudi lake storage was selected "
+                + "intentionally and that the required Hudi support/module is available.");
     }
 
     @Override
     public LakeCatalog createLakeCatalog() {
-        throw new UnsupportedOperationException("Not implemented");
+        throw new UnsupportedOperationException(
+            "HudiLakeStorage is currently a scaffold and does not support creating a "
+                + "LakeCatalog yet. Verify that Hudi lake storage was selected "
+                + "intentionally and that the required Hudi support/module is available.");
     }
 
     @Override
     public LakeSource<?> createLakeSource(TablePath tablePath) {
-        throw new UnsupportedOperationException("Not implemented");
+        throw new UnsupportedOperationException(
+            "HudiLakeStorage is currently a scaffold and does not support creating a "
+                + "LakeSource for table '"
+                + tablePath
+                + "' yet. Verify that Hudi lake storage was selected intentionally "
+                + "and that the required Hudi support/module is available.");
     }
 }

--- a/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStoragePlugin.java
+++ b/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStoragePlugin.java
@@ -21,7 +21,7 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.lake.lakestorage.LakeStorage;
 import org.apache.fluss.lake.lakestorage.LakeStoragePlugin;
 
-/** Implement of Hudi Lake Storage Plugin. */
+/** Hudi implementation of {@link LakeStoragePlugin}. */
 public class HudiLakeStoragePlugin implements LakeStoragePlugin {
 
     private static final String IDENTIFIER = "hudi";

--- a/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStoragePlugin.java
+++ b/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/HudiLakeStoragePlugin.java
@@ -15,23 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.fluss.metadata;
+package org.apache.fluss.lake.hudi;
 
-/** An enum for datalake format. */
-public enum DataLakeFormat {
-    PAIMON("paimon"),
-    LANCE("lance"),
-    ICEBERG("iceberg"),
-    HUDI("hudi");
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.lake.lakestorage.LakeStorage;
+import org.apache.fluss.lake.lakestorage.LakeStoragePlugin;
 
-    private final String value;
+/** Implement of Hudi Lake Storage Plugin. */
+public class HudiLakeStoragePlugin implements LakeStoragePlugin {
 
-    DataLakeFormat(String value) {
-        this.value = value;
+    private static final String IDENTIFIER = "hudi";
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
     }
 
     @Override
-    public String toString() {
-        return value;
+    public LakeStorage createLakeStorage(Configuration configuration) {
+        return new HudiLakeStorage(configuration);
     }
 }

--- a/fluss-lake/fluss-lake-hudi/src/main/resources/META-INF/NOTICE
+++ b/fluss-lake/fluss-lake-hudi/src/main/resources/META-INF/NOTICE
@@ -5,5 +5,3 @@ This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-- org.apache.hudi:hudi-flink1.20-bundle:1.1.0

--- a/fluss-lake/fluss-lake-hudi/src/main/resources/META-INF/NOTICE
+++ b/fluss-lake/fluss-lake-hudi/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+fluss-lake-hudi
+Copyright 2025-2026 The Apache Software Foundation
+
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.apache.hudi:hudi-flink1.20-bundle:1.1.0

--- a/fluss-lake/fluss-lake-hudi/src/main/resources/META-INF/services/org.apache.fluss.lake.lakestorage.LakeStoragePlugin
+++ b/fluss-lake/fluss-lake-hudi/src/main/resources/META-INF/services/org.apache.fluss.lake.lakestorage.LakeStoragePlugin
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.fluss.lake.hudi.HudiLakeStoragePlugin

--- a/fluss-lake/fluss-lake-hudi/src/test/resources/log4j2-test.properties
+++ b/fluss-lake/fluss-lake-hudi/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 #
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level=INFO
+rootLogger.level=OFF
 rootLogger.appenderRef.test.ref=TestLogger
 appender.testlogger.name=TestLogger
 appender.testlogger.type=CONSOLE

--- a/fluss-lake/fluss-lake-hudi/src/test/resources/log4j2-test.properties
+++ b/fluss-lake/fluss-lake-hudi/src/test/resources/log4j2-test.properties
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level=INFO
+rootLogger.appenderRef.test.ref=TestLogger
+appender.testlogger.name=TestLogger
+appender.testlogger.type=CONSOLE
+appender.testlogger.target=SYSTEM_ERR
+appender.testlogger.layout.type=PatternLayout
+appender.testlogger.layout.pattern=%-4r [%t] %-5p %c %x - %m%n

--- a/fluss-lake/fluss-lake-hudi/src/test/resources/org.junit.jupiter.api.extension.Extension
+++ b/fluss-lake/fluss-lake-hudi/src/test/resources/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.fluss.testutils.common.TestLoggerExtension

--- a/fluss-lake/pom.xml
+++ b/fluss-lake/pom.xml
@@ -79,6 +79,7 @@
         <module>fluss-lake-paimon</module>
         <module>fluss-lake-iceberg</module>
         <module>fluss-lake-lance</module>
+        <module>fluss-lake-hudi</module>
     </modules>
     <packaging>pom</packaging>
 </project>

--- a/fluss-test-coverage/pom.xml
+++ b/fluss-test-coverage/pom.xml
@@ -448,6 +448,8 @@
                                         <exclude>org.apache.fluss.lake.iceberg.*</exclude>
                                         <exclude>org.apache.fluss.row.encode.iceberg.*</exclude>
                                         <exclude>org.apache.fluss.bucketing.IcebergBucketingFunction</exclude>
+                                        <!-- temporarily exclude hudi -->
+                                        <exclude>org.apache.fluss.lake.hudi.*</exclude>
                                         <!-- start exclude for flink tiering service -->
                                         <exclude>org.apache.fluss.flink.tiering.source.TieringSourceOptions</exclude>
                                         <exclude>org.apache.fluss.flink.tiering.source.TieringSource.Builder</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <arrow.version>15.0.0</arrow.version>
         <paimon.version>1.3.1</paimon.version>
         <iceberg.version>1.10.1</iceberg.version>
+        <hudi.version>1.1.0</hudi.version>
         <roaringbitmap.version>1.3.0</roaringbitmap.version>
 
         <!-- spark & scala -->


### PR DESCRIPTION
### Purpose
Linked issue: https://github.com/apache/fluss/issues/3258

Introduce an initial Hudi LakeStorage plugin module for Fluss and wire it into build/distribution, so Hudi can be recognized as a supported data lake format.

### Brief change log

- Add HUDI("hudi") to DataLakeFormat.
- Introduce new module fluss-lake-hudi.
- Add HudiLakeStorage and HudiLakeStoragePlugin as the initial Hudi LakeStorage implementation scaffold.
- Register LakeStoragePlugin via service loader metadata.
- Include the new module in lake parent modules and distribution/plugin assembly.
- Update quickstart-flink build preparation to include hudi plugin artifact.

### Tests

- This commit mainly introduces module/plugin scaffolding and build wiring.

- Suggested verification:

mvn -pl fluss-lake/fluss-lake-hudi -am clean test
mvn -pl fluss-dist -am clean package -DskipTests

- No dedicated Hudi functional UT/IT is included in this commit.

### API and Format

- API impact: additive change by introducing HUDI in DataLakeFormat.
- No storage format migration or incompatible format change in this PR.

### Documentation

- No user-facing documentation changes in this PR.
- Hudi usage/configuration docs can be added in a follow-up PR.
