### PR TITLE
[server] Fix flaky RebalanceManagerITCase.testBuildClusterModel

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/RebalanceManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/RebalanceManager.java
@@ -362,7 +362,11 @@ public class RebalanceManager {
             List<Integer> assignment = coordinatorContext.getAssignment(tableBucket);
             Optional<LeaderAndIsr> bucketLeaderAndIsrOpt =
                     coordinatorContext.getBucketLeaderAndIsr(tableBucket);
-            checkArgument(bucketLeaderAndIsrOpt.isPresent(), "Bucket leader and isr is empty.");
+            // Skip the bucket if leader and ISR information is not available yet
+            // This can happen during table creation when leader election is not completed
+            if (!bucketLeaderAndIsrOpt.isPresent()) {
+                continue;
+            }
             LeaderAndIsr isr = bucketLeaderAndIsrOpt.get();
             int leader = isr.leader();
             // Skip the bucket if it is in a transient state (e.g., during table creation)


### PR DESCRIPTION

### Purpose

Linked issue: close #3063 

### Brief change log

- Modified `RebalanceManager.buildClusterModel()` method to gracefully handle buckets without LeaderAndIsr information
- Replaced the strict `checkArgument` with a conditional `continue` statement
- Added explanatory comments about the transient state handling

This change addresses the race condition that occurs during table creation when leader election is not yet completed. The fix allows the rebalance manager to skip buckets in transient states rather than failing the entire operation.


### Tests

./mvnw -pl fluss-server \\
  -Dtest='RebalanceManagerITCase#testBuildClusterModel' \\
  -DfailIfNoTests=false \\
  test

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
