### PR TITLE
[server] Preserve exception cause when rethrowing exceptions in RpcServiceBase

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/exception/KvSnapshotNotExistException.java
+++ b/fluss-common/src/main/java/org/apache/fluss/exception/KvSnapshotNotExistException.java
@@ -32,4 +32,8 @@ public class KvSnapshotNotExistException extends ApiException {
     public KvSnapshotNotExistException(String message) {
         super(message);
     }
+
+    public KvSnapshotNotExistException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/RpcServiceBase.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/RpcServiceBase.java
@@ -444,7 +444,8 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
             throw new KvSnapshotNotExistException(
                     String.format(
                             "Failed to get kv snapshot metadata for table bucket %s and snapshot id %s. Error: %s",
-                            tableBucket, snapshotId, e.getMessage()));
+                            tableBucket, snapshotId, e.getMessage()),
+                    e);
         }
     }
 
@@ -466,7 +467,7 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
                             remoteFileSystem.getUri().getScheme(), securityToken));
         } catch (Exception e) {
             throw new SecurityTokenException(
-                    "Failed to get file access security token: " + e.getMessage());
+                    "Failed to get file access security token: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
The catch blocks in `getKvSnapshotMetadata()` and `getFileSystemSecurityToken()` were discarding the original exception cause, making it very difficult to diagnose root causes in production.

Changes:
- Pass the caught exception as the cause parameter to `SecurityTokenException` (which already supports it)
- Add a `(String, Throwable)` constructor to `KvSnapshotNotExistException` and pass the caught exception as the cause

This is consistent with all other exception re-throwing patterns in the codebase (e.g., `CoordinatorService`, `HadoopConfSerde`, `PaimonLakeCatalog`) which always preserve the original exception chain.

## Purpose

Preserve exception cause for better debuggability in production. Same pattern as #3281 but for `RpcServiceBase`.

## Brief change log

- Added `(String, Throwable)` constructor to `KvSnapshotNotExistException`
- Passed original exception as cause in `RpcServiceBase#getKvSnapshotMetadata()`
- Passed original exception as cause in `RpcServiceBase#getFileSystemSecurityToken()`

## Tests

- No new tests needed. This change only preserves additional exception information that was previously discarded. Existing tests continue to pass.

## API and Format

- Added a new public constructor to `KvSnapshotNotExistException`. This is a backwards-compatible addition.

## Documentation

- No documentation changes needed.
