### PR TITLE
[Bug] Avoid altering lake catalog for tables that never enabled datalake

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
@@ -603,8 +603,12 @@ public class MetadataManager {
         // We should always alter lake table even though datalake is disabled.
         // Otherwise, if user alter the fluss table when datalake is disabled, then enable datalake
         // again, the lake table will mismatch.
-        // Only sync to lake if this table has ever opted into datalake (key present regardless of value).
-        if (lakeCatalog != null && tableDescriptor.getProperties().containsKey(ConfigOptions.TABLE_DATALAKE_ENABLED.key())) {
+        // Only sync to lake if this table has ever opted into datalake (key present regardless of
+        // value).
+        if (lakeCatalog != null
+                && tableDescriptor
+                        .getProperties()
+                        .containsKey(ConfigOptions.TABLE_DATALAKE_ENABLED.key())) {
             try {
                 lakeCatalog.alterTable(tablePath, tableChanges, lakeCatalogContext);
             } catch (TableNotExistException e) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
@@ -603,7 +603,7 @@ public class MetadataManager {
         // We should always alter lake table even though datalake is disabled.
         // Otherwise, if user alter the fluss table when datalake is disabled, then enable datalake
         // again, the lake table will mismatch.
-        if (lakeCatalog != null) {
+        if (lakeCatalog != null && tableDescriptor.getProperties().containsKey(ConfigOptions.TABLE_DATALAKE_ENABLED.key())) {
             try {
                 lakeCatalog.alterTable(tablePath, tableChanges, lakeCatalogContext);
             } catch (TableNotExistException e) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
@@ -603,6 +603,7 @@ public class MetadataManager {
         // We should always alter lake table even though datalake is disabled.
         // Otherwise, if user alter the fluss table when datalake is disabled, then enable datalake
         // again, the lake table will mismatch.
+        // Only sync to lake if this table has ever opted into datalake (key present regardless of value).
         if (lakeCatalog != null && tableDescriptor.getProperties().containsKey(ConfigOptions.TABLE_DATALAKE_ENABLED.key())) {
             try {
                 lakeCatalog.alterTable(tablePath, tableChanges, lakeCatalogContext);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose
Linked issue: close #3297

The `preAlterTableProperties` method was calling `lakeCatalog.alterTable()` 
for every table alter operation whenever a lake catalog was configured at the 
cluster level, even for plain Fluss tables that never had `table.datalake.enabled` 
set. This resulted in unnecessary calls to the lake catalog, which would throw 
`TableNotExistException` (silently swallowed) for tables unknown to the lake catalog.

### Brief change log
- In `MetadataManager#preAlterTableProperties`, tightened the guard condition 
  from `if (lakeCatalog != null)` to also check that the current table descriptor 
  contains the `table.datalake.enabled` key (regardless of its value).
- This ensures `lakeCatalog.alterTable()` is only called for tables that have 
  ever opted into datalake, while preserving the existing sync behavior for 
  tables that were previously lake-enabled and later disabled.

### Tests
- No Tests required

### API and Format
No API or storage format changes. This is a behavioral fix in the coordinator's 
metadata management logic only.

### Documentation
No new feature introduced. No documentation changes required.