### PR TITLE
[catalog] Preserve exception cause when rethrowing catalog exceptions

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -519,9 +519,9 @@ public class FlinkCatalog extends AbstractCatalog {
             } else if (CatalogExceptionUtils.isTableAlreadyExist(t)) {
                 throw new TableAlreadyExistException(getName(), objectPath);
             } else if (CatalogExceptionUtils.isLakeTableAlreadyExist(t)) {
-                throw new CatalogException(t.getMessage());
+                throw new CatalogException(t.getMessage(), t);
             } else if (isTableInvalid(t)) {
-                throw new InvalidTableException(t.getMessage());
+                throw new InvalidTableException(t.getMessage(), t);
             } else {
                 throw new CatalogException(
                         String.format("Failed to create table %s in %s", objectPath, getName()), t);
@@ -565,7 +565,7 @@ public class FlinkCatalog extends AbstractCatalog {
             if (CatalogExceptionUtils.isTableNotExist(t)) {
                 throw new TableNotExistException(getName(), objectPath);
             } else if (isTableInvalid(t)) {
-                throw new InvalidTableException(t.getMessage());
+                throw new InvalidTableException(t.getMessage(), t);
             } else {
                 throw new CatalogException(
                         String.format("Failed to alter table %s in %s", objectPath, getName()), t);

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/PaimonLakeCatalog.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/PaimonLakeCatalog.java
@@ -151,7 +151,7 @@ public class PaimonLakeCatalog implements LakeCatalog {
             }
         } catch (Catalog.ColumnAlreadyExistException | Catalog.ColumnNotExistException e) {
             // This shouldn't happen for AddColumn operations
-            throw new InvalidAlterTableException(e.getMessage());
+            throw new InvalidAlterTableException(e.getMessage(), e);
         } catch (Catalog.TableNotExistException e) {
             throw new TableNotExistException("Table " + tablePath + " does not exist.");
         }

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
@@ -442,10 +442,10 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
         } catch (Exception e) {
             if (e instanceof UncheckedIOException) {
                 throw new InvalidTableException(
-                        "Failed to parse table descriptor: " + e.getMessage());
+                        "Failed to parse table descriptor: " + e.getMessage(), e);
             } else {
                 // wrap the validate message to InvalidTableException
-                throw new InvalidTableException(e.getMessage());
+                throw new InvalidTableException(e.getMessage(), e);
             }
         }
 


### PR DESCRIPTION
Several places in the catalog code rethrow caught exceptions by passing only getMessage() to the new exception, which drops the original stack trace and cause. This makes diagnosing failures harder because the root cause is lost.

Preserve the cause by passing the original Throwable as the second argument to the exception constructor in:
  - FlinkCatalog (createTable: lake-table-already-exist and invalid-table branches; alterTable: invalid-table branch)
  - PaimonLakeCatalog (AddColumn ColumnAlready/NotExistException branch)
  - CoordinatorService (UncheckedIOException and generic validate branches when wrapping into InvalidTableException)

No behavior change other than richer exception chaining.

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: none (minor code cleanup, no GitHub issue filed)

Several places in the catalog code rethrow caught exceptions by passing only
`getMessage()` to the new exception, which drops the original stack trace and
cause. This makes diagnosing failures harder because the root cause is lost
from the logs.

This PR preserves the cause by passing the original `Throwable` as the second
argument to the exception constructor, so that exception chaining is kept
intact and the root cause is visible in logs.

### Brief change log

- `FlinkCatalog#createTable`: preserve cause in the `lake-table-already-exist`
  branch (`new CatalogException(t.getMessage(), t)`) and the `invalid-table`
  branch (`new InvalidTableException(t.getMessage(), t)`).
- `FlinkCatalog#alterTable`: preserve cause in the `invalid-table` branch
  (`new InvalidTableException(t.getMessage(), t)`).
- `PaimonLakeCatalog`: preserve cause for the
  `ColumnAlreadyExistException | ColumnNotExistException` branch in
  `AddColumn` handling
  (`new InvalidAlterTableException(e.getMessage(), e)`).
- `CoordinatorService`: preserve cause when wrapping `UncheckedIOException`
  and generic validation errors into `InvalidTableException`.

### Tests

No new tests are added. This is a trivial rework that only changes the
exception-construction call to additionally pass the original `Throwable`
as the cause. Behavior of existing tests is unaffected.

### API and Format

No API or storage format changes. The exception types thrown remain the
same; only the `cause` field of the thrown exceptions is now populated.

### Documentation

No documentation changes. This is an internal cleanup without any
user-facing behavior change.
