### PR TITLE
[server] Add authorization to listOffsets for TABLE/DESCRIBE operations

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -23,6 +23,7 @@ import org.apache.fluss.client.FlussConnection;
 import org.apache.fluss.client.admin.Admin;
 import org.apache.fluss.client.admin.FlussAdmin;
 import org.apache.fluss.client.admin.KvSnapshotLease;
+import org.apache.fluss.client.admin.OffsetSpec;
 import org.apache.fluss.client.table.Table;
 import org.apache.fluss.client.table.scanner.batch.BatchScanner;
 import org.apache.fluss.client.table.writer.AppendWriter;
@@ -416,6 +417,7 @@ public class FlussAuthorizationITCase {
         // 4. getLatestKvSnapshots
         // 5. listPartitionInfos
         // 6. getLatestLakeSnapshot
+        // 7. listOffsets
 
         // first check call these methods without authorization.
         assertThat(guestAdmin.listTables(DATA1_TABLE_PATH_PK.getDatabaseName()).get())
@@ -426,6 +428,15 @@ public class FlussAuthorizationITCase {
         assertNoTableDescribeAuth(() -> guestAdmin.listPartitionInfos(DATA1_TABLE_PATH_PK).get());
         assertNoTableDescribeAuth(
                 () -> guestAdmin.getLatestLakeSnapshot(DATA1_TABLE_PATH_PK).get());
+        assertNoTableDescribeAuth(
+                () ->
+                        guestAdmin
+                                .listOffsets(
+                                        DATA1_TABLE_PATH_PK,
+                                        Arrays.asList(0),
+                                        new OffsetSpec.LatestSpec())
+                                .all()
+                                .get());
 
         // add acl to allow guest describe table resource
         List<AclBinding> aclBindings =
@@ -459,6 +470,15 @@ public class FlussAuthorizationITCase {
                 .rootCause()
                 .isInstanceOf(LakeTableSnapshotNotExistException.class)
                 .hasMessageContaining("Lake table snapshot doesn't exist for table");
+        assertThat(
+                        guestAdmin
+                                .listOffsets(
+                                        DATA1_TABLE_PATH_PK,
+                                        Arrays.asList(0),
+                                        new OffsetSpec.LatestSpec())
+                                .all()
+                                .get())
+                .isNotEmpty();
     }
 
     @ParameterizedTest

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
@@ -109,6 +109,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import static org.apache.fluss.security.acl.OperationType.DESCRIBE;
 import static org.apache.fluss.security.acl.OperationType.READ;
 import static org.apache.fluss.security.acl.OperationType.WRITE;
 import static org.apache.fluss.server.coordinator.CoordinatorContext.INITIAL_COORDINATOR_EPOCH;
@@ -395,7 +396,7 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
 
     @Override
     public CompletableFuture<ListOffsetsResponse> listOffsets(ListOffsetsRequest request) {
-        // TODO: authorize DESCRIBE permission
+        authorizeTable(DESCRIBE, request.getTableId());
         CompletableFuture<ListOffsetsResponse> response = new CompletableFuture<>();
         Set<TableBucket> tableBuckets = getListOffsetsData(request);
         replicaManager.listOffsets(


### PR DESCRIPTION
## Summary

Implements authorization checks for the `listOffsets` method to complete issue #3247.

This PR adds TABLE/DESCRIBE authorization for the three table metadata read operations mentioned in the issue:
- ✅ `getTableSchema` - Already had authorization 
- ✅ `listPartitionInfos` - Already had authorization
- ✅ `listOffsets` - **Added in this PR**

## Changes

### Server Implementation (`TabletService.java`)
- Added `authorizeTable(DESCRIBE, request.getTableId())` check in the `listOffsets` method
- Added static import for `OperationType.DESCRIBE` to follow existing code patterns
- Removed the TODO comment that indicated this authorization was needed

### Test Coverage (`FlussAuthorizationITCase.java`)
- Added import for `OffsetSpec` class
- Extended `testDescribeTableOperation` test to include `listOffsets` authorization testing
  - **Test 1**: Verifies `listOffsets` throws `AuthorizationException` when user lacks DESCRIBE permission
  - **Test 2**: Verifies `listOffsets` succeeds when user has DESCRIBE permission

## Test Plan

- ✅ Code compiles successfully for both `fluss-server` and `fluss-client` modules
- ✅ Implementation follows existing authorization patterns in the codebase
- ✅ Tests follow the same structure as other DESCRIBE operation tests (getTableSchema, listPartitionInfos)
- ✅ Authorization logic is consistent with other table metadata operations

**Note**: Integration tests have a pre-existing SASL authentication environment issue (`Subject.getSubject()` not supported) that affects all tests in `FlussAuthorizationITCase`, not just these changes. This is confirmed by testing the main branch without modifications. The CI pipeline should have the correct Java environment configuration.

## Related Issue

Closes #3247