### PR TITLE
[lake] Avoid aborting Paimon commit after failure

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/PaimonLakeCommitter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/PaimonLakeCommitter.java
@@ -153,10 +153,6 @@ public class PaimonLakeCommitter implements LakeCommitter<PaimonWriteResult, Pai
             }
 
         } catch (Throwable t) {
-            if (tableCommit != null) {
-                // if any error happen while commit, abort the commit to clean committable
-                tableCommit.abort(manifestCommittable.fileCommittables());
-            }
             throw new IOException(t);
         }
     }


### PR DESCRIPTION
<!--
Generated-by: OpenAI Codex following https://github.com/apache/fluss/blob/main/AGENTS.md
-->

### Purpose

Linked issue: N/A (hotfix)

Avoid deleting Paimon data files when `PaimonLakeCommitter.commit` observes an exception after the Paimon commit may already have succeeded.

Generative AI: OpenAI Codex was used in authoring this PR.

### Brief change log

- Removed the automatic `tableCommit.abort(...)` call from the `commit` catch block.
- Kept the explicit `abort(PaimonCommittable)` behavior unchanged.

### Tests

- `./mvnw -pl fluss-lake/fluss-lake-paimon spotless:check`

### API and Format

No API or storage format changes.

### Documentation

No documentation changes.