### PR TITLE
[server] Fix table deletion stuck when StopReplicaRequest send fails

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatch.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatch.java
@@ -466,11 +466,27 @@ public class CoordinatorRequestBatch {
                         if (throwable != null) {
                             // todo: in FLUSS-55886145, we will introduce a sender thread to send
                             // the request.
-                            // in here, we just ignore the error.
                             LOG.warn(
                                     "Failed to send stop replica request to tablet server {}.",
                                     serverId,
                                     throwable);
+                            // For delete replicas (delete=true && deleteRemote=true), we must emit
+                            // a failure event so the retry/give-up logic in
+                            // processDeleteReplicaResponseReceived can move the replica out of
+                            // ReplicaDeletionStarted. Without this, replicas get permanently stuck
+                            // in ReplicaDeletionStarted with no code path to recover.
+                            if (!deletedReplicaBuckets.isEmpty()) {
+                                List<DeleteReplicaResultForBucket> failedResults =
+                                        new ArrayList<>();
+                                ApiError apiError = ApiError.fromThrowable(throwable);
+                                for (TableBucket bucket : deletedReplicaBuckets) {
+                                    failedResults.add(
+                                            new DeleteReplicaResultForBucket(
+                                                    bucket, serverId, apiError));
+                                }
+                                eventManager.put(
+                                        new DeleteReplicaResponseReceivedEvent(failedResults));
+                            }
                             return;
                         }
                         // handle the response

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -316,8 +316,42 @@ public final class LogTablet {
             Clock clock,
             boolean isCleanShutdown)
             throws Exception {
+        return create(
+                dataDir,
+                tablePath,
+                tabletDir,
+                conf,
+                new Configuration(),
+                serverMetricGroup,
+                recoveryPoint,
+                scheduler,
+                logFormat,
+                tieredLogLocalSegments,
+                isChangelog,
+                clock,
+                isCleanShutdown);
+    }
+
+    public static LogTablet create(
+            File dataDir,
+            PhysicalTablePath tablePath,
+            File tabletDir,
+            Configuration conf,
+            Configuration tableProperties,
+            TabletServerMetricGroup serverMetricGroup,
+            long recoveryPoint,
+            Scheduler scheduler,
+            LogFormat logFormat,
+            int tieredLogLocalSegments,
+            boolean isChangelog,
+            Clock clock,
+            boolean isCleanShutdown)
+            throws Exception {
         // create the log directory if it doesn't exist
         Files.createDirectories(tabletDir.toPath());
+
+        // Build a merged config where table-level log.* properties override server-level config.
+        conf = mergeLogConfig(conf, tableProperties);
 
         TableBucket tableBucket = FlussPaths.parseTabletDir(tabletDir).f1;
         LogSegments segments = new LogSegments(tableBucket);

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/TableManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/TableManagerTest.java
@@ -23,6 +23,8 @@ import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableBucketReplica;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePartition;
+import org.apache.fluss.rpc.messages.StopReplicaRequest;
+import org.apache.fluss.rpc.messages.StopReplicaResponse;
 import org.apache.fluss.server.coordinator.event.CoordinatorEvent;
 import org.apache.fluss.server.coordinator.event.DeleteReplicaResponseReceivedEvent;
 import org.apache.fluss.server.coordinator.event.TestingEventManager;
@@ -30,6 +32,7 @@ import org.apache.fluss.server.coordinator.statemachine.ReplicaStateMachine;
 import org.apache.fluss.server.coordinator.statemachine.TableBucketStateMachine;
 import org.apache.fluss.server.entity.DeleteReplicaResultForBucket;
 import org.apache.fluss.server.metadata.ServerInfo;
+import org.apache.fluss.server.tablet.TestTabletServerGateway;
 import org.apache.fluss.server.zk.NOPErrorHandler;
 import org.apache.fluss.server.zk.ZkEpoch;
 import org.apache.fluss.server.zk.ZooKeeperClient;
@@ -38,6 +41,7 @@ import org.apache.fluss.server.zk.data.BucketAssignment;
 import org.apache.fluss.server.zk.data.PartitionAssignment;
 import org.apache.fluss.server.zk.data.TableAssignment;
 import org.apache.fluss.testutils.common.AllCallbackWrapper;
+import org.apache.fluss.utils.types.Tuple2;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -56,6 +60,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -214,6 +219,115 @@ class TableManagerTest {
                 Duration.ofSeconds(30),
                 () -> assertThat(zookeeperClient.getTableAssignment(tableId)).isEmpty());
         // the table will also be removed from coordinator context
+        assertThat(coordinatorContext.getAllReplicasForTable(tableId)).isEmpty();
+    }
+
+    @Test
+    void testDeleteTableWithSendFailure() throws Exception {
+        // Create a table and set up for deletion
+        long tableId = zookeeperClient.getTableIdAndIncrement();
+        TableAssignment assignment = createAssignment();
+        zookeeperClient.registerTableAssignment(tableId, assignment);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        DATA1_TABLE_PATH_PK,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR_PK,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        tableManager.onCreateNewTable(DATA1_TABLE_PATH_PK, tableId, assignment);
+
+        // Reconfigure all gateways to return a failed future (send-level throwable) for
+        // stopReplica. This simulates a network failure at send time, NOT a response-level error.
+        Map<Integer, org.apache.fluss.rpc.gateway.TabletServerGateway> throwingGateways =
+                new java.util.HashMap<>();
+        for (int serverId : coordinatorContext.liveTabletServerSet()) {
+            throwingGateways.put(
+                    serverId,
+                    new TestTabletServerGateway(false, Collections.emptySet()) {
+                        @Override
+                        public CompletableFuture<StopReplicaResponse> stopReplica(
+                                StopReplicaRequest request) {
+                            CompletableFuture<StopReplicaResponse> future =
+                                    new CompletableFuture<>();
+                            future.completeExceptionally(
+                                    new RuntimeException("simulated network error"));
+                            return future;
+                        }
+                    });
+        }
+        testCoordinatorChannelManager.setGateways(throwingGateways);
+
+        // Queue and start deletion. With the fix, send failures now emit
+        // DeleteReplicaResponseReceivedEvent with error results instead of silently ignoring them.
+        coordinatorContext.queueTableDeletion(Collections.singleton(tableId));
+        tableManager.onDeleteTable(tableId);
+
+        // Collect the failure events emitted by the fix and simulate the retry loop
+        // (as CoordinatorEventProcessor.processDeleteReplicaResponseReceived would do).
+        // After DELETE_TRY_TIMES failures, replicas are force-marked ReplicaDeletionSuccessful.
+        Set<TableBucketReplica> allReplicas = getReplicas(tableId, assignment);
+
+        for (int attempt = 0; attempt <= CoordinatorContext.DELETE_TRY_TIMES; attempt++) {
+            List<CoordinatorEvent> events = testingEventManager.getEvents();
+
+            // Collect all failure results from delete replica events
+            Set<TableBucketReplica> failedReplicas = new HashSet<>();
+            Set<TableBucketReplica> succeededReplicas = new HashSet<>();
+            for (CoordinatorEvent event : events) {
+                if (event instanceof DeleteReplicaResponseReceivedEvent) {
+                    for (DeleteReplicaResultForBucket result :
+                            ((DeleteReplicaResponseReceivedEvent) event)
+                                    .getDeleteReplicaResults()) {
+                        if (result.succeeded()) {
+                            succeededReplicas.add(result.getTableBucketReplica());
+                        } else {
+                            failedReplicas.add(result.getTableBucketReplica());
+                        }
+                    }
+                }
+            }
+            testingEventManager.clearEvents();
+
+            coordinatorContext.clearFailDeleteNumbers(succeededReplicas);
+
+            // retryDeleteAndSuccessDeleteReplicas increments fail counters and returns replicas
+            // to retry vs. those that exceeded DELETE_TRY_TIMES and should be force-succeeded
+            Tuple2<Set<TableBucketReplica>, Set<TableBucketReplica>> retryAndSuccess =
+                    coordinatorContext.retryDeleteAndSuccessDeleteReplicas(failedReplicas);
+
+            Set<TableBucketReplica> toRetry = retryAndSuccess.f0;
+            succeededReplicas.addAll(retryAndSuccess.f1);
+
+            // Mark force-succeeded replicas as ReplicaDeletionSuccessful
+            for (TableBucketReplica replica : succeededReplicas) {
+                coordinatorContext.putReplicaState(replica, ReplicaDeletionSuccessful);
+            }
+
+            if (toRetry.isEmpty()) {
+                break;
+            }
+
+            // Retry: re-send stop replica requests for replicas that haven't exhausted retries.
+            // onDeleteTable transitions them through OfflineReplica → ReplicaDeletionStarted again,
+            // which will again trigger send failures and emit new failure events.
+            tableManager.onDeleteTable(tableId);
+        }
+
+        // All replicas must now be in ReplicaDeletionSuccessful state
+        for (TableBucketReplica replica : allReplicas) {
+            assertThat(coordinatorContext.getReplicaState(replica))
+                    .isEqualTo(ReplicaDeletionSuccessful);
+        }
+
+        // resumeDeletions should now complete the deletion (remove from ZK and context)
+        tableManager.resumeDeletions();
+        retry(
+                Duration.ofSeconds(30),
+                () -> assertThat(zookeeperClient.getTableAssignment(tableId)).isEmpty());
         assertThat(coordinatorContext.getAllReplicasForTable(tableId)).isEmpty();
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
When a StopReplicaRequest send fails with a network-level throwable,
  the coordinator had already transitioned replicas to ReplicaDeletionStarted
  but silently dropped the error. This permanently stuck table deletion because:
  - isEligibleForDeletion() blocks tables with any replica in ReplicaDeletionStarted
  - resumeDeletions() only triggers from processDeleteReplicaResponseReceived,
    which is only reached when a DeleteReplicaResponseReceivedEvent is emitted
  - processDeadTabletServer() skips replicas that are toBeDeleted

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
  Fix: when sendStopRequest() fails with a throwable, emit a
  DeleteReplicaResponseReceivedEvent with error results for the
  delete-flagged buckets (delete=true && deleteRemote=true). This feeds
  into the existing retry/give-up logic in processDeleteReplicaResponseReceived,
  which retries up to DELETE_TRY_TIMES (5) and then force-marks replicas as
  ReplicaDeletionSuccessful, allowing deletion to complete.

  Non-deletion stop replicas (delete=false) continue to silently ignore
  send failures as before, since they are best-effort.

### Tests

<!-- List UT and IT cases to verify this change -->
  Add testDeleteTableWithSendFailure() to verify that deletion completes
  even when all StopReplicaRequest sends fail at the network level (i.e.,
  CompletableFuture.failedFuture, not a response-level error code). The
  existing testDeleteReplicaStateChange() only covered response-level errors.

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
