### PR TITLE
[client] Fix inverted awaitTermination condition in LookupClient#close

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/lookup/LookupClient.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/lookup/LookupClient.java
@@ -122,7 +122,7 @@ public class LookupClient {
         if (lookupSenderThreadPool != null) {
             lookupSenderThreadPool.shutdown();
             try {
-                if (lookupSenderThreadPool.awaitTermination(
+                if (!lookupSenderThreadPool.awaitTermination(
                         timeout.toMillis(), TimeUnit.MILLISECONDS)) {
                     lookupSenderThreadPool.shutdownNow();
 


### PR DESCRIPTION
The shutdown logic in `LookupClient#close()` had the awaitTermination condition inverted - it called `shutdownNow()` when the thread pool had already terminated gracefully, and did nothing when it timed out.

This is inconsistent with `WriterClient#close()` and all other shutdown patterns in the codebase which correctly negate `awaitTermination()` to trigger shutdownNow() on timeout.

The bug could cause the lookup sender thread pool to not be forcefully terminated when graceful shutdown times out, potentially leading to resource leaks.

## Purpose

Fix a logic bug in `LookupClient#close()` where a missing `!` operator caused inverted shutdown behavior for the lookup sender thread pool.

## Brief change log

- Fixed the inverted `awaitTermination()` condition in `LookupClient#close()` by adding the missing `!` negation operator, making it consistent with `WriterClient#close()` and the standard `ExecutorService` shutdown pattern documented in the [Java SE docs](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ExecutorService.html).

## Tests

- No new tests needed. This is a one-character fix (`!`) to an existing condition.
- The correct pattern is already validated by the existing shutdown behavior in `WriterClient#close()` and `RemoteLogManager#shutdownAndAwaitTermination()`.

## API and Format

- No API or format changes.

## Documentation

- No documentation changes needed.
