### PR TITLE
[common] Fix resource leak and silenced exceptions in FileLock

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/utils/FileLock.java
+++ b/fluss-common/src/main/java/org/apache/fluss/utils/FileLock.java
@@ -19,6 +19,9 @@ package org.apache.fluss.utils;
 
 import org.apache.fluss.annotation.Internal;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -31,6 +34,8 @@ import static org.apache.fluss.utils.Preconditions.checkNotNull;
 /** A file lock used for avoiding race condition among multiple threads/processes. */
 @Internal
 public class FileLock {
+    private static final Logger LOG = LoggerFactory.getLogger(FileLock.class);
+
     private static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
     private final File file;
     private FileOutputStream outputStream;
@@ -151,8 +156,10 @@ public class FileLock {
         }
         try {
             outputStream.close();
-        } catch (IOException ignored) {
+        } catch (IOException e) {
             // Best-effort cleanup; the original failure will be propagated by the caller.
+            // Log here so users are aware that closing the output stream also failed.
+            LOG.warn("Failed to close output stream for file lock {}", file, e);
         } finally {
             outputStream = null;
         }

--- a/fluss-common/src/main/java/org/apache/fluss/utils/FileLock.java
+++ b/fluss-common/src/main/java/org/apache/fluss/utils/FileLock.java
@@ -22,6 +22,7 @@ import org.apache.fluss.annotation.Internal;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -70,8 +71,14 @@ public class FileLock {
      * Try to acquire a lock on the locking file. This method immediately returns whenever the lock
      * is acquired or not.
      *
+     * <p>Returns {@code false} when the lock is already held (either by another process via {@link
+     * java.nio.channels.FileChannel#tryLock()} returning {@code null}, or by another lock in the
+     * same JVM signalled by {@link OverlappingFileLockException}). Genuine I/O failures are
+     * propagated to the caller instead of being silently swallowed, so they are not mistaken for a
+     * contended lock.
+     *
      * @return True if successfully acquired the lock
-     * @throws IOException If the file path is invalid
+     * @throws IOException If an I/O error occurs while acquiring the lock
      */
     public boolean tryLock() throws IOException {
         if (outputStream == null) {
@@ -79,8 +86,17 @@ public class FileLock {
         }
         try {
             lock = outputStream.getChannel().tryLock();
-        } catch (Exception e) {
+        } catch (OverlappingFileLockException e) {
+            // Another lock in the same JVM already holds (or overlaps) this region; treat it as
+            // an unsuccessful attempt rather than an error, mirroring the FileChannel#tryLock
+            // contract for inter-process contention.
             return false;
+        } catch (IOException | RuntimeException e) {
+            // The FileOutputStream was opened by init() above; if acquiring the lock fails for
+            // any reason other than contention we must release it here, otherwise the underlying
+            // file descriptor leaks for the lifetime of the JVM.
+            closeOutputStreamQuietly();
+            throw e;
         }
 
         return lock != null;
@@ -106,18 +122,39 @@ public class FileLock {
      */
     public void unlockAndDestroy() throws IOException {
         try {
-            unlock();
-            if (lock != null) {
-                lock.channel().close();
-                lock = null;
+            try {
+                unlock();
+            } finally {
+                try {
+                    if (lock != null) {
+                        lock.channel().close();
+                        lock = null;
+                    }
+                } finally {
+                    // Always close the output stream, even when releasing or closing the channel
+                    // above threw; otherwise the file descriptor would leak whenever cleanup
+                    // failed partway through.
+                    if (outputStream != null) {
+                        outputStream.close();
+                        outputStream = null;
+                    }
+                }
             }
-            if (outputStream != null) {
-                outputStream.close();
-                outputStream = null;
-            }
-
         } finally {
             this.file.delete();
+        }
+    }
+
+    private void closeOutputStreamQuietly() {
+        if (outputStream == null) {
+            return;
+        }
+        try {
+            outputStream.close();
+        } catch (IOException ignored) {
+            // Best-effort cleanup; the original failure will be propagated by the caller.
+        } finally {
+            outputStream = null;
         }
     }
 

--- a/fluss-common/src/main/java/org/apache/fluss/utils/FileLock.java
+++ b/fluss-common/src/main/java/org/apache/fluss/utils/FileLock.java
@@ -132,16 +132,26 @@ public class FileLock {
             } finally {
                 try {
                     if (lock != null) {
-                        lock.channel().close();
-                        lock = null;
+                        try {
+                            lock.channel().close();
+                        } finally {
+                            // Reset state even when close fails so the FileLock is not left in
+                            // an inconsistent, partially-destroyed state.
+                            lock = null;
+                        }
                     }
                 } finally {
                     // Always close the output stream, even when releasing or closing the channel
                     // above threw; otherwise the file descriptor would leak whenever cleanup
                     // failed partway through.
                     if (outputStream != null) {
-                        outputStream.close();
-                        outputStream = null;
+                        try {
+                            outputStream.close();
+                        } finally {
+                            // Guarantee state reset even when close fails so a later tryLock()
+                            // can re-initialize the stream cleanly.
+                            outputStream = null;
+                        }
                     }
                 }
             }

--- a/fluss-common/src/test/java/org/apache/fluss/utils/FileLockTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/utils/FileLockTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link FileLock}. */
+class FileLockTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testTryLockAndUnlock() throws Exception {
+        File lockFile = tempDir.resolve("lock1").toFile();
+        FileLock fileLock = new FileLock(lockFile.getAbsolutePath());
+
+        assertThat(fileLock.tryLock()).isTrue();
+        assertThat(fileLock.isValid()).isTrue();
+        assertThat(lockFile).exists();
+
+        fileLock.unlock();
+        assertThat(fileLock.isValid()).isFalse();
+
+        fileLock.unlockAndDestroy();
+        assertThat(lockFile).doesNotExist();
+    }
+
+    @Test
+    void testTryLockReturnsFalseOnSameJvmContention() throws Exception {
+        // Two FileLock instances in the same JVM target the same underlying file. The second
+        // attempt must return false instead of swallowing OverlappingFileLockException as an
+        // I/O failure or leaking a file descriptor.
+        File lockFile = tempDir.resolve("lockcontended").toFile();
+        FileLock first = new FileLock(lockFile.getAbsolutePath());
+        FileLock second = new FileLock(lockFile.getAbsolutePath());
+
+        try {
+            assertThat(first.tryLock()).isTrue();
+            assertThat(second.tryLock()).isFalse();
+            assertThat(second.isValid()).isFalse();
+        } finally {
+            second.unlockAndDestroy();
+            first.unlockAndDestroy();
+        }
+        assertThat(lockFile).doesNotExist();
+    }
+
+    @Test
+    void testTryLockAfterUnlockAndDestroyIsReusable() throws Exception {
+        // After unlockAndDestroy() the internal output stream must be closed and reset so a
+        // subsequent tryLock() can re-initialize it without leaking the previous descriptor.
+        File lockFile = tempDir.resolve("lockreuse").toFile();
+        FileLock fileLock = new FileLock(lockFile.getAbsolutePath());
+
+        assertThat(fileLock.tryLock()).isTrue();
+        fileLock.unlockAndDestroy();
+        assertThat(lockFile).doesNotExist();
+
+        // Reusing the same instance should transparently re-create the underlying file.
+        assertThat(fileLock.tryLock()).isTrue();
+        assertThat(fileLock.isValid()).isTrue();
+        fileLock.unlockAndDestroy();
+        assertThat(lockFile).doesNotExist();
+    }
+
+    @Test
+    void testUnlockAndDestroyWithoutAcquiringLock() throws Exception {
+        // Calling unlockAndDestroy() without ever acquiring the lock must not throw and must
+        // leave no resources behind.
+        File lockFile = tempDir.resolve("lockneveracquired").toFile();
+        FileLock fileLock = new FileLock(lockFile.getAbsolutePath());
+
+        fileLock.unlockAndDestroy();
+        assertThat(fileLock.isValid()).isFalse();
+        assertThat(lockFile).doesNotExist();
+    }
+
+    @Test
+    void testIsValidIsFalseBeforeTryLock() {
+        FileLock fileLock = new FileLock(tempDir.resolve("lockfresh").toString());
+        assertThat(fileLock.isValid()).isFalse();
+    }
+
+    @Test
+    void testConstructorRejectsFileNameWithoutLegalCharacters() {
+        // The constructor strips everything outside [\w/\\] from the file name; a name made up
+        // entirely of illegal characters must fail fast rather than silently locking an empty
+        // path.
+        assertThatThrownBy(() -> new FileLock(tempDir.resolve("???").toString()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("legal characters");
+    }
+}


### PR DESCRIPTION
## Purpose

`FileLock#tryLock()` previously caught every `Exception` and returned `false`, which had two issues: (1) genuine I/O failures were indistinguishable from inter-process lock contention, hiding real problems from callers; and (2) when lock acquisition failed *after* `init()` had opened the `FileOutputStream`, that stream was never closed, leaking the underlying file descriptor for the lifetime of the JVM.

`FileLock#unlockAndDestroy()` also chained `unlock()`, channel close and stream close inside a single `try` block; if releasing the lock or closing the channel threw, the `FileOutputStream` was never closed and the lock file might not be deleted.

This PR fixes both bugs and adds a dedicated test class for `FileLock`.

Linked issue: close #xxx

## Brief change log

- `FileLock#tryLock()`
  - Catch `OverlappingFileLockException` explicitly to preserve the documented "return `false` on contention" semantics.
  - Propagate `IOException` / `RuntimeException` so callers can react to real failures instead of silently treating them as contention.
  - Close the `FileOutputStream` opened by `init()` whenever lock acquisition fails, preventing the file-descriptor leak.
- `FileLock#unlockAndDestroy()`
  - Rewritten with nested `try` / `finally` blocks so the channel and the output stream are each closed independently, and the lock file is always deleted at the end — even if releasing the lock or closing the channel throws.
- No behavioral change for the happy path; `NetUtilsTest` (the only production caller) still passes unchanged.

## Tests

Added `FileLockTest` in `fluss-common`, covering:

- happy path: `tryLock()` → `unlock()` → `unlockAndDestroy()` and lock file is removed.
- in-JVM contention: a second `tryLock()` on the same path returns `false` and does **not** throw or leak the stream.
- reuse of the same `FileLock` instance after `unlockAndDestroy()` (re-acquire works).
- `unlockAndDestroy()` is safe to call when `tryLock()` was never invoked.
- `isValid()` returns `false` before any `tryLock()`.
- constructor rejects file names composed entirely of illegal characters.

Existing tests:

- `NetUtilsTest` (the only production user of `FileLock`) continues to pass.

## API and Format

- Public API: **no changes**. Method signatures and contracts of `FileLock` are preserved; only internal exception handling and resource cleanup are corrected.
- Wire / serialization format: not affected.
- Configuration: not affected.

## Documentation

- No user-facing documentation changes required.
- Method-level Javadoc on `tryLock()` already states that `false` means the lock is held elsewhere; the new behavior aligns the implementation with that contract (real I/O errors are no longer hidden behind `false`).