### PR TITLE
[server] Add authorization to Remote Log & Tiering RPCs

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -1393,6 +1393,11 @@ public class FlussAuthorizationITCase {
 
             // Test 1: notifyRemoteLogOffsets without WRITE permission
             NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
+            notifyRemoteRequest.setTableId(1L);
+            notifyRemoteRequest.setBucketId(0);
+            notifyRemoteRequest.setCoordinatorEpoch(1);
+            notifyRemoteRequest.setRemoteStartOffset(0L);
+            notifyRemoteRequest.setRemoteEndOffset(100L);
             assertThatThrownBy(
                             () ->
                                     guestTabletGateway
@@ -1408,6 +1413,13 @@ public class FlussAuthorizationITCase {
             // Test 2: commitRemoteLogManifest without WRITE permission
             CommitRemoteLogManifestRequest commitManifestRequest =
                     new CommitRemoteLogManifestRequest();
+            commitManifestRequest.setTableId(1L);
+            commitManifestRequest.setBucketId(0);
+            commitManifestRequest.setRemoteLogManifestPath("/path/to/manifest");
+            commitManifestRequest.setRemoteLogStartOffset(0L);
+            commitManifestRequest.setRemoteLogEndOffset(100L);
+            commitManifestRequest.setCoordinatorEpoch(1);
+            commitManifestRequest.setBucketLeaderEpoch(1);
             assertThatThrownBy(
                             () ->
                                     guestCoordinatorGateway
@@ -1465,6 +1477,11 @@ public class FlussAuthorizationITCase {
 
             // Test notifyRemoteLogOffsets with permission
             NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
+            notifyRemoteRequest.setTableId(1L);
+            notifyRemoteRequest.setBucketId(0);
+            notifyRemoteRequest.setCoordinatorEpoch(1);
+            notifyRemoteRequest.setRemoteStartOffset(0L);
+            notifyRemoteRequest.setRemoteEndOffset(100L);
             Throwable thrown1 =
                     catchThrowable(
                             () ->
@@ -1478,6 +1495,13 @@ public class FlussAuthorizationITCase {
             // Test commitRemoteLogManifest with permission
             CommitRemoteLogManifestRequest commitManifestRequest =
                     new CommitRemoteLogManifestRequest();
+            commitManifestRequest.setTableId(1L);
+            commitManifestRequest.setBucketId(0);
+            commitManifestRequest.setRemoteLogManifestPath("/path/to/manifest");
+            commitManifestRequest.setRemoteLogStartOffset(0L);
+            commitManifestRequest.setRemoteLogEndOffset(100L);
+            commitManifestRequest.setCoordinatorEpoch(1);
+            commitManifestRequest.setBucketLeaderEpoch(1);
             Throwable thrown2 =
                     catchThrowable(
                             () ->
@@ -1516,6 +1540,11 @@ public class FlussAuthorizationITCase {
 
         // Internal connections should NOT throw AuthorizationException
         NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
+        notifyRemoteRequest.setTableId(1L);
+        notifyRemoteRequest.setBucketId(0);
+        notifyRemoteRequest.setCoordinatorEpoch(1);
+        notifyRemoteRequest.setRemoteStartOffset(0L);
+        notifyRemoteRequest.setRemoteEndOffset(100L);
         Throwable thrown4 =
                 catchThrowable(
                         () ->
@@ -1527,6 +1556,13 @@ public class FlussAuthorizationITCase {
         }
 
         CommitRemoteLogManifestRequest commitManifestRequest = new CommitRemoteLogManifestRequest();
+        commitManifestRequest.setTableId(1L);
+        commitManifestRequest.setBucketId(0);
+        commitManifestRequest.setRemoteLogManifestPath("/path/to/manifest");
+        commitManifestRequest.setRemoteLogStartOffset(0L);
+        commitManifestRequest.setRemoteLogEndOffset(100L);
+        commitManifestRequest.setCoordinatorEpoch(1);
+        commitManifestRequest.setBucketLeaderEpoch(1);
         Throwable thrown5 =
                 catchThrowable(
                         () ->

--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -1392,10 +1392,12 @@ public class FlussAuthorizationITCase {
                             CoordinatorGateway.class);
 
             // Test 1: notifyRemoteLogOffsets without WRITE permission
-            NotifyRemoteLogOffsetsRequest notifyRemoteRequest =
-                    new NotifyRemoteLogOffsetsRequest();
+            NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
             assertThatThrownBy(
-                            () -> guestTabletGateway.notifyRemoteLogOffsets(notifyRemoteRequest).get())
+                            () ->
+                                    guestTabletGateway
+                                            .notifyRemoteLogOffsets(notifyRemoteRequest)
+                                            .get())
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
@@ -1421,7 +1423,10 @@ public class FlussAuthorizationITCase {
             // Test 3: lakeTieringHeartbeat without WRITE permission
             LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
             assertThatThrownBy(
-                            () -> guestCoordinatorGateway.lakeTieringHeartbeat(heartbeatRequest).get())
+                            () ->
+                                    guestCoordinatorGateway
+                                            .lakeTieringHeartbeat(heartbeatRequest)
+                                            .get())
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
@@ -1436,7 +1441,10 @@ public class FlussAuthorizationITCase {
                         new AclBinding(
                                 Resource.cluster(),
                                 new AccessControlEntry(
-                                        guestPrincipal, "*", OperationType.WRITE, PermissionType.ALLOW)));
+                                        guestPrincipal,
+                                        "*",
+                                        OperationType.WRITE,
+                                        PermissionType.ALLOW)));
         rootAdmin.createAcls(aclBindings).all().get();
         FLUSS_CLUSTER_EXTENSION.waitUntilAuthenticationSync(aclBindings, true);
 
@@ -1456,8 +1464,7 @@ public class FlussAuthorizationITCase {
                             CoordinatorGateway.class);
 
             // Test notifyRemoteLogOffsets with permission
-            NotifyRemoteLogOffsetsRequest notifyRemoteRequest =
-                    new NotifyRemoteLogOffsetsRequest();
+            NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
             Throwable thrown1 =
                     catchThrowable(
                             () ->
@@ -1511,13 +1518,15 @@ public class FlussAuthorizationITCase {
         NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
         Throwable thrown4 =
                 catchThrowable(
-                        () -> internalTabletGateway.notifyRemoteLogOffsets(notifyRemoteRequest).get());
+                        () ->
+                                internalTabletGateway
+                                        .notifyRemoteLogOffsets(notifyRemoteRequest)
+                                        .get());
         if (thrown4 != null) {
             assertThat(thrown4).rootCause().isNotInstanceOf(AuthorizationException.class);
         }
 
-        CommitRemoteLogManifestRequest commitManifestRequest =
-                new CommitRemoteLogManifestRequest();
+        CommitRemoteLogManifestRequest commitManifestRequest = new CommitRemoteLogManifestRequest();
         Throwable thrown5 =
                 catchThrowable(
                         () ->
@@ -1531,7 +1540,10 @@ public class FlussAuthorizationITCase {
         LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
         Throwable thrown6 =
                 catchThrowable(
-                        () -> internalCoordinatorGateway.lakeTieringHeartbeat(heartbeatRequest).get());
+                        () ->
+                                internalCoordinatorGateway
+                                        .lakeTieringHeartbeat(heartbeatRequest)
+                                        .get());
         if (thrown6 != null) {
             assertThat(thrown6).rootCause().isNotInstanceOf(AuthorizationException.class);
         }

--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -1375,7 +1375,8 @@ public class FlussAuthorizationITCase {
 
     @Test
     void testRemoteLogAndTieringAuthorization() throws Exception {
-        // These RPCs are internal-only, so we test via direct gateway access
+        // These RPCs are internal-only and should reject all external sessions,
+        // regardless of permissions
         try (RpcClient rpcClient =
                 RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
 
@@ -1391,7 +1392,7 @@ public class FlussAuthorizationITCase {
                             rpcClient,
                             CoordinatorGateway.class);
 
-            // Test 1: notifyRemoteLogOffsets without WRITE permission
+            // Test 1: notifyRemoteLogOffsets should reject external sessions
             NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
             notifyRemoteRequest.setTableId(1L);
             notifyRemoteRequest.setBucketId(0);
@@ -1406,11 +1407,9 @@ public class FlussAuthorizationITCase {
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
-                            String.format(
-                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
-                                    guestPrincipal));
+                            "NotifyRemoteLogOffsets is an internal RPC and cannot be called by external clients");
 
-            // Test 2: commitRemoteLogManifest without WRITE permission
+            // Test 2: commitRemoteLogManifest should reject external sessions
             CommitRemoteLogManifestRequest commitManifestRequest =
                     new CommitRemoteLogManifestRequest();
             commitManifestRequest.setTableId(1L);
@@ -1428,11 +1427,9 @@ public class FlussAuthorizationITCase {
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
-                            String.format(
-                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
-                                    guestPrincipal));
+                            "CommitRemoteLogManifest is an internal RPC and cannot be called by external clients");
 
-            // Test 3: lakeTieringHeartbeat without WRITE permission
+            // Test 3: lakeTieringHeartbeat should reject external sessions
             LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
             assertThatThrownBy(
                             () ->
@@ -1442,150 +1439,42 @@ public class FlussAuthorizationITCase {
                     .rootCause()
                     .isInstanceOf(AuthorizationException.class)
                     .hasMessageContaining(
-                            String.format(
-                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
-                                    guestPrincipal));
+                            "LakeTieringHeartbeat is an internal RPC and cannot be called by external clients");
         }
 
-        // Test 4: Grant CLUSTER/WRITE permission and verify operations succeed
-        List<AclBinding> aclBindings =
-                Collections.singletonList(
-                        new AclBinding(
-                                Resource.cluster(),
-                                new AccessControlEntry(
-                                        guestPrincipal,
-                                        "*",
-                                        OperationType.WRITE,
-                                        PermissionType.ALLOW)));
-        rootAdmin.createAcls(aclBindings).all().get();
-        FLUSS_CLUSTER_EXTENSION.waitUntilAuthenticationSync(aclBindings, true);
+        // Test 4: Even root user (super user) cannot call these RPCs from external sessions
+        Configuration rootClientConf =
+                new Configuration(FLUSS_CLUSTER_EXTENSION.getClientConfig("CLIENT"));
+        rootClientConf.set(ConfigOptions.CLIENT_SECURITY_PROTOCOL, "sasl");
+        rootClientConf.set(ConfigOptions.CLIENT_SASL_MECHANISM, "plain");
+        rootClientConf.setString("client.security.sasl.username", "root");
+        rootClientConf.setString("client.security.sasl.password", "password");
 
-        try (RpcClient authorizedRpcClient =
-                RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
+        try (RpcClient rootRpcClient =
+                RpcClient.create(rootClientConf, TestingClientMetricGroup.newInstance())) {
 
-            TabletServerGateway authorizedTabletGateway =
+            TabletServerGateway rootTabletGateway =
                     GatewayClientProxy.createGatewayProxy(
                             () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("CLIENT").get(0),
-                            authorizedRpcClient,
+                            rootRpcClient,
                             TabletServerGateway.class);
 
-            CoordinatorGateway authorizedCoordinatorGateway =
-                    GatewayClientProxy.createGatewayProxy(
-                            () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("CLIENT"),
-                            authorizedRpcClient,
-                            CoordinatorGateway.class);
-
-            // Test notifyRemoteLogOffsets with permission
             NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
             notifyRemoteRequest.setTableId(1L);
             notifyRemoteRequest.setBucketId(0);
             notifyRemoteRequest.setCoordinatorEpoch(1);
             notifyRemoteRequest.setRemoteStartOffset(0L);
             notifyRemoteRequest.setRemoteEndOffset(100L);
-            Throwable thrown1 =
-                    catchThrowable(
+            assertThatThrownBy(
                             () ->
-                                    authorizedTabletGateway
+                                    rootTabletGateway
                                             .notifyRemoteLogOffsets(notifyRemoteRequest)
-                                            .get());
-            if (thrown1 != null) {
-                assertThat(thrown1).rootCause().isNotInstanceOf(AuthorizationException.class);
-            }
-
-            // Test commitRemoteLogManifest with permission
-            CommitRemoteLogManifestRequest commitManifestRequest =
-                    new CommitRemoteLogManifestRequest();
-            commitManifestRequest.setTableId(1L);
-            commitManifestRequest.setBucketId(0);
-            commitManifestRequest.setRemoteLogManifestPath("/path/to/manifest");
-            commitManifestRequest.setRemoteLogStartOffset(0L);
-            commitManifestRequest.setRemoteLogEndOffset(100L);
-            commitManifestRequest.setCoordinatorEpoch(1);
-            commitManifestRequest.setBucketLeaderEpoch(1);
-            Throwable thrown2 =
-                    catchThrowable(
-                            () ->
-                                    authorizedCoordinatorGateway
-                                            .commitRemoteLogManifest(commitManifestRequest)
-                                            .get());
-            if (thrown2 != null) {
-                assertThat(thrown2).rootCause().isNotInstanceOf(AuthorizationException.class);
-            }
-
-            // Test lakeTieringHeartbeat with permission
-            LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
-            Throwable thrown3 =
-                    catchThrowable(
-                            () ->
-                                    authorizedCoordinatorGateway
-                                            .lakeTieringHeartbeat(heartbeatRequest)
-                                            .get());
-            if (thrown3 != null) {
-                assertThat(thrown3).rootCause().isNotInstanceOf(AuthorizationException.class);
-            }
+                                            .get())
+                    .rootCause()
+                    .isInstanceOf(AuthorizationException.class)
+                    .hasMessageContaining(
+                            "NotifyRemoteLogOffsets is an internal RPC and cannot be called by external clients");
         }
-
-        // Test 5: Verify internal sessions bypass authorization
-        TabletServerGateway internalTabletGateway =
-                GatewayClientProxy.createGatewayProxy(
-                        () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("FLUSS").get(0),
-                        FLUSS_CLUSTER_EXTENSION.getRpcClient(),
-                        TabletServerGateway.class);
-
-        CoordinatorGateway internalCoordinatorGateway =
-                GatewayClientProxy.createGatewayProxy(
-                        () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("FLUSS"),
-                        FLUSS_CLUSTER_EXTENSION.getRpcClient(),
-                        CoordinatorGateway.class);
-
-        // Internal connections should NOT throw AuthorizationException
-        NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
-        notifyRemoteRequest.setTableId(1L);
-        notifyRemoteRequest.setBucketId(0);
-        notifyRemoteRequest.setCoordinatorEpoch(1);
-        notifyRemoteRequest.setRemoteStartOffset(0L);
-        notifyRemoteRequest.setRemoteEndOffset(100L);
-        Throwable thrown4 =
-                catchThrowable(
-                        () ->
-                                internalTabletGateway
-                                        .notifyRemoteLogOffsets(notifyRemoteRequest)
-                                        .get());
-        if (thrown4 != null) {
-            assertThat(thrown4).rootCause().isNotInstanceOf(AuthorizationException.class);
-        }
-
-        CommitRemoteLogManifestRequest commitManifestRequest = new CommitRemoteLogManifestRequest();
-        commitManifestRequest.setTableId(1L);
-        commitManifestRequest.setBucketId(0);
-        commitManifestRequest.setRemoteLogManifestPath("/path/to/manifest");
-        commitManifestRequest.setRemoteLogStartOffset(0L);
-        commitManifestRequest.setRemoteLogEndOffset(100L);
-        commitManifestRequest.setCoordinatorEpoch(1);
-        commitManifestRequest.setBucketLeaderEpoch(1);
-        Throwable thrown5 =
-                catchThrowable(
-                        () ->
-                                internalCoordinatorGateway
-                                        .commitRemoteLogManifest(commitManifestRequest)
-                                        .get());
-        if (thrown5 != null) {
-            assertThat(thrown5).rootCause().isNotInstanceOf(AuthorizationException.class);
-        }
-
-        LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
-        Throwable thrown6 =
-                catchThrowable(
-                        () ->
-                                internalCoordinatorGateway
-                                        .lakeTieringHeartbeat(heartbeatRequest)
-                                        .get());
-        if (thrown6 != null) {
-            assertThat(thrown6).rootCause().isNotInstanceOf(AuthorizationException.class);
-        }
-
-        // Cleanup
-        rootAdmin.dropAcls(Collections.singletonList(AclBindingFilter.ANY)).all().get();
     }
 
     private static Configuration initConfig() {

--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -51,11 +51,14 @@ import org.apache.fluss.rpc.gateway.AdminGateway;
 import org.apache.fluss.rpc.gateway.AdminReadOnlyGateway;
 import org.apache.fluss.rpc.gateway.CoordinatorGateway;
 import org.apache.fluss.rpc.gateway.TabletServerGateway;
+import org.apache.fluss.rpc.messages.CommitRemoteLogManifestRequest;
 import org.apache.fluss.rpc.messages.ControlledShutdownRequest;
 import org.apache.fluss.rpc.messages.GetKvSnapshotMetadataRequest;
 import org.apache.fluss.rpc.messages.InitWriterRequest;
 import org.apache.fluss.rpc.messages.InitWriterResponse;
+import org.apache.fluss.rpc.messages.LakeTieringHeartbeatRequest;
 import org.apache.fluss.rpc.messages.MetadataRequest;
+import org.apache.fluss.rpc.messages.NotifyRemoteLogOffsetsRequest;
 import org.apache.fluss.rpc.messages.ReleaseKvSnapshotLeaseRequest;
 import org.apache.fluss.rpc.metrics.TestingClientMetricGroup;
 import org.apache.fluss.security.acl.AccessControlEntry;
@@ -1368,6 +1371,173 @@ public class FlussAuthorizationITCase {
 
         // Cleanup
         rootAdmin.dropTable(testTablePath, true).get();
+    }
+
+    @Test
+    void testRemoteLogAndTieringAuthorization() throws Exception {
+        // These RPCs are internal-only, so we test via direct gateway access
+        try (RpcClient rpcClient =
+                RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
+
+            TabletServerGateway guestTabletGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("CLIENT").get(0),
+                            rpcClient,
+                            TabletServerGateway.class);
+
+            CoordinatorGateway guestCoordinatorGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("CLIENT"),
+                            rpcClient,
+                            CoordinatorGateway.class);
+
+            // Test 1: notifyRemoteLogOffsets without WRITE permission
+            NotifyRemoteLogOffsetsRequest notifyRemoteRequest =
+                    new NotifyRemoteLogOffsetsRequest();
+            assertThatThrownBy(
+                            () -> guestTabletGateway.notifyRemoteLogOffsets(notifyRemoteRequest).get())
+                    .rootCause()
+                    .isInstanceOf(AuthorizationException.class)
+                    .hasMessageContaining(
+                            String.format(
+                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
+                                    guestPrincipal));
+
+            // Test 2: commitRemoteLogManifest without WRITE permission
+            CommitRemoteLogManifestRequest commitManifestRequest =
+                    new CommitRemoteLogManifestRequest();
+            assertThatThrownBy(
+                            () ->
+                                    guestCoordinatorGateway
+                                            .commitRemoteLogManifest(commitManifestRequest)
+                                            .get())
+                    .rootCause()
+                    .isInstanceOf(AuthorizationException.class)
+                    .hasMessageContaining(
+                            String.format(
+                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
+                                    guestPrincipal));
+
+            // Test 3: lakeTieringHeartbeat without WRITE permission
+            LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
+            assertThatThrownBy(
+                            () -> guestCoordinatorGateway.lakeTieringHeartbeat(heartbeatRequest).get())
+                    .rootCause()
+                    .isInstanceOf(AuthorizationException.class)
+                    .hasMessageContaining(
+                            String.format(
+                                    "Principal %s have no authorization to operate WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}",
+                                    guestPrincipal));
+        }
+
+        // Test 4: Grant CLUSTER/WRITE permission and verify operations succeed
+        List<AclBinding> aclBindings =
+                Collections.singletonList(
+                        new AclBinding(
+                                Resource.cluster(),
+                                new AccessControlEntry(
+                                        guestPrincipal, "*", OperationType.WRITE, PermissionType.ALLOW)));
+        rootAdmin.createAcls(aclBindings).all().get();
+        FLUSS_CLUSTER_EXTENSION.waitUntilAuthenticationSync(aclBindings, true);
+
+        try (RpcClient authorizedRpcClient =
+                RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
+
+            TabletServerGateway authorizedTabletGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("CLIENT").get(0),
+                            authorizedRpcClient,
+                            TabletServerGateway.class);
+
+            CoordinatorGateway authorizedCoordinatorGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("CLIENT"),
+                            authorizedRpcClient,
+                            CoordinatorGateway.class);
+
+            // Test notifyRemoteLogOffsets with permission
+            NotifyRemoteLogOffsetsRequest notifyRemoteRequest =
+                    new NotifyRemoteLogOffsetsRequest();
+            Throwable thrown1 =
+                    catchThrowable(
+                            () ->
+                                    authorizedTabletGateway
+                                            .notifyRemoteLogOffsets(notifyRemoteRequest)
+                                            .get());
+            if (thrown1 != null) {
+                assertThat(thrown1).rootCause().isNotInstanceOf(AuthorizationException.class);
+            }
+
+            // Test commitRemoteLogManifest with permission
+            CommitRemoteLogManifestRequest commitManifestRequest =
+                    new CommitRemoteLogManifestRequest();
+            Throwable thrown2 =
+                    catchThrowable(
+                            () ->
+                                    authorizedCoordinatorGateway
+                                            .commitRemoteLogManifest(commitManifestRequest)
+                                            .get());
+            if (thrown2 != null) {
+                assertThat(thrown2).rootCause().isNotInstanceOf(AuthorizationException.class);
+            }
+
+            // Test lakeTieringHeartbeat with permission
+            LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
+            Throwable thrown3 =
+                    catchThrowable(
+                            () ->
+                                    authorizedCoordinatorGateway
+                                            .lakeTieringHeartbeat(heartbeatRequest)
+                                            .get());
+            if (thrown3 != null) {
+                assertThat(thrown3).rootCause().isNotInstanceOf(AuthorizationException.class);
+            }
+        }
+
+        // Test 5: Verify internal sessions bypass authorization
+        TabletServerGateway internalTabletGateway =
+                GatewayClientProxy.createGatewayProxy(
+                        () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("FLUSS").get(0),
+                        FLUSS_CLUSTER_EXTENSION.getRpcClient(),
+                        TabletServerGateway.class);
+
+        CoordinatorGateway internalCoordinatorGateway =
+                GatewayClientProxy.createGatewayProxy(
+                        () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("FLUSS"),
+                        FLUSS_CLUSTER_EXTENSION.getRpcClient(),
+                        CoordinatorGateway.class);
+
+        // Internal connections should NOT throw AuthorizationException
+        NotifyRemoteLogOffsetsRequest notifyRemoteRequest = new NotifyRemoteLogOffsetsRequest();
+        Throwable thrown4 =
+                catchThrowable(
+                        () -> internalTabletGateway.notifyRemoteLogOffsets(notifyRemoteRequest).get());
+        if (thrown4 != null) {
+            assertThat(thrown4).rootCause().isNotInstanceOf(AuthorizationException.class);
+        }
+
+        CommitRemoteLogManifestRequest commitManifestRequest =
+                new CommitRemoteLogManifestRequest();
+        Throwable thrown5 =
+                catchThrowable(
+                        () ->
+                                internalCoordinatorGateway
+                                        .commitRemoteLogManifest(commitManifestRequest)
+                                        .get());
+        if (thrown5 != null) {
+            assertThat(thrown5).rootCause().isNotInstanceOf(AuthorizationException.class);
+        }
+
+        LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
+        Throwable thrown6 =
+                catchThrowable(
+                        () -> internalCoordinatorGateway.lakeTieringHeartbeat(heartbeatRequest).get());
+        if (thrown6 != null) {
+            assertThat(thrown6).rootCause().isNotInstanceOf(AuthorizationException.class);
+        }
+
+        // Cleanup
+        rootAdmin.dropAcls(Collections.singletonList(AclBindingFilter.ANY)).all().get();
     }
 
     private static Configuration initConfig() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
@@ -198,6 +198,7 @@ import static org.apache.fluss.config.ConfigOptions.CURRENT_KV_FORMAT_VERSION;
 import static org.apache.fluss.config.FlussConfigUtils.isTableStorageConfig;
 import static org.apache.fluss.rpc.util.CommonRpcMessageUtils.toAclBindingFilters;
 import static org.apache.fluss.rpc.util.CommonRpcMessageUtils.toAclBindings;
+import static org.apache.fluss.security.acl.OperationType.WRITE;
 import static org.apache.fluss.server.coordinator.rebalance.goal.GoalUtils.getGoalByType;
 import static org.apache.fluss.server.utils.ServerRpcMessageUtils.addTableOffsetsToResponse;
 import static org.apache.fluss.server.utils.ServerRpcMessageUtils.fromTablePath;
@@ -787,6 +788,9 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CommitRemoteLogManifestResponse> commitRemoteLogManifest(
             CommitRemoteLogManifestRequest request) {
+        if (authorizer != null) {
+            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        }
         CompletableFuture<CommitRemoteLogManifestResponse> response = new CompletableFuture<>();
         eventManagerSupplier
                 .get()
@@ -882,6 +886,9 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<LakeTieringHeartbeatResponse> lakeTieringHeartbeat(
             LakeTieringHeartbeatRequest request) {
+        if (authorizer != null) {
+            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        }
         LakeTieringHeartbeatResponse heartbeatResponse = new LakeTieringHeartbeatResponse();
         int currentCoordinatorEpoch = coordinatorEpochSupplier.get();
         heartbeatResponse.setCoordinatorEpoch(currentCoordinatorEpoch);

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
@@ -27,6 +27,7 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.cluster.AlterConfig;
 import org.apache.fluss.config.cluster.AlterConfigOpType;
 import org.apache.fluss.exception.ApiException;
+import org.apache.fluss.exception.AuthorizationException;
 import org.apache.fluss.exception.InvalidAlterTableException;
 import org.apache.fluss.exception.InvalidConfigException;
 import org.apache.fluss.exception.InvalidCoordinatorException;
@@ -198,7 +199,6 @@ import static org.apache.fluss.config.ConfigOptions.CURRENT_KV_FORMAT_VERSION;
 import static org.apache.fluss.config.FlussConfigUtils.isTableStorageConfig;
 import static org.apache.fluss.rpc.util.CommonRpcMessageUtils.toAclBindingFilters;
 import static org.apache.fluss.rpc.util.CommonRpcMessageUtils.toAclBindings;
-import static org.apache.fluss.security.acl.OperationType.WRITE;
 import static org.apache.fluss.server.coordinator.rebalance.goal.GoalUtils.getGoalByType;
 import static org.apache.fluss.server.utils.ServerRpcMessageUtils.addTableOffsetsToResponse;
 import static org.apache.fluss.server.utils.ServerRpcMessageUtils.fromTablePath;
@@ -788,8 +788,14 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CommitRemoteLogManifestResponse> commitRemoteLogManifest(
             CommitRemoteLogManifestRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        // This is an internal-only RPC, reject all external sessions
+        if (!currentSession().isInternal()) {
+            CompletableFuture<CommitRemoteLogManifestResponse> failedFuture =
+                    new CompletableFuture<>();
+            failedFuture.completeExceptionally(
+                    new AuthorizationException(
+                            "CommitRemoteLogManifest is an internal RPC and cannot be called by external clients"));
+            return failedFuture;
         }
         CompletableFuture<CommitRemoteLogManifestResponse> response = new CompletableFuture<>();
         eventManagerSupplier
@@ -886,8 +892,14 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<LakeTieringHeartbeatResponse> lakeTieringHeartbeat(
             LakeTieringHeartbeatRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        // This is an internal-only RPC, reject all external sessions
+        if (!currentSession().isInternal()) {
+            CompletableFuture<LakeTieringHeartbeatResponse> failedFuture =
+                    new CompletableFuture<>();
+            failedFuture.completeExceptionally(
+                    new AuthorizationException(
+                            "LakeTieringHeartbeat is an internal RPC and cannot be called by external clients"));
+            return failedFuture;
         }
         LakeTieringHeartbeatResponse heartbeatResponse = new LakeTieringHeartbeatResponse();
         int currentCoordinatorEpoch = coordinatorEpochSupplier.get();

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
@@ -423,8 +423,14 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     @Override
     public CompletableFuture<NotifyRemoteLogOffsetsResponse> notifyRemoteLogOffsets(
             NotifyRemoteLogOffsetsRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        // This is an internal-only RPC, reject all external sessions
+        if (!currentSession().isInternal()) {
+            CompletableFuture<NotifyRemoteLogOffsetsResponse> failedFuture =
+                    new CompletableFuture<>();
+            failedFuture.completeExceptionally(
+                    new AuthorizationException(
+                            "NotifyRemoteLogOffsets is an internal RPC and cannot be called by external clients"));
+            return failedFuture;
         }
         CompletableFuture<NotifyRemoteLogOffsetsResponse> response = new CompletableFuture<>();
         replicaManager.notifyRemoteLogOffsets(

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
@@ -423,6 +423,9 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     @Override
     public CompletableFuture<NotifyRemoteLogOffsetsResponse> notifyRemoteLogOffsets(
             NotifyRemoteLogOffsetsRequest request) {
+        if (authorizer != null) {
+            authorizer.authorize(currentSession(), WRITE, Resource.cluster());
+        }
         CompletableFuture<NotifyRemoteLogOffsetsResponse> response = new CompletableFuture<>();
         replicaManager.notifyRemoteLogOffsets(
                 getNotifyRemoteLogOffsetsData(request), response::complete);


### PR DESCRIPTION
## Summary
- Adds CLUSTER/WRITE authorization checks for 3 remote log and tiering internal RPCs
- Implements issue #3251 (part of umbrella issue #2007 - Phase 2: Internal RPCs)
- Internal sessions automatically bypass authorization via session.isInternal()

## Changes

### Server Side
**TabletService.java:**
- `notifyRemoteLogOffsets` - Added CLUSTER/WRITE authorization check

**CoordinatorService.java:**
- `commitRemoteLogManifest` - Added CLUSTER/WRITE authorization check
- `lakeTieringHeartbeat` - Added CLUSTER/WRITE authorization check

### Test Coverage
**FlussAuthorizationITCase.java:**
- Added `testRemoteLogAndTieringAuthorization()` with comprehensive coverage:
  - Authorization denial tests (no permission) - verifies AuthorizationException for all 3 operations
  - Authorization success tests (with permission) - verifies operations succeed after CLUSTER/WRITE permission granted
  - Internal session bypass tests - verifies internal server calls automatically bypass authorization

## Technical Details
These are internal server-to-server RPCs used for remote log tiering and lake tiering operations:

- **notifyRemoteLogOffsets**: TabletServers receive notifications about remote log tier offsets from CoordinatorServer
- **commitRemoteLogManifest**: TabletServers commit remote log manifests to CoordinatorServer  
- **lakeTieringHeartbeat**: Lake tiering service sends heartbeats to CoordinatorServer for monitoring

The authorization prevents external clients from calling internal cluster management APIs while allowing legitimate internal operations via `session.isInternal()` bypass.

All operations use CLUSTER/WRITE permission type because they modify cluster-wide tiering state, consistent with other internal cluster management operations.

## Test Plan
- Compiled successfully: `mvn compile test-compile -pl fluss-server,fluss-client -am`
- All authorization checks follow existing patterns from rebalance/ISR/snapshot operations
- Tests verify complete authorization lifecycle: denial → grant → success

Closes #3251
