### PR TITLE
[client] Fix unbounded growth of stale partition entries in writer metadata cache

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/utils/MetadataUtils.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/utils/MetadataUtils.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -103,6 +104,14 @@ public class MetadataUtils {
         MetadataRequest metadataRequest =
                 ClientRpcMessageUtils.makeMetadataRequest(
                         tablePaths, tablePartitions, tablePartitionIds);
+        // Collect the table paths for which partition metadata is being refreshed, so that stale
+        // partition entries can be removed during partial updates.
+        final Set<TablePath> refreshedPartitionTables = new HashSet<>();
+        if (tablePartitions != null) {
+            for (PhysicalTablePath ptp : tablePartitions) {
+                refreshedPartitionTables.add(ptp.getTablePath());
+            }
+        }
         return gateway.metadata(metadataRequest)
                 .thenApply(
                         response -> {
@@ -134,6 +143,28 @@ public class MetadataUtils {
                                         new HashMap<>(originCluster.getBucketLocationsByPath());
                                 newPartitionIdByPath =
                                         new HashMap<>(originCluster.getPartitionIdByPath());
+
+                                // Remove stale partition entries for tables whose partition
+                                // metadata was refreshed. The response only contains currently
+                                // existing partitions, so any entry not in the response is stale
+                                // (e.g., dropped partitions).
+                                if (!refreshedPartitionTables.isEmpty()) {
+                                    newPartitionIdByPath
+                                            .keySet()
+                                            .removeIf(
+                                                    path ->
+                                                            refreshedPartitionTables.contains(
+                                                                    path.getTablePath()));
+                                    newBucketLocations
+                                            .keySet()
+                                            .removeIf(
+                                                    path ->
+                                                            path.getPartitionName() != null
+                                                                    && refreshedPartitionTables
+                                                                            .contains(
+                                                                                    path
+                                                                                            .getTablePath()));
+                                }
 
                                 newTablePathToTableId.putAll(newTableMetadata.tablePathToTableId);
                                 newBucketLocations.putAll(newTableMetadata.bucketLocations);

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
@@ -113,6 +113,18 @@ public final class RecordAccumulator {
     private final ConcurrentMap<PhysicalTablePath, BucketAndWriteBatches> writeBatches =
             new CopyOnWriteMap<>();
 
+    /**
+     * Paths that have been marked stale (e.g. the partition was dropped). New appends to these
+     * paths are rejected. The Sender thread removes an entry from {@link #writeBatches} once all
+     * its deques are drained.
+     *
+     * <p>All accesses must be guarded by {@link #staleLock}.
+     */
+    private final Set<PhysicalTablePath> stalePaths = new HashSet<>();
+
+    /** Guards {@link #stalePaths} and the remove-if-empty logic in {@link #writeBatches}. */
+    private final Object staleLock = new Object();
+
     private final IncompleteBatches incomplete;
 
     private final Map<Integer, Integer> nodesDrainIndex;
@@ -185,6 +197,17 @@ public final class RecordAccumulator {
         // The metadata may return null for the partition id, but it is fine to pass null here,
         // because we will fill the partitionId in bucketReady() before send the batch.
         Optional<Long> partitionIdOpt = cluster.getPartitionId(physicalTablePath);
+
+        // Reject appends to paths that the Sender has marked as stale (e.g. dropped partitions).
+        // This check must happen before computeIfAbsent so that a concurrent markPathsAsStale +
+        // removeStalePathIfEmpty cannot race with a new append re-inserting the same path.
+        synchronized (staleLock) {
+            if (stalePaths.contains(physicalTablePath)) {
+                throw new IllegalStateException(
+                        "Cannot append to a stale (dropped) partition: " + physicalTablePath);
+            }
+        }
+
         BucketAndWriteBatches bucketAndWriteBatches =
                 writeBatches.computeIfAbsent(
                         physicalTablePath,
@@ -426,6 +449,50 @@ public final class RecordAccumulator {
 
     public Set<PhysicalTablePath> getPhysicalTablePathsInBatches() {
         return writeBatches.keySet();
+    }
+
+    /**
+     * Mark the given physical table paths as stale. Subsequent {@link #append} calls for these
+     * paths will be rejected. The Sender should call {@link #removeStalePathIfEmpty} once a path's
+     * deques have been fully drained.
+     *
+     * @param paths the paths to mark as stale (e.g. dropped partitions)
+     */
+    public void markPathsAsStale(Set<PhysicalTablePath> paths) {
+        synchronized (staleLock) {
+            stalePaths.addAll(paths);
+        }
+    }
+
+    /**
+     * Remove a stale path from {@link #writeBatches} if and only if all its deques are empty.
+     *
+     * <p>This is safe to call from the Sender thread. The {@link #staleLock} prevents a concurrent
+     * {@link #append} from sneaking in between the emptiness check and the remove.
+     *
+     * @param path the stale path to try to remove
+     * @return {@code true} if the path was removed, {@code false} if it still had pending data
+     */
+    public boolean removeStalePathIfEmpty(PhysicalTablePath path) {
+        synchronized (staleLock) {
+            BucketAndWriteBatches entry = writeBatches.get(path);
+            if (entry == null) {
+                stalePaths.remove(path);
+                return true;
+            }
+            for (Deque<WriteBatch> deque : entry.batches.values()) {
+                synchronized (deque) {
+                    if (!deque.isEmpty()) {
+                        return false;
+                    }
+                }
+            }
+            // All deques are empty under staleLock: no concurrent append can insert new data
+            // because append() checks stalePaths while holding staleLock before computeIfAbsent.
+            writeBatches.remove(path);
+            stalePaths.remove(path);
+            return true;
+        }
     }
 
     private List<MemorySegment> allocateMemorySegments(

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
@@ -231,6 +231,11 @@ public class Sender implements Runnable {
                     readyCheckResult.unknownLeaderTables);
         }
 
+        // Clean up stale physical table path entries from the accumulator on every cycle.
+        // Dropped partitions will no longer appear in the cluster's bucket locations; any
+        // writeBatches entry whose deques are all empty can be safely removed.
+        cleanupStaleWriteBatches(metadataUpdater.getCluster());
+
         Set<Integer> readyNodes = readyCheckResult.readyNodes;
         if (readyNodes.isEmpty()) {
             // TODO The method sendWriteData is in a busy loop. If there is no data continuously, it
@@ -253,6 +258,37 @@ public class Sender implements Runnable {
 
             // move metrics update to the end to make sure the batches has been built.
             updateWriterMetrics(batches);
+        }
+    }
+
+    /**
+     * Mark physical table paths that no longer appear in the cluster as stale, then try to remove
+     * any stale path whose deques have been fully drained.
+     *
+     * <p>Marking prevents new appends to dropped partitions. Removal is deferred until all
+     * in-flight batches for a path have been drained, so no data is silently lost.
+     */
+    private void cleanupStaleWriteBatches(Cluster cluster) {
+        Set<PhysicalTablePath> clusterPaths = cluster.getBucketLocationsByPath().keySet();
+        Set<PhysicalTablePath> newStalePaths = new HashSet<>();
+        for (PhysicalTablePath path : accumulator.getPhysicalTablePathsInBatches()) {
+            if (!clusterPaths.contains(path)) {
+                newStalePaths.add(path);
+            }
+        }
+        if (!newStalePaths.isEmpty()) {
+            LOG.debug(
+                    "Marking {} stale physical table path(s) from write batches: {}",
+                    newStalePaths.size(),
+                    newStalePaths);
+            accumulator.markPathsAsStale(newStalePaths);
+        }
+
+        // Try to remove every path that has been marked stale and is now fully drained.
+        for (PhysicalTablePath path : accumulator.getPhysicalTablePathsInBatches()) {
+            if (!clusterPaths.contains(path)) {
+                accumulator.removeStalePathIfEmpty(path);
+            }
         }
     }
 

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
@@ -30,6 +30,7 @@ import org.apache.fluss.exception.RetriableException;
 import org.apache.fluss.exception.UnknownTableOrBucketException;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.rpc.gateway.TabletServerGateway;
 import org.apache.fluss.rpc.messages.PbProduceLogRespForBucket;
 import org.apache.fluss.rpc.messages.PbPutKvRespForBucket;
@@ -267,12 +268,16 @@ public class Sender implements Runnable {
      *
      * <p>Marking prevents new appends to dropped partitions. Removal is deferred until all
      * in-flight batches for a path have been drained, so no data is silently lost.
+     *
+     * <p>Uses {@code partitionsIdByPath} / {@code tableIdByPath} as the drop signal, not {@code
+     * bucketLocationsByPath}. Leader election and server outages can transiently empty {@code
+     * bucketLocationsByPath} without the partition or table actually being dropped; using the
+     * partition/table ID maps avoids false positives.
      */
     private void cleanupStaleWriteBatches(Cluster cluster) {
-        Set<PhysicalTablePath> clusterPaths = cluster.getBucketLocationsByPath().keySet();
         Set<PhysicalTablePath> newStalePaths = new HashSet<>();
         for (PhysicalTablePath path : accumulator.getPhysicalTablePathsInBatches()) {
-            if (!clusterPaths.contains(path)) {
+            if (isPathDropped(cluster, path)) {
                 newStalePaths.add(path);
             }
         }
@@ -286,9 +291,22 @@ public class Sender implements Runnable {
 
         // Try to remove every path that has been marked stale and is now fully drained.
         for (PhysicalTablePath path : accumulator.getPhysicalTablePathsInBatches()) {
-            if (!clusterPaths.contains(path)) {
+            if (isPathDropped(cluster, path)) {
                 accumulator.removeStalePathIfEmpty(path);
             }
+        }
+    }
+
+    private boolean isPathDropped(Cluster cluster, PhysicalTablePath path) {
+        if (path.getPartitionName() != null) {
+            // Partitioned path: dropped if metadata no longer carries the partition ID.
+            // partitionsIdByPath is only cleared on an explicit metadata refresh that confirms the
+            // partition is gone; transient leader failures do NOT clear it.
+            return !cluster.getPartitionId(path).isPresent();
+        } else {
+            // Non-partitioned path: dropped iff the table itself is no longer known.
+            TablePath tablePath = path.getTablePath();
+            return !cluster.getTableId(tablePath).isPresent();
         }
     }
 

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/RecordAccumulatorTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/RecordAccumulatorTest.java
@@ -574,6 +574,34 @@ class RecordAccumulatorTest {
                 Collections.emptyMap());
     }
 
+    /**
+     * Create a cluster that contains all the given bucket locations for DATA1 table plus an extra
+     * physical table path with its single bucket. Used to test stale-path cleanup.
+     */
+    private Cluster updateClusterWithExtra(
+            List<BucketLocation> bucketLocations,
+            PhysicalTablePath extraPath,
+            BucketLocation extraBucket) {
+        Map<Integer, ServerNode> aliveTabletServersById = new HashMap<>();
+        aliveTabletServersById.put(node1.id(), node1);
+        aliveTabletServersById.put(node2.id(), node2);
+        aliveTabletServersById.put(node3.id(), node3);
+
+        Map<PhysicalTablePath, List<BucketLocation>> bucketsByPath = new HashMap<>();
+        bucketsByPath.put(DATA1_PHYSICAL_TABLE_PATH, bucketLocations);
+        bucketsByPath.put(extraPath, Collections.singletonList(extraBucket));
+
+        Map<TablePath, Long> tableIdByPath = new HashMap<>();
+        tableIdByPath.put(DATA1_TABLE_PATH, DATA1_TABLE_ID);
+        tableIdByPath.put(extraPath.getTablePath(), DATA1_TABLE_ID);
+        return new Cluster(
+                aliveTabletServersById,
+                new ServerNode(0, "localhost", 89, ServerType.COORDINATOR),
+                bucketsByPath,
+                tableIdByPath,
+                Collections.emptyMap());
+    }
+
     private void delayedInterrupt(final Thread thread, final long delayMs) {
         Thread t =
                 new Thread(
@@ -600,6 +628,87 @@ class RecordAccumulatorTest {
                     tableBucketsInBatch.addAll(tbList);
                 });
         assertThat(tableBucketsInBatch).containsExactlyInAnyOrder(tb);
+    }
+
+    @Test
+    void testMarkAndRemoveStalePathAfterDrain() throws Exception {
+        IndexedRow row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
+        // batchTimeoutMs=0 so batches are immediately ready and drain() polls them out.
+        RecordAccumulator accum = createTestRecordAccumulator(0, 4 * 1024, 256, 64 * 1024);
+
+        // Create a stale path representing a dropped partition.
+        PhysicalTablePath stalePath =
+                PhysicalTablePath.of(TablePath.of("test_db", "test_table"), "stale_partition");
+        BucketLocation staleBucket =
+                new BucketLocation(stalePath, DATA1_TABLE_ID, 0, node1.id(), serverNodes);
+        Cluster clusterWithStale =
+                updateClusterWithExtra(Arrays.asList(bucket1, bucket2), stalePath, staleBucket);
+
+        accum.append(createRecord(row), writeCallback, cluster, 0, false);
+        accum.append(
+                WriteRecord.forIndexedAppend(
+                        DATA1_TABLE_INFO,
+                        stalePath,
+                        indexedRow(DATA1_ROW_TYPE, new Object[] {2, "b"}),
+                        null),
+                writeCallback,
+                clusterWithStale,
+                0,
+                false);
+
+        assertThat(accum.getPhysicalTablePathsInBatches()).contains(DATA1_PHYSICAL_TABLE_PATH);
+        assertThat(accum.getPhysicalTablePathsInBatches()).contains(stalePath);
+
+        // Mark stale: subsequent appends to stalePath must be rejected.
+        accum.markPathsAsStale(Collections.singleton(stalePath));
+        assertThatThrownBy(
+                        () ->
+                                accum.append(
+                                        WriteRecord.forIndexedAppend(
+                                                DATA1_TABLE_INFO,
+                                                stalePath,
+                                                indexedRow(DATA1_ROW_TYPE, new Object[] {3, "c"}),
+                                                null),
+                                        writeCallback,
+                                        clusterWithStale,
+                                        0,
+                                        false))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("stale");
+
+        // Drain and deallocate — deque becomes empty.
+        Map<Integer, List<ReadyWriteBatch>> drained =
+                accum.drain(clusterWithStale, Collections.singleton(node1.id()), Integer.MAX_VALUE);
+        for (List<ReadyWriteBatch> batches : drained.values()) {
+            for (ReadyWriteBatch b : batches) {
+                accum.deallocate(b.writeBatch());
+            }
+        }
+
+        // Now the deque is empty: removeStalePathIfEmpty must succeed.
+        boolean removed = accum.removeStalePathIfEmpty(stalePath);
+        assertThat(removed).isTrue();
+        assertThat(accum.getPhysicalTablePathsInBatches()).doesNotContain(stalePath);
+        // The live path still has un-drained data and must not be removed.
+        assertThat(accum.getPhysicalTablePathsInBatches()).contains(DATA1_PHYSICAL_TABLE_PATH);
+    }
+
+    @Test
+    void testRemoveStalePathReturnsFalseWhenDequeNonEmpty() throws Exception {
+        IndexedRow row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
+        RecordAccumulator accum = createTestRecordAccumulator(4 * 1024, 64 * 1024);
+
+        // Append a record but do NOT drain — deque is non-empty.
+        accum.append(createRecord(row), writeCallback, cluster, 0, false);
+        assertThat(accum.getPhysicalTablePathsInBatches()).contains(DATA1_PHYSICAL_TABLE_PATH);
+
+        // Mark stale and attempt removal while there is still pending data.
+        accum.markPathsAsStale(Collections.singleton(DATA1_PHYSICAL_TABLE_PATH));
+        boolean removed = accum.removeStalePathIfEmpty(DATA1_PHYSICAL_TABLE_PATH);
+
+        assertThat(removed).isFalse();
+        // Path must still be present because data is pending.
+        assertThat(accum.getPhysicalTablePathsInBatches()).contains(DATA1_PHYSICAL_TABLE_PATH);
     }
 
     @Test

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
@@ -890,6 +890,279 @@ final class SenderTest {
         assertThat(accumulator.getPhysicalTablePathsInBatches()).doesNotContain(stalePath);
     }
 
+    /**
+     * Verifies that a path is NOT marked stale when bucket leaders become unavailable (server down)
+     * but the table/partition ID is still present in the cluster metadata. This guards against the
+     * false-positive where transient leader election empties bucketLocationsByPath and triggers
+     * premature stale marking.
+     */
+    @Test
+    void testSenderDoesNotMarkPathStaleOnLeaderUnavailability() throws Exception {
+        PhysicalTablePath path = PhysicalTablePath.of(TablePath.of("test_db", "live_table"));
+        long tableId = 99902L;
+        ServerNode leader = TestingMetadataUpdater.NODE1;
+        int[] replicas = new int[] {leader.id()};
+        BucketLocation bucket = new BucketLocation(path, tableId, 0, leader.id(), replicas);
+
+        // Build a cluster that includes the table path with a live leader.
+        Cluster clusterWithLeader =
+                new Cluster(
+                        metadataUpdater.getCluster().getAliveTabletServers(),
+                        metadataUpdater.getCluster().getCoordinatorServer(),
+                        addExtraPath(
+                                metadataUpdater.getCluster().getBucketLocationsByPath(),
+                                path,
+                                bucket),
+                        addExtraTableId(
+                                metadataUpdater.getCluster().getTableIdByPath(),
+                                path.getTablePath(),
+                                tableId),
+                        metadataUpdater.getCluster().getPartitionIdByPath());
+        metadataUpdater.updateCluster(clusterWithLeader);
+
+        TableInfo tableInfo =
+                TableInfo.of(
+                        path.getTablePath(),
+                        tableId,
+                        1,
+                        DATA1_TABLE_INFO.toTableDescriptor(),
+                        null,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis());
+
+        accumulator.append(
+                WriteRecord.forArrowAppend(tableInfo, path, row(1, "a"), null),
+                (tb, leo, e) -> {},
+                clusterWithLeader,
+                0,
+                false);
+
+        assertThat(accumulator.getPhysicalTablePathsInBatches()).contains(path);
+
+        // Simulate leader failure: remove path from bucketLocationsByPath but keep tableIdByPath.
+        Map<PhysicalTablePath, List<BucketLocation>> bucketsWithoutLeader =
+                new HashMap<>(clusterWithLeader.getBucketLocationsByPath());
+        bucketsWithoutLeader.remove(path);
+        Cluster clusterWithoutLeader =
+                new Cluster(
+                        metadataUpdater.getCluster().getAliveTabletServers(),
+                        metadataUpdater.getCluster().getCoordinatorServer(),
+                        bucketsWithoutLeader,
+                        addExtraTableId(
+                                metadataUpdater.getCluster().getTableIdByPath(),
+                                path.getTablePath(),
+                                tableId),
+                        metadataUpdater.getCluster().getPartitionIdByPath());
+        metadataUpdater.updateCluster(clusterWithoutLeader);
+
+        // runOnce() must NOT remove the path because the table still exists in metadata.
+        sender.runOnce();
+
+        assertThat(accumulator.getPhysicalTablePathsInBatches()).contains(path);
+
+        // Drain and deallocate to avoid a memory-leak in teardown.
+        RecordAccumulator.ReadyCheckResult ready = accumulator.ready(clusterWithLeader);
+        Map<Integer, List<ReadyWriteBatch>> batches =
+                accumulator.drain(clusterWithLeader, ready.readyNodes, MAX_REQUEST_SIZE);
+        for (List<ReadyWriteBatch> batchList : batches.values()) {
+            for (ReadyWriteBatch b : batchList) {
+                accumulator.deallocate(b.writeBatch());
+            }
+        }
+    }
+
+    /**
+     * Tests that a partitioned-table path is cleaned up from writeBatches after the partition is
+     * dropped and partitionsIdByPath no longer contains it. This is the partitioned-table
+     * counterpart to testSenderCleansUpStaleWriteBatchesAfterMetadataUpdate.
+     */
+    @Test
+    void testSenderCleansUpStalePartitionedPathAfterPartitionDrop() throws Exception {
+        TablePath tablePath = TablePath.of("test_db", "partitioned_table");
+        long tableId = 99903L;
+        long partitionId = 88801L;
+        String partitionName = "p_2024";
+        PhysicalTablePath partitionPath = PhysicalTablePath.of(tablePath, partitionName);
+        ServerNode leader = TestingMetadataUpdater.NODE1;
+        int[] replicas = new int[] {leader.id()};
+        // Include partitionId in TableBucket so Cluster.leaderFor() can match it correctly.
+        BucketLocation bucket =
+                new BucketLocation(
+                        partitionPath,
+                        new TableBucket(tableId, partitionId, 0),
+                        leader.id(),
+                        replicas);
+
+        // Build cluster with the partition present in both bucketLocationsByPath and
+        // partitionsIdByPath.
+        Map<PhysicalTablePath, Long> partitionIdByPathWithPartition =
+                new HashMap<>(metadataUpdater.getCluster().getPartitionIdByPath());
+        partitionIdByPathWithPartition.put(partitionPath, partitionId);
+        Cluster clusterWithPartition =
+                new Cluster(
+                        metadataUpdater.getCluster().getAliveTabletServers(),
+                        metadataUpdater.getCluster().getCoordinatorServer(),
+                        addExtraPath(
+                                metadataUpdater.getCluster().getBucketLocationsByPath(),
+                                partitionPath,
+                                bucket),
+                        addExtraTableId(
+                                metadataUpdater.getCluster().getTableIdByPath(),
+                                tablePath,
+                                tableId),
+                        partitionIdByPathWithPartition);
+        metadataUpdater.updateCluster(clusterWithPartition);
+
+        TableInfo partitionedTableInfo =
+                TableInfo.of(
+                        tablePath,
+                        tableId,
+                        1,
+                        DATA1_TABLE_INFO.toTableDescriptor(),
+                        null,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis());
+
+        accumulator.append(
+                WriteRecord.forArrowAppend(partitionedTableInfo, partitionPath, row(1, "a"), null),
+                (tb, leo, e) -> {},
+                clusterWithPartition,
+                0,
+                false);
+
+        assertThat(accumulator.getPhysicalTablePathsInBatches()).contains(partitionPath);
+
+        // Drain and deallocate so the deque is empty before cleanup.
+        RecordAccumulator.ReadyCheckResult ready = accumulator.ready(clusterWithPartition);
+        Map<Integer, List<ReadyWriteBatch>> batches =
+                accumulator.drain(clusterWithPartition, ready.readyNodes, MAX_REQUEST_SIZE);
+        for (List<ReadyWriteBatch> batchList : batches.values()) {
+            for (ReadyWriteBatch b : batchList) {
+                accumulator.deallocate(b.writeBatch());
+            }
+        }
+
+        // Simulate partition drop: remove partition from both bucketLocationsByPath and
+        // partitionsIdByPath (as MetadataUtils does after a metadata refresh).
+        Map<PhysicalTablePath, List<BucketLocation>> bucketsWithoutPartition =
+                new HashMap<>(clusterWithPartition.getBucketLocationsByPath());
+        bucketsWithoutPartition.remove(partitionPath);
+        Map<PhysicalTablePath, Long> partitionIdByPathWithoutPartition =
+                new HashMap<>(partitionIdByPathWithPartition);
+        partitionIdByPathWithoutPartition.remove(partitionPath);
+        Cluster clusterWithoutPartition =
+                new Cluster(
+                        metadataUpdater.getCluster().getAliveTabletServers(),
+                        metadataUpdater.getCluster().getCoordinatorServer(),
+                        bucketsWithoutPartition,
+                        addExtraTableId(
+                                metadataUpdater.getCluster().getTableIdByPath(),
+                                tablePath,
+                                tableId),
+                        partitionIdByPathWithoutPartition);
+        metadataUpdater.updateCluster(clusterWithoutPartition);
+
+        sender.runOnce();
+
+        assertThat(accumulator.getPhysicalTablePathsInBatches()).doesNotContain(partitionPath);
+    }
+
+    /**
+     * Tests that a partitioned-table path is NOT marked stale when bucket leaders become
+     * unavailable (server down / leader election) but partitionsIdByPath still contains the
+     * partition. This is the partitioned-table counterpart to
+     * testSenderDoesNotMarkPathStaleOnLeaderUnavailability.
+     */
+    @Test
+    void testSenderDoesNotMarkPartitionedPathStaleOnLeaderUnavailability() throws Exception {
+        TablePath tablePath = TablePath.of("test_db", "partitioned_table2");
+        long tableId = 99904L;
+        long partitionId = 88802L;
+        String partitionName = "p_2025";
+        PhysicalTablePath partitionPath = PhysicalTablePath.of(tablePath, partitionName);
+        ServerNode leader = TestingMetadataUpdater.NODE1;
+        int[] replicas = new int[] {leader.id()};
+        // Include partitionId in TableBucket so Cluster.leaderFor() can match it correctly.
+        BucketLocation bucket =
+                new BucketLocation(
+                        partitionPath,
+                        new TableBucket(tableId, partitionId, 0),
+                        leader.id(),
+                        replicas);
+
+        // Cluster with partition fully present.
+        Map<PhysicalTablePath, Long> partitionIdByPathWithPartition =
+                new HashMap<>(metadataUpdater.getCluster().getPartitionIdByPath());
+        partitionIdByPathWithPartition.put(partitionPath, partitionId);
+        Cluster clusterWithPartition =
+                new Cluster(
+                        metadataUpdater.getCluster().getAliveTabletServers(),
+                        metadataUpdater.getCluster().getCoordinatorServer(),
+                        addExtraPath(
+                                metadataUpdater.getCluster().getBucketLocationsByPath(),
+                                partitionPath,
+                                bucket),
+                        addExtraTableId(
+                                metadataUpdater.getCluster().getTableIdByPath(),
+                                tablePath,
+                                tableId),
+                        partitionIdByPathWithPartition);
+        metadataUpdater.updateCluster(clusterWithPartition);
+
+        TableInfo partitionedTableInfo =
+                TableInfo.of(
+                        tablePath,
+                        tableId,
+                        1,
+                        DATA1_TABLE_INFO.toTableDescriptor(),
+                        null,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis());
+
+        accumulator.append(
+                WriteRecord.forArrowAppend(partitionedTableInfo, partitionPath, row(1, "a"), null),
+                (tb, leo, e) -> {},
+                clusterWithPartition,
+                0,
+                false);
+
+        assertThat(accumulator.getPhysicalTablePathsInBatches()).contains(partitionPath);
+
+        // Drain and deallocate BEFORE simulating leader failure so that the deque is empty.
+        // This prevents ready() from adding the path to unknownLeaderTables (which would trigger
+        // a metadata update in TestingMetadataUpdater and cause an unexpected exception).
+        RecordAccumulator.ReadyCheckResult readyBefore = accumulator.ready(clusterWithPartition);
+        Map<Integer, List<ReadyWriteBatch>> batchesBefore =
+                accumulator.drain(clusterWithPartition, readyBefore.readyNodes, MAX_REQUEST_SIZE);
+        for (List<ReadyWriteBatch> batchList : batchesBefore.values()) {
+            for (ReadyWriteBatch b : batchList) {
+                accumulator.deallocate(b.writeBatch());
+            }
+        }
+
+        // Simulate leader failure: remove partition from bucketLocationsByPath only.
+        // partitionsIdByPath still contains the partition — it has not been dropped.
+        Map<PhysicalTablePath, List<BucketLocation>> bucketsWithoutLeader =
+                new HashMap<>(clusterWithPartition.getBucketLocationsByPath());
+        bucketsWithoutLeader.remove(partitionPath);
+        Cluster clusterWithoutLeader =
+                new Cluster(
+                        metadataUpdater.getCluster().getAliveTabletServers(),
+                        metadataUpdater.getCluster().getCoordinatorServer(),
+                        bucketsWithoutLeader,
+                        addExtraTableId(
+                                metadataUpdater.getCluster().getTableIdByPath(),
+                                tablePath,
+                                tableId),
+                        partitionIdByPathWithPartition);
+        metadataUpdater.updateCluster(clusterWithoutLeader);
+
+        // runOnce() must NOT remove the partition path because it still exists in metadata.
+        sender.runOnce();
+
+        assertThat(accumulator.getPhysicalTablePathsInBatches()).contains(partitionPath);
+    }
+
     private static Map<PhysicalTablePath, List<BucketLocation>> addExtraPath(
             Map<PhysicalTablePath, List<BucketLocation>> original,
             PhysicalTablePath extraPath,

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
@@ -19,6 +19,7 @@ package org.apache.fluss.client.write;
 
 import org.apache.fluss.client.metadata.TestingMetadataUpdater;
 import org.apache.fluss.client.metrics.TestingWriterMetricGroup;
+import org.apache.fluss.cluster.BucketLocation;
 import org.apache.fluss.cluster.Cluster;
 import org.apache.fluss.cluster.ServerNode;
 import org.apache.fluss.config.ConfigOptions;
@@ -799,6 +800,110 @@ final class SenderTest {
         assertThat(idempotenceManager.lastAckedBatchSequence(tb1)).isEqualTo(Optional.of(0));
         assertThat(future1.isDone()).isTrue();
         assertThat(future1.get()).isNull();
+    }
+
+    /**
+     * Tests that Sender.runOnce() cleans up stale physical table path entries from the
+     * RecordAccumulator after a metadata update reveals that a partition no longer exists in the
+     * cluster. This prevents unbounded growth of writeBatches for long-running partition-write jobs
+     * where partitions are continuously created and dropped.
+     */
+    @Test
+    void testSenderCleansUpStaleWriteBatchesAfterMetadataUpdate() throws Exception {
+        // Use a non-partitioned stale path so that ready() / drain() work without needing
+        // a partition ID in the cluster's partitionsIdByPath map.
+        PhysicalTablePath stalePath = PhysicalTablePath.of(TablePath.of("test_db", "stale_table"));
+        long staleTableId = 99901L;
+        ServerNode leader = TestingMetadataUpdater.NODE1;
+        int[] replicas = new int[] {leader.id()};
+        BucketLocation staleBucket =
+                new BucketLocation(stalePath, staleTableId, 0, leader.id(), replicas);
+
+        // Build a cluster that includes the normal path AND the soon-to-be-dropped stale path.
+        Cluster clusterWithStale =
+                new Cluster(
+                        metadataUpdater.getCluster().getAliveTabletServers(),
+                        metadataUpdater.getCluster().getCoordinatorServer(),
+                        addExtraPath(
+                                metadataUpdater.getCluster().getBucketLocationsByPath(),
+                                stalePath,
+                                staleBucket),
+                        addExtraTableId(
+                                metadataUpdater.getCluster().getTableIdByPath(),
+                                stalePath.getTablePath(),
+                                staleTableId),
+                        metadataUpdater.getCluster().getPartitionIdByPath());
+        metadataUpdater.updateCluster(clusterWithStale);
+
+        // Create a minimal TableInfo for the stale table so we can append to it.
+        TableInfo staleTableInfo =
+                TableInfo.of(
+                        stalePath.getTablePath(),
+                        staleTableId,
+                        1,
+                        DATA1_TABLE_INFO.toTableDescriptor(),
+                        null,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis());
+
+        // Append a record to the stale path — this registers it in writeBatches.
+        accumulator.append(
+                WriteRecord.forArrowAppend(staleTableInfo, stalePath, row(1, "a"), null),
+                (tb, leo, e) -> {},
+                clusterWithStale,
+                0,
+                false);
+
+        assertThat(accumulator.getPhysicalTablePathsInBatches()).contains(stalePath);
+
+        // Drain and deallocate to empty the stale deque. batchTimeoutMs=0 so the batch is
+        // immediately ready and drain() will poll it out.
+        RecordAccumulator.ReadyCheckResult ready = accumulator.ready(clusterWithStale);
+        Map<Integer, List<ReadyWriteBatch>> batches =
+                accumulator.drain(clusterWithStale, ready.readyNodes, MAX_REQUEST_SIZE);
+        for (List<ReadyWriteBatch> batchList : batches.values()) {
+            for (ReadyWriteBatch b : batchList) {
+                accumulator.deallocate(b.writeBatch());
+            }
+        }
+
+        // Simulate partition drop: update the cluster without the stale path.
+        Map<PhysicalTablePath, List<BucketLocation>> bucketsWithoutStale =
+                new HashMap<>(metadataUpdater.getCluster().getBucketLocationsByPath());
+        bucketsWithoutStale.remove(stalePath);
+        Map<TablePath, Long> tableIdsWithoutStale =
+                new HashMap<>(metadataUpdater.getCluster().getTableIdByPath());
+        tableIdsWithoutStale.remove(stalePath.getTablePath());
+        Cluster clusterWithoutStale =
+                new Cluster(
+                        metadataUpdater.getCluster().getAliveTabletServers(),
+                        metadataUpdater.getCluster().getCoordinatorServer(),
+                        bucketsWithoutStale,
+                        tableIdsWithoutStale,
+                        metadataUpdater.getCluster().getPartitionIdByPath());
+        metadataUpdater.updateCluster(clusterWithoutStale);
+
+        // runOnce() calls cleanupStaleWriteBatches: marks the path stale, then removes it
+        // because the deque is already empty.
+        sender.runOnce();
+
+        assertThat(accumulator.getPhysicalTablePathsInBatches()).doesNotContain(stalePath);
+    }
+
+    private static Map<PhysicalTablePath, List<BucketLocation>> addExtraPath(
+            Map<PhysicalTablePath, List<BucketLocation>> original,
+            PhysicalTablePath extraPath,
+            BucketLocation extraBucket) {
+        Map<PhysicalTablePath, List<BucketLocation>> result = new HashMap<>(original);
+        result.put(extraPath, Collections.singletonList(extraBucket));
+        return result;
+    }
+
+    private static Map<TablePath, Long> addExtraTableId(
+            Map<TablePath, Long> original, TablePath tablePath, long tableId) {
+        Map<TablePath, Long> result = new HashMap<>(original);
+        result.put(tablePath, tableId);
+        return result;
     }
 
     @Test


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
  When partitions are continuously created and dropped, physical table path
  entries in RecordAccumulator.writeBatches and Cluster.partitionsIdByPath
  were never removed, causing unbounded memory growth and CPU waste from
  iterating over stale entries in ready() and drain() hot loops.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
  Fix 1 (RecordAccumulator): introduce markPathsAsStale() and
  removeStalePathIfEmpty() with a dedicated staleLock so that the
  check-then-remove is atomic with respect to concurrent append() calls.
  New appends to stale paths are rejected immediately.

  Fix 2 (MetadataUtils): during partial metadata updates, remove stale
  partition entries for any table whose partition list was refreshed, so
  that dropped partitions no longer linger in partitionsIdByPath.

  Fix 3 (Sender): call cleanupStaleWriteBatches() on every sendWriteData()
  cycle to mark paths absent from the cluster as stale and remove them once
  their deques are fully drained.

### Tests

<!-- List UT and IT cases to verify this change -->
  - RecordAccumulatorTest.testMarkAndRemoveStalePathAfterDrain: verifies
    that append() is rejected after markPathsAsStale(), and that
    removeStalePathIfEmpty() succeeds once the deque is drained.
  - RecordAccumulatorTest.testRemoveStalePathReturnsFalseWhenDequeNonEmpty:
    verifies that removeStalePathIfEmpty() returns false and preserves the
    path when pending batches remain.
  - SenderTest.testSenderCleansUpStaleWriteBatchesAfterMetadataUpdate:
    verifies end-to-end that runOnce() removes a stale path from
    writeBatches after the cluster no longer contains it and its deque
    has been drained.

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
