### PR TITLE
[flink] add split assignment mechanism w/o partitionId

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/sink/ChannelComputer.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/sink/ChannelComputer.java
@@ -59,6 +59,11 @@ public interface ChannelComputer<T> extends Serializable {
         return (startChannel + bucket) % numChannels;
     }
 
+    static int select(Long partitionId, int bucket, int numChannels) {
+        int startChannel = ((partitionId.hashCode() * 31) & 0x7FFFFFFF) % numChannels;
+        return (startChannel + bucket) % numChannels;
+    }
+
     static int select(int bucket, int numChannels) {
         return bucket % numChannels;
     }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -32,7 +32,6 @@ import org.apache.fluss.exception.UnsupportedVersionException;
 import org.apache.fluss.flink.lake.LakeSplitGenerator;
 import org.apache.fluss.flink.lake.split.LakeSnapshotAndFlussLogSplit;
 import org.apache.fluss.flink.lake.split.LakeSnapshotSplit;
-import org.apache.fluss.flink.sink.ChannelComputer;
 import org.apache.fluss.flink.source.FlinkSource;
 import org.apache.fluss.flink.source.event.FinishedKvSnapshotConsumeEvent;
 import org.apache.fluss.flink.source.event.PartitionBucketsUnsubscribedEvent;
@@ -84,6 +83,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import static org.apache.fluss.flink.sink.ChannelComputer.select;
+import static org.apache.fluss.flink.sink.ChannelComputer.shouldCombinePartitionInSharding;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
 import static org.apache.fluss.utils.Preconditions.checkState;
 
@@ -955,11 +956,11 @@ public class FlinkSourceEnumerator
 
         Long partitionId = tableBucket.getPartitionId();
         int bucketId = tableBucket.getBucket();
-        if (ChannelComputer.shouldCombinePartitionInSharding(
+        if (shouldCombinePartitionInSharding(
                 partitionId != null, tableInfo.getNumBuckets(), numChannels)) {
-            return ChannelComputer.select(partitionId, bucketId, numChannels);
+            return select(partitionId, bucketId, numChannels);
         }
-        return ChannelComputer.select(bucketId, numChannels);
+        return select(bucketId, numChannels);
     }
 
     private void checkReaderRegistered(int readerId) {

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -926,20 +926,32 @@ public class FlinkSourceEnumerator
     /**
      * Returns the index of the target subtask that a specific split should be assigned to.
      *
-     * <p>The resulting distribution of splits of a single table has the following contract:
+     * <p>Routing rules (in order):
      *
      * <ul>
-     *   <li>1. Splits in same bucket are assigned to same subtask
-     *   <li>2. Uniformly distributed across subtasks
-     *   <li>3. For partitioned table, the buckets in same partition are round-robin distributed
-     *       (strictly clockwise w.r.t. ascending subtask indices) by using the partition id as the
-     *       offset from a starting index. The starting index is the index of the subtask which
-     *       bucket 0 of the partition will be assigned to, determined using the partition id to
-     *       make sure the partitions' buckets of a table are distributed uniformly
+     *   <li>Lake splits with bucket {@code -1}: subtask is {@code splitId().hashCode() %
+     *       parallelism} (bucket-unaware lake paths).
+     *   <li>Otherwise, let {@code P} be parallelism and {@code B} be the table bucket count from
+     *       {@link org.apache.fluss.metadata.TableInfo#getNumBuckets()}:
+     *       <ul>
+     *         <li>If the split has no partition id (non-partitioned table): {@code bucket % P}.
+     *         <li>If the split has a partition id and {@code B % P == 0}: {@code bucket % P} only;
+     *             partition id is not used (same channel formula as without partitioning).
+     *         <li>If the split has a partition id and {@code B % P != 0}: partition id participates
+     *             in the channel via {@link org.apache.fluss.flink.sink.ChannelComputer} (hash of
+     *             partition id picks a starting channel, then buckets of that partition round-robin
+     *             from there) so buckets from different partitions spread more evenly when {@code
+     *             B} does not divide {@code P}.
+     *       </ul>
      * </ul>
+     *
+     * <p>All splits for the same physical bucket still map to the same subtask.
      *
      * @param split the split to assign.
      * @return the id of the subtask that owns the split.
+     * @throws IllegalStateException if table metadata is not loaded yet (see {@link #start()});
+     *     bucket-based routing requires {@code tableInfo}. Lake splits with bucket {@code -1} do
+     *     not consult {@code tableInfo} and may be resolved before {@link #start()}.
      */
     @VisibleForTesting
     protected int getSplitOwner(SourceSplitBase split) {
@@ -954,11 +966,15 @@ public class FlinkSourceEnumerator
             return (split.splitId().hashCode() & 0x7FFFFFFF) % numChannels;
         }
 
-        Long partitionId = tableBucket.getPartitionId();
+        checkState(
+                tableInfo != null,
+                "Table metadata is not loaded yet; call start() on the enumerator before "
+                        + "getSplitOwner() for this split (bucket-based assignment needs numBuckets).");
+
         int bucketId = tableBucket.getBucket();
         if (shouldCombinePartitionInSharding(
-                partitionId != null, tableInfo.getNumBuckets(), numChannels)) {
-            return select(partitionId, bucketId, numChannels);
+                tableInfo.isPartitioned(), tableInfo.getNumBuckets(), numChannels)) {
+            return select(tableBucket.getPartitionId(), bucketId, numChannels);
         }
         return select(bucketId, numChannels);
     }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -973,7 +973,7 @@ public class FlinkSourceEnumerator
 
         int bucketId = tableBucket.getBucket();
         if (shouldCombinePartitionInSharding(
-                tableInfo.isPartitioned(), tableInfo.getNumBuckets(), numChannels)) {
+                tableBucket.getPartitionId() != null, tableInfo.getNumBuckets(), numChannels)) {
             return select(tableBucket.getPartitionId(), bucketId, numChannels);
         }
         return select(bucketId, numChannels);

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -32,6 +32,7 @@ import org.apache.fluss.exception.UnsupportedVersionException;
 import org.apache.fluss.flink.lake.LakeSplitGenerator;
 import org.apache.fluss.flink.lake.split.LakeSnapshotAndFlussLogSplit;
 import org.apache.fluss.flink.lake.split.LakeSnapshotSplit;
+import org.apache.fluss.flink.sink.ChannelComputer;
 import org.apache.fluss.flink.source.FlinkSource;
 import org.apache.fluss.flink.source.event.FinishedKvSnapshotConsumeEvent;
 import org.apache.fluss.flink.source.event.PartitionBucketsUnsubscribedEvent;
@@ -942,21 +943,23 @@ public class FlinkSourceEnumerator
     @VisibleForTesting
     protected int getSplitOwner(SourceSplitBase split) {
         TableBucket tableBucket = split.getTableBucket();
-        int startIndex =
-                tableBucket.getPartitionId() == null
-                        ? 0
-                        : ((tableBucket.getPartitionId().hashCode() * 31) & 0x7FFFFFFF)
-                                % context.currentParallelism();
+        int numChannels = context.currentParallelism();
 
         // super hack logic, if the bucket is -1, it means the split is
         // for bucket unaware, like paimon unaware bucket log table,
         // we use hash split id to get the split owner
         // todo: refactor the split assign logic
         if (split.isLakeSplit() && tableBucket.getBucket() == -1) {
-            return (split.splitId().hashCode() & 0x7FFFFFFF) % context.currentParallelism();
+            return (split.splitId().hashCode() & 0x7FFFFFFF) % numChannels;
         }
 
-        return (startIndex + tableBucket.getBucket()) % context.currentParallelism();
+        Long partitionId = tableBucket.getPartitionId();
+        int bucketId = tableBucket.getBucket();
+        if (ChannelComputer.shouldCombinePartitionInSharding(
+                partitionId != null, tableInfo.getNumBuckets(), numChannels)) {
+            return ChannelComputer.select(partitionId, bucketId, numChannels);
+        }
+        return ChannelComputer.select(bucketId, numChannels);
     }
 
     private void checkReaderRegistered(int readerId) {

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
@@ -598,8 +598,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                 // partition id), so both splits share the same owner.
                 assertThat(enumerator.getSplitOwner(s1)).isEqualTo(enumerator.getSplitOwner(s2));
             } else {
-                assertThat(enumerator.getSplitOwner(s1)).isEqualTo(1);
-                assertThat(enumerator.getSplitOwner(s2)).isEqualTo(0);
+                assertThat(enumerator.getSplitOwner(s1)).isNotEqualTo(enumerator.getSplitOwner(s2));
             }
         }
     }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
@@ -543,12 +543,12 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
         }
     }
 
-    @Test
-    void testGetSplitOwner() throws Exception {
-        int numSubtasks = 3;
+    @ParameterizedTest
+    @ValueSource(ints = {2, 3})
+    void testGetSplitOwner(int parallelism) throws Exception {
         long tableId = createTable(DEFAULT_TABLE_PATH, DEFAULT_PK_TABLE_DESCRIPTOR);
         try (MockSplitEnumeratorContext<SourceSplitBase> context =
-                        new MockSplitEnumeratorContext<>(numSubtasks);
+                        new MockSplitEnumeratorContext<>(parallelism);
                 FlinkSourceEnumerator enumerator =
                         new FlinkSourceEnumerator(
                                 DEFAULT_TABLE_PATH,
@@ -563,6 +563,8 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                                 null,
                                 LeaseContext.DEFAULT,
                                 false)) {
+
+            enumerator.start();
 
             // test splits for same non-partitioned bucket, should assign to same task
             TableBucket t1 = new TableBucket(tableId, 0);
@@ -585,13 +587,20 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
             assertThat(enumerator.getSplitOwner(s1)).isEqualTo(0);
             assertThat(enumerator.getSplitOwner(s2)).isEqualTo(1);
 
-            // splits are with different partitions
             t1 = new TableBucket(tableId, 1L, 0);
             t2 = new TableBucket(tableId, 2L, 0);
             s1 = new LogSplit(t1, "p1", 0);
             s2 = new LogSplit(t2, "p2", 0);
-            assertThat(enumerator.getSplitOwner(s1)).isEqualTo(1);
-            assertThat(enumerator.getSplitOwner(s2)).isEqualTo(2);
+
+            if (parallelism % DEFAULT_BUCKET_NUM == 0) {
+                // splits are with different partitions but the same bucket: when bucket count is
+                // divisible by parallelism, the enumerator uses bucket-only routing (same as w/o
+                // partition id), so both splits share the same owner.
+                assertThat(enumerator.getSplitOwner(s1)).isEqualTo(enumerator.getSplitOwner(s2));
+            } else {
+                assertThat(enumerator.getSplitOwner(s1)).isEqualTo(1);
+                assertThat(enumerator.getSplitOwner(s2)).isEqualTo(0);
+            }
         }
     }
 


### PR DESCRIPTION
### Purpose

Linked issue: close #3269 

The motivation of this PR is to align with the sink channel selector. And another point is to make it possible that all bucket data could be routed into the same subtasks if having the partitionIds when `numBucket % concurrency = 0` , that could emlinate the shuffle to improve the performance to reduce backfill time for large-scale data.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
