### PR TITLE
[flink] Fix batch fallback generating mixed split types for primary-key tables

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -377,9 +377,12 @@ public class FlinkSourceEnumerator
                                                                         p.getPartitionId(),
                                                                         p.getPartitionName()))
                                                 .collect(Collectors.toList());
-                                splits = this.initPartitionedSplits(partitions);
+                                // Use log-only splits to avoid generating mixed split
+                                // types (HybridSnapshotLogSplit + LogSplit) for
+                                // primary-key tables, which is not supported.
+                                splits = this.initLogTablePartitionSplits(partitions);
                             } else {
-                                splits = this.initNonPartitionedSplits();
+                                splits = this.getLogSplit(null, null);
                             }
                         }
                         return splits;
@@ -734,18 +737,21 @@ public class FlinkSourceEnumerator
         }
 
         if (!bucketsNeedInitOffset.isEmpty()) {
-            startingOffsetsInitializer
-                    .getBucketOffsets(partitionName, bucketsNeedInitOffset, bucketOffsetsRetriever)
-                    .forEach(
-                            (bucketId, startingOffset) ->
-                                    splits.add(
-                                            new LogSplit(
-                                                    new TableBucket(
-                                                            tableInfo.getTableId(),
-                                                            partitionId,
-                                                            bucketId),
-                                                    partitionName,
-                                                    startingOffset)));
+            Map<Integer, Long> startingOffsets =
+                    startingOffsetsInitializer.getBucketOffsets(
+                            partitionName, bucketsNeedInitOffset, bucketOffsetsRetriever);
+            Map<Integer, Long> stoppingOffsets =
+                    stoppingOffsetsInitializer.getBucketOffsets(
+                            partitionName, bucketsNeedInitOffset, bucketOffsetsRetriever);
+            startingOffsets.forEach(
+                    (bucketId, startingOffset) ->
+                            splits.add(
+                                    new LogSplit(
+                                            new TableBucket(
+                                                    tableInfo.getTableId(), partitionId, bucketId),
+                                            partitionName,
+                                            startingOffset,
+                                            stoppingOffsets.get(bucketId))));
         }
         return splits;
     }


### PR DESCRIPTION
## Summary

Follow-up fix for #3208.

For primary-key tables in batch mode, when no lake snapshot exists, the previous
fallback logic had two issues:

1. **Mixed split types**: `initPartitionedSplits()` / `initNonPartitionedSplits()`
   may produce both `HybridSnapshotLogSplit` and `LogSplit`, which the Flink
   connector does not support merging.

2. **Missing stopping offset**: `getLogSplit()` used the 3-parameter `LogSplit`
   constructor without stopping offset, causing the reader to never stop in
   batch mode.

### Changes
- Use `initLogTablePartitionSplits()` / `getLogSplit()` in the fallback path
  to generate uniform `LogSplit` for all buckets.
- Add `stoppingOffsetsInitializer.getBucketOffsets()` in `getLogSplit()` to
  provide stopping offsets for batch mode bounded reads.