### PR TITLE
[test] Fix flaky FlussAdminITCase.testDynamicConfigs

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
@@ -1519,6 +1519,23 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
 
         waitUntil(
                 () -> {
+                    // First, verify that cluster configs have been updated
+                    Collection<ConfigEntry> configEntries = admin.describeClusterConfigs().get();
+                    Map<String, String> clusterConfigs =
+                            configEntries.stream()
+                                    .collect(
+                                            Collectors.toMap(ConfigEntry::key, ConfigEntry::value));
+                    return clusterConfigs.containsKey(DATALAKE_FORMAT.key())
+                            && PAIMON.toString().equals(clusterConfigs.get(DATALAKE_FORMAT.key()))
+                            && clusterConfigs.containsKey("datalake.paimon.warehouse")
+                            && "test-warehouse"
+                                    .equals(clusterConfigs.get("datalake.paimon.warehouse"));
+                },
+                Duration.ofMinutes(1),
+                "Cluster configs should be updated with datalake properties");
+
+        waitUntil(
+                () -> {
                     TableInfo tableInfo = admin.getTableInfo(tablePath).get();
                     Map<String, String> tableProperties = tableInfo.getProperties().toMap();
                     return tableProperties.containsKey(TABLE_DATALAKE_FORMAT.key())


### PR DESCRIPTION

### Purpose

Linked issue: close #3127

### Brief change log

- Modify `FlussAdminITCase.testDynamicConfigs` test method
- Add a verify step that first checks cluster config has been updated before checking table info
- Use `describeClusterConfigs` to confirm cluster config is updated first, then verify table info reflects latest config
- Avoid the race condition where `LakeCatalogDynamicLoader` hasn't finished reconfiguring when table info is queried

### Tests

- `FlussAdminITCase#testDynamicConfigs` test passed and runs stably
- Run multiple times to verify test stability

./mvnw -pl fluss-client -Dtest='FlussAdminITCase#testDynamicConfigs' -DfailIfNoTests=false test

### API and Format


### Documentation

