### PR TITLE
[server] Allow table-level overrides for log segment/index/flush options

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -1557,6 +1557,56 @@ public class ConfigOptions {
                             "The number of log segments to retain in local for each table when log tiered storage is enabled. "
                                     + "It must be greater that 0. The default is 2.");
 
+    public static final ConfigOption<MemorySize> TABLE_LOG_SEGMENT_FILE_SIZE =
+            key("table.log.segment.file-size")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The segment file size for the log of this table. "
+                                    + "When set, overrides the cluster-level '"
+                                    + LOG_SEGMENT_FILE_SIZE.key()
+                                    + "' for this table only.");
+
+    public static final ConfigOption<MemorySize> TABLE_LOG_INDEX_FILE_SIZE =
+            key("table.log.index.file-size")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The index file size for the log of this table. "
+                                    + "When set, overrides the cluster-level '"
+                                    + LOG_INDEX_FILE_SIZE.key()
+                                    + "' for this table only.");
+
+    public static final ConfigOption<MemorySize> TABLE_LOG_INDEX_INTERVAL_SIZE =
+            key("table.log.index.interval-size")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The index interval size for the log of this table. "
+                                    + "When set, overrides the cluster-level '"
+                                    + LOG_INDEX_INTERVAL_SIZE.key()
+                                    + "' for this table only.");
+
+    public static final ConfigOption<Boolean> TABLE_LOG_FILE_PREALLOCATE =
+            key("table.log.file-preallocate")
+                    .booleanType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Whether to preallocate log segment files for this table. "
+                                    + "When set, overrides the cluster-level '"
+                                    + LOG_FILE_PREALLOCATE.key()
+                                    + "' for this table only.");
+
+    public static final ConfigOption<Long> TABLE_LOG_FLUSH_INTERVAL_MESSAGES =
+            key("table.log.flush.interval-messages")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The flush interval in number of messages for the log of this table. "
+                                    + "When set, overrides the cluster-level '"
+                                    + LOG_FLUSH_INTERVAL_MESSAGES.key()
+                                    + "' for this table only.");
+
     public static final ConfigOption<Boolean> TABLE_DATALAKE_ENABLED =
             key("table.datalake.enabled")
                     .booleanType()

--- a/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
@@ -50,7 +50,12 @@ public class FlussConfigUtils {
                         ConfigOptions.TABLE_DATALAKE_FRESHNESS.key(),
                         ConfigOptions.TABLE_TIERED_LOG_LOCAL_SEGMENTS.key(),
                         ConfigOptions.TABLE_AUTO_PARTITION_NUM_RETENTION.key(),
-                        ConfigOptions.TABLE_STATISTICS_COLUMNS.key());
+                        ConfigOptions.TABLE_STATISTICS_COLUMNS.key(),
+                        ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE.key(),
+                        ConfigOptions.TABLE_LOG_INDEX_FILE_SIZE.key(),
+                        ConfigOptions.TABLE_LOG_INDEX_INTERVAL_SIZE.key(),
+                        ConfigOptions.TABLE_LOG_FILE_PREALLOCATE.key(),
+                        ConfigOptions.TABLE_LOG_FLUSH_INTERVAL_MESSAGES.key());
     }
 
     public static boolean isTableStorageConfig(String key) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogManager.java
@@ -263,6 +263,7 @@ public final class LogManager extends TabletManagerBase {
      * @param logFormat the log format
      * @param tieredLogLocalSegments the number of segments to retain in local for tiered log
      * @param isChangelog whether the log is a changelog of primary key table
+     * @param tableProperties table-level configuration properties
      */
     public LogTablet getOrCreateLog(
             File dataDir,
@@ -270,7 +271,8 @@ public final class LogManager extends TabletManagerBase {
             TableBucket tableBucket,
             LogFormat logFormat,
             int tieredLogLocalSegments,
-            boolean isChangelog)
+            boolean isChangelog,
+            Configuration tableProperties)
             throws Exception {
         return inLock(
                 logCreationOrDeletionLock,
@@ -287,6 +289,7 @@ public final class LogManager extends TabletManagerBase {
                                     tablePath,
                                     tabletDir,
                                     conf,
+                                    tableProperties,
                                     serverMetricGroup,
                                     0L,
                                     scheduler,
@@ -304,6 +307,25 @@ public final class LogManager extends TabletManagerBase {
 
                     return logTablet;
                 });
+    }
+
+    @VisibleForTesting
+    public LogTablet getOrCreateLog(
+            File dataDir,
+            PhysicalTablePath tablePath,
+            TableBucket tableBucket,
+            LogFormat logFormat,
+            int tieredLogLocalSegments,
+            boolean isChangelog)
+            throws Exception {
+        return getOrCreateLog(
+                dataDir,
+                tablePath,
+                tableBucket,
+                logFormat,
+                tieredLogLocalSegments,
+                isChangelog,
+                new Configuration());
     }
 
     public Optional<LogTablet> getLog(TableBucket tableBucket) {
@@ -392,6 +414,7 @@ public final class LogManager extends TabletManagerBase {
                         physicalTablePath,
                         tabletDir,
                         conf,
+                        tableInfo.getProperties(),
                         serverMetricGroup,
                         logRecoveryPoint,
                         scheduler,

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -316,6 +316,38 @@ public final class LogTablet {
             Clock clock,
             boolean isCleanShutdown)
             throws Exception {
+        return create(
+                dataDir,
+                tablePath,
+                tabletDir,
+                conf,
+                new Configuration(),
+                serverMetricGroup,
+                recoveryPoint,
+                scheduler,
+                logFormat,
+                tieredLogLocalSegments,
+                isChangelog,
+                clock,
+                isCleanShutdown);
+    }
+
+    public static LogTablet create(
+            File dataDir,
+            PhysicalTablePath tablePath,
+            File tabletDir,
+            Configuration conf,
+            Configuration tableProperties,
+            TabletServerMetricGroup serverMetricGroup,
+            long recoveryPoint,
+            Scheduler scheduler,
+            LogFormat logFormat,
+            int tieredLogLocalSegments,
+            boolean isChangelog,
+            Clock clock,
+            boolean isCleanShutdown)
+            throws Exception {
+        conf = buildEffectiveLogConfig(conf, tableProperties);
         // create the log directory if it doesn't exist
         Files.createDirectories(tabletDir.toPath());
 
@@ -1377,5 +1409,31 @@ public final class LogTablet {
     @VisibleForTesting
     public long getMinRetainOffset() {
         return minRetainOffset;
+    }
+
+    /**
+     * Builds an effective log configuration by overlaying table-level log.* overrides onto the
+     * server-level configuration. Table-level values take precedence. Options not set at table
+     * level transparently fall back to the server value.
+     */
+    private static Configuration buildEffectiveLogConfig(
+            Configuration serverConf, Configuration tableProperties) {
+        Configuration effective = new Configuration(serverConf);
+        tableProperties
+                .getOptional(ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE)
+                .ifPresent(v -> effective.set(ConfigOptions.LOG_SEGMENT_FILE_SIZE, v));
+        tableProperties
+                .getOptional(ConfigOptions.TABLE_LOG_INDEX_FILE_SIZE)
+                .ifPresent(v -> effective.set(ConfigOptions.LOG_INDEX_FILE_SIZE, v));
+        tableProperties
+                .getOptional(ConfigOptions.TABLE_LOG_INDEX_INTERVAL_SIZE)
+                .ifPresent(v -> effective.set(ConfigOptions.LOG_INDEX_INTERVAL_SIZE, v));
+        tableProperties
+                .getOptional(ConfigOptions.TABLE_LOG_FILE_PREALLOCATE)
+                .ifPresent(v -> effective.set(ConfigOptions.LOG_FILE_PREALLOCATE, v));
+        tableProperties
+                .getOptional(ConfigOptions.TABLE_LOG_FLUSH_INTERVAL_MESSAGES)
+                .ifPresent(v -> effective.set(ConfigOptions.LOG_FLUSH_INTERVAL_MESSAGES, v));
+        return effective;
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -2159,7 +2159,8 @@ public final class Replica {
                         tableBucket,
                         tableConfig.getLogFormat(),
                         tableConfig.getTieredLogLocalSegments(),
-                        isKvTable());
+                        isKvTable(),
+                        tableInfo.getProperties());
         // update high watermark.
         Optional<Long> watermarkOpt = lazyHighWatermarkCheckpoint.fetch(tableBucket);
         long watermark =

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/TableDescriptorValidation.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/TableDescriptorValidation.java
@@ -127,6 +127,7 @@ public class TableDescriptorValidation {
         checkSystemColumns(schema.getRowType());
         validateStatisticsConfig(tableDescriptor);
         checkTableLakeFormatMatchesCluster(tableConf, clusterDataLakeFormat);
+        checkLogSegmentFileSize(tableConf);
     }
 
     private static void checkTableLakeFormatMatchesCluster(
@@ -406,6 +407,21 @@ public class TableDescriptorValidation {
                                 column.getName(), e.getMessage()));
             }
         }
+    }
+
+    private static void checkLogSegmentFileSize(Configuration tableConf) {
+        tableConf
+                .getOptional(ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE)
+                .ifPresent(
+                        size -> {
+                            if (size.getBytes() > Integer.MAX_VALUE) {
+                                throw new InvalidConfigException(
+                                        String.format(
+                                                "Invalid configuration for '%s', it must be less than or equal to %d bytes.",
+                                                ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE.key(),
+                                                Integer.MAX_VALUE));
+                            }
+                        });
     }
 
     private static void checkTieredLog(Configuration tableConf) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LogTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LogTabletTest.java
@@ -482,7 +482,55 @@ final class LogTabletTest extends LogTestBase {
                                 logTablet.getTableBucket().getBucket()));
     }
 
+    @Test
+    void testTableLevelSegmentFileSizeOverridesServerConfig() throws Exception {
+        // Server-level default is 1024m; set table-level override to a tiny value so that
+        // each single-row append triggers a segment roll.
+        MemoryLogRecords records =
+                genMemoryLogRecordsByObject(Collections.singletonList(new Object[] {1, "a"}));
+        int recordsSize = records.sizeInBytes();
+
+        // Without table-level override: segment file size is the server default (1024m),
+        // appending a few small records stays in one segment.
+        LogTablet logDefault = createLogTablet(conf);
+        logDefault.appendAsLeader(records);
+        logDefault.appendAsLeader(
+                genMemoryLogRecordsByObject(Collections.singletonList(new Object[] {2, "b"})));
+        assertThat(logDefault.logSegments().size()).isEqualTo(1);
+
+        // With table-level override: set segment size just large enough for one batch so that
+        // the second append triggers a roll to a new segment.
+        Configuration tableProperties = new Configuration();
+        tableProperties.set(ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE, new MemorySize(recordsSize));
+        LogTablet logOverride = createLogTablet(conf, tableProperties);
+        logOverride.appendAsLeader(records);
+        logOverride.appendAsLeader(
+                genMemoryLogRecordsByObject(Collections.singletonList(new Object[] {2, "b"})));
+        assertThat(logOverride.logSegments().size()).isGreaterThan(1);
+    }
+
+    @Test
+    void testTableLevelFlushIntervalMessagesOverridesServerConfig() throws Exception {
+        // Server-level default is Long.MAX_VALUE (flush only on explicit flush()).
+        // With table-level override of 1, every message triggers a flush.
+        Configuration tableProperties = new Configuration();
+        tableProperties.set(ConfigOptions.TABLE_LOG_FLUSH_INTERVAL_MESSAGES, 1L);
+        LogTablet log = createLogTablet(conf, tableProperties);
+
+        MemoryLogRecords records =
+                genMemoryLogRecordsByObject(Collections.singletonList(new Object[] {1, "a"}));
+        log.appendAsLeader(records);
+        // After appending with flushIntervalMessages=1, the unflushed offset should equal
+        // the log end offset (i.e., the flush happened automatically).
+        assertThat(log.localLogEndOffset()).isEqualTo(log.getRecoveryPoint());
+    }
+
     private LogTablet createLogTablet(Configuration config) throws Exception {
+        return createLogTablet(config, new Configuration());
+    }
+
+    private LogTablet createLogTablet(Configuration config, Configuration tableProperties)
+            throws Exception {
         File logDir =
                 LogTestUtils.makeRandomLogTabletDir(
                         tempDir,
@@ -496,6 +544,7 @@ final class LogTabletTest extends LogTestBase {
                 PhysicalTablePath.of(DATA1_TABLE_PATH),
                 logDir,
                 config,
+                tableProperties,
                 TestingMetricGroups.TABLET_SERVER_METRICS,
                 0,
                 scheduler,

--- a/fluss-server/src/test/java/org/apache/fluss/server/utils/TableDescriptorValidationTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/utils/TableDescriptorValidationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.utils;
+
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.MemorySize;
+import org.apache.fluss.exception.InvalidConfigException;
+import org.apache.fluss.metadata.Schema;
+import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for table-level log config options in {@link TableDescriptorValidation}. */
+class TableDescriptorValidationTest {
+
+    private static final Schema SCHEMA = Schema.newBuilder().column("id", DataTypes.INT()).build();
+
+    /** Builds a minimal valid {@link TableDescriptor} with the given extra property. */
+    private static TableDescriptor descriptorWithProperty(String key, String value) {
+        return TableDescriptor.builder()
+                .schema(SCHEMA)
+                .distributedBy(1)
+                .property(ConfigOptions.TABLE_REPLICATION_FACTOR.key(), "1")
+                .property(key, value)
+                .build();
+    }
+
+    @Test
+    void testTableLogSegmentFileSizeValidValue() {
+        // A valid value (e.g. 16m) should not throw.
+        TableDescriptor descriptor =
+                descriptorWithProperty(ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE.key(), "16m");
+        // Should succeed without exception
+        TableDescriptorValidation.validateTableDescriptor(descriptor, 100, null);
+    }
+
+    @Test
+    void testTableLogSegmentFileSizeOverflowThrows() {
+        // Integer.MAX_VALUE bytes = 2147483647 bytes; set one byte more.
+        long overflowBytes = (long) Integer.MAX_VALUE + 1;
+        String overflowValue = overflowBytes + "b";
+        TableDescriptor descriptor =
+                descriptorWithProperty(
+                        ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE.key(), overflowValue);
+        assertThatThrownBy(
+                        () ->
+                                TableDescriptorValidation.validateTableDescriptor(
+                                        descriptor, 100, null))
+                .isInstanceOf(InvalidConfigException.class)
+                .hasMessageContaining(ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE.key())
+                .hasMessageContaining(String.valueOf(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void testTableLogSegmentFileSizeAtMaxIntegerAllowed() {
+        // Exactly Integer.MAX_VALUE bytes should be accepted.
+        MemorySize maxSize = new MemorySize(Integer.MAX_VALUE);
+        TableDescriptor descriptor =
+                descriptorWithProperty(
+                        ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE.key(), maxSize.toString());
+        // Should succeed without exception
+        TableDescriptorValidation.validateTableDescriptor(descriptor, 100, null);
+    }
+
+    @Test
+    void testTableLogIndexFileSizeValidValue() {
+        TableDescriptor descriptor =
+                descriptorWithProperty(ConfigOptions.TABLE_LOG_INDEX_FILE_SIZE.key(), "8m");
+        TableDescriptorValidation.validateTableDescriptor(descriptor, 100, null);
+    }
+
+    @Test
+    void testTableLogIndexIntervalSizeValidValue() {
+        TableDescriptor descriptor =
+                descriptorWithProperty(ConfigOptions.TABLE_LOG_INDEX_INTERVAL_SIZE.key(), "4096b");
+        TableDescriptorValidation.validateTableDescriptor(descriptor, 100, null);
+    }
+
+    @Test
+    void testTableLogFilePreallocateValidValue() {
+        TableDescriptor descriptor =
+                descriptorWithProperty(ConfigOptions.TABLE_LOG_FILE_PREALLOCATE.key(), "true");
+        TableDescriptorValidation.validateTableDescriptor(descriptor, 100, null);
+    }
+
+    @Test
+    void testTableLogFlushIntervalMessagesValidValue() {
+        TableDescriptor descriptor =
+                descriptorWithProperty(
+                        ConfigOptions.TABLE_LOG_FLUSH_INTERVAL_MESSAGES.key(), "100");
+        TableDescriptorValidation.validateTableDescriptor(descriptor, 100, null);
+    }
+
+    @Test
+    void testTableLogOptionsRecognizedAsTableOptions() {
+        // All five new options must be recognised as valid table properties (i.e. present in
+        // TABLE_OPTIONS); otherwise validateTableDescriptor would throw InvalidConfigException
+        // with "not a recognized Fluss table property".
+        assertThat(org.apache.fluss.config.FlussConfigUtils.TABLE_OPTIONS.keySet())
+                .contains(
+                        ConfigOptions.TABLE_LOG_SEGMENT_FILE_SIZE.key(),
+                        ConfigOptions.TABLE_LOG_INDEX_FILE_SIZE.key(),
+                        ConfigOptions.TABLE_LOG_INDEX_INTERVAL_SIZE.key(),
+                        ConfigOptions.TABLE_LOG_FILE_PREALLOCATE.key(),
+                        ConfigOptions.TABLE_LOG_FLUSH_INTERVAL_MESSAGES.key());
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3315 

<!-- What is the purpose of the change -->
  Add five new table-scoped ConfigOptions (table.log.segment.file-size,
  table.log.index.file-size, table.log.index.interval-size,
  table.log.file-preallocate, table.log.flush.interval-messages) that
  override the corresponding cluster-level log.* settings for a single
  table when explicitly set.  Tables without these properties continue
  to use the server-global values unchanged.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
  - ConfigOptions: add TABLE_LOG_* options with noDefaultValue() so
    absent values fall back to server config automatically
  - FlussConfigUtils: register all five keys in ALTERABLE_TABLE_OPTIONS
    so ALTER TABLE SET takes effect on the next segment roll
  - TableDescriptorValidation: add overflow guard for
    table.log.segment.file-size (mirrors existing server-level check)
  - LogTablet: add buildEffectiveLogConfig() helper and a new create()
    overload that accepts tableProperties; old overload delegates with
    an empty Configuration for full backward compatibility
  - LogManager: thread tableProperties through getOrCreateLog() and
    loadLog() so both the online and recovery paths honour overrides
  - Replica: pass tableInfo.getProperties() into getOrCreateLog()

### Tests

<!-- List UT and IT cases to verify this change -->
  - LogTabletTest: verify segment roll and auto-flush behaviour with
    table-level overrides vs. server defaults
  - TableDescriptorValidationTest: cover valid values, Integer.MAX_VALUE
    boundary, overflow rejection, and TABLE_OPTIONS registration for
    all five new keys

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
