### PR TITLE
[server] fix stop-replica deletion stuck when TabletServer is offline

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
@@ -99,6 +99,15 @@ public class CoordinatorContext {
     private final Set<TablePartition> partitionsToBeDeleted = new HashSet<>();
 
     /**
+     * Tables/partitions temporarily ineligible for deletion retry. Marked when a replica's hosting
+     * TabletServer is offline or stopReplica RPC failed; cleared when the TabletServer reconnects.
+     * The value stores the reason for diagnostic logging.
+     */
+    private final Map<Long, String> tablesIneligibleForDeletion = new HashMap<>();
+
+    private final Map<TablePartition, String> partitionsIneligibleForDeletion = new HashMap<>();
+
+    /**
      * A mapping from tablet server to offline buckets. When the leader replica of a table bucket
      * become offline, we'll put the entry tablet_server_id -> table_bucket to this map so that we
      * won't elect the tablet server as the leader again in re-election. We'll remove the key
@@ -652,8 +661,63 @@ public class CoordinatorContext {
         partitionsToBeDeleted.addAll(tablePartitions);
     }
 
+    /** Mark a table as ineligible for deletion (only effective if queued for deletion). */
+    public void markTableIneligibleForDeletion(long tableId, String reason) {
+        if (tablesToBeDeleted.contains(tableId)) {
+            String prev = tablesIneligibleForDeletion.put(tableId, reason);
+            if (prev == null) {
+                LOG.info("Marking table {} ineligible for deletion. Reason: {}", tableId, reason);
+            }
+        }
+    }
+
+    public void markPartitionIneligibleForDeletion(TablePartition tablePartition, String reason) {
+        if (partitionsToBeDeleted.contains(tablePartition)) {
+            String prev = partitionsIneligibleForDeletion.put(tablePartition, reason);
+            if (prev == null) {
+                LOG.info(
+                        "Marking partition {} ineligible for deletion. Reason: {}",
+                        tablePartition,
+                        reason);
+            }
+        }
+    }
+
+    /** Remove the ineligible mark, allowing deletion to be retried. */
+    public void markTableEligibleForDeletion(long tableId) {
+        tablesIneligibleForDeletion.remove(tableId);
+    }
+
+    public void markPartitionEligibleForDeletion(TablePartition tablePartition) {
+        partitionsIneligibleForDeletion.remove(tablePartition);
+    }
+
+    public boolean isTableIneligibleForDeletion(long tableId) {
+        return tablesIneligibleForDeletion.containsKey(tableId);
+    }
+
+    public boolean isPartitionIneligibleForDeletion(TablePartition tablePartition) {
+        return partitionsIneligibleForDeletion.containsKey(tablePartition);
+    }
+
+    public Set<TableBucketReplica> getReplicasInState(long tableId, ReplicaState state) {
+        return getAllReplicasForTable(tableId).stream()
+                .filter(r -> getReplicaState(r) == state)
+                .collect(Collectors.toSet());
+    }
+
+    public Set<TableBucketReplica> getReplicasInState(
+            TablePartition tablePartition, ReplicaState state) {
+        return getAllReplicasForPartition(
+                        tablePartition.getTableId(), tablePartition.getPartitionId())
+                .stream()
+                .filter(r -> getReplicaState(r) == state)
+                .collect(Collectors.toSet());
+    }
+
     public void removeTable(long tableId) {
         tablesToBeDeleted.remove(tableId);
+        tablesIneligibleForDeletion.remove(tableId);
         Map<Integer, List<Integer>> assignment = tableAssignments.remove(tableId);
         if (assignment != null) {
             // remove leadership info for each bucket from the context
@@ -671,6 +735,7 @@ public class CoordinatorContext {
 
     public void removePartition(TablePartition tablePartition) {
         partitionsToBeDeleted.remove(tablePartition);
+        partitionsIneligibleForDeletion.remove(tablePartition);
         Map<Integer, List<Integer>> assignment = partitionAssignments.remove(tablePartition);
         if (assignment != null) {
             // remove leadership info for each bucket from the context
@@ -728,6 +793,9 @@ public class CoordinatorContext {
 
     public void resetContext() {
         tablesToBeDeleted.clear();
+        partitionsToBeDeleted.clear();
+        tablesIneligibleForDeletion.clear();
+        partitionsIneligibleForDeletion.clear();
         clearTablesState();
         liveTabletServers.clear();
         liveCoordinatorServers.clear();

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -87,6 +87,7 @@ import org.apache.fluss.server.coordinator.event.NotifyLeaderAndIsrResponseRecei
 import org.apache.fluss.server.coordinator.event.RebalanceEvent;
 import org.apache.fluss.server.coordinator.event.RemoveServerTagEvent;
 import org.apache.fluss.server.coordinator.event.SchemaChangeEvent;
+import org.apache.fluss.server.coordinator.event.StopReplicaSendFailedEvent;
 import org.apache.fluss.server.coordinator.event.TableRegistrationChangeEvent;
 import org.apache.fluss.server.coordinator.event.watcher.CoordinatorChangeWatcher;
 import org.apache.fluss.server.coordinator.event.watcher.TableChangeWatcher;
@@ -95,6 +96,7 @@ import org.apache.fluss.server.coordinator.lease.KvSnapshotLeaseManager;
 import org.apache.fluss.server.coordinator.rebalance.RebalanceManager;
 import org.apache.fluss.server.coordinator.statemachine.ReplicaLeaderElection.ControlledShutdownLeaderElection;
 import org.apache.fluss.server.coordinator.statemachine.ReplicaLeaderElection.ReassignmentLeaderElection;
+import org.apache.fluss.server.coordinator.statemachine.ReplicaState;
 import org.apache.fluss.server.coordinator.statemachine.ReplicaStateMachine;
 import org.apache.fluss.server.coordinator.statemachine.TableBucketStateMachine;
 import org.apache.fluss.server.entity.AdjustIsrResultForBucket;
@@ -150,6 +152,7 @@ import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.NewR
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.NonExistentReplica;
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.OfflineReplica;
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.OnlineReplica;
+import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.ReplicaDeletionIneligible;
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.ReplicaDeletionStarted;
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.ReplicaDeletionSuccessful;
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.ReplicaMigrationStarted;
@@ -453,6 +456,10 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 "Load table and partition assignment success in {}ms when initializing coordinator context.",
                 System.currentTimeMillis() - start4loadAssignment);
 
+        // Rebuild ineligible marks lost during failover by scanning queued-for-deletion
+        // tables/partitions for replicas on offline tablet servers.
+        initIneligibleForDeletion();
+
         long end = System.currentTimeMillis();
         LOG.info("Current total {} tables in the cluster.", coordinatorContext.allTables().size());
         LOG.info(
@@ -462,6 +469,36 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 "Detect partition {} to be deleted after initializing coordinator context. ",
                 coordinatorContext.getPartitionsToBeDeleted());
         LOG.info("End initializing coordinator context, cost {}ms", end - start);
+    }
+
+    private void initIneligibleForDeletion() {
+        Set<Integer> liveServers = coordinatorContext.liveTabletServerSet();
+        for (long tableId : coordinatorContext.getTablesToBeDeleted()) {
+            for (TableBucketReplica replica : coordinatorContext.getAllReplicasForTable(tableId)) {
+                if (!liveServers.contains(replica.getReplica())) {
+                    coordinatorContext.markTableIneligibleForDeletion(
+                            tableId,
+                            "tabletServer "
+                                    + replica.getReplica()
+                                    + " hosting replica is offline at coordinator startup");
+                    break;
+                }
+            }
+        }
+        for (TablePartition partition : coordinatorContext.getPartitionsToBeDeleted()) {
+            for (TableBucketReplica replica :
+                    coordinatorContext.getAllReplicasForPartition(
+                            partition.getTableId(), partition.getPartitionId())) {
+                if (!liveServers.contains(replica.getReplica())) {
+                    coordinatorContext.markPartitionIneligibleForDeletion(
+                            partition,
+                            "tabletServer "
+                                    + replica.getReplica()
+                                    + " hosting replica is offline at coordinator startup");
+                    break;
+                }
+            }
+        }
     }
 
     private void loadTableAssignment() throws Exception {
@@ -584,6 +621,8 @@ public class CoordinatorEventProcessor implements EventProcessor {
                     (NotifyLeaderAndIsrResponseReceivedEvent) event);
         } else if (event instanceof DeleteReplicaResponseReceivedEvent) {
             processDeleteReplicaResponseReceived((DeleteReplicaResponseReceivedEvent) event);
+        } else if (event instanceof StopReplicaSendFailedEvent) {
+            processStopReplicaSendFailed((StopReplicaSendFailedEvent) event);
         } else if (event instanceof NewCoordinatorEvent) {
             processNewCoordinator((NewCoordinatorEvent) event);
         } else if (event instanceof DeadCoordinatorEvent) {
@@ -869,7 +908,8 @@ public class CoordinatorEventProcessor implements EventProcessor {
         }
 
         coordinatorContext.queueTableDeletion(Collections.singleton(tableId));
-        tableManager.onDeleteTable(tableId);
+        // Route through resumeDeletions so that the eligibility check applies uniformly.
+        tableManager.resumeDeletions();
         if (dropTableEvent.isAutoPartitionTable()) {
             autoPartitionManager.removeAutoPartitionTable(tableId);
         }
@@ -904,7 +944,8 @@ public class CoordinatorEventProcessor implements EventProcessor {
         }
 
         coordinatorContext.queuePartitionDeletion(Collections.singleton(tablePartition));
-        tableManager.onDeletePartition(tableId, dropPartitionEvent.getPartitionId());
+        // Route through resumeDeletions so that the eligibility check applies uniformly.
+        tableManager.resumeDeletions();
         autoPartitionManager.removePartition(tableId, dropPartitionEvent.getPartitionName());
 
         // send update metadata request.
@@ -939,7 +980,9 @@ public class CoordinatorEventProcessor implements EventProcessor {
         // clear the fail deleted number for the success deleted replicas
         coordinatorContext.clearFailDeleteNumbers(successDeletedReplicas);
 
-        // pick up the replicas to retry delete and replicas that considered as success delete
+        // Response-level failures (TS replied with per-bucket error): retry up to
+        // DELETE_TRY_TIMES then force-succeed. RPC-layer failures (no response) are
+        // handled separately via StopReplicaSendFailedEvent.
         Tuple2<Set<TableBucketReplica>, Set<TableBucketReplica>>
                 retryDeleteAndSuccessDeleteReplicas =
                         coordinatorContext.retryDeleteAndSuccessDeleteReplicas(failDeletedReplicas);
@@ -956,6 +999,38 @@ public class CoordinatorEventProcessor implements EventProcessor {
         // if any success deletion, we can resume
         if (!successDeletedReplicas.isEmpty()) {
             tableManager.resumeDeletions();
+        }
+    }
+
+    private void processStopReplicaSendFailed(StopReplicaSendFailedEvent event) {
+        // Transition replicas to ReplicaDeletionIneligible and mark the table/partition
+        // ineligible until the TabletServer reconnects. Only process replicas still in
+        // ReplicaDeletionStarted (parallel events may have already moved them).
+        Set<TableBucketReplica> stillInDeletion =
+                event.getFailedReplicas().stream()
+                        .filter(
+                                replica ->
+                                        coordinatorContext.getReplicaState(replica)
+                                                == ReplicaDeletionStarted)
+                        .collect(Collectors.toSet());
+        if (stillInDeletion.isEmpty()) {
+            return;
+        }
+        replicaStateMachine.handleStateChanges(stillInDeletion, ReplicaDeletionIneligible);
+        markFailedReplicasIneligible(stillInDeletion, "stopReplica RPC send failed");
+        tableManager.resumeDeletions();
+    }
+
+    private void markFailedReplicasIneligible(
+            Set<TableBucketReplica> failedReplicas, String reason) {
+        for (TableBucketReplica replica : failedReplicas) {
+            TableBucket tb = replica.getTableBucket();
+            if (tb.getPartitionId() != null) {
+                coordinatorContext.markPartitionIneligibleForDeletion(
+                        new TablePartition(tb.getTableId(), tb.getPartitionId()), reason);
+            } else {
+                coordinatorContext.markTableIneligibleForDeletion(tb.getTableId(), reason);
+            }
         }
     }
 
@@ -1116,6 +1191,31 @@ public class CoordinatorEventProcessor implements EventProcessor {
         // and offline partitions to see if those tablet servers become leaders for some/all
         // of those
         tableBucketStateMachine.triggerOnlineBucketStateChange();
+
+        // Clear ineligible marks for tables/partitions with replicas on the reconnecting
+        // server and resume their deletion.
+        Set<TableBucketReplica> replicasOnReconnectingServer =
+                coordinatorContext.replicasOnTabletServer(tabletServerId);
+        Set<Long> tablesToResume =
+                replicasOnReconnectingServer.stream()
+                        .map(r -> r.getTableBucket().getTableId())
+                        .filter(coordinatorContext::isTableQueuedForDeletion)
+                        .collect(Collectors.toSet());
+        Set<TablePartition> partitionsToResume =
+                replicasOnReconnectingServer.stream()
+                        .filter(r -> r.getTableBucket().getPartitionId() != null)
+                        .map(
+                                r ->
+                                        new TablePartition(
+                                                r.getTableBucket().getTableId(),
+                                                r.getTableBucket().getPartitionId()))
+                        .filter(coordinatorContext::isPartitionQueuedForDeletion)
+                        .collect(Collectors.toSet());
+        if (!tablesToResume.isEmpty() || !partitionsToResume.isEmpty()) {
+            tablesToResume.forEach(coordinatorContext::markTableEligibleForDeletion);
+            partitionsToResume.forEach(coordinatorContext::markPartitionEligibleForDeletion);
+            tableManager.resumeDeletions();
+        }
     }
 
     private void processDeadTabletServer(DeadTabletServerEvent deadTabletServerEvent) {
@@ -1174,6 +1274,38 @@ public class CoordinatorEventProcessor implements EventProcessor {
 
         // trigger OfflineReplica state change for those newly offline replicas
         replicaStateMachine.handleStateChanges(replicas, OfflineReplica);
+
+        // For to-be-deleted replicas on the dead server, transition them to
+        // ReplicaDeletionIneligible and mark the owning table/partition ineligible
+        // until the TabletServer reconnects.
+        Set<TableBucketReplica> deletedReplicasInDeletion = new HashSet<>();
+        Set<TableBucketReplica> deletedReplicasNotInDeletion = new HashSet<>();
+        for (TableBucketReplica replica :
+                coordinatorContext.replicasOnTabletServer(tabletServerId)) {
+            if (!coordinatorContext.isToBeDeleted(replica.getTableBucket())) {
+                continue;
+            }
+            ReplicaState state = coordinatorContext.getReplicaState(replica);
+            if (state == ReplicaDeletionStarted) {
+                deletedReplicasInDeletion.add(replica);
+            } else if (state == OnlineReplica || state == NewReplica || state == OfflineReplica) {
+                deletedReplicasNotInDeletion.add(replica);
+            }
+        }
+        if (!deletedReplicasNotInDeletion.isEmpty()) {
+            replicaStateMachine.handleStateChanges(deletedReplicasNotInDeletion, OfflineReplica);
+            replicaStateMachine.handleStateChanges(
+                    deletedReplicasNotInDeletion, ReplicaDeletionIneligible);
+            markFailedReplicasIneligible(deletedReplicasNotInDeletion, "tabletServer offline");
+        }
+        if (!deletedReplicasInDeletion.isEmpty()) {
+            replicaStateMachine.handleStateChanges(
+                    deletedReplicasInDeletion, ReplicaDeletionIneligible);
+            markFailedReplicasIneligible(deletedReplicasInDeletion, "tabletServer offline");
+        }
+        if (!deletedReplicasInDeletion.isEmpty() || !deletedReplicasNotInDeletion.isEmpty()) {
+            tableManager.resumeDeletions();
+        }
 
         // update tabletServer metadata cache by send updateMetadata request.
         updateTabletServerMetadataCache(serverInfos, null, null, bucketsWithOfflineLeader);

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatch.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatch.java
@@ -38,6 +38,7 @@ import org.apache.fluss.rpc.protocol.ApiError;
 import org.apache.fluss.server.coordinator.event.DeleteReplicaResponseReceivedEvent;
 import org.apache.fluss.server.coordinator.event.EventManager;
 import org.apache.fluss.server.coordinator.event.NotifyLeaderAndIsrResponseReceivedEvent;
+import org.apache.fluss.server.coordinator.event.StopReplicaSendFailedEvent;
 import org.apache.fluss.server.entity.DeleteReplicaResultForBucket;
 import org.apache.fluss.server.entity.NotifyLeaderAndIsrData;
 import org.apache.fluss.server.metadata.BucketMetadata;
@@ -440,6 +441,7 @@ public class CoordinatorRequestBatch {
     }
 
     private void sendStopRequest(int coordinatorEpoch) {
+        Set<Integer> liveServers = coordinatorContext.liveTabletServerSet();
         for (Map.Entry<Integer, Map<TableBucket, PbStopReplicaReqForBucket>> stopReplciaEntry :
                 stopReplicaRequestMap.entrySet()) {
             // send request for each tablet server
@@ -459,18 +461,48 @@ public class CoordinatorRequestBatch {
                             .map(t -> toTableBucket(t.getTableBucket()))
                             .collect(Collectors.toSet());
 
+            // If the TS is not live, the channel manager has no gateway and would silently
+            // drop the request. Surface the failure so deletion replicas can be marked
+            // ineligible instead of stuck in ReplicaDeletionStarted.
+            if (!liveServers.contains(serverId)) {
+                if (!deletedReplicaBuckets.isEmpty()) {
+                    LOG.warn(
+                            "Tablet server {} is not in the live set when sending stop replica "
+                                    + "request; surfacing as StopReplicaSendFailedEvent for {} "
+                                    + "deletion replica(s).",
+                            serverId,
+                            deletedReplicaBuckets.size());
+                    Set<TableBucketReplica> failedReplicas =
+                            deletedReplicaBuckets.stream()
+                                    .map(bucket -> new TableBucketReplica(bucket, serverId))
+                                    .collect(Collectors.toSet());
+                    eventManager.put(new StopReplicaSendFailedEvent(failedReplicas));
+                }
+                continue;
+            }
+
             coordinatorChannelManager.sendStopBucketReplicaRequest(
                     serverId,
                     stopReplicaRequest,
                     (response, throwable) -> {
                         if (throwable != null) {
-                            // todo: in FLUSS-55886145, we will introduce a sender thread to send
-                            // the request.
-                            // in here, we just ignore the error.
                             LOG.warn(
                                     "Failed to send stop replica request to tablet server {}.",
                                     serverId,
                                     throwable);
+                            // For deletion replicas, surface as StopReplicaSendFailedEvent so
+                            // they can be marked ineligible. Non-delete stop replica failures
+                            // are best-effort and can be ignored.
+                            if (!deletedReplicaBuckets.isEmpty()) {
+                                Set<TableBucketReplica> failedReplicas =
+                                        deletedReplicaBuckets.stream()
+                                                .map(
+                                                        bucket ->
+                                                                new TableBucketReplica(
+                                                                        bucket, serverId))
+                                                .collect(Collectors.toSet());
+                                eventManager.put(new StopReplicaSendFailedEvent(failedReplicas));
+                            }
                             return;
                         }
                         // handle the response

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/TableManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/TableManager.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 
 /** A manager for tables. */
 public class TableManager {
@@ -186,19 +187,57 @@ public class TableManager {
      *
      * <p>It does the following:
      *
-     * <p>1. Move all the replicas to offline state. This will send stop replica request to the
-     * replicas.
+     * <p>1. Skip replicas already in {@code ReplicaDeletionSuccessful}.
      *
-     * <p>2. Move all the replicas to deletion started state. This will send stop replica request
-     * with delete=true which will delete all persistent data from all the replicas of the all the
-     * respective buckets.
+     * <p>2. For dead replicas (owning TS not live): transition to {@code ReplicaDeletionIneligible}
+     * and mark the table/partition ineligible until the TS reconnects.
+     *
+     * <p>3. For alive replicas: transition through {@code OfflineReplica -> ReplicaDeletionStarted}
+     * which sends {@code stopReplica(delete=true)}.
      */
     private void onDeleteTableBucket(Set<TableBucketReplica> allReplicas) {
-        // to offline, send stop replica to all followers that are not in the OfflineReplica state
-        // so they stop sending fetch requests to the leader
-        replicaStateMachine.handleStateChanges(allReplicas, ReplicaState.OfflineReplica);
-        // to deletion started
-        replicaStateMachine.handleStateChanges(allReplicas, ReplicaState.ReplicaDeletionStarted);
+        Set<TableBucketReplica> pending =
+                allReplicas.stream()
+                        .filter(
+                                r ->
+                                        coordinatorContext.getReplicaState(r)
+                                                != ReplicaState.ReplicaDeletionSuccessful)
+                        .collect(Collectors.toSet());
+
+        Set<Integer> liveServers = coordinatorContext.liveTabletServerSet();
+        Set<TableBucketReplica> aliveReplicas = new HashSet<>();
+        Set<TableBucketReplica> deadReplicas = new HashSet<>();
+        for (TableBucketReplica replica : pending) {
+            if (liveServers.contains(replica.getReplica())) {
+                aliveReplicas.add(replica);
+            } else {
+                deadReplicas.add(replica);
+            }
+        }
+
+        if (!deadReplicas.isEmpty()) {
+            replicaStateMachine.handleStateChanges(deadReplicas, ReplicaState.OfflineReplica);
+            replicaStateMachine.handleStateChanges(
+                    deadReplicas, ReplicaState.ReplicaDeletionIneligible);
+            for (TableBucketReplica replica : deadReplicas) {
+                TableBucket tb = replica.getTableBucket();
+                if (tb.getPartitionId() != null) {
+                    coordinatorContext.markPartitionIneligibleForDeletion(
+                            new TablePartition(tb.getTableId(), tb.getPartitionId()),
+                            "tabletServer was not in live set at deletion kickoff");
+                } else {
+                    coordinatorContext.markTableIneligibleForDeletion(
+                            tb.getTableId(),
+                            "tabletServer was not in live set at deletion kickoff");
+                }
+            }
+        }
+
+        if (!aliveReplicas.isEmpty()) {
+            replicaStateMachine.handleStateChanges(aliveReplicas, ReplicaState.OfflineReplica);
+            replicaStateMachine.handleStateChanges(
+                    aliveReplicas, ReplicaState.ReplicaDeletionStarted);
+        }
     }
 
     public void resumeDeletions() {
@@ -208,19 +247,38 @@ public class TableManager {
 
     private void resumeTableDeletions() {
         Set<Long> tablesToBeDeleted = new HashSet<>(coordinatorContext.getTablesToBeDeleted());
+        Set<Long> tablesEligibleForRetry = new HashSet<>();
         Set<Long> eligibleTableDeletion = new HashSet<>();
 
         for (long tableId : tablesToBeDeleted) {
-            // if all replicas are marked as deleted successfully, then table deletion is done
+            // Step 1: if all replicas are marked as deleted successfully, complete deletion.
             if (coordinatorContext.areAllReplicasInState(
                     tableId, ReplicaState.ReplicaDeletionSuccessful)) {
                 completeDeleteTable(tableId);
                 LOG.info("Deletion of table with id {} successfully completed.", tableId);
+                continue;
             }
+
+            // Step 2: if no replica is in ReplicaDeletionStarted AND any is Ineligible,
+            // transition Ineligible replicas back to OfflineReplica for retry.
+            if (!coordinatorContext.isAnyReplicaInState(
+                            tableId, ReplicaState.ReplicaDeletionStarted)
+                    && coordinatorContext.isAnyReplicaInState(
+                            tableId, ReplicaState.ReplicaDeletionIneligible)) {
+                tablesEligibleForRetry.add(tableId);
+            }
+
+            // Step 3: only tables that pass the ineligible-flag guard get onDeleteTable.
             if (isEligibleForDeletion(tableId)) {
                 eligibleTableDeletion.add(tableId);
             }
         }
+
+        // Retry transitions run first so that eligible replicas can be re-started below.
+        if (!tablesEligibleForRetry.isEmpty()) {
+            retryDeletionForIneligibleReplicas(tablesEligibleForRetry);
+        }
+
         if (!eligibleTableDeletion.isEmpty()) {
             for (long tableId : eligibleTableDeletion) {
                 onDeleteTable(tableId);
@@ -231,23 +289,69 @@ public class TableManager {
     private void resumePartitionDeletions() {
         Set<TablePartition> partitionsToDelete =
                 new HashSet<>(coordinatorContext.getPartitionsToBeDeleted());
+        Set<TablePartition> partitionsEligibleForRetry = new HashSet<>();
         Set<TablePartition> eligiblePartitionDeletion = new HashSet<>();
 
         for (TablePartition partition : partitionsToDelete) {
-            // if all replicas are marked as deleted successfully, then partition deletion is done
             if (coordinatorContext.areAllReplicasInState(
                     partition, ReplicaState.ReplicaDeletionSuccessful)) {
                 completeDeletePartition(partition);
                 LOG.info("Deletion of partition {} successfully completed.", partition);
+                continue;
             }
+
+            if (!coordinatorContext.isAnyReplicaInState(
+                            partition, ReplicaState.ReplicaDeletionStarted)
+                    && coordinatorContext.isAnyReplicaInState(
+                            partition, ReplicaState.ReplicaDeletionIneligible)) {
+                partitionsEligibleForRetry.add(partition);
+            }
+
             if (isEligibleForDeletion(partition)) {
                 eligiblePartitionDeletion.add(partition);
             }
         }
+
+        if (!partitionsEligibleForRetry.isEmpty()) {
+            retryDeletionForIneligibleReplicasInPartitions(partitionsEligibleForRetry);
+        }
+
         if (!eligiblePartitionDeletion.isEmpty()) {
             for (TablePartition partition : eligiblePartitionDeletion) {
                 onDeletePartition(partition.getTableId(), partition.getPartitionId());
             }
+        }
+    }
+
+    /** Transitions all Ineligible replicas for the given tables to OfflineReplica. */
+    private void retryDeletionForIneligibleReplicas(Set<Long> tableIds) {
+        Set<TableBucketReplica> replicas =
+                tableIds.stream()
+                        .flatMap(
+                                id ->
+                                        coordinatorContext
+                                                .getReplicasInState(
+                                                        id, ReplicaState.ReplicaDeletionIneligible)
+                                                .stream())
+                        .collect(Collectors.toSet());
+        if (!replicas.isEmpty()) {
+            replicaStateMachine.handleStateChanges(replicas, ReplicaState.OfflineReplica);
+        }
+    }
+
+    /** Transitions all Ineligible replicas for the given partitions to OfflineReplica. */
+    private void retryDeletionForIneligibleReplicasInPartitions(Set<TablePartition> partitions) {
+        Set<TableBucketReplica> replicas =
+                partitions.stream()
+                        .flatMap(
+                                p ->
+                                        coordinatorContext
+                                                .getReplicasInState(
+                                                        p, ReplicaState.ReplicaDeletionIneligible)
+                                                .stream())
+                        .collect(Collectors.toSet());
+        if (!replicas.isEmpty()) {
+            replicaStateMachine.handleStateChanges(replicas, ReplicaState.OfflineReplica);
         }
     }
 
@@ -321,18 +425,17 @@ public class TableManager {
     }
 
     private boolean isEligibleForDeletion(long tableId) {
-        // the table is queued for deletion and
-        // no any replica is in state deletion started
+        // Three-guard check: queued, no replica in Started, not in ineligible set.
         return coordinatorContext.isTableQueuedForDeletion(tableId)
                 && !coordinatorContext.isAnyReplicaInState(
-                        tableId, ReplicaState.ReplicaDeletionStarted);
+                        tableId, ReplicaState.ReplicaDeletionStarted)
+                && !coordinatorContext.isTableIneligibleForDeletion(tableId);
     }
 
     private boolean isEligibleForDeletion(TablePartition tablePartition) {
-        // the partition is queued for deletion and
-        // no any replica is in state deletion started
         return coordinatorContext.isPartitionQueuedForDeletion(tablePartition)
                 && !coordinatorContext.isAnyReplicaInState(
-                        tablePartition, ReplicaState.ReplicaDeletionStarted);
+                        tablePartition, ReplicaState.ReplicaDeletionStarted)
+                && !coordinatorContext.isPartitionIneligibleForDeletion(tablePartition);
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/StopReplicaSendFailedEvent.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/StopReplicaSendFailedEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator.event;
+
+import org.apache.fluss.metadata.TableBucketReplica;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Signals that a {@code stopReplica(delete=true)} request could not be delivered at the RPC layer
+ * (e.g., gateway missing or network error). The event processor transitions affected replicas to
+ * {@code ReplicaDeletionIneligible} until the tablet server reconnects.
+ */
+public class StopReplicaSendFailedEvent implements CoordinatorEvent {
+
+    private final Set<TableBucketReplica> failedReplicas;
+
+    public StopReplicaSendFailedEvent(Set<TableBucketReplica> failedReplicas) {
+        this.failedReplicas = Collections.unmodifiableSet(failedReplicas);
+    }
+
+    public Set<TableBucketReplica> getFailedReplicas() {
+        return failedReplicas;
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/ReplicaState.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/ReplicaState.java
@@ -39,13 +39,13 @@ public enum ReplicaState implements BaseState<ReplicaState> {
     OnlineReplica {
         @Override
         public Set<ReplicaState> getValidPreviousStates() {
-            return EnumSet.of(NewReplica, OnlineReplica, OfflineReplica);
+            return EnumSet.of(NewReplica, OnlineReplica, OfflineReplica, ReplicaDeletionIneligible);
         }
     },
     OfflineReplica {
         @Override
         public Set<ReplicaState> getValidPreviousStates() {
-            return EnumSet.of(NewReplica, OnlineReplica, OfflineReplica);
+            return EnumSet.of(NewReplica, OnlineReplica, OfflineReplica, ReplicaDeletionIneligible);
         }
     },
     ReplicaMigrationStarted {
@@ -68,6 +68,12 @@ public enum ReplicaState implements BaseState<ReplicaState> {
         @Override
         public Set<ReplicaState> getValidPreviousStates() {
             return EnumSet.of(ReplicaDeletionStarted);
+        }
+    },
+    ReplicaDeletionIneligible {
+        @Override
+        public Set<ReplicaState> getValidPreviousStates() {
+            return EnumSet.of(OfflineReplica, ReplicaDeletionStarted);
         }
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/ReplicaStateMachine.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/ReplicaStateMachine.java
@@ -346,6 +346,10 @@ public class ReplicaStateMachine {
                 validReplicas.forEach(
                         replica -> doStateChange(replica, ReplicaState.ReplicaDeletionSuccessful));
                 break;
+            case ReplicaDeletionIneligible:
+                validReplicas.forEach(
+                        replica -> doStateChange(replica, ReplicaState.ReplicaDeletionIneligible));
+                break;
             case NonExistentReplica:
                 validReplicas.forEach(replica -> doStateChange(replica, null));
                 break;

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorContextTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorContextTest.java
@@ -21,6 +21,7 @@ import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.metadata.Schema;
 import org.apache.fluss.metadata.TableDescriptor;
 import org.apache.fluss.metadata.TableInfo;
+import org.apache.fluss.metadata.TablePartition;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.server.zk.ZkEpoch;
 import org.apache.fluss.types.DataTypes;
@@ -28,6 +29,7 @@ import org.apache.fluss.types.DataTypes;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Collections;
 
 import static org.apache.fluss.config.ConfigOptions.TABLE_DATALAKE_ENABLED;
 import static org.apache.fluss.record.TestData.DEFAULT_REMOTE_DATA_DIR;
@@ -67,6 +69,81 @@ class CoordinatorContextTest {
 
         assertThat(context.allTables()).hasSize(3);
         assertThat(context.getLakeTableCount()).isEqualTo(2);
+    }
+
+    @Test
+    void testIneligibleForDeletionMarkAndRemove() {
+        CoordinatorContext context = new CoordinatorContext(ZkEpoch.INITIAL_EPOCH);
+
+        long queuedTableId = 100L;
+        long unqueuedTableId = 200L;
+        TablePartition queuedPartition = new TablePartition(300L, 1L);
+        TablePartition unqueuedPartition = new TablePartition(400L, 2L);
+
+        // only tables/partitions that are queued for deletion can be marked ineligible
+        context.queueTableDeletion(Collections.singleton(queuedTableId));
+        context.queuePartitionDeletion(Collections.singleton(queuedPartition));
+
+        // initially nothing is ineligible
+        assertThat(context.isTableIneligibleForDeletion(queuedTableId)).isFalse();
+        assertThat(context.isPartitionIneligibleForDeletion(queuedPartition)).isFalse();
+
+        // (a) mark-when-queued sets the ineligible flag
+        context.markTableIneligibleForDeletion(queuedTableId, "first reason");
+        context.markPartitionIneligibleForDeletion(queuedPartition, "first reason");
+        assertThat(context.isTableIneligibleForDeletion(queuedTableId)).isTrue();
+        assertThat(context.isPartitionIneligibleForDeletion(queuedPartition)).isTrue();
+
+        // (b) re-mark same id with new reason keeps the flag set (reason is overwritten)
+        context.markTableIneligibleForDeletion(queuedTableId, "updated reason");
+        context.markPartitionIneligibleForDeletion(queuedPartition, "updated reason");
+        assertThat(context.isTableIneligibleForDeletion(queuedTableId)).isTrue();
+        assertThat(context.isPartitionIneligibleForDeletion(queuedPartition)).isTrue();
+
+        // (c) mark-when-NOT-queued is a no-op
+        context.markTableIneligibleForDeletion(unqueuedTableId, "should be ignored");
+        context.markPartitionIneligibleForDeletion(unqueuedPartition, "should be ignored");
+        assertThat(context.isTableIneligibleForDeletion(unqueuedTableId)).isFalse();
+        assertThat(context.isPartitionIneligibleForDeletion(unqueuedPartition)).isFalse();
+
+        // (d) markEligibleForDeletion removes the ineligible flag
+        context.markTableEligibleForDeletion(queuedTableId);
+        context.markPartitionEligibleForDeletion(queuedPartition);
+        assertThat(context.isTableIneligibleForDeletion(queuedTableId)).isFalse();
+        assertThat(context.isPartitionIneligibleForDeletion(queuedPartition)).isFalse();
+
+        // re-marking after eligible should set it back to ineligible
+        context.markTableIneligibleForDeletion(queuedTableId, "second-time reason");
+        context.markPartitionIneligibleForDeletion(queuedPartition, "second-time reason");
+        assertThat(context.isTableIneligibleForDeletion(queuedTableId)).isTrue();
+        assertThat(context.isPartitionIneligibleForDeletion(queuedPartition)).isTrue();
+    }
+
+    @Test
+    void testResetContextClearsAllDeletionState() {
+        CoordinatorContext context = new CoordinatorContext(ZkEpoch.INITIAL_EPOCH);
+
+        long tableId = 100L;
+        TablePartition partition = new TablePartition(200L, 1L);
+
+        // pre-seed all four collections covered by the fix
+        context.queueTableDeletion(Collections.singleton(tableId));
+        context.queuePartitionDeletion(Collections.singleton(partition));
+        context.markTableIneligibleForDeletion(tableId, "blocked");
+        context.markPartitionIneligibleForDeletion(partition, "blocked");
+
+        // sanity-check pre-conditions before reset
+        assertThat(context.getTablesToBeDeleted()).contains(tableId);
+        assertThat(context.getPartitionsToBeDeleted()).contains(partition);
+        assertThat(context.isTableIneligibleForDeletion(tableId)).isTrue();
+        assertThat(context.isPartitionIneligibleForDeletion(partition)).isTrue();
+
+        context.resetContext();
+
+        assertThat(context.getTablesToBeDeleted()).isEmpty();
+        assertThat(context.getPartitionsToBeDeleted()).isEmpty();
+        assertThat(context.isTableIneligibleForDeletion(tableId)).isFalse();
+        assertThat(context.isPartitionIneligibleForDeletion(partition)).isFalse();
     }
 
     private TableInfo createTableInfo(long tableId, TablePath tablePath, boolean isLake) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
@@ -51,6 +51,11 @@ import org.apache.fluss.server.coordinator.event.AdjustIsrReceivedEvent;
 import org.apache.fluss.server.coordinator.event.CommitKvSnapshotEvent;
 import org.apache.fluss.server.coordinator.event.CommitRemoteLogManifestEvent;
 import org.apache.fluss.server.coordinator.event.CoordinatorEventManager;
+import org.apache.fluss.server.coordinator.event.DeadTabletServerEvent;
+import org.apache.fluss.server.coordinator.event.DropPartitionEvent;
+import org.apache.fluss.server.coordinator.event.DropTableEvent;
+import org.apache.fluss.server.coordinator.event.NewTabletServerEvent;
+import org.apache.fluss.server.coordinator.event.StopReplicaSendFailedEvent;
 import org.apache.fluss.server.coordinator.lease.KvSnapshotLeaseManager;
 import org.apache.fluss.server.coordinator.remote.RemoteDirDynamicLoader;
 import org.apache.fluss.server.coordinator.statemachine.BucketState;
@@ -341,6 +346,542 @@ class CoordinatorEventProcessorTest {
         retry(
                 Duration.ofMinutes(1),
                 () -> assertThat(zookeeperClient.getTableAssignment(t1Id)).isEmpty());
+    }
+
+    @Test
+    void testStopReplicaSendFailedTransitionsReplicasToOffline() throws Exception {
+        // Verification #3: dispatch StopReplicaSendFailedEvent. Replicas in
+        // ReplicaDeletionStarted should be transitioned to ReplicaDeletionIneligible by
+        // processStopReplicaSendFailed, then resumeDeletions Step 2 retries them back to
+        // OfflineReplica. The owning table is marked ineligible so onDeleteTable does not
+        // fire.
+        initCoordinatorChannel();
+        TablePath t1 = TablePath.of(defaultDatabase, "t_stop_replica_send_failed");
+        final long t1Id =
+                createTable(
+                        t1,
+                        new TabletServerInfo[] {
+                            new TabletServerInfo(0, "rack0"),
+                            new TabletServerInfo(1, "rack1"),
+                            new TabletServerInfo(2, "rack2")
+                        });
+        // wait until the table has its full replica set in the context AND all are online
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.replicaCounts(t1Id)).isEqualTo(N_BUCKETS * REPLICATION_FACTOR);
+                    assertThat(ctx.areAllReplicasInState(t1Id, OnlineReplica)).isTrue();
+                });
+
+        // Setup: queue table for deletion and force all replicas into ReplicaDeletionStarted.
+        Set<TableBucketReplica> replicas =
+                fromCtx(
+                        ctx -> {
+                            ctx.queueTableDeletion(Collections.singleton(t1Id));
+                            Set<TableBucketReplica> all = ctx.getAllReplicasForTable(t1Id);
+                            for (TableBucketReplica r : all) {
+                                ctx.putReplicaState(r, ReplicaState.ReplicaDeletionStarted);
+                            }
+                            return all;
+                        });
+        assertThat(replicas).hasSize(N_BUCKETS * REPLICATION_FACTOR);
+
+        // Dispatch the event under test.
+        eventProcessor.getCoordinatorEventManager().put(new StopReplicaSendFailedEvent(replicas));
+
+        // After processing: table is ineligible and all replicas land in OfflineReplica
+        // (Started -> Ineligible by processStopReplicaSendFailed, then Ineligible ->
+        // OfflineReplica by resumeDeletions Step 2 retry).
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.isTableIneligibleForDeletion(t1Id)).isTrue();
+                    for (TableBucketReplica r : replicas) {
+                        assertThat(ctx.getReplicaState(r)).isEqualTo(OfflineReplica);
+                    }
+                });
+    }
+
+    @Test
+    void testProcessDeadTabletServerHandlesAllToBeDeletedReplicas() throws Exception {
+        // Verification #4 + Fix #8: processDeadTabletServer must transition BOTH subsets
+        // of to-be-deleted replicas on the dead server:
+        //   - Subset A: already in ReplicaDeletionStarted -> Ineligible
+        //   - Subset B: in OnlineReplica -> OfflineReplica -> Ineligible
+        // After resumeDeletions Step 2, both end up in OfflineReplica. The owning table
+        // is marked ineligible.
+        initCoordinatorChannel();
+        TablePath t1 = TablePath.of(defaultDatabase, "t_dead_ts_to_be_deleted");
+        final long t1Id =
+                createTable(
+                        t1,
+                        new TabletServerInfo[] {
+                            new TabletServerInfo(0, "rack0"),
+                            new TabletServerInfo(1, "rack1"),
+                            new TabletServerInfo(2, "rack2")
+                        });
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.replicaCounts(t1Id)).isEqualTo(N_BUCKETS * REPLICATION_FACTOR);
+                    assertThat(ctx.areAllReplicasInState(t1Id, OnlineReplica)).isTrue();
+                });
+
+        // Setup: queue table for deletion. Pick replicas on server 0; force one into
+        // ReplicaDeletionStarted (subset A); leave others as OnlineReplica (subset B).
+        final int deadServer = 0;
+        Set<TableBucketReplica> server0Replicas =
+                fromCtx(
+                        ctx -> {
+                            ctx.queueTableDeletion(Collections.singleton(t1Id));
+                            Set<TableBucketReplica> all =
+                                    ctx.getAllReplicasForTable(t1Id).stream()
+                                            .filter(r -> r.getReplica() == deadServer)
+                                            .collect(Collectors.toSet());
+                            assertThat(all).isNotEmpty();
+                            boolean first = true;
+                            for (TableBucketReplica r : all) {
+                                if (first) {
+                                    ctx.putReplicaState(r, ReplicaState.ReplicaDeletionStarted);
+                                    first = false;
+                                }
+                                // others remain in OnlineReplica
+                            }
+                            return all;
+                        });
+
+        // Dispatch the event under test.
+        eventProcessor.getCoordinatorEventManager().put(new DeadTabletServerEvent(deadServer));
+
+        // After processing: server 0 removed from live set, table marked ineligible,
+        // BOTH subsets in OfflineReplica (Ineligible -> OfflineReplica via Step 2).
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.liveTabletServerSet()).doesNotContain(deadServer);
+                    assertThat(ctx.isTableIneligibleForDeletion(t1Id)).isTrue();
+                    for (TableBucketReplica r : server0Replicas) {
+                        assertThat(ctx.getReplicaState(r)).isEqualTo(OfflineReplica);
+                    }
+                });
+    }
+
+    @Test
+    void testProcessNewTabletServerResumesTableDeletion() throws Exception {
+        // Verification #5: when a previously-dead tablet server reconnects,
+        // processNewTabletServer should clear the ineligible mark on tables queued for
+        // deletion that have replicas on it, then resumeDeletions which re-fires
+        // onDeleteTable. The deletion completes normally.
+        initCoordinatorChannel();
+        TablePath t1 = TablePath.of(defaultDatabase, "t_new_ts_resume_table");
+        final long t1Id =
+                createTable(
+                        t1,
+                        new TabletServerInfo[] {
+                            new TabletServerInfo(0, "rack0"),
+                            new TabletServerInfo(1, "rack1"),
+                            new TabletServerInfo(2, "rack2")
+                        });
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.replicaCounts(t1Id)).isEqualTo(N_BUCKETS * REPLICATION_FACTOR);
+                    assertThat(ctx.areAllReplicasInState(t1Id, OnlineReplica)).isTrue();
+                });
+
+        final int reconnectingServer = 0;
+        // capture serverInfo BEFORE removing the server from live set
+        ServerInfo capturedServerInfo =
+                fromCtx(ctx -> ctx.getLiveTabletServers().get(reconnectingServer));
+        assertThat(capturedServerInfo).isNotNull();
+
+        // Setup: queue + mark ineligible + transition all replicas to OfflineReplica and
+        // remove the server from the live set so processNewTabletServer's guard does not
+        // short-circuit.
+        fromCtx(
+                ctx -> {
+                    ctx.queueTableDeletion(Collections.singleton(t1Id));
+                    ctx.markTableIneligibleForDeletion(t1Id, "test-setup");
+                    for (TableBucketReplica r : ctx.getAllReplicasForTable(t1Id)) {
+                        ctx.putReplicaState(r, OfflineReplica);
+                    }
+                    ctx.removeLiveTabletServer(reconnectingServer);
+                    return null;
+                });
+
+        // Sanity: ineligible flag is set before the event.
+        Boolean wasIneligible = fromCtx(ctx -> ctx.isTableIneligibleForDeletion(t1Id));
+        assertThat(wasIneligible).isTrue();
+
+        // Dispatch the reconnect event.
+        eventProcessor
+                .getCoordinatorEventManager()
+                .put(new NewTabletServerEvent(capturedServerInfo));
+
+        // After processing: server back in live set, ineligible flag cleared, deletion
+        // proceeds, assignment eventually removed from ZK.
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.liveTabletServerSet()).contains(reconnectingServer);
+                    assertThat(ctx.isTableIneligibleForDeletion(t1Id)).isFalse();
+                });
+        retry(
+                Duration.ofMinutes(1),
+                () -> assertThat(zookeeperClient.getTableAssignment(t1Id)).isEmpty());
+    }
+
+    @Test
+    void testInitIneligibleForDeletionMarksTableWithReplicaOnDeadServer() throws Exception {
+        // Fix #4 (Verification #17): when the coordinator initializes and finds tables
+        // queued for deletion (assignment in ZK but no table info in metadataManager) whose
+        // replicas live on a tablet server NOT in liveTabletServerSet, mark the table
+        // ineligible for deletion until that server reconnects.
+        final int extraServer = 3;
+        TabletServerRegistration serverRegistration =
+                new TabletServerRegistration(
+                        "rack3",
+                        Collections.singletonList(
+                                new Endpoint("host3", 2222, DEFAULT_LISTENER_NAME)),
+                        System.currentTimeMillis());
+        // register a 4th tablet server so we can place a replica on it
+        zookeeperClient.registerTabletServer(extraServer, serverRegistration);
+        try {
+            retryVerifyContext(ctx -> assertThat(ctx.liveTabletServerSet()).contains(extraServer));
+            initCoordinatorChannel();
+
+            TablePath t1 = TablePath.of(defaultDatabase, "t_init_ineligible");
+            TableAssignment tableAssignment =
+                    TableAssignment.builder()
+                            .add(0, BucketAssignment.of(extraServer, 0, 1))
+                            .build();
+            long t1Id =
+                    metadataManager.createTable(
+                            t1, remoteDataDir, TEST_TABLE, tableAssignment, false);
+            retryVerifyContext(
+                    ctx -> {
+                        assertThat(ctx.getTablePathById(t1Id)).isNotNull();
+                        assertThat(ctx.replicaCounts(t1Id)).isEqualTo(3);
+                        assertThat(ctx.areAllReplicasInState(t1Id, OnlineReplica)).isTrue();
+                    });
+
+            // shutdown so the drop-table event below is not processed
+            eventProcessor.shutdown();
+            // delete only the table node from ZK - the assignment node is left behind so on
+            // restart the coordinator detects this as a queued-for-deletion table
+            metadataManager.dropTable(t1, false);
+            // remove the 4th server from ZK so init sees it as offline
+            ZOO_KEEPER_EXTENSION_WRAPPER
+                    .getCustomExtension()
+                    .cleanupPath(ZkData.ServerIdZNode.path(extraServer));
+
+            // restart the coordinator
+            eventProcessor = buildCoordinatorEventProcessor();
+            initCoordinatorChannel();
+            eventProcessor.startup();
+
+            // Verify: table is queued and marked ineligible (replica on dead server 3).
+            retryVerifyContext(
+                    ctx -> {
+                        assertThat(ctx.liveTabletServerSet()).doesNotContain(extraServer);
+                        assertThat(ctx.isTableQueuedForDeletion(t1Id)).isTrue();
+                        assertThat(ctx.isTableIneligibleForDeletion(t1Id)).isTrue();
+                    });
+        } finally {
+            ZOO_KEEPER_EXTENSION_WRAPPER
+                    .getCustomExtension()
+                    .cleanupPath(ZkData.ServerIdZNode.path(extraServer));
+        }
+    }
+
+    @Test
+    void testInitIneligibleRecoversWhenServerReconnects() throws Exception {
+        // Fix #4 + Change 6 (Verification #18): after init marks a table ineligible because
+        // a hosting tablet server is offline, when that server reconnects via
+        // NewTabletServerEvent, the ineligible mark is cleared and resumeDeletions
+        // re-fires onDeleteTable. The deletion completes normally.
+        final int extraServer = 3;
+        TabletServerRegistration serverRegistration =
+                new TabletServerRegistration(
+                        "rack3",
+                        Collections.singletonList(
+                                new Endpoint("host3", 3333, DEFAULT_LISTENER_NAME)),
+                        System.currentTimeMillis());
+        zookeeperClient.registerTabletServer(extraServer, serverRegistration);
+        try {
+            retryVerifyContext(ctx -> assertThat(ctx.liveTabletServerSet()).contains(extraServer));
+            initCoordinatorChannel();
+
+            TablePath t1 = TablePath.of(defaultDatabase, "t_init_recover");
+            TableAssignment tableAssignment =
+                    TableAssignment.builder()
+                            .add(0, BucketAssignment.of(extraServer, 0, 1))
+                            .build();
+            long t1Id =
+                    metadataManager.createTable(
+                            t1, remoteDataDir, TEST_TABLE, tableAssignment, false);
+            retryVerifyContext(
+                    ctx -> {
+                        assertThat(ctx.getTablePathById(t1Id)).isNotNull();
+                        assertThat(ctx.replicaCounts(t1Id)).isEqualTo(3);
+                        assertThat(ctx.areAllReplicasInState(t1Id, OnlineReplica)).isTrue();
+                    });
+
+            // shutdown coordinator, drop table (leaves assignment in ZK), kill server 3
+            eventProcessor.shutdown();
+            metadataManager.dropTable(t1, false);
+            ZOO_KEEPER_EXTENSION_WRAPPER
+                    .getCustomExtension()
+                    .cleanupPath(ZkData.ServerIdZNode.path(extraServer));
+
+            // restart - init marks the table ineligible
+            eventProcessor = buildCoordinatorEventProcessor();
+            initCoordinatorChannel();
+            eventProcessor.startup();
+            retryVerifyContext(ctx -> assertThat(ctx.isTableIneligibleForDeletion(t1Id)).isTrue());
+
+            // bring server 3 back - the watcher will trigger NewTabletServerEvent
+            zookeeperClient.registerTabletServer(extraServer, serverRegistration);
+            // refresh the gateway map so stopReplica calls succeed for all servers
+            initCoordinatorChannel();
+
+            // After reconnect: ineligible flag cleared, deletion completes.
+            retryVerifyContext(
+                    ctx -> {
+                        assertThat(ctx.liveTabletServerSet()).contains(extraServer);
+                        assertThat(ctx.isTableIneligibleForDeletion(t1Id)).isFalse();
+                    });
+            retry(
+                    Duration.ofMinutes(1),
+                    () -> assertThat(zookeeperClient.getTableAssignment(t1Id)).isEmpty());
+        } finally {
+            ZOO_KEEPER_EXTENSION_WRAPPER
+                    .getCustomExtension()
+                    .cleanupPath(ZkData.ServerIdZNode.path(extraServer));
+        }
+    }
+
+    @Test
+    void testProcessDropTableSkipsOnDeleteWhenIneligible() throws Exception {
+        // Fix #9 (Verification #21): processDropTable now routes through
+        // tableManager.resumeDeletions instead of calling onDeleteTable directly. This
+        // means the three-guard check (queued + no Started + not ineligible) is applied
+        // uniformly. If we pre-mark the table ineligible before the drop event is
+        // processed, onDeleteTable must NOT fire and replicas must remain in OnlineReplica.
+        initCoordinatorChannel();
+        TablePath t1 = TablePath.of(defaultDatabase, "t_drop_ineligible_skip");
+        final long t1Id =
+                createTable(
+                        t1,
+                        new TabletServerInfo[] {
+                            new TabletServerInfo(0, "rack0"),
+                            new TabletServerInfo(1, "rack1"),
+                            new TabletServerInfo(2, "rack2")
+                        });
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.replicaCounts(t1Id)).isEqualTo(N_BUCKETS * REPLICATION_FACTOR);
+                    assertThat(ctx.areAllReplicasInState(t1Id, OnlineReplica)).isTrue();
+                });
+
+        // Pre-queue and pre-mark ineligible BEFORE the drop event is processed.
+        fromCtx(
+                ctx -> {
+                    ctx.queueTableDeletion(Collections.singleton(t1Id));
+                    ctx.markTableIneligibleForDeletion(t1Id, "test-pre-mark");
+                    return null;
+                });
+
+        // Dispatch drop event - processDropTable will queue (idempotent) and call
+        // resumeDeletions, but the ineligible flag prevents onDeleteTable.
+        eventProcessor.getCoordinatorEventManager().put(new DropTableEvent(t1Id, false, false));
+
+        // Replicas should remain in OnlineReplica - onDeleteTable was guarded.
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.isTableIneligibleForDeletion(t1Id)).isTrue();
+                    for (TableBucketReplica r : ctx.getAllReplicasForTable(t1Id)) {
+                        assertThat(ctx.getReplicaState(r)).isEqualTo(OnlineReplica);
+                    }
+                });
+    }
+
+    @Test
+    void testProcessDropPartitionSkipsOnDeleteWhenIneligible() throws Exception {
+        // Fix #9 (Verification #22): partition variant of #21. processDropPartition routes
+        // through tableManager.resumeDeletions; with a pre-set ineligible flag, the
+        // partition should not be deleted and its replicas stay in OnlineReplica.
+        TablePath tablePath = TablePath.of(defaultDatabase, "t_drop_partition_skip");
+        initCoordinatorChannel();
+        TableDescriptor descriptor = getPartitionedTable();
+        long tableId =
+                metadataManager.createTable(tablePath, remoteDataDir, descriptor, null, false);
+
+        int nBuckets = 3;
+        int replicationFactor = 3;
+        Map<Integer, BucketAssignment> assignments =
+                generateAssignment(
+                                nBuckets,
+                                replicationFactor,
+                                new TabletServerInfo[] {
+                                    new TabletServerInfo(0, "rack0"),
+                                    new TabletServerInfo(1, "rack1"),
+                                    new TabletServerInfo(2, "rack2")
+                                })
+                        .getBucketAssignments();
+        PartitionAssignment partitionAssignment = new PartitionAssignment(tableId, assignments);
+        Tuple2<PartitionIdName, PartitionIdName> partitions =
+                preparePartitionAssignment(tablePath, tableId, partitionAssignment);
+        long partitionId = partitions.f0.partitionId;
+        String partitionName = partitions.f0.partitionName;
+        TablePartition tablePartition = new TablePartition(tableId, partitionId);
+
+        verifyPartitionCreated(tablePartition, partitionAssignment, nBuckets, replicationFactor);
+
+        // Pre-queue and pre-mark ineligible.
+        fromCtx(
+                ctx -> {
+                    ctx.queuePartitionDeletion(Collections.singleton(tablePartition));
+                    ctx.markPartitionIneligibleForDeletion(tablePartition, "test-pre-mark");
+                    return null;
+                });
+
+        eventProcessor
+                .getCoordinatorEventManager()
+                .put(new DropPartitionEvent(tableId, partitionId, partitionName));
+
+        // The partition replicas should remain in OnlineReplica - onDeletePartition skipped.
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.isPartitionIneligibleForDeletion(tablePartition)).isTrue();
+                    for (TableBucketReplica r :
+                            ctx.getAllReplicasForPartition(tableId, partitionId)) {
+                        assertThat(ctx.getReplicaState(r)).isEqualTo(OnlineReplica);
+                    }
+                });
+    }
+
+    @Test
+    void testProcessDeadTabletServerMarksPartitionIneligible() throws Exception {
+        // Fix #8 partition variant (Verification #24): same as #4 but for partition replicas.
+        TablePath tablePath = TablePath.of(defaultDatabase, "t_dead_ts_partition_ineligible");
+        initCoordinatorChannel();
+        TableDescriptor descriptor = getPartitionedTable();
+        long tableId =
+                metadataManager.createTable(tablePath, remoteDataDir, descriptor, null, false);
+
+        int nBuckets = 3;
+        int replicationFactor = 3;
+        Map<Integer, BucketAssignment> assignments =
+                generateAssignment(
+                                nBuckets,
+                                replicationFactor,
+                                new TabletServerInfo[] {
+                                    new TabletServerInfo(0, "rack0"),
+                                    new TabletServerInfo(1, "rack1"),
+                                    new TabletServerInfo(2, "rack2")
+                                })
+                        .getBucketAssignments();
+        PartitionAssignment partitionAssignment = new PartitionAssignment(tableId, assignments);
+        Tuple2<PartitionIdName, PartitionIdName> partitions =
+                preparePartitionAssignment(tablePath, tableId, partitionAssignment);
+        long partitionId = partitions.f0.partitionId;
+        TablePartition tablePartition = new TablePartition(tableId, partitionId);
+
+        verifyPartitionCreated(tablePartition, partitionAssignment, nBuckets, replicationFactor);
+
+        final int deadServer = 0;
+        // Setup: queue partition for deletion. Force one server-0 replica into Started
+        // (subset A); leave others as OnlineReplica (subset B).
+        Set<TableBucketReplica> server0Replicas =
+                fromCtx(
+                        ctx -> {
+                            ctx.queuePartitionDeletion(Collections.singleton(tablePartition));
+                            Set<TableBucketReplica> all =
+                                    ctx.getAllReplicasForPartition(tableId, partitionId).stream()
+                                            .filter(r -> r.getReplica() == deadServer)
+                                            .collect(Collectors.toSet());
+                            assertThat(all).isNotEmpty();
+                            boolean first = true;
+                            for (TableBucketReplica r : all) {
+                                if (first) {
+                                    ctx.putReplicaState(r, ReplicaState.ReplicaDeletionStarted);
+                                    first = false;
+                                }
+                            }
+                            return all;
+                        });
+
+        eventProcessor.getCoordinatorEventManager().put(new DeadTabletServerEvent(deadServer));
+
+        // After processing: server 0 not live, partition marked ineligible, both subsets
+        // ultimately in OfflineReplica.
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.liveTabletServerSet()).doesNotContain(deadServer);
+                    assertThat(ctx.isPartitionIneligibleForDeletion(tablePartition)).isTrue();
+                    for (TableBucketReplica r : server0Replicas) {
+                        assertThat(ctx.getReplicaState(r)).isEqualTo(OfflineReplica);
+                    }
+                });
+    }
+
+    @Test
+    void testProcessNewTabletServerResumesPartitionDeletion() throws Exception {
+        // Change 6 partition variant (Verification #25): partition queued for deletion
+        // with replicas on a previously-offline TS that's now reconnecting.
+        // markPartitionEligibleForDeletion is called and resumeDeletions completes the
+        // partition deletion.
+        TablePath tablePath = TablePath.of(defaultDatabase, "t_new_ts_resume_partition");
+        initCoordinatorChannel();
+        TableDescriptor descriptor = getPartitionedTable();
+        long tableId =
+                metadataManager.createTable(tablePath, remoteDataDir, descriptor, null, false);
+
+        int nBuckets = 3;
+        int replicationFactor = 3;
+        Map<Integer, BucketAssignment> assignments =
+                generateAssignment(
+                                nBuckets,
+                                replicationFactor,
+                                new TabletServerInfo[] {
+                                    new TabletServerInfo(0, "rack0"),
+                                    new TabletServerInfo(1, "rack1"),
+                                    new TabletServerInfo(2, "rack2")
+                                })
+                        .getBucketAssignments();
+        PartitionAssignment partitionAssignment = new PartitionAssignment(tableId, assignments);
+        Tuple2<PartitionIdName, PartitionIdName> partitionsTuple =
+                preparePartitionAssignment(tablePath, tableId, partitionAssignment);
+        long partitionId = partitionsTuple.f0.partitionId;
+        TablePartition tablePartition = new TablePartition(tableId, partitionId);
+
+        verifyPartitionCreated(tablePartition, partitionAssignment, nBuckets, replicationFactor);
+
+        final int reconnectingServer = 0;
+        ServerInfo capturedServerInfo =
+                fromCtx(ctx -> ctx.getLiveTabletServers().get(reconnectingServer));
+        assertThat(capturedServerInfo).isNotNull();
+
+        // Setup: queue + mark ineligible + replicas in OfflineReplica + remove server 0.
+        fromCtx(
+                ctx -> {
+                    ctx.queuePartitionDeletion(Collections.singleton(tablePartition));
+                    ctx.markPartitionIneligibleForDeletion(tablePartition, "test-setup");
+                    for (TableBucketReplica r :
+                            ctx.getAllReplicasForPartition(tableId, partitionId)) {
+                        ctx.putReplicaState(r, OfflineReplica);
+                    }
+                    ctx.removeLiveTabletServer(reconnectingServer);
+                    return null;
+                });
+
+        eventProcessor
+                .getCoordinatorEventManager()
+                .put(new NewTabletServerEvent(capturedServerInfo));
+
+        retryVerifyContext(
+                ctx -> {
+                    assertThat(ctx.liveTabletServerSet()).contains(reconnectingServer);
+                    assertThat(ctx.isPartitionIneligibleForDeletion(tablePartition)).isFalse();
+                });
+        retry(
+                Duration.ofMinutes(1),
+                () -> assertThat(zookeeperClient.getPartitionAssignment(partitionId)).isEmpty());
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatchTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatchTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator;
+
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.metadata.TableBucketReplica;
+import org.apache.fluss.server.coordinator.event.CoordinatorEvent;
+import org.apache.fluss.server.coordinator.event.StopReplicaSendFailedEvent;
+import org.apache.fluss.server.coordinator.event.TestingEventManager;
+import org.apache.fluss.server.zk.ZkEpoch;
+import org.apache.fluss.server.zk.data.LeaderAndIsr;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.fluss.server.coordinator.CoordinatorTestUtils.createServers;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link CoordinatorRequestBatch}, focusing on the pre-check in {@code sendStopRequest}
+ * that surfaces a {@link StopReplicaSendFailedEvent} when a target tablet server is not in the live
+ * set.
+ */
+class CoordinatorRequestBatchTest {
+
+    private static final long TABLE_ID = 1L;
+    private static final int BUCKET = 0;
+    private static final int LIVE_SERVER = 1;
+    private static final int DEAD_SERVER = 2;
+    private static final int LEADER_EPOCH = 0;
+    private static final int COORDINATOR_EPOCH = 0;
+
+    private CoordinatorContext coordinatorContext;
+    private TestCoordinatorChannelManager testCoordinatorChannelManager;
+    private TestingEventManager testingEventManager;
+    private CoordinatorRequestBatch requestBatch;
+    private TableBucket tableBucket;
+
+    @BeforeEach
+    void beforeEach() {
+        coordinatorContext = new CoordinatorContext(ZkEpoch.INITIAL_EPOCH);
+        // servers 0 and 1 are live; server 2 is intentionally NOT in the live set
+        coordinatorContext.setLiveTabletServers(createServers(Arrays.asList(0, LIVE_SERVER)));
+
+        // bucket has replicas on the live server and the dead server
+        tableBucket = new TableBucket(TABLE_ID, BUCKET);
+        coordinatorContext.updateBucketReplicaAssignment(
+                tableBucket, Arrays.asList(LIVE_SERVER, DEAD_SERVER));
+        coordinatorContext.putBucketLeaderAndIsr(
+                tableBucket,
+                new LeaderAndIsr(
+                        LIVE_SERVER,
+                        LEADER_EPOCH,
+                        Arrays.asList(LIVE_SERVER, DEAD_SERVER),
+                        Collections.emptyList(),
+                        COORDINATOR_EPOCH,
+                        0));
+
+        // no gateways are set on the channel manager; the live-set pre-check is what matters here
+        testCoordinatorChannelManager = new TestCoordinatorChannelManager();
+        testingEventManager = new TestingEventManager();
+        requestBatch =
+                new CoordinatorRequestBatch(
+                        testCoordinatorChannelManager, testingEventManager, coordinatorContext);
+    }
+
+    @Test
+    void testSendStopRequestEmitsFailedEventWhenServerNotInLiveSet() {
+        // schedule a delete=true stop-replica targeting BOTH the live and dead server
+        Set<Integer> targetServers = new HashSet<>(Arrays.asList(LIVE_SERVER, DEAD_SERVER));
+        requestBatch.newBatch();
+        requestBatch.addStopReplicaRequestForTabletServers(
+                targetServers, tableBucket, true, true, LEADER_EPOCH);
+
+        // fire sendStopRequest internally
+        requestBatch.sendRequestToTabletServers(COORDINATOR_EPOCH);
+
+        // exactly one StopReplicaSendFailedEvent should be emitted (for the dead server)
+        List<StopReplicaSendFailedEvent> failedEvents =
+                testingEventManager.getEvents().stream()
+                        .filter(e -> e instanceof StopReplicaSendFailedEvent)
+                        .map(e -> (StopReplicaSendFailedEvent) e)
+                        .collect(Collectors.toList());
+        assertThat(failedEvents).hasSize(1);
+
+        Set<TableBucketReplica> failedReplicas = failedEvents.get(0).getFailedReplicas();
+        assertThat(failedReplicas)
+                .containsExactly(new TableBucketReplica(tableBucket, DEAD_SERVER))
+                .doesNotContain(new TableBucketReplica(tableBucket, LIVE_SERVER));
+    }
+
+    @Test
+    void testSendStopRequestSilentlySkipsNonDeleteForDeadServer() {
+        // schedule a non-deletion stop-replica (delete=false, deleteRemote=false) targeting the
+        // dead server; this should be silently skipped without surfacing any event
+        requestBatch.newBatch();
+        requestBatch.addStopReplicaRequestForTabletServers(
+                Collections.singleton(DEAD_SERVER), tableBucket, false, false, LEADER_EPOCH);
+
+        requestBatch.sendRequestToTabletServers(COORDINATOR_EPOCH);
+
+        // no StopReplicaSendFailedEvent should be emitted for non-delete stop replicas
+        List<CoordinatorEvent> failedEvents =
+                testingEventManager.getEvents().stream()
+                        .filter(e -> e instanceof StopReplicaSendFailedEvent)
+                        .collect(Collectors.toList());
+        assertThat(failedEvents).isEmpty();
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/StopReplicaITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/StopReplicaITCase.java
@@ -19,8 +19,11 @@ package org.apache.fluss.server.coordinator;
 
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.metadata.PartitionSpec;
+import org.apache.fluss.metadata.Schema;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.metadata.TablePartition;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.rpc.gateway.CoordinatorGateway;
 import org.apache.fluss.server.replica.Replica;
@@ -29,8 +32,13 @@ import org.apache.fluss.server.testutils.FlussClusterExtension;
 import org.apache.fluss.server.testutils.RpcMessageTestUtils;
 import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.data.LeaderAndIsr;
+import org.apache.fluss.server.zk.data.PartitionAssignment;
+import org.apache.fluss.server.zk.data.PartitionRegistration;
+import org.apache.fluss.types.DataTypes;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -38,7 +46,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR_PK;
@@ -132,6 +143,281 @@ public class StopReplicaITCase {
         retryUtilReplicaNotExist(tb, isr2, tableDirs2);
     }
 
+    /**
+     * Verification item #10 (table-path end-to-end recovery): verifies that when a tablet server
+     * hosting one of the table's replicas goes offline, dropping the table does NOT get stuck and
+     * deletion completes once the offline tablet server reconnects (Change 5 + Change 6 + Change 9
+     * cooperate to pause and then resume the deletion).
+     */
+    @Test
+    void testDropTableCompletesAfterOfflineTabletServerReconnect() throws Exception {
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
+        FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(3);
+
+        TablePath tablePath = TablePath.of("test_db_stop_replica", "test_drop_after_reconnect");
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("a", DataTypes.INT())
+                                        .column("b", DataTypes.STRING())
+                                        .build())
+                        .distributedBy(1)
+                        .property(ConfigOptions.TABLE_REPLICATION_FACTOR, 3)
+                        .build();
+        long tableId =
+                RpcMessageTestUtils.createTable(
+                        FLUSS_CLUSTER_EXTENSION, tablePath, tableDescriptor);
+        TableBucket tb = new TableBucket(tableId, 0);
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(tb);
+
+        List<Integer> isr = waitAndGetIsr(tb);
+        List<Path> tableDirs = assertReplicaExistAndGetTableOrPartitionDirs(tb, isr, false);
+
+        // pick a non-leader replica to take offline so that leadership churn does not prevent
+        // dropTable from being processed quickly.
+        int leader = FLUSS_CLUSTER_EXTENSION.waitAndGetLeader(tb);
+        int offlineServerId =
+                isr.stream().filter(id -> id != leader).findFirst().orElse(isr.get(0));
+
+        FLUSS_CLUSTER_EXTENSION.stopTabletServer(offlineServerId);
+        // wait until coordinator has observed the tablet server going away.
+        FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(2);
+
+        // drop the table — this returns after queueing; the actual deletion is paused because
+        // one of the replica's tablet servers is offline.
+        coordinatorGateway
+                .dropTable(
+                        RpcMessageTestUtils.newDropTableRequest(
+                                tablePath.getDatabaseName(), tablePath.getTableName(), false))
+                .get();
+        // the table's metadata is removed from zk synchronously in dropTable, but the bucket
+        // assignment lives on until all replicas have been stopped.
+        assertThat(zkClient.tableExist(tablePath)).isFalse();
+
+        // bring the tablet server back. Change 6 (processNewTabletServer) clears the ineligible
+        // mark and resumeDeletions drives the pending deletion to completion.
+        FLUSS_CLUSTER_EXTENSION.startTabletServer(offlineServerId);
+        FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(3);
+
+        retryUntilDeletionCleanedInZk(tb, isr, tableDirs, offlineServerId);
+    }
+
+    /**
+     * Verification item #11 (Change 4b end-to-end): would verify that when a stopReplica RPC fails
+     * to send while the target tablet server is still in {@code liveTabletServerSet}, the replica
+     * ends up in {@code OfflineReplica} and the table is marked ineligible until the next event
+     * removes the ineligibility.
+     *
+     * <p>Reason for {@code @Disabled}: deterministically simulating only the RPC-layer send failure
+     * (without taking the tablet server offline) requires fault injection into the coordinator's
+     * gateway, which {@link FlussClusterExtension} does not currently expose. Killing the tablet
+     * server to trigger the same code path is functionally equivalent to {@link
+     * #testDropTableCompletesAfterOfflineTabletServerReconnect()} (#10) and would be redundant. The
+     * corresponding behaviour is already covered at the unit level by the {@code
+     * StopReplicaSendFailedEvent} / {@code CoordinatorRequestBatch} tests (verification items 3 and
+     * 16).
+     */
+    @Test
+    @Disabled(
+            "Requires gateway-level fault injection not yet supported by FlussClusterExtension; "
+                    + "covered by unit tests for StopReplicaSendFailedEvent and "
+                    + "CoordinatorRequestBatch.sendStopRequest.")
+    void testDropTableRecoversFromStopReplicaRpcSendFailure() {
+        // Intentionally left blank — see @Disabled rationale.
+    }
+
+    /**
+     * Verification item #14 (Change 9 end-to-end): when a tablet server is already offline at the
+     * time {@code dropTable} is invoked, deletion must NOT throw and must NOT get stuck. Replicas
+     * on the dead tablet server should be parked in {@code ReplicaDeletionIneligible} and the table
+     * marked ineligible; once the tablet server reconnects, deletion completes.
+     */
+    @Test
+    void testDropTableNotStuckWhenTabletServerDeadAtKickoff() throws Exception {
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
+        FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(3);
+
+        TablePath tablePath = TablePath.of("test_db_stop_replica", "test_drop_dead_kickoff");
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("a", DataTypes.INT())
+                                        .column("b", DataTypes.STRING())
+                                        .build())
+                        .distributedBy(1)
+                        .property(ConfigOptions.TABLE_REPLICATION_FACTOR, 3)
+                        .build();
+        long tableId =
+                RpcMessageTestUtils.createTable(
+                        FLUSS_CLUSTER_EXTENSION, tablePath, tableDescriptor);
+        TableBucket tb = new TableBucket(tableId, 0);
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(tb);
+
+        List<Integer> isr = waitAndGetIsr(tb);
+        List<Path> tableDirs = assertReplicaExistAndGetTableOrPartitionDirs(tb, isr, false);
+
+        int leader = FLUSS_CLUSTER_EXTENSION.waitAndGetLeader(tb);
+        int offlineServerId =
+                isr.stream().filter(id -> id != leader).findFirst().orElse(isr.get(0));
+
+        // 1. Take the tablet server offline BEFORE issuing dropTable so the coordinator hits
+        //    the dead-TS branch in onDeleteTableBucket (Change 9).
+        FLUSS_CLUSTER_EXTENSION.stopTabletServer(offlineServerId);
+        FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(2);
+
+        // 2. dropTable must return successfully even though replicas live on a dead TS.
+        coordinatorGateway
+                .dropTable(
+                        RpcMessageTestUtils.newDropTableRequest(
+                                tablePath.getDatabaseName(), tablePath.getTableName(), false))
+                .get();
+        assertThat(zkClient.tableExist(tablePath)).isFalse();
+
+        // 3. Deletion must be paused (table marked ineligible, assignment still present in zk).
+        CoordinatorContext coordinatorContext =
+                FLUSS_CLUSTER_EXTENSION
+                        .getCoordinatorServer()
+                        .getCoordinatorEventProcessor()
+                        .getCoordinatorContext();
+        retry(
+                Duration.ofMinutes(1),
+                () ->
+                        assertThat(coordinatorContext.isTableIneligibleForDeletion(tableId))
+                                .as(
+                                        "table should be marked ineligible while tablet server "
+                                                + offlineServerId
+                                                + " is offline")
+                                .isTrue());
+        // table assignment still in zk — deletion paused, NOT stuck.
+        assertThat(zkClient.getTableAssignment(tableId)).isPresent();
+
+        // 4. Bring the tablet server back; Change 6 clears the ineligible mark and the
+        //    pending deletion resumes.
+        FLUSS_CLUSTER_EXTENSION.startTabletServer(offlineServerId);
+        FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(3);
+
+        retryUntilDeletionCleanedInZk(tb, isr, tableDirs, offlineServerId);
+        retry(
+                Duration.ofMinutes(1),
+                () ->
+                        assertThat(coordinatorContext.isTableIneligibleForDeletion(tableId))
+                                .as("ineligible mark should be cleared after deletion completes")
+                                .isFalse());
+    }
+
+    /**
+     * Verification item #27 (partition variant of #14): when a tablet server is offline at the time
+     * a partition is dropped, partition deletion must NOT get stuck. Once the tablet server
+     * reconnects, the partition is fully removed.
+     */
+    @Test
+    void testDropPartitionNotStuckWhenTabletServerDeadAtKickoff() throws Exception {
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
+        FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(3);
+
+        TablePath tablePath = TablePath.of("test_db_stop_replica", "test_drop_partition_dead");
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("a", DataTypes.INT())
+                                        .column("b", DataTypes.STRING())
+                                        .build())
+                        .distributedBy(1)
+                        .partitionedBy("b")
+                        .property(ConfigOptions.TABLE_REPLICATION_FACTOR, 3)
+                        .build();
+        long tableId =
+                RpcMessageTestUtils.createTable(
+                        FLUSS_CLUSTER_EXTENSION, tablePath, tableDescriptor);
+
+        // Create one partition explicitly (auto-partition is disabled for this descriptor).
+        String partitionName = "p1";
+        long partitionId =
+                RpcMessageTestUtils.createPartition(
+                        FLUSS_CLUSTER_EXTENSION,
+                        tablePath,
+                        new PartitionSpec(Collections.singletonMap("b", partitionName)),
+                        false);
+        TableBucket tb = new TableBucket(tableId, partitionId, 0);
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(tb);
+
+        List<Integer> isr = waitAndGetIsr(tb);
+        List<Path> partitionDirs = assertReplicaExistAndGetTableOrPartitionDirs(tb, isr, false);
+
+        int leader = FLUSS_CLUSTER_EXTENSION.waitAndGetLeader(tb);
+        int offlineServerId =
+                isr.stream().filter(id -> id != leader).findFirst().orElse(isr.get(0));
+
+        // Take the tablet server offline BEFORE dropping the partition.
+        FLUSS_CLUSTER_EXTENSION.stopTabletServer(offlineServerId);
+        FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(2);
+
+        // dropPartition must return without throwing.
+        coordinatorGateway
+                .dropPartition(
+                        RpcMessageTestUtils.newDropPartitionRequest(
+                                tablePath,
+                                new PartitionSpec(Collections.singletonMap("b", partitionName)),
+                                false))
+                .get();
+
+        // Partition registration is removed synchronously, but the assignment for the
+        // partition's buckets remains until all replicas finish stopping.
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    Map<String, PartitionRegistration> partitions =
+                            zkClient.getPartitionRegistrations(tablePath);
+                    assertThat(partitions).doesNotContainKey(partitionName);
+                });
+
+        TablePartition tablePartition = new TablePartition(tableId, partitionId);
+        CoordinatorContext coordinatorContext =
+                FLUSS_CLUSTER_EXTENSION
+                        .getCoordinatorServer()
+                        .getCoordinatorEventProcessor()
+                        .getCoordinatorContext();
+        retry(
+                Duration.ofMinutes(1),
+                () ->
+                        assertThat(
+                                        coordinatorContext.isPartitionIneligibleForDeletion(
+                                                tablePartition))
+                                .as(
+                                        "partition should be marked ineligible while tablet "
+                                                + "server "
+                                                + offlineServerId
+                                                + " is offline")
+                                .isTrue());
+        Optional<PartitionAssignment> partitionAssignment =
+                zkClient.getPartitionAssignment(partitionId);
+        assertThat(partitionAssignment)
+                .as("partition assignment should still be present while paused")
+                .isPresent();
+
+        // Bring the tablet server back; partition deletion should resume and complete.
+        FLUSS_CLUSTER_EXTENSION.startTabletServer(offlineServerId);
+        FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(3);
+
+        retryUntilDeletionCleanedInZk(tb, isr, partitionDirs, offlineServerId);
+        retry(
+                Duration.ofMinutes(1),
+                () -> assertThat(zkClient.getPartitionAssignment(partitionId)).isEmpty());
+        retry(
+                Duration.ofMinutes(1),
+                () ->
+                        assertThat(
+                                        coordinatorContext.isPartitionIneligibleForDeletion(
+                                                tablePartition))
+                                .as(
+                                        "partition ineligible mark should be cleared after "
+                                                + "deletion completes")
+                                .isFalse());
+    }
+
     private List<Integer> waitAndGetIsr(TableBucket tb) {
         LeaderAndIsr leaderAndIsr =
                 waitValue(
@@ -187,6 +473,46 @@ public class StopReplicaITCase {
                             });
 
                     // at last, when all Replicas are shutdown, the zk data should be removed.
+                    assertThat(zkClient.getTableAssignment(tableBucket.getTableId())).isEmpty();
+                    assertThat(zkClient.getLeaderAndIsr(tableBucket)).isEmpty();
+                });
+    }
+
+    /**
+     * Variant of {@link #retryUtilReplicaNotExist} for tests that restart a tablet server during
+     * the drop flow. The on-disk directory check is skipped for the restarted tablet server because
+     * its {@code ReplicaManager.allReplicas} is empty after restart and {@code stopReplica} for a
+     * {@code NoneReplica} bucket is a no-op (pre-existing TabletServer-side limitation, orthogonal
+     * to the coordinator-side deletion-resume fix exercised by this test). All other assertions —
+     * ZK assignment / LeaderAndIsr emptiness and {@code NoneReplica} state on every replica — are
+     * preserved.
+     */
+    private void retryUntilDeletionCleanedInZk(
+            TableBucket tableBucket,
+            List<Integer> isr,
+            List<Path> tableDirs,
+            int restartedServerId) {
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    for (int i = 0; i < isr.size(); i++) {
+                        int replicaId = isr.get(i);
+                        if (replicaId != restartedServerId) {
+                            assertThat(tableDirs.get(i))
+                                    .as(
+                                            "local replica dir on still-running tablet server "
+                                                    + replicaId
+                                                    + " should be removed")
+                                    .doesNotExist();
+                        }
+                        ReplicaManager replicaManager =
+                                FLUSS_CLUSTER_EXTENSION
+                                        .getTabletServerById(replicaId)
+                                        .getReplicaManager();
+                        assertThat(replicaManager.getReplica(tableBucket))
+                                .isInstanceOf(ReplicaManager.NoneReplica.class);
+                    }
+
                     assertThat(zkClient.getTableAssignment(tableBucket.getTableId())).isEmpty();
                     assertThat(zkClient.getLeaderAndIsr(tableBucket)).isEmpty();
                 });

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/TableManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/TableManagerTest.java
@@ -26,6 +26,7 @@ import org.apache.fluss.metadata.TablePartition;
 import org.apache.fluss.server.coordinator.event.CoordinatorEvent;
 import org.apache.fluss.server.coordinator.event.DeleteReplicaResponseReceivedEvent;
 import org.apache.fluss.server.coordinator.event.TestingEventManager;
+import org.apache.fluss.server.coordinator.statemachine.ReplicaState;
 import org.apache.fluss.server.coordinator.statemachine.ReplicaStateMachine;
 import org.apache.fluss.server.coordinator.statemachine.TableBucketStateMachine;
 import org.apache.fluss.server.entity.DeleteReplicaResultForBucket;
@@ -322,6 +323,359 @@ class TableManagerTest {
                 () -> assertThat(zookeeperClient.getPartitionAssignment(partitionId)).isEmpty());
         // the partition will also be removed from coordinator context
         assertThat(coordinatorContext.getAllReplicasForPartition(tableId, partitionId)).isEmpty();
+    }
+
+    @Test
+    void testResumeTableDeletionsCompletesWhenAllReplicasSuccessful() throws Exception {
+        // Step 1 happy-path: when all replicas are ReplicaDeletionSuccessful,
+        // resumeTableDeletions should finalize deletion (remove ZK assignment + replicas).
+        long tableId = zookeeperClient.getTableIdAndIncrement();
+        TableAssignment assignment = createAssignment();
+        zookeeperClient.registerTableAssignment(tableId, assignment);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        DATA1_TABLE_PATH_PK,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR_PK,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        tableManager.onCreateNewTable(DATA1_TABLE_PATH_PK, tableId, assignment);
+
+        // queue table for deletion and put all replicas in ReplicaDeletionSuccessful
+        coordinatorContext.queueTableDeletion(Collections.singleton(tableId));
+        for (TableBucketReplica replica : getReplicas(tableId, assignment)) {
+            coordinatorContext.putReplicaState(replica, ReplicaDeletionSuccessful);
+        }
+
+        tableManager.resumeDeletions();
+
+        retry(
+                Duration.ofSeconds(30),
+                () -> assertThat(zookeeperClient.getTableAssignment(tableId)).isEmpty());
+        assertThat(coordinatorContext.getAllReplicasForTable(tableId)).isEmpty();
+    }
+
+    @Test
+    void testResumeTableDeletionsRetryStepTransitionsIneligibleToOffline() throws Exception {
+        // Step 2: when no replica is ReplicaDeletionStarted AND any replica is
+        // ReplicaDeletionIneligible, push Ineligible -> OfflineReplica regardless of the
+        // table-ineligible flag (Ineligible is transient). Step 3 guard still keeps the
+        // table from being onDeleteTable'd while the ineligible mark remains.
+        long tableId = zookeeperClient.getTableIdAndIncrement();
+        TableAssignment assignment = createAssignment();
+        zookeeperClient.registerTableAssignment(tableId, assignment);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        DATA1_TABLE_PATH_PK,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR_PK,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        tableManager.onCreateNewTable(DATA1_TABLE_PATH_PK, tableId, assignment);
+
+        coordinatorContext.queueTableDeletion(Collections.singleton(tableId));
+        coordinatorContext.markTableIneligibleForDeletion(tableId, "test reason");
+
+        // half of the replicas in Ineligible, the rest in OfflineReplica; none Started
+        Set<TableBucketReplica> replicas = getReplicas(tableId, assignment);
+        Set<TableBucketReplica> ineligibleReplicas = new HashSet<>();
+        int idx = 0;
+        for (TableBucketReplica replica : replicas) {
+            if (idx % 2 == 0) {
+                coordinatorContext.putReplicaState(replica, ReplicaState.ReplicaDeletionIneligible);
+                ineligibleReplicas.add(replica);
+            } else {
+                coordinatorContext.putReplicaState(replica, ReplicaState.OfflineReplica);
+            }
+            idx++;
+        }
+
+        testingEventManager.clearEvents();
+        tableManager.resumeDeletions();
+
+        // (a) previously-Ineligible replicas now in OfflineReplica
+        for (TableBucketReplica replica : ineligibleReplicas) {
+            assertThat(coordinatorContext.getReplicaState(replica))
+                    .isEqualTo(ReplicaState.OfflineReplica);
+        }
+        // (b) the table is still ineligible (Step 3 guard kept it)
+        assertThat(coordinatorContext.isTableIneligibleForDeletion(tableId)).isTrue();
+        // (c) no DeleteReplicaResponseReceivedEvent emitted (onDeleteTable not invoked)
+        assertThat(collectDeleteReplicaSuccessEvents()).isEmpty();
+    }
+
+    @Test
+    void testResumeTableDeletionsStep3GuardBlocksWhenIneligible() throws Exception {
+        // Step 3 guard: a table queued for deletion but marked ineligible must NOT be
+        // onDeleteTable'd; replicas should remain in OfflineReplica (not transition to
+        // ReplicaDeletionStarted) and no stop-replica delete event should fire.
+        long tableId = zookeeperClient.getTableIdAndIncrement();
+        TableAssignment assignment = createAssignment();
+        zookeeperClient.registerTableAssignment(tableId, assignment);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        DATA1_TABLE_PATH_PK,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR_PK,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        tableManager.onCreateNewTable(DATA1_TABLE_PATH_PK, tableId, assignment);
+
+        coordinatorContext.queueTableDeletion(Collections.singleton(tableId));
+        coordinatorContext.markTableIneligibleForDeletion(tableId, "guard test");
+
+        Set<TableBucketReplica> replicas = getReplicas(tableId, assignment);
+        for (TableBucketReplica replica : replicas) {
+            coordinatorContext.putReplicaState(replica, ReplicaState.OfflineReplica);
+        }
+
+        testingEventManager.clearEvents();
+        tableManager.resumeDeletions();
+
+        assertThat(collectDeleteReplicaSuccessEvents()).isEmpty();
+        for (TableBucketReplica replica : replicas) {
+            assertThat(coordinatorContext.getReplicaState(replica))
+                    .isEqualTo(ReplicaState.OfflineReplica);
+        }
+    }
+
+    @Test
+    void testResumeTableDeletionsStep3FiresWhenEligibilityRestored() throws Exception {
+        // After eligibility is restored (e.g., owning TS reconnected), the next
+        // resumeDeletions should pass the Step 3 guard and invoke onDeleteTable, which
+        // pushes replicas to ReplicaDeletionStarted and emits DeleteReplicaResponseReceivedEvent
+        // for each via the always-success gateway.
+        long tableId = zookeeperClient.getTableIdAndIncrement();
+        TableAssignment assignment = createAssignment();
+        zookeeperClient.registerTableAssignment(tableId, assignment);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        DATA1_TABLE_PATH_PK,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR_PK,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        tableManager.onCreateNewTable(DATA1_TABLE_PATH_PK, tableId, assignment);
+
+        coordinatorContext.queueTableDeletion(Collections.singleton(tableId));
+        coordinatorContext.markTableIneligibleForDeletion(tableId, "before restore");
+
+        Set<TableBucketReplica> replicas = getReplicas(tableId, assignment);
+        for (TableBucketReplica replica : replicas) {
+            coordinatorContext.putReplicaState(replica, ReplicaState.OfflineReplica);
+        }
+
+        // simulate the TS-reconnect / eligibility-restore path
+        coordinatorContext.markTableEligibleForDeletion(tableId);
+
+        testingEventManager.clearEvents();
+        tableManager.resumeDeletions();
+
+        // gateway always succeeds; checkReplicaDelete asserts the expected
+        // DeleteReplicaResponseReceivedEvent set was emitted by onDeleteTable.
+        checkReplicaDelete(tableId, null, assignment);
+    }
+
+    @Test
+    void testOnDeleteTableBucketSplitsAliveAndDeadByLiveSet() throws Exception {
+        // Drop server 2 from the live set BEFORE the bucket is created so that
+        // onDeleteTableBucket sees an alive/dead split.
+        coordinatorContext.removeLiveTabletServer(2);
+        CoordinatorTestUtils.makeSendLeaderAndStopRequestAlwaysSuccess(
+                coordinatorContext, testCoordinatorChannelManager);
+
+        long tableId = zookeeperClient.getTableIdAndIncrement();
+        TableAssignment assignment =
+                TableAssignment.builder().add(0, BucketAssignment.of(1, 2)).build();
+        zookeeperClient.registerTableAssignment(tableId, assignment);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        DATA1_TABLE_PATH_PK,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR_PK,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        tableManager.onCreateNewTable(DATA1_TABLE_PATH_PK, tableId, assignment);
+
+        coordinatorContext.queueTableDeletion(Collections.singleton(tableId));
+        tableManager.onDeleteTable(tableId);
+
+        TableBucket tableBucket = new TableBucket(tableId, 0);
+        TableBucketReplica aliveReplica = new TableBucketReplica(tableBucket, 1);
+        TableBucketReplica deadReplica = new TableBucketReplica(tableBucket, 2);
+
+        // alive replica went OfflineReplica -> ReplicaDeletionStarted
+        assertThat(coordinatorContext.getReplicaState(aliveReplica))
+                .isEqualTo(ReplicaState.ReplicaDeletionStarted);
+        // dead replica went OfflineReplica -> ReplicaDeletionIneligible
+        assertThat(coordinatorContext.getReplicaState(deadReplica))
+                .isEqualTo(ReplicaState.ReplicaDeletionIneligible);
+        // and the table is marked ineligible (with the documented reason internally)
+        assertThat(coordinatorContext.isTableIneligibleForDeletion(tableId)).isTrue();
+    }
+
+    @Test
+    void testResumePartitionDeletionsMirrorsTablePath() throws Exception {
+        // Partition counterpart combining Step 1 (success completion) and
+        // Step 2 + Step 3 (ineligible-flag retry + guard) in one test.
+        long tableId = zookeeperClient.getTableIdAndIncrement();
+        TableAssignment tableAssignment = TableAssignment.builder().build();
+        zookeeperClient.registerTableAssignment(tableId, tableAssignment);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        DATA1_TABLE_PATH,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        tableManager.onCreateNewTable(DATA1_TABLE_PATH, tableId, tableAssignment);
+
+        // ----- Step 1: all replicas successful, partition deletion completes -----
+        PartitionAssignment partitionAssignment =
+                new PartitionAssignment(tableId, createAssignment().getBucketAssignments());
+        long partitionId = zookeeperClient.getPartitionIdAndIncrement();
+        // partition name is keyed off the auto-incremented partitionId so it is unique
+        // across all tests in the class — partition metadata znodes (PartitionZNode) are
+        // not removed by completeDeletePartition and would otherwise collide between tests.
+        String partitionName = "p_resume_step1_" + partitionId;
+        zookeeperClient.registerPartitionAssignmentAndMetadata(
+                partitionId,
+                partitionName,
+                partitionAssignment,
+                DEFAULT_REMOTE_DATA_DIR,
+                DATA1_TABLE_PATH,
+                tableId);
+        tableManager.onCreateNewPartition(
+                DATA1_TABLE_PATH, tableId, partitionId, partitionName, partitionAssignment);
+
+        TablePartition tp1 = new TablePartition(tableId, partitionId);
+        coordinatorContext.queuePartitionDeletion(Collections.singleton(tp1));
+        for (TableBucketReplica replica : getReplicas(tableId, partitionId, partitionAssignment)) {
+            coordinatorContext.putReplicaState(replica, ReplicaDeletionSuccessful);
+        }
+
+        tableManager.resumeDeletions();
+        retry(
+                Duration.ofSeconds(30),
+                () -> assertThat(zookeeperClient.getPartitionAssignment(partitionId)).isEmpty());
+        assertThat(coordinatorContext.getAllReplicasForPartition(tableId, partitionId)).isEmpty();
+
+        // ----- Step 2 + Step 3: ineligible-flag retry transition + guard -----
+        PartitionAssignment partitionAssignment2 =
+                new PartitionAssignment(tableId, createAssignment().getBucketAssignments());
+        long partitionId2 = zookeeperClient.getPartitionIdAndIncrement();
+        String partitionName2 = "p_resume_step23_" + partitionId2;
+        zookeeperClient.registerPartitionAssignmentAndMetadata(
+                partitionId2,
+                partitionName2,
+                partitionAssignment2,
+                DEFAULT_REMOTE_DATA_DIR,
+                DATA1_TABLE_PATH,
+                tableId);
+        tableManager.onCreateNewPartition(
+                DATA1_TABLE_PATH, tableId, partitionId2, partitionName2, partitionAssignment2);
+
+        TablePartition tp2 = new TablePartition(tableId, partitionId2);
+        coordinatorContext.queuePartitionDeletion(Collections.singleton(tp2));
+        coordinatorContext.markPartitionIneligibleForDeletion(tp2, "test reason");
+
+        Set<TableBucketReplica> replicas2 =
+                getReplicas(tableId, partitionId2, partitionAssignment2);
+        Set<TableBucketReplica> ineligibleReplicas = new HashSet<>();
+        int idx = 0;
+        for (TableBucketReplica replica : replicas2) {
+            if (idx % 2 == 0) {
+                coordinatorContext.putReplicaState(replica, ReplicaState.ReplicaDeletionIneligible);
+                ineligibleReplicas.add(replica);
+            } else {
+                coordinatorContext.putReplicaState(replica, ReplicaState.OfflineReplica);
+            }
+            idx++;
+        }
+
+        testingEventManager.clearEvents();
+        tableManager.resumeDeletions();
+
+        // Step 2: previously-Ineligible replicas now in OfflineReplica
+        for (TableBucketReplica replica : ineligibleReplicas) {
+            assertThat(coordinatorContext.getReplicaState(replica))
+                    .isEqualTo(ReplicaState.OfflineReplica);
+        }
+        // Step 3 guard: partition still marked ineligible, onDeletePartition NOT invoked
+        assertThat(coordinatorContext.isPartitionIneligibleForDeletion(tp2)).isTrue();
+        assertThat(collectDeleteReplicaSuccessEvents()).isEmpty();
+    }
+
+    @Test
+    void testOnDeletePartitionAliveDeadSplit() throws Exception {
+        // Partition variant of the alive/dead split: dead replicas go to
+        // ReplicaDeletionIneligible and the partition is marked ineligible.
+        coordinatorContext.removeLiveTabletServer(2);
+        CoordinatorTestUtils.makeSendLeaderAndStopRequestAlwaysSuccess(
+                coordinatorContext, testCoordinatorChannelManager);
+
+        long tableId = zookeeperClient.getTableIdAndIncrement();
+        TableAssignment tableAssignment = TableAssignment.builder().build();
+        zookeeperClient.registerTableAssignment(tableId, tableAssignment);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        DATA1_TABLE_PATH,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        tableManager.onCreateNewTable(DATA1_TABLE_PATH, tableId, tableAssignment);
+
+        PartitionAssignment partitionAssignment =
+                new PartitionAssignment(
+                        tableId,
+                        TableAssignment.builder()
+                                .add(0, BucketAssignment.of(1, 2))
+                                .build()
+                                .getBucketAssignments());
+        long partitionId = zookeeperClient.getPartitionIdAndIncrement();
+        String partitionName = "p_alive_dead_" + partitionId;
+        zookeeperClient.registerPartitionAssignmentAndMetadata(
+                partitionId,
+                partitionName,
+                partitionAssignment,
+                DEFAULT_REMOTE_DATA_DIR,
+                DATA1_TABLE_PATH,
+                tableId);
+        tableManager.onCreateNewPartition(
+                DATA1_TABLE_PATH, tableId, partitionId, partitionName, partitionAssignment);
+
+        TablePartition tp = new TablePartition(tableId, partitionId);
+        coordinatorContext.queuePartitionDeletion(Collections.singleton(tp));
+        tableManager.onDeletePartition(tableId, partitionId);
+
+        TableBucket tableBucket = new TableBucket(tableId, partitionId, 0);
+        TableBucketReplica deadReplica = new TableBucketReplica(tableBucket, 2);
+
+        assertThat(coordinatorContext.getReplicaState(deadReplica))
+                .isEqualTo(ReplicaState.ReplicaDeletionIneligible);
+        assertThat(coordinatorContext.isPartitionIneligibleForDeletion(tp)).isTrue();
     }
 
     private TableAssignment createAssignment() {

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/ReplicaStateMachineTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/ReplicaStateMachineTest.java
@@ -60,6 +60,7 @@ import static org.apache.fluss.record.TestData.DEFAULT_REMOTE_DATA_DIR;
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.NewReplica;
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.OfflineReplica;
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.OnlineReplica;
+import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.ReplicaDeletionIneligible;
 import static org.apache.fluss.server.coordinator.statemachine.ReplicaState.ReplicaDeletionStarted;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -302,6 +303,52 @@ class ReplicaStateMachineTest {
                                 Collections.emptyList(),
                                 0,
                                 3));
+    }
+
+    @Test
+    void testReplicaDeletionIneligibleTransitions() {
+        CoordinatorContext coordinatorContext = new CoordinatorContext(zkEpoch);
+        coordinatorContext.setLiveTabletServers(
+                CoordinatorTestUtils.createServers(Arrays.asList(0, 1)));
+        ReplicaStateMachine replicaStateMachine = createReplicaStateMachine(coordinatorContext);
+
+        long tableId = 1;
+        TableBucket tableBucket = new TableBucket(tableId, 0);
+        TableBucketReplica replica = new TableBucketReplica(tableBucket, 0);
+
+        // pre-seed: directly put replica into ReplicaDeletionStarted; we are exercising
+        // the state machine's transition validation, not how the replica got into Started.
+        coordinatorContext.putReplicaState(replica, ReplicaDeletionStarted);
+
+        // ReplicaDeletionStarted -> ReplicaDeletionIneligible should be a valid transition
+        replicaStateMachine.handleStateChanges(
+                Collections.singletonList(replica), ReplicaDeletionIneligible);
+        assertThat(coordinatorContext.getReplicaState(replica))
+                .isEqualTo(ReplicaDeletionIneligible);
+
+        // ReplicaDeletionIneligible -> OfflineReplica should be a valid transition
+        replicaStateMachine.handleStateChanges(Collections.singletonList(replica), OfflineReplica);
+        assertThat(coordinatorContext.getReplicaState(replica)).isEqualTo(OfflineReplica);
+    }
+
+    @Test
+    void testIneligibleToOnlineTransitionIsValid() {
+        CoordinatorContext coordinatorContext = new CoordinatorContext(zkEpoch);
+        coordinatorContext.setLiveTabletServers(
+                CoordinatorTestUtils.createServers(Arrays.asList(0, 1)));
+        ReplicaStateMachine replicaStateMachine = createReplicaStateMachine(coordinatorContext);
+
+        long tableId = 1;
+        TableBucket tableBucket = new TableBucket(tableId, 0);
+        TableBucketReplica replica = new TableBucketReplica(tableBucket, 0);
+
+        // pre-seed Ineligible directly: we want to verify checkValidReplicaStateChange
+        // accepts Ineligible -> OnlineReplica.
+        coordinatorContext.putReplicaState(replica, ReplicaDeletionIneligible);
+
+        replicaStateMachine.handleStateChanges(Collections.singletonList(replica), OnlineReplica);
+
+        assertThat(coordinatorContext.getReplicaState(replica)).isEqualTo(OnlineReplica);
     }
 
     private void toReplicaDeletionStartedState(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3357 

<!-- What is the purpose of the change -->

### Brief change log

Previously, when a stopReplica(delete=true) RPC failed (e.g., TabletServer offline or network error), replicas got permanently stuck in ReplicaDeletionStarted, blocking table/partition deletion forever.

This PR aligns the deletion flow with Kafka's approach by introducing a `ReplicaDeletionIneligible` state. When a stopReplica RPC fails to send or the target TabletServer goes offline, affected replicas are transitioned to ReplicaDeletionIneligible and the owning table/partition is marked ineligible for deletion. When the TabletServer reconnects, the ineligible mark is cleared and deletion is automatically retried.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
