### PR TITLE
[client] Cache synchronously fetched schemas

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/metadata/ClientSchemaGetter.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/metadata/ClientSchemaGetter.java
@@ -67,6 +67,7 @@ public class ClientSchemaGetter implements SchemaGetter {
             try {
                 SchemaInfo schemaInfo =
                         admin.getTableSchema(tablePath, schemaId).get(1, TimeUnit.MINUTES);
+                schemasById.put(schemaId, schemaInfo.getSchema());
                 if (schemaId > latestSchemaInfo.getSchemaId()) {
                     latestSchemaInfo = schemaInfo;
                 }

--- a/fluss-client/src/test/java/org/apache/fluss/client/metadata/ClientSchemaGetterTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/metadata/ClientSchemaGetterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.client.metadata;
+
+import org.apache.fluss.client.admin.Admin;
+import org.apache.fluss.metadata.Schema;
+import org.apache.fluss.metadata.SchemaInfo;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link ClientSchemaGetter}. */
+class ClientSchemaGetterTest {
+
+    @Test
+    void testGetSchemaCachesSynchronouslyFetchedSchema() {
+        TablePath tablePath = TablePath.of("db", "table");
+        SchemaInfo initialSchemaInfo = new SchemaInfo(schema("id"), 1);
+        SchemaInfo fetchedSchemaInfo = new SchemaInfo(schema("id", "name"), 2);
+        Map<Integer, SchemaInfo> schemasById = new HashMap<>();
+        schemasById.put(fetchedSchemaInfo.getSchemaId(), fetchedSchemaInfo);
+        AtomicInteger fetchCount = new AtomicInteger();
+        Admin admin = adminWithSchemas(schemasById, fetchCount);
+        ClientSchemaGetter schemaGetter =
+                new ClientSchemaGetter(tablePath, initialSchemaInfo, admin);
+
+        assertThat(schemaGetter.getSchema(fetchedSchemaInfo.getSchemaId()))
+                .isEqualTo(fetchedSchemaInfo.getSchema());
+        assertThat(schemaGetter.getSchema(fetchedSchemaInfo.getSchemaId()))
+                .isEqualTo(fetchedSchemaInfo.getSchema());
+
+        assertThat(fetchCount.get()).isEqualTo(1);
+        assertThat(schemaGetter.getLatestSchemaInfo()).isEqualTo(fetchedSchemaInfo);
+    }
+
+    private static Schema schema(String... fields) {
+        Schema.Builder builder = Schema.newBuilder();
+        for (String field : fields) {
+            builder.column(field, DataTypes.STRING());
+        }
+        return builder.build();
+    }
+
+    private static Admin adminWithSchemas(
+            Map<Integer, SchemaInfo> schemasById, AtomicInteger fetchCount) {
+        InvocationHandler invocationHandler =
+                new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object proxy, Method method, Object[] args) {
+                        if ("getTableSchema".equals(method.getName())
+                                && args != null
+                                && args.length == 2) {
+                            fetchCount.incrementAndGet();
+                            return CompletableFuture.completedFuture(schemasById.get(args[1]));
+                        } else if ("close".equals(method.getName())) {
+                            return null;
+                        } else if ("toString".equals(method.getName())) {
+                            return "TestingAdmin";
+                        }
+                        throw new UnsupportedOperationException(method.getName());
+                    }
+                };
+        return (Admin)
+                Proxy.newProxyInstance(
+                        Admin.class.getClassLoader(),
+                        new Class<?>[] {Admin.class},
+                        invocationHandler);
+    }
+}


### PR DESCRIPTION
### Purpose

Linked issue: close #3336

`ClientSchemaGetter#getSchema` already looked up missing schema IDs through `Admin#getTableSchema`, but the synchronously fetched schema was not stored in the local `schemasById` cache. As a result, repeated lookups for the same schema ID could issue repeated admin requests.

This PR caches schemas fetched through the synchronous fallback path. It also adds a focused unit test that verifies the first lookup fetches the schema, the second lookup reuses the cache, and the latest schema metadata is advanced when the fetched schema is newer.

### Brief change log

- Store synchronously fetched schemas in `ClientSchemaGetter`'s local schema cache.
- Add `ClientSchemaGetterTest` covering cache reuse and latest-schema update behavior.

### Why this is better

Repeated `getSchema(schemaId)` calls for a schema that was initially missing from the client cache no longer need to call `Admin#getTableSchema` every time. This reduces unnecessary metadata calls while preserving the existing latest-schema update behavior.

### Tests

- `env PATH=/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin ./mvnw -pl fluss-client -am -Dtest=ClientSchemaGetterTest -DfailIfNoTests=false test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 11) ./mvnw clean verify` was attempted locally with Java 11.0.31. It failed in unrelated `fluss-server` integration test `TableManagerITCase.testPartitionedTableManagement`, where the expected date partition key was `20260518` but the actual key was `20260517`. The failure is in server coordinator date partition handling and does not overlap with this client schema cache change.

### API and Format

No public API or storage format changes.

### Documentation

No documentation changes; this is an internal client metadata cache behavior fix.

### Generative AI disclosure

Yes. This PR was authored with assistance from OpenAI Codex and reviewed by the human contributor before submission.

Generated-by: OpenAI Codex following https://github.com/apache/fluss/blob/main/AGENTS.md