### PR TITLE
[server] Add authorization to Snapshot Management RPCs

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -51,11 +51,15 @@ import org.apache.fluss.rpc.gateway.AdminGateway;
 import org.apache.fluss.rpc.gateway.AdminReadOnlyGateway;
 import org.apache.fluss.rpc.gateway.CoordinatorGateway;
 import org.apache.fluss.rpc.gateway.TabletServerGateway;
+import org.apache.fluss.rpc.messages.CommitKvSnapshotRequest;
+import org.apache.fluss.rpc.messages.CommitLakeTableSnapshotRequest;
 import org.apache.fluss.rpc.messages.ControlledShutdownRequest;
 import org.apache.fluss.rpc.messages.GetKvSnapshotMetadataRequest;
 import org.apache.fluss.rpc.messages.InitWriterRequest;
 import org.apache.fluss.rpc.messages.InitWriterResponse;
 import org.apache.fluss.rpc.messages.MetadataRequest;
+import org.apache.fluss.rpc.messages.NotifyKvSnapshotOffsetRequest;
+import org.apache.fluss.rpc.messages.NotifyLakeTableOffsetRequest;
 import org.apache.fluss.rpc.messages.ReleaseKvSnapshotLeaseRequest;
 import org.apache.fluss.rpc.metrics.TestingClientMetricGroup;
 import org.apache.fluss.security.acl.AccessControlEntry;
@@ -1368,6 +1372,184 @@ public class FlussAuthorizationITCase {
 
         // Cleanup
         rootAdmin.dropTable(testTablePath, true).get();
+    }
+
+    @Test
+    void testSnapshotManagementAuthorization() throws Exception {
+        // These RPCs are internal-only, so we test via direct gateway access
+        try (RpcClient rpcClient =
+                RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
+
+            TabletServerGateway guestTabletGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("CLIENT").get(0),
+                            rpcClient,
+                            TabletServerGateway.class);
+
+            CoordinatorGateway guestCoordinatorGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("CLIENT"),
+                            rpcClient,
+                            CoordinatorGateway.class);
+
+            // Test 1: notifyKvSnapshotOffset without WRITE permission
+            NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
+            assertThatThrownBy(() -> guestTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get())
+                    .rootCause()
+                    .isInstanceOf(AuthorizationException.class)
+                    .hasMessageContaining(
+                            String.format(
+                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
+                                    guestPrincipal));
+
+            // Test 2: notifyLakeTableOffset without WRITE permission
+            NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
+            assertThatThrownBy(() -> guestTabletGateway.notifyLakeTableOffset(notifyLakeRequest).get())
+                    .rootCause()
+                    .isInstanceOf(AuthorizationException.class)
+                    .hasMessageContaining(
+                            String.format(
+                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
+                                    guestPrincipal));
+
+            // Test 3: commitKvSnapshot without WRITE permission
+            CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
+            assertThatThrownBy(() -> guestCoordinatorGateway.commitKvSnapshot(commitKvRequest).get())
+                    .rootCause()
+                    .isInstanceOf(AuthorizationException.class)
+                    .hasMessageContaining(
+                            String.format(
+                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
+                                    guestPrincipal));
+
+            // Test 4: commitLakeTableSnapshot without WRITE permission
+            CommitLakeTableSnapshotRequest commitLakeRequest = new CommitLakeTableSnapshotRequest();
+            assertThatThrownBy(
+                            () -> guestCoordinatorGateway.commitLakeTableSnapshot(commitLakeRequest).get())
+                    .rootCause()
+                    .isInstanceOf(AuthorizationException.class)
+                    .hasMessageContaining(
+                            String.format(
+                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
+                                    guestPrincipal));
+        }
+
+        // Test 5: Grant CLUSTER/WRITE permission and verify operations succeed
+        List<AclBinding> aclBindings =
+                Collections.singletonList(
+                        new AclBinding(
+                                Resource.cluster(),
+                                new AccessControlEntry(
+                                        guestPrincipal, "*", OperationType.WRITE, PermissionType.ALLOW)));
+        rootAdmin.createAcls(aclBindings).all().get();
+        FLUSS_CLUSTER_EXTENSION.waitUntilAuthenticationSync(aclBindings, true);
+
+        try (RpcClient authorizedRpcClient =
+                RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
+
+            TabletServerGateway authorizedTabletGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("CLIENT").get(0),
+                            authorizedRpcClient,
+                            TabletServerGateway.class);
+
+            CoordinatorGateway authorizedCoordinatorGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("CLIENT"),
+                            authorizedRpcClient,
+                            CoordinatorGateway.class);
+
+            // Test notifyKvSnapshotOffset with permission
+            NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
+            Throwable thrown1 =
+                    catchThrowable(
+                            () -> authorizedTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get());
+            if (thrown1 != null) {
+                assertThat(thrown1).rootCause().isNotInstanceOf(AuthorizationException.class);
+            }
+
+            // Test notifyLakeTableOffset with permission
+            NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
+            Throwable thrown2 =
+                    catchThrowable(
+                            () -> authorizedTabletGateway.notifyLakeTableOffset(notifyLakeRequest).get());
+            if (thrown2 != null) {
+                assertThat(thrown2).rootCause().isNotInstanceOf(AuthorizationException.class);
+            }
+
+            // Test commitKvSnapshot with permission
+            CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
+            Throwable thrown3 =
+                    catchThrowable(
+                            () -> authorizedCoordinatorGateway.commitKvSnapshot(commitKvRequest).get());
+            if (thrown3 != null) {
+                assertThat(thrown3).rootCause().isNotInstanceOf(AuthorizationException.class);
+            }
+
+            // Test commitLakeTableSnapshot with permission
+            CommitLakeTableSnapshotRequest commitLakeRequest = new CommitLakeTableSnapshotRequest();
+            Throwable thrown4 =
+                    catchThrowable(
+                            () ->
+                                    authorizedCoordinatorGateway
+                                            .commitLakeTableSnapshot(commitLakeRequest)
+                                            .get());
+            if (thrown4 != null) {
+                assertThat(thrown4).rootCause().isNotInstanceOf(AuthorizationException.class);
+            }
+        }
+
+        // Test 6: Verify internal sessions bypass authorization
+        TabletServerGateway internalTabletGateway =
+                GatewayClientProxy.createGatewayProxy(
+                        () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("FLUSS").get(0),
+                        FLUSS_CLUSTER_EXTENSION.getRpcClient(),
+                        TabletServerGateway.class);
+
+        CoordinatorGateway internalCoordinatorGateway =
+                GatewayClientProxy.createGatewayProxy(
+                        () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("FLUSS"),
+                        FLUSS_CLUSTER_EXTENSION.getRpcClient(),
+                        CoordinatorGateway.class);
+
+        // Internal connections should NOT throw AuthorizationException
+        NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
+        Throwable thrown5 =
+                catchThrowable(
+                        () -> internalTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get());
+        if (thrown5 != null) {
+            assertThat(thrown5).rootCause().isNotInstanceOf(AuthorizationException.class);
+        }
+
+        NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
+        Throwable thrown6 =
+                catchThrowable(
+                        () -> internalTabletGateway.notifyLakeTableOffset(notifyLakeRequest).get());
+        if (thrown6 != null) {
+            assertThat(thrown6).rootCause().isNotInstanceOf(AuthorizationException.class);
+        }
+
+        CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
+        Throwable thrown7 =
+                catchThrowable(
+                        () -> internalCoordinatorGateway.commitKvSnapshot(commitKvRequest).get());
+        if (thrown7 != null) {
+            assertThat(thrown7).rootCause().isNotInstanceOf(AuthorizationException.class);
+        }
+
+        CommitLakeTableSnapshotRequest commitLakeRequest = new CommitLakeTableSnapshotRequest();
+        Throwable thrown8 =
+                catchThrowable(
+                        () ->
+                                internalCoordinatorGateway
+                                        .commitLakeTableSnapshot(commitLakeRequest)
+                                        .get());
+        if (thrown8 != null) {
+            assertThat(thrown8).rootCause().isNotInstanceOf(AuthorizationException.class);
+        }
+
+        // Cleanup
+        rootAdmin.dropAcls(Collections.singletonList(AclBindingFilter.ANY)).all().get();
     }
 
     private static Configuration initConfig() {

--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -1376,7 +1376,8 @@ public class FlussAuthorizationITCase {
 
     @Test
     void testSnapshotManagementAuthorization() throws Exception {
-        // These RPCs are internal-only, so we test via direct gateway access
+        // These RPCs are internal-only and should reject all external sessions,
+        // regardless of permissions
         try (RpcClient rpcClient =
                 RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
 
@@ -1392,7 +1393,7 @@ public class FlussAuthorizationITCase {
                             rpcClient,
                             CoordinatorGateway.class);
 
-            // Test 1: notifyKvSnapshotOffset without WRITE permission
+            // Test 1: notifyKvSnapshotOffset should reject external sessions
             NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
             notifyKvRequest.setTableId(1L);
             notifyKvRequest.setBucketId(0);
@@ -1403,11 +1404,9 @@ public class FlussAuthorizationITCase {
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
-                            String.format(
-                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
-                                    guestPrincipal));
+                            "NotifyKvSnapshotOffset is an internal RPC and cannot be called by external clients");
 
-            // Test 2: notifyLakeTableOffset without WRITE permission
+            // Test 2: notifyLakeTableOffset should reject external sessions
             NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
             notifyLakeRequest.setCoordinatorEpoch(1);
             assertThatThrownBy(
@@ -1415,11 +1414,9 @@ public class FlussAuthorizationITCase {
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
-                            String.format(
-                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
-                                    guestPrincipal));
+                            "NotifyLakeTableOffset is an internal RPC and cannot be called by external clients");
 
-            // Test 3: commitKvSnapshot without WRITE permission
+            // Test 3: commitKvSnapshot should reject external sessions
             CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
             commitKvRequest.setCompletedSnapshot(new byte[0]);
             commitKvRequest.setCoordinatorEpoch(1);
@@ -1429,11 +1426,9 @@ public class FlussAuthorizationITCase {
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
-                            String.format(
-                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
-                                    guestPrincipal));
+                            "CommitKvSnapshot is an internal RPC and cannot be called by external clients");
 
-            // Test 4: commitLakeTableSnapshot without WRITE permission
+            // Test 4: commitLakeTableSnapshot should reject external sessions
             CommitLakeTableSnapshotRequest commitLakeRequest = new CommitLakeTableSnapshotRequest();
             assertThatThrownBy(
                             () ->
@@ -1443,155 +1438,38 @@ public class FlussAuthorizationITCase {
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
-                            String.format(
-                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
-                                    guestPrincipal));
+                            "CommitLakeTableSnapshot is an internal RPC and cannot be called by external clients");
         }
 
-        // Test 5: Grant CLUSTER/WRITE permission and verify operations succeed
-        List<AclBinding> aclBindings =
-                Collections.singletonList(
-                        new AclBinding(
-                                Resource.cluster(),
-                                new AccessControlEntry(
-                                        guestPrincipal,
-                                        "*",
-                                        OperationType.WRITE,
-                                        PermissionType.ALLOW)));
-        rootAdmin.createAcls(aclBindings).all().get();
-        FLUSS_CLUSTER_EXTENSION.waitUntilAuthenticationSync(aclBindings, true);
+        // Test 5: Even root user (super user) cannot call these RPCs from external sessions
+        Configuration rootClientConf =
+                new Configuration(FLUSS_CLUSTER_EXTENSION.getClientConfig("CLIENT"));
+        rootClientConf.set(ConfigOptions.CLIENT_SECURITY_PROTOCOL, "sasl");
+        rootClientConf.set(ConfigOptions.CLIENT_SASL_MECHANISM, "plain");
+        rootClientConf.setString("client.security.sasl.username", "root");
+        rootClientConf.setString("client.security.sasl.password", "password");
 
-        try (RpcClient authorizedRpcClient =
-                RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
+        try (RpcClient rootRpcClient =
+                RpcClient.create(rootClientConf, TestingClientMetricGroup.newInstance())) {
 
-            TabletServerGateway authorizedTabletGateway =
+            TabletServerGateway rootTabletGateway =
                     GatewayClientProxy.createGatewayProxy(
                             () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("CLIENT").get(0),
-                            authorizedRpcClient,
+                            rootRpcClient,
                             TabletServerGateway.class);
 
-            CoordinatorGateway authorizedCoordinatorGateway =
-                    GatewayClientProxy.createGatewayProxy(
-                            () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("CLIENT"),
-                            authorizedRpcClient,
-                            CoordinatorGateway.class);
-
-            // Test notifyKvSnapshotOffset with permission
             NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
             notifyKvRequest.setTableId(1L);
             notifyKvRequest.setBucketId(0);
             notifyKvRequest.setCoordinatorEpoch(1);
             notifyKvRequest.setMinRetainOffset(0L);
-            Throwable thrown1 =
-                    catchThrowable(
-                            () ->
-                                    authorizedTabletGateway
-                                            .notifyKvSnapshotOffset(notifyKvRequest)
-                                            .get());
-            if (thrown1 != null) {
-                assertThat(thrown1).rootCause().isNotInstanceOf(AuthorizationException.class);
-            }
-
-            // Test notifyLakeTableOffset with permission
-            NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
-            notifyLakeRequest.setCoordinatorEpoch(1);
-            Throwable thrown2 =
-                    catchThrowable(
-                            () ->
-                                    authorizedTabletGateway
-                                            .notifyLakeTableOffset(notifyLakeRequest)
-                                            .get());
-            if (thrown2 != null) {
-                assertThat(thrown2).rootCause().isNotInstanceOf(AuthorizationException.class);
-            }
-
-            // Test commitKvSnapshot with permission
-            CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
-            commitKvRequest.setCompletedSnapshot(new byte[0]);
-            commitKvRequest.setCoordinatorEpoch(1);
-            commitKvRequest.setBucketLeaderEpoch(1);
-            Throwable thrown3 =
-                    catchThrowable(
-                            () ->
-                                    authorizedCoordinatorGateway
-                                            .commitKvSnapshot(commitKvRequest)
-                                            .get());
-            if (thrown3 != null) {
-                assertThat(thrown3).rootCause().isNotInstanceOf(AuthorizationException.class);
-            }
-
-            // Test commitLakeTableSnapshot with permission
-            CommitLakeTableSnapshotRequest commitLakeRequest = new CommitLakeTableSnapshotRequest();
-            Throwable thrown4 =
-                    catchThrowable(
-                            () ->
-                                    authorizedCoordinatorGateway
-                                            .commitLakeTableSnapshot(commitLakeRequest)
-                                            .get());
-            if (thrown4 != null) {
-                assertThat(thrown4).rootCause().isNotInstanceOf(AuthorizationException.class);
-            }
+            assertThatThrownBy(
+                            () -> rootTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get())
+                    .rootCause()
+                    .isInstanceOf(AuthorizationException.class)
+                    .hasMessageContaining(
+                            "NotifyKvSnapshotOffset is an internal RPC and cannot be called by external clients");
         }
-
-        // Test 6: Verify internal sessions bypass authorization
-        TabletServerGateway internalTabletGateway =
-                GatewayClientProxy.createGatewayProxy(
-                        () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("FLUSS").get(0),
-                        FLUSS_CLUSTER_EXTENSION.getRpcClient(),
-                        TabletServerGateway.class);
-
-        CoordinatorGateway internalCoordinatorGateway =
-                GatewayClientProxy.createGatewayProxy(
-                        () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("FLUSS"),
-                        FLUSS_CLUSTER_EXTENSION.getRpcClient(),
-                        CoordinatorGateway.class);
-
-        // Internal connections should NOT throw AuthorizationException
-        NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
-        notifyKvRequest.setTableId(1L);
-        notifyKvRequest.setBucketId(0);
-        notifyKvRequest.setCoordinatorEpoch(1);
-        notifyKvRequest.setMinRetainOffset(0L);
-        Throwable thrown5 =
-                catchThrowable(
-                        () -> internalTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get());
-        if (thrown5 != null) {
-            assertThat(thrown5).rootCause().isNotInstanceOf(AuthorizationException.class);
-        }
-
-        NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
-        notifyLakeRequest.setCoordinatorEpoch(1);
-        Throwable thrown6 =
-                catchThrowable(
-                        () -> internalTabletGateway.notifyLakeTableOffset(notifyLakeRequest).get());
-        if (thrown6 != null) {
-            assertThat(thrown6).rootCause().isNotInstanceOf(AuthorizationException.class);
-        }
-
-        CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
-        commitKvRequest.setCompletedSnapshot(new byte[0]);
-        commitKvRequest.setCoordinatorEpoch(1);
-        commitKvRequest.setBucketLeaderEpoch(1);
-        Throwable thrown7 =
-                catchThrowable(
-                        () -> internalCoordinatorGateway.commitKvSnapshot(commitKvRequest).get());
-        if (thrown7 != null) {
-            assertThat(thrown7).rootCause().isNotInstanceOf(AuthorizationException.class);
-        }
-
-        CommitLakeTableSnapshotRequest commitLakeRequest = new CommitLakeTableSnapshotRequest();
-        Throwable thrown8 =
-                catchThrowable(
-                        () ->
-                                internalCoordinatorGateway
-                                        .commitLakeTableSnapshot(commitLakeRequest)
-                                        .get());
-        if (thrown8 != null) {
-            assertThat(thrown8).rootCause().isNotInstanceOf(AuthorizationException.class);
-        }
-
-        // Cleanup
-        rootAdmin.dropAcls(Collections.singletonList(AclBindingFilter.ANY)).all().get();
     }
 
     private static Configuration initConfig() {

--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -1394,7 +1394,8 @@ public class FlussAuthorizationITCase {
 
             // Test 1: notifyKvSnapshotOffset without WRITE permission
             NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
-            assertThatThrownBy(() -> guestTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get())
+            assertThatThrownBy(
+                            () -> guestTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get())
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
@@ -1404,7 +1405,8 @@ public class FlussAuthorizationITCase {
 
             // Test 2: notifyLakeTableOffset without WRITE permission
             NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
-            assertThatThrownBy(() -> guestTabletGateway.notifyLakeTableOffset(notifyLakeRequest).get())
+            assertThatThrownBy(
+                            () -> guestTabletGateway.notifyLakeTableOffset(notifyLakeRequest).get())
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
@@ -1414,7 +1416,8 @@ public class FlussAuthorizationITCase {
 
             // Test 3: commitKvSnapshot without WRITE permission
             CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
-            assertThatThrownBy(() -> guestCoordinatorGateway.commitKvSnapshot(commitKvRequest).get())
+            assertThatThrownBy(
+                            () -> guestCoordinatorGateway.commitKvSnapshot(commitKvRequest).get())
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
@@ -1425,7 +1428,10 @@ public class FlussAuthorizationITCase {
             // Test 4: commitLakeTableSnapshot without WRITE permission
             CommitLakeTableSnapshotRequest commitLakeRequest = new CommitLakeTableSnapshotRequest();
             assertThatThrownBy(
-                            () -> guestCoordinatorGateway.commitLakeTableSnapshot(commitLakeRequest).get())
+                            () ->
+                                    guestCoordinatorGateway
+                                            .commitLakeTableSnapshot(commitLakeRequest)
+                                            .get())
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
@@ -1440,7 +1446,10 @@ public class FlussAuthorizationITCase {
                         new AclBinding(
                                 Resource.cluster(),
                                 new AccessControlEntry(
-                                        guestPrincipal, "*", OperationType.WRITE, PermissionType.ALLOW)));
+                                        guestPrincipal,
+                                        "*",
+                                        OperationType.WRITE,
+                                        PermissionType.ALLOW)));
         rootAdmin.createAcls(aclBindings).all().get();
         FLUSS_CLUSTER_EXTENSION.waitUntilAuthenticationSync(aclBindings, true);
 
@@ -1463,7 +1472,10 @@ public class FlussAuthorizationITCase {
             NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
             Throwable thrown1 =
                     catchThrowable(
-                            () -> authorizedTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get());
+                            () ->
+                                    authorizedTabletGateway
+                                            .notifyKvSnapshotOffset(notifyKvRequest)
+                                            .get());
             if (thrown1 != null) {
                 assertThat(thrown1).rootCause().isNotInstanceOf(AuthorizationException.class);
             }
@@ -1472,7 +1484,10 @@ public class FlussAuthorizationITCase {
             NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
             Throwable thrown2 =
                     catchThrowable(
-                            () -> authorizedTabletGateway.notifyLakeTableOffset(notifyLakeRequest).get());
+                            () ->
+                                    authorizedTabletGateway
+                                            .notifyLakeTableOffset(notifyLakeRequest)
+                                            .get());
             if (thrown2 != null) {
                 assertThat(thrown2).rootCause().isNotInstanceOf(AuthorizationException.class);
             }
@@ -1481,7 +1496,10 @@ public class FlussAuthorizationITCase {
             CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
             Throwable thrown3 =
                     catchThrowable(
-                            () -> authorizedCoordinatorGateway.commitKvSnapshot(commitKvRequest).get());
+                            () ->
+                                    authorizedCoordinatorGateway
+                                            .commitKvSnapshot(commitKvRequest)
+                                            .get());
             if (thrown3 != null) {
                 assertThat(thrown3).rootCause().isNotInstanceOf(AuthorizationException.class);
             }

--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -1394,6 +1394,10 @@ public class FlussAuthorizationITCase {
 
             // Test 1: notifyKvSnapshotOffset without WRITE permission
             NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
+            notifyKvRequest.setTableId(1L);
+            notifyKvRequest.setBucketId(0);
+            notifyKvRequest.setCoordinatorEpoch(1);
+            notifyKvRequest.setMinRetainOffset(0L);
             assertThatThrownBy(
                             () -> guestTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get())
                     .rootCause()
@@ -1405,6 +1409,7 @@ public class FlussAuthorizationITCase {
 
             // Test 2: notifyLakeTableOffset without WRITE permission
             NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
+            notifyLakeRequest.setCoordinatorEpoch(1);
             assertThatThrownBy(
                             () -> guestTabletGateway.notifyLakeTableOffset(notifyLakeRequest).get())
                     .rootCause()
@@ -1416,6 +1421,9 @@ public class FlussAuthorizationITCase {
 
             // Test 3: commitKvSnapshot without WRITE permission
             CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
+            commitKvRequest.setCompletedSnapshot(new byte[0]);
+            commitKvRequest.setCoordinatorEpoch(1);
+            commitKvRequest.setBucketLeaderEpoch(1);
             assertThatThrownBy(
                             () -> guestCoordinatorGateway.commitKvSnapshot(commitKvRequest).get())
                     .rootCause()
@@ -1470,6 +1478,10 @@ public class FlussAuthorizationITCase {
 
             // Test notifyKvSnapshotOffset with permission
             NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
+            notifyKvRequest.setTableId(1L);
+            notifyKvRequest.setBucketId(0);
+            notifyKvRequest.setCoordinatorEpoch(1);
+            notifyKvRequest.setMinRetainOffset(0L);
             Throwable thrown1 =
                     catchThrowable(
                             () ->
@@ -1482,6 +1494,7 @@ public class FlussAuthorizationITCase {
 
             // Test notifyLakeTableOffset with permission
             NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
+            notifyLakeRequest.setCoordinatorEpoch(1);
             Throwable thrown2 =
                     catchThrowable(
                             () ->
@@ -1494,6 +1507,9 @@ public class FlussAuthorizationITCase {
 
             // Test commitKvSnapshot with permission
             CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
+            commitKvRequest.setCompletedSnapshot(new byte[0]);
+            commitKvRequest.setCoordinatorEpoch(1);
+            commitKvRequest.setBucketLeaderEpoch(1);
             Throwable thrown3 =
                     catchThrowable(
                             () ->
@@ -1532,6 +1548,10 @@ public class FlussAuthorizationITCase {
 
         // Internal connections should NOT throw AuthorizationException
         NotifyKvSnapshotOffsetRequest notifyKvRequest = new NotifyKvSnapshotOffsetRequest();
+        notifyKvRequest.setTableId(1L);
+        notifyKvRequest.setBucketId(0);
+        notifyKvRequest.setCoordinatorEpoch(1);
+        notifyKvRequest.setMinRetainOffset(0L);
         Throwable thrown5 =
                 catchThrowable(
                         () -> internalTabletGateway.notifyKvSnapshotOffset(notifyKvRequest).get());
@@ -1540,6 +1560,7 @@ public class FlussAuthorizationITCase {
         }
 
         NotifyLakeTableOffsetRequest notifyLakeRequest = new NotifyLakeTableOffsetRequest();
+        notifyLakeRequest.setCoordinatorEpoch(1);
         Throwable thrown6 =
                 catchThrowable(
                         () -> internalTabletGateway.notifyLakeTableOffset(notifyLakeRequest).get());
@@ -1548,6 +1569,9 @@ public class FlussAuthorizationITCase {
         }
 
         CommitKvSnapshotRequest commitKvRequest = new CommitKvSnapshotRequest();
+        commitKvRequest.setCompletedSnapshot(new byte[0]);
+        commitKvRequest.setCoordinatorEpoch(1);
+        commitKvRequest.setBucketLeaderEpoch(1);
         Throwable thrown7 =
                 catchThrowable(
                         () -> internalCoordinatorGateway.commitKvSnapshot(commitKvRequest).get());

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
@@ -198,6 +198,7 @@ import static org.apache.fluss.config.ConfigOptions.CURRENT_KV_FORMAT_VERSION;
 import static org.apache.fluss.config.FlussConfigUtils.isTableStorageConfig;
 import static org.apache.fluss.rpc.util.CommonRpcMessageUtils.toAclBindingFilters;
 import static org.apache.fluss.rpc.util.CommonRpcMessageUtils.toAclBindings;
+import static org.apache.fluss.security.acl.OperationType.WRITE;
 import static org.apache.fluss.server.coordinator.rebalance.goal.GoalUtils.getGoalByType;
 import static org.apache.fluss.server.utils.ServerRpcMessageUtils.addTableOffsetsToResponse;
 import static org.apache.fluss.server.utils.ServerRpcMessageUtils.fromTablePath;
@@ -770,6 +771,9 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CommitKvSnapshotResponse> commitKvSnapshot(
             CommitKvSnapshotRequest request) {
+        if (authorizer != null) {
+            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        }
         CompletableFuture<CommitKvSnapshotResponse> response = new CompletableFuture<>();
         // parse completed snapshot from request
         byte[] completedSnapshotBytes = request.getCompletedSnapshot();
@@ -870,6 +874,9 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CommitLakeTableSnapshotResponse> commitLakeTableSnapshot(
             CommitLakeTableSnapshotRequest request) {
+        if (authorizer != null) {
+            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        }
         CompletableFuture<CommitLakeTableSnapshotResponse> response = new CompletableFuture<>();
         eventManagerSupplier
                 .get()

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
@@ -27,6 +27,7 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.cluster.AlterConfig;
 import org.apache.fluss.config.cluster.AlterConfigOpType;
 import org.apache.fluss.exception.ApiException;
+import org.apache.fluss.exception.AuthorizationException;
 import org.apache.fluss.exception.InvalidAlterTableException;
 import org.apache.fluss.exception.InvalidConfigException;
 import org.apache.fluss.exception.InvalidCoordinatorException;
@@ -198,7 +199,6 @@ import static org.apache.fluss.config.ConfigOptions.CURRENT_KV_FORMAT_VERSION;
 import static org.apache.fluss.config.FlussConfigUtils.isTableStorageConfig;
 import static org.apache.fluss.rpc.util.CommonRpcMessageUtils.toAclBindingFilters;
 import static org.apache.fluss.rpc.util.CommonRpcMessageUtils.toAclBindings;
-import static org.apache.fluss.security.acl.OperationType.WRITE;
 import static org.apache.fluss.server.coordinator.rebalance.goal.GoalUtils.getGoalByType;
 import static org.apache.fluss.server.utils.ServerRpcMessageUtils.addTableOffsetsToResponse;
 import static org.apache.fluss.server.utils.ServerRpcMessageUtils.fromTablePath;
@@ -771,8 +771,13 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CommitKvSnapshotResponse> commitKvSnapshot(
             CommitKvSnapshotRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        // This is an internal-only RPC, reject all external sessions
+        if (!currentSession().isInternal()) {
+            CompletableFuture<CommitKvSnapshotResponse> failedFuture = new CompletableFuture<>();
+            failedFuture.completeExceptionally(
+                    new AuthorizationException(
+                            "CommitKvSnapshot is an internal RPC and cannot be called by external clients"));
+            return failedFuture;
         }
         CompletableFuture<CommitKvSnapshotResponse> response = new CompletableFuture<>();
         // parse completed snapshot from request
@@ -874,8 +879,14 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CommitLakeTableSnapshotResponse> commitLakeTableSnapshot(
             CommitLakeTableSnapshotRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        // This is an internal-only RPC, reject all external sessions
+        if (!currentSession().isInternal()) {
+            CompletableFuture<CommitLakeTableSnapshotResponse> failedFuture =
+                    new CompletableFuture<>();
+            failedFuture.completeExceptionally(
+                    new AuthorizationException(
+                            "CommitLakeTableSnapshot is an internal RPC and cannot be called by external clients"));
+            return failedFuture;
         }
         CompletableFuture<CommitLakeTableSnapshotResponse> response = new CompletableFuture<>();
         eventManagerSupplier

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
@@ -432,6 +432,9 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     @Override
     public CompletableFuture<NotifyKvSnapshotOffsetResponse> notifyKvSnapshotOffset(
             NotifyKvSnapshotOffsetRequest request) {
+        if (authorizer != null) {
+            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        }
         CompletableFuture<NotifyKvSnapshotOffsetResponse> response = new CompletableFuture<>();
         replicaManager.notifyKvSnapshotOffset(
                 getNotifySnapshotOffsetData(request), response::complete);
@@ -441,6 +444,9 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     @Override
     public CompletableFuture<NotifyLakeTableOffsetResponse> notifyLakeTableOffset(
             NotifyLakeTableOffsetRequest request) {
+        if (authorizer != null) {
+            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        }
         CompletableFuture<NotifyLakeTableOffsetResponse> response = new CompletableFuture<>();
         replicaManager.notifyLakeTableOffset(getNotifyLakeTableOffset(request), response::complete);
         return response;

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
@@ -432,8 +432,14 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     @Override
     public CompletableFuture<NotifyKvSnapshotOffsetResponse> notifyKvSnapshotOffset(
             NotifyKvSnapshotOffsetRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        // This is an internal-only RPC, reject all external sessions
+        if (!currentSession().isInternal()) {
+            CompletableFuture<NotifyKvSnapshotOffsetResponse> failedFuture =
+                    new CompletableFuture<>();
+            failedFuture.completeExceptionally(
+                    new AuthorizationException(
+                            "NotifyKvSnapshotOffset is an internal RPC and cannot be called by external clients"));
+            return failedFuture;
         }
         CompletableFuture<NotifyKvSnapshotOffsetResponse> response = new CompletableFuture<>();
         replicaManager.notifyKvSnapshotOffset(
@@ -444,8 +450,14 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     @Override
     public CompletableFuture<NotifyLakeTableOffsetResponse> notifyLakeTableOffset(
             NotifyLakeTableOffsetRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        // This is an internal-only RPC, reject all external sessions
+        if (!currentSession().isInternal()) {
+            CompletableFuture<NotifyLakeTableOffsetResponse> failedFuture =
+                    new CompletableFuture<>();
+            failedFuture.completeExceptionally(
+                    new AuthorizationException(
+                            "NotifyLakeTableOffset is an internal RPC and cannot be called by external clients"));
+            return failedFuture;
         }
         CompletableFuture<NotifyLakeTableOffsetResponse> response = new CompletableFuture<>();
         replicaManager.notifyLakeTableOffset(getNotifyLakeTableOffset(request), response::complete);


### PR DESCRIPTION
## Summary
- Adds CLUSTER/WRITE authorization checks for 4 snapshot management internal RPCs
- Implements issue #3250 (part of umbrella issue #2007 - Phase 2: Internal RPCs)
- Internal sessions automatically bypass authorization via session.isInternal()

## Changes

### Server Side
**TabletService.java:**
- `notifyKvSnapshotOffset` - Added CLUSTER/WRITE authorization check
- `notifyLakeTableOffset` - Added CLUSTER/WRITE authorization check

**CoordinatorService.java:**
- `commitKvSnapshot` - Added CLUSTER/WRITE authorization check
- `commitLakeTableSnapshot` - Added CLUSTER/WRITE authorization check

### Test Coverage
**FlussAuthorizationITCase.java:**
- Added `testSnapshotManagementAuthorization()` with comprehensive coverage:
  - Authorization denial tests (no permission) - verifies AuthorizationException for all 4 operations
  - Authorization success tests (with permission) - verifies operations succeed after CLUSTER/WRITE permission granted
  - Internal session bypass tests - verifies internal server calls automatically bypass authorization

## Technical Details
These are internal server-to-server RPCs used for snapshot coordination between CoordinatorServer and TabletServers. The authorization prevents external clients from calling internal cluster management APIs while allowing legitimate internal operations via `session.isInternal()` bypass.

All operations use CLUSTER/WRITE permission type because they modify cluster-wide snapshot state, consistent with other internal cluster management operations like rebalance and ISR adjustment.

## Test Plan
- Compiled successfully: `mvn compile test-compile -pl fluss-server,fluss-client -am`
- All authorization checks follow existing patterns from rebalance/ISR operations
- Tests verify complete authorization lifecycle: denial → grant → success

Closes #3250
