### PR TITLE
[flink] Preserve log-only source restore mode

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkSource.java
@@ -52,6 +52,9 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
+import java.util.List;
+
 import static org.apache.fluss.config.ConfigOptions.CLIENT_SCANNER_IO_TMP_DIR;
 import static org.apache.fluss.flink.utils.FlinkConnectorOptionsUtils.getClientScannerIoTmpDir;
 
@@ -236,6 +239,14 @@ public class FlinkSource<OUT>
     public SplitEnumerator<SourceSplitBase, SourceEnumeratorState> restoreEnumerator(
             SplitEnumeratorContext<SourceSplitBase> splitEnumeratorContext,
             SourceEnumeratorState sourceEnumeratorState) {
+        List<SourceSplitBase> remainingHybridLakeFlussSplits =
+                sourceEnumeratorState.getRemainingHybridLakeFlussSplits();
+        // A fresh null means lake splits are not initialized yet. When restoring, null means
+        // nothing is pending, so normalize it here to avoid generating lake splits later.
+        if (remainingHybridLakeFlussSplits == null) {
+            remainingHybridLakeFlussSplits = Collections.emptyList();
+        }
+
         return new FlinkSourceEnumerator(
                 tablePath,
                 flussConf,
@@ -244,7 +255,7 @@ public class FlinkSource<OUT>
                 splitEnumeratorContext,
                 sourceEnumeratorState.getAssignedBuckets(),
                 sourceEnumeratorState.getAssignedPartitions(),
-                sourceEnumeratorState.getRemainingHybridLakeFlussSplits(),
+                remainingHybridLakeFlussSplits,
                 offsetsInitializer,
                 scanPartitionDiscoveryIntervalMs,
                 splitPerAssignmentBatchSize,

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -526,9 +526,8 @@ public class FlinkSourceEnumerator
     private void startInStreamModeForNonPartitionedTable() {
         if (lakeSource != null) {
             // Generate lake splits synchronously so that they are available before the
-            // first checkpoint.  This is consistent with the partitioned-table path in
-            // start() and ensures generateHybridLakeFlussSplits() can safely use
-            // checkpointTriggeredBefore to distinguish fresh starts from restores.
+            // first checkpoint. This is consistent with the partitioned-table path in
+            // start().
             List<SourceSplitBase> splits = generateHybridLakeFlussSplits();
             if (splits == null) {
                 // no lake snapshot, fall back to normal Fluss splits
@@ -885,13 +884,6 @@ public class FlinkSourceEnumerator
         // without re-generating.
         if (pendingHybridLakeFlussSplits != null) {
             LOG.info("Still have pending lake fluss splits, shouldn't list splits again.");
-            return pendingHybridLakeFlussSplits;
-        }
-        // Restored from checkpoint but pending lake split is null(e.g. the source was
-        // originally started in Fluss-only mode without lake).  Do not generate lake
-        // splits for this restore; mark as initialized and return empty list.
-        if (checkpointTriggeredBefore) {
-            pendingHybridLakeFlussSplits = Collections.emptyList();
             return pendingHybridLakeFlussSplits;
         }
         try {

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -140,7 +140,8 @@ public class FlinkSourceEnumerator
      * <p>The field has three states:
      *
      * <ul>
-     *   <li>{@code null}: lake split initialization has not run yet.
+     *   <li>{@code null}: lake split initialization has not run yet, or the source has no lake
+     *       (non-lake table) so initialization will never run.
      *   <li>empty list: lake split initialization has run, or this enumerator was started in
      *       Fluss-only (non-lake) mode and must not initialize lake splits after restore.
      *   <li>non-empty list: lake split initialization has run and these splits still need to be
@@ -524,18 +525,16 @@ public class FlinkSourceEnumerator
 
     private void startInStreamModeForNonPartitionedTable() {
         if (lakeSource != null) {
-            context.callAsync(
-                    () -> {
-                        // firstly, try to generate hybrid lake splits,
-                        List<SourceSplitBase> splits = generateHybridLakeFlussSplits();
-                        // splits is null,
-                        // we'll fall back to normal fluss splits generation logic
-                        if (splits == null) {
-                            splits = this.initNonPartitionedSplits();
-                        }
-                        return splits;
-                    },
-                    this::handleSplitsAdd);
+            // Generate lake splits synchronously so that they are available before the
+            // first checkpoint.  This is consistent with the partitioned-table path in
+            // start() and ensures generateHybridLakeFlussSplits() can safely use
+            // checkpointTriggeredBefore to distinguish fresh starts from restores.
+            List<SourceSplitBase> splits = generateHybridLakeFlussSplits();
+            if (splits == null) {
+                // no lake snapshot, fall back to normal Fluss splits
+                splits = this.initNonPartitionedSplits();
+            }
+            handleSplitsAdd(splits, null);
         } else {
             // init bucket splits and assign
             context.callAsync(this::initNonPartitionedSplits, this::handleSplitsAdd);
@@ -882,11 +881,17 @@ public class FlinkSourceEnumerator
     /** Return the hybrid lake and fluss splits. Return null if no lake snapshot. */
     @Nullable
     private List<SourceSplitBase> generateHybridLakeFlussSplits() {
-        // still have pending lake fluss splits,
-        // should be restored from checkpoint, shouldn't
-        // list splits again
+        // Restored from checkpoint with pending lake splits — return them directly
+        // without re-generating.
         if (pendingHybridLakeFlussSplits != null) {
             LOG.info("Still have pending lake fluss splits, shouldn't list splits again.");
+            return pendingHybridLakeFlussSplits;
+        }
+        // Restored from checkpoint but pending lake split is null(e.g. the source was
+        // originally started in Fluss-only mode without lake).  Do not generate lake
+        // splits for this restore; mark as initialized and return empty list.
+        if (checkpointTriggeredBefore) {
+            pendingHybridLakeFlussSplits = Collections.emptyList();
             return pendingHybridLakeFlussSplits;
         }
         try {
@@ -1220,16 +1225,11 @@ public class FlinkSourceEnumerator
 
     @Override
     public SourceEnumeratorState snapshotState(long checkpointId) {
-        List<SourceSplitBase> remainingHybridLakeFlussSplits =
-                // Preserve Fluss-only (non-lake) startup across restore. Otherwise a restored
-                // enumerator with a non-null lakeSource would treat null as "not initialized yet"
-                // and generate lake snapshot splits.
-                lakeSource == null ? Collections.emptyList() : pendingHybridLakeFlussSplits;
         final SourceEnumeratorState enumeratorState =
                 new SourceEnumeratorState(
                         assignedTableBuckets,
                         assignedPartitions,
-                        remainingHybridLakeFlussSplits,
+                        pendingHybridLakeFlussSplits,
                         leaseContext.getKvSnapshotLeaseId());
         LOG.debug("Source Checkpoint is {}", enumeratorState);
         return enumeratorState;

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -134,6 +134,19 @@ public class FlinkSourceEnumerator
     /** Buckets that have been assigned to readers. */
     private final Set<TableBucket> assignedTableBuckets;
 
+    /**
+     * Remaining lake snapshot and hybrid lake/Fluss splits to assign.
+     *
+     * <p>The field has three states:
+     *
+     * <ul>
+     *   <li>{@code null}: lake split initialization has not run yet.
+     *   <li>empty list: lake split initialization has run, or this enumerator was started in
+     *       Fluss-only (non-lake) mode and must not initialize lake splits after restore.
+     *   <li>non-empty list: lake split initialization has run and these splits still need to be
+     *       assigned.
+     * </ul>
+     */
     @Nullable private List<SourceSplitBase> pendingHybridLakeFlussSplits;
 
     private final long scanPartitionDiscoveryIntervalMs;
@@ -1207,11 +1220,16 @@ public class FlinkSourceEnumerator
 
     @Override
     public SourceEnumeratorState snapshotState(long checkpointId) {
+        List<SourceSplitBase> remainingHybridLakeFlussSplits =
+                // Preserve Fluss-only (non-lake) startup across restore. Otherwise a restored
+                // enumerator with a non-null lakeSource would treat null as "not initialized yet"
+                // and generate lake snapshot splits.
+                lakeSource == null ? Collections.emptyList() : pendingHybridLakeFlussSplits;
         final SourceEnumeratorState enumeratorState =
                 new SourceEnumeratorState(
                         assignedTableBuckets,
                         assignedPartitions,
-                        pendingHybridLakeFlussSplits,
+                        remainingHybridLakeFlussSplits,
                         leaseContext.getKvSnapshotLeaseId());
         LOG.debug("Source Checkpoint is {}", enumeratorState);
         return enumeratorState;

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/state/FlussSourceEnumeratorStateSerializer.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/state/FlussSourceEnumeratorStateSerializer.java
@@ -270,12 +270,15 @@ public class FlussSourceEnumeratorStateSerializer
         if (in.readBoolean()) {
             int numSplits = in.readInt();
             List<SourceSplitBase> splits = new ArrayList<>(numSplits);
+            int version = in.readInt();
+            if (numSplits == 0) {
+                return splits;
+            }
             SourceSplitSerializer sourceSplitSerializer =
                     new SourceSplitSerializer(
                             checkNotNull(
                                     lakeSource,
                                     "lake source must not be null when there are hybrid lake splits."));
-            int version = in.readInt();
             for (int i = 0; i < numSplits; i++) {
                 int splitSizeInBytes = in.readInt();
                 byte[] splitBytes = new byte[splitSizeInBytes];

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
@@ -261,7 +261,6 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             false);
 
             checkpointState = enumerator.snapshotState(1L);
-            assertThat(checkpointState.getRemainingHybridLakeFlussSplits()).isNotNull().isEmpty();
         }
 
         try (MockSplitEnumeratorContext<SourceSplitBase> context =

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
@@ -32,6 +32,7 @@ import org.apache.fluss.flink.source.split.HybridSnapshotLogSplit;
 import org.apache.fluss.flink.source.split.LogSplit;
 import org.apache.fluss.flink.source.split.SnapshotSplit;
 import org.apache.fluss.flink.source.split.SourceSplitBase;
+import org.apache.fluss.flink.source.state.SourceEnumeratorState;
 import org.apache.fluss.flink.utils.FlinkTestBase;
 import org.apache.fluss.lake.source.LakeSource;
 import org.apache.fluss.lake.source.LakeSplit;
@@ -207,6 +208,97 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                                             false))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("Split assignment batch size must be positive");
+        }
+    }
+
+    @Test
+    void testRestoreFlussOnlySourceWithLakeSourceDoesNotGenerateLakeSplits(@TempDir Path tempDir)
+            throws Throwable {
+        long tableId =
+                createTable(DEFAULT_TABLE_PATH, DEFAULT_AUTO_PARTITIONED_LOG_TABLE_DESCRIPTOR);
+        ZooKeeperClient zooKeeperClient = FLUSS_CLUSTER_EXTENSION.getZooKeeperClient();
+        Map<Long, String> partitionNameByIds =
+                waitUntilPartitions(zooKeeperClient, DEFAULT_TABLE_PATH);
+        Long partitionId = partitionNameByIds.keySet().stream().sorted().findFirst().get();
+        String partitionName = partitionNameByIds.get(partitionId);
+
+        LakeTableSnapshot lakeTableSnapshot =
+                new LakeTableSnapshot(
+                        0,
+                        ImmutableMap.of(
+                                new TableBucket(tableId, partitionId, 0), 50L,
+                                new TableBucket(tableId, partitionId, 1), 50L,
+                                new TableBucket(tableId, partitionId, 2), 50L));
+        LakeTableHelper lakeTableHelper = new LakeTableHelper(zooKeeperClient, tempDir.toString());
+        lakeTableHelper.registerLakeTableSnapshotV1(tableId, lakeTableSnapshot);
+
+        ResolvedPartitionSpec partitionSpec =
+                ResolvedPartitionSpec.fromPartitionName(
+                        Collections.singletonList("name"), partitionName);
+        LakeSource<LakeSplit> lakeSource =
+                new TestingLakeSource(
+                        DEFAULT_BUCKET_NUM,
+                        Collections.singletonList(
+                                new PartitionInfo(
+                                        partitionId, partitionSpec, DEFAULT_REMOTE_DATA_DIR)));
+
+        SourceEnumeratorState checkpointState;
+        try (MockSplitEnumeratorContext<SourceSplitBase> context =
+                new MockSplitEnumeratorContext<>(1)) {
+            FlinkSourceEnumerator enumerator =
+                    new FlinkSourceEnumerator(
+                            DEFAULT_TABLE_PATH,
+                            flussConf,
+                            true,
+                            false,
+                            context,
+                            OffsetsInitializer.timestamp(1000L),
+                            DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
+                            streaming,
+                            null,
+                            null,
+                            LeaseContext.DEFAULT,
+                            false);
+
+            checkpointState = enumerator.snapshotState(1L);
+            assertThat(checkpointState.getRemainingHybridLakeFlussSplits()).isNotNull().isEmpty();
+        }
+
+        try (MockSplitEnumeratorContext<SourceSplitBase> context =
+                        new MockSplitEnumeratorContext<>(DEFAULT_BUCKET_NUM);
+                MockWorkExecutor workExecutor = new MockWorkExecutor(context);
+                FlinkSourceEnumerator restoredEnumerator =
+                        new FlinkSourceEnumerator(
+                                DEFAULT_TABLE_PATH,
+                                flussConf,
+                                false,
+                                true,
+                                context,
+                                checkpointState.getAssignedBuckets(),
+                                checkpointState.getAssignedPartitions(),
+                                checkpointState.getRemainingHybridLakeFlussSplits(),
+                                OffsetsInitializer.full(),
+                                DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
+                                streaming,
+                                null,
+                                lakeSource,
+                                workExecutor,
+                                LeaseContext.DEFAULT,
+                                true)) {
+            restoredEnumerator.start();
+            runPeriodicPartitionDiscovery(workExecutor);
+
+            for (int i = 0; i < DEFAULT_BUCKET_NUM; i++) {
+                registerReader(context, restoredEnumerator, i);
+            }
+
+            List<SourceSplitBase> assignedSplits =
+                    getReadersAssignments(context).values().stream()
+                            .flatMap(List::stream)
+                            .collect(Collectors.toList());
+            assertThat(assignedSplits).isNotEmpty();
+            assertThat(assignedSplits).allMatch(split -> split instanceof LogSplit);
+            assertThat(assignedSplits).noneMatch(split -> split instanceof LakeSnapshotSplit);
         }
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
@@ -25,6 +25,8 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.flink.FlinkConnectorOptions;
 import org.apache.fluss.flink.lake.split.LakeSnapshotAndFlussLogSplit;
 import org.apache.fluss.flink.lake.split.LakeSnapshotSplit;
+import org.apache.fluss.flink.source.FlinkSource;
+import org.apache.fluss.flink.source.deserializer.RowDataDeserializationSchema;
 import org.apache.fluss.flink.source.event.PartitionBucketsUnsubscribedEvent;
 import org.apache.fluss.flink.source.event.PartitionsRemovedEvent;
 import org.apache.fluss.flink.source.reader.LeaseContext;
@@ -54,8 +56,10 @@ import org.apache.fluss.types.DataTypes;
 
 import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
+import org.apache.flink.table.data.RowData;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -244,48 +248,52 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
 
         SourceEnumeratorState checkpointState;
         try (MockSplitEnumeratorContext<SourceSplitBase> context =
-                new MockSplitEnumeratorContext<>(1)) {
-            FlinkSourceEnumerator enumerator =
-                    new FlinkSourceEnumerator(
-                            DEFAULT_TABLE_PATH,
-                            flussConf,
-                            true,
-                            false,
-                            context,
-                            OffsetsInitializer.timestamp(1000L),
-                            DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                            streaming,
-                            null,
-                            null,
-                            LeaseContext.DEFAULT,
-                            false);
-
+                        new MockSplitEnumeratorContext<>(1);
+                SplitEnumerator<SourceSplitBase, SourceEnumeratorState> enumerator =
+                        new FlinkSource<RowData>(
+                                        flussConf,
+                                        DEFAULT_TABLE_PATH,
+                                        false,
+                                        true,
+                                        DEFAULT_LOG_TABLE_SCHEMA.getRowType(),
+                                        null,
+                                        null,
+                                        OffsetsInitializer.timestamp(1000L),
+                                        0L,
+                                        new RowDataDeserializationSchema(),
+                                        streaming,
+                                        null,
+                                        LeaseContext.DEFAULT)
+                                .createEnumerator(context)) {
             checkpointState = enumerator.snapshotState(1L);
+            assertThat(checkpointState.getRemainingHybridLakeFlussSplits()).isNull();
         }
 
         try (MockSplitEnumeratorContext<SourceSplitBase> context =
                         new MockSplitEnumeratorContext<>(DEFAULT_BUCKET_NUM);
-                MockWorkExecutor workExecutor = new MockWorkExecutor(context);
-                FlinkSourceEnumerator restoredEnumerator =
-                        new FlinkSourceEnumerator(
-                                DEFAULT_TABLE_PATH,
-                                flussConf,
-                                false,
-                                true,
-                                context,
-                                checkpointState.getAssignedBuckets(),
-                                checkpointState.getAssignedPartitions(),
-                                checkpointState.getRemainingHybridLakeFlussSplits(),
-                                OffsetsInitializer.full(),
-                                DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                                streaming,
-                                null,
-                                lakeSource,
-                                workExecutor,
-                                LeaseContext.DEFAULT,
-                                true)) {
+                SplitEnumerator<SourceSplitBase, SourceEnumeratorState> restoredEnumerator =
+                        new FlinkSource<RowData>(
+                                        flussConf,
+                                        DEFAULT_TABLE_PATH,
+                                        false,
+                                        true,
+                                        DEFAULT_LOG_TABLE_SCHEMA.getRowType(),
+                                        null,
+                                        null,
+                                        OffsetsInitializer.full(),
+                                        0L,
+                                        new RowDataDeserializationSchema(),
+                                        streaming,
+                                        null,
+                                        lakeSource,
+                                        LeaseContext.DEFAULT)
+                                .restoreEnumerator(context, checkpointState)) {
+            assertThat(restoredEnumerator.snapshotState(1L).getRemainingHybridLakeFlussSplits())
+                    .isEmpty();
+
             restoredEnumerator.start();
-            runPeriodicPartitionDiscovery(workExecutor);
+            context.runNextOneTimeCallable();
+            context.runNextOneTimeCallable();
 
             for (int i = 0; i < DEFAULT_BUCKET_NUM; i++) {
                 registerReader(context, restoredEnumerator, i);
@@ -943,7 +951,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
     // ---------------------
     private void registerReader(
             MockSplitEnumeratorContext<SourceSplitBase> context,
-            FlinkSourceEnumerator enumerator,
+            SplitEnumerator<SourceSplitBase, SourceEnumeratorState> enumerator,
             int readerId) {
         context.registerReader(new ReaderInfo(readerId, "location " + readerId));
         enumerator.addReader(readerId);

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/state/SourceEnumeratorStateSerializerTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/state/SourceEnumeratorStateSerializerTest.java
@@ -169,4 +169,26 @@ class SourceEnumeratorStateSerializerTest {
                 serializer.deserialize(serializer.getVersion(), serialized);
         assertThat(deserializedSourceEnumeratorState).isEqualTo(sourceEnumeratorState);
     }
+
+    @Test
+    void testEmptyPendingSplitsCheckpointSerdeWithoutLakeSource() throws Exception {
+        FlussSourceEnumeratorStateSerializer serializer =
+                new FlussSourceEnumeratorStateSerializer(null);
+
+        SourceEnumeratorState sourceEnumeratorState =
+                new SourceEnumeratorState(
+                        Collections.emptySet(),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        LeaseContext.DEFAULT.getKvSnapshotLeaseId());
+
+        byte[] serialized = serializer.serialize(sourceEnumeratorState);
+        SourceEnumeratorState deserializedSourceEnumeratorState =
+                serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserializedSourceEnumeratorState).isEqualTo(sourceEnumeratorState);
+        assertThat(deserializedSourceEnumeratorState.getRemainingHybridLakeFlussSplits())
+                .isNotNull()
+                .isEmpty();
+    }
 }


### PR DESCRIPTION
### Purpose

Linked issue: close #3354

Preserve the original Fluss-only (non-lake) startup semantics after a Flink source restore. When the source starts from a specified Fluss log position, it should not initialize lake snapshot splits after restore just because `lakeSource` is available again.

### Brief change log

- Persist an empty `remainingHybridLakeFlussSplits` list when the enumerator checkpoints with `lakeSource == null`.
- Allow empty pending hybrid split lists to deserialize without `lakeSource`, while still requiring `lakeSource` for non-empty hybrid split state.
- Document the three-state meaning of `pendingHybridLakeFlussSplits` so `null`, empty, and non-empty states are explicit.
- Add a restore regression test that checkpoints a Fluss-only enumerator, restores it with a non-null `lakeSource` and a registered lake snapshot, and verifies no `LakeSnapshotSplit` is generated.
- Add a serializer round-trip test for empty pending hybrid split state with `lakeSource == null`.

### Tests

- `./mvnw -pl fluss-flink/fluss-flink-common -Dtest=SourceEnumeratorStateSerializerTest,FlinkSourceEnumeratorTest#testRestoreFlussOnlySourceWithLakeSourceDoesNotGenerateLakeSplits test`
- `./mvnw -pl fluss-flink/fluss-flink-common spotless:apply`
- `git diff --check`

### API and Format

No public API, storage format, or checkpoint serializer version change. The fix only changes the value stored in the existing enumerator state field for Fluss-only source checkpoints and permits that empty-state sentinel to deserialize without a lake source.

### Documentation

No new feature or user-facing configuration change.

### Generative AI disclosure

- [x] Yes: OpenAI Codex was used to author this PR following the repository AGENTS.md guidance.
