### PR TITLE
[build] Add Apache Incubator disclaimer to Maven POM metadata

### DIFF
--- a/fluss-client/pom.xml
+++ b/fluss-client/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-client</artifactId>
-    <name>Fluss : Client</name>
+    <name>Apache Fluss (Incubating) : Client</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/fluss-common/pom.xml
+++ b/fluss-common/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-common</artifactId>
-    <name>Fluss : Common</name>
+    <name>Apache Fluss (Incubating) : Common</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/fluss-dist/pom.xml
+++ b/fluss-dist/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-dist</artifactId>
-    <name>Fluss : Dist</name>
+    <name>Apache Fluss (Incubating) : Dist</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/fluss-docgen/pom.xml
+++ b/fluss-docgen/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-docgen</artifactId>
-    <name>Fluss : Documentation Generator</name>
+    <name>Apache Fluss (Incubating) : Documentation Generator</name>
 
     <dependencies>
         <dependency>

--- a/fluss-filesystems/fluss-fs-azure/pom.xml
+++ b/fluss-filesystems/fluss-fs-azure/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-fs-azure</artifactId>
-    <name>Fluss : FileSystems : Azure FS</name>
+    <name>Apache Fluss (Incubating) : FileSystems : Azure FS</name>
 
     <packaging>jar</packaging>
 

--- a/fluss-filesystems/fluss-fs-gs/pom.xml
+++ b/fluss-filesystems/fluss-fs-gs/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-fs-gs</artifactId>
-    <name>Fluss : FileSystems : Google Cloud Storage FS</name>
+    <name>Apache Fluss (Incubating) : FileSystems : Google Cloud Storage FS</name>
 
     <packaging>jar</packaging>
 

--- a/fluss-filesystems/fluss-fs-hadoop-shaded/pom.xml
+++ b/fluss-filesystems/fluss-fs-hadoop-shaded/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-fs-hadoop-shaded</artifactId>
-    <name>Fluss : FileSystems : Hadoop FS shaded</name>
+    <name>Apache Fluss (Incubating) : FileSystems : Hadoop FS shaded</name>
 
     <packaging>jar</packaging>
 

--- a/fluss-filesystems/fluss-fs-hadoop/pom.xml
+++ b/fluss-filesystems/fluss-fs-hadoop/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-fs-hadoop</artifactId>
-    <name>Fluss : FileSystems : Hadoop FS</name>
+    <name>Apache Fluss (Incubating) : FileSystems : Hadoop FS</name>
 
     <packaging>jar</packaging>
 

--- a/fluss-filesystems/fluss-fs-hdfs/pom.xml
+++ b/fluss-filesystems/fluss-fs-hdfs/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-fs-hdfs</artifactId>
-    <name>Fluss : FileSystems : HDFS FS</name>
+    <name>Apache Fluss (Incubating) : FileSystems : HDFS FS</name>
 
     <packaging>jar</packaging>
 

--- a/fluss-filesystems/fluss-fs-obs/pom.xml
+++ b/fluss-filesystems/fluss-fs-obs/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-fs-obs</artifactId>
-    <name>Fluss : FileSystems : OBS FS</name>
+    <name>Apache Fluss (Incubating) : FileSystems : OBS FS</name>
 
     <properties>
         <fs.obs.sdk.version>3.24.12</fs.obs.sdk.version>

--- a/fluss-filesystems/fluss-fs-oss/pom.xml
+++ b/fluss-filesystems/fluss-fs-oss/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-fs-oss</artifactId>
-    <name>Fluss : FileSystems : OSS FS</name>
+    <name>Apache Fluss (Incubating) : FileSystems : OSS FS</name>
 
     <properties>
         <fs.oss.sdk.version>3.17.4</fs.oss.sdk.version>

--- a/fluss-filesystems/fluss-fs-s3/pom.xml
+++ b/fluss-filesystems/fluss-fs-s3/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-fs-s3</artifactId>
-    <name>Fluss : FileSystems : S3 FS</name>
+    <name>Apache Fluss (Incubating) : FileSystems : S3 FS</name>
 
     <packaging>jar</packaging>
 

--- a/fluss-filesystems/pom.xml
+++ b/fluss-filesystems/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-filesystems</artifactId>
-    <name>Fluss : FileSystems :</name>
+    <name>Apache Fluss (Incubating) : FileSystems :</name>
     <modules>
         <module>fluss-fs-hadoop</module>
         <module>fluss-fs-hadoop-shaded</module>

--- a/fluss-flink/fluss-flink-1.18/pom.xml
+++ b/fluss-flink/fluss-flink-1.18/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>fluss-flink-1.18</artifactId>
 
-    <name>Fluss : Engine Flink : 1.18</name>
+    <name>Apache Fluss (Incubating) : Engine Flink : 1.18</name>
 
     <properties>
         <flink.major.version>1.18</flink.major.version>

--- a/fluss-flink/fluss-flink-1.19/pom.xml
+++ b/fluss-flink/fluss-flink-1.19/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>fluss-flink-1.19</artifactId>
 
-    <name>Fluss : Engine Flink : 1.19</name>
+    <name>Apache Fluss (Incubating) : Engine Flink : 1.19</name>
 
     <properties>
         <flink.major.version>1.19</flink.major.version>

--- a/fluss-flink/fluss-flink-1.20/pom.xml
+++ b/fluss-flink/fluss-flink-1.20/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>fluss-flink-1.20</artifactId>
 
-    <name>Fluss : Engine Flink : 1.20</name>
+    <name>Apache Fluss (Incubating) : Engine Flink : 1.20</name>
 
     <properties>
         <flink.major.version>1.20</flink.major.version>

--- a/fluss-flink/fluss-flink-2.2/pom.xml
+++ b/fluss-flink/fluss-flink-2.2/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-flink-2.2</artifactId>
-    <name>Fluss : Engine Flink : 2.2 </name>
+    <name>Apache Fluss (Incubating) : Engine Flink : 2.2 </name>
     <properties>
         <flink.major.version>2.2</flink.major.version>
         <flink.minor.version>2.2.0</flink.minor.version>

--- a/fluss-flink/fluss-flink-common/pom.xml
+++ b/fluss-flink/fluss-flink-common/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>fluss-flink-common</artifactId>
 
-    <name>Fluss : Engine Flink : Common</name>
+    <name>Apache Fluss (Incubating) : Engine Flink : Common</name>
 
     <properties>
         <flink.major.version>1.20</flink.major.version>

--- a/fluss-flink/fluss-flink-tiering/pom.xml
+++ b/fluss-flink/fluss-flink-tiering/pom.xml
@@ -30,7 +30,7 @@
     <packaging>jar</packaging>
 
     <artifactId>fluss-flink-tiering</artifactId>
-    <name>Fluss : Flink : Tiering</name>
+    <name>Apache Fluss (Incubating) : Flink : Tiering</name>
 
     <properties>
         <flink.minor.version>1.20.3</flink.minor.version>

--- a/fluss-flink/pom.xml
+++ b/fluss-flink/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-flink</artifactId>
-    <name>Fluss : Engine Flink :</name>
+    <name>Apache Fluss (Incubating) : Engine Flink :</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/fluss-jmh/pom.xml
+++ b/fluss-jmh/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-jmh</artifactId>
-    <name>Fluss : JMH</name>
+    <name>Apache Fluss (Incubating) : JMH</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/fluss-kafka/pom.xml
+++ b/fluss-kafka/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-kafka</artifactId>
-    <name>Fluss : Kafka Compatibility</name>
+    <name>Apache Fluss (Incubating) : Kafka Compatibility</name>
 
     <properties>
         <kafka.version>3.9.2</kafka.version>

--- a/fluss-lake/fluss-lake-hudi/pom.xml
+++ b/fluss-lake/fluss-lake-hudi/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>fluss-lake-hudi</artifactId>
-    <name>Fluss : Lake : Hudi</name>
+    <name>Apache Fluss (Incubating) : Lake : Hudi</name>
 
     <packaging>jar</packaging>
 

--- a/fluss-lake/fluss-lake-iceberg/pom.xml
+++ b/fluss-lake/fluss-lake-iceberg/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-lake-iceberg</artifactId>
-    <name>Fluss : Lake : Iceberg</name>
+    <name>Apache Fluss (Incubating) : Lake : Iceberg</name>
 
     <packaging>jar</packaging>
     <dependencies>

--- a/fluss-lake/fluss-lake-lance/pom.xml
+++ b/fluss-lake/fluss-lake-lance/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-lake-lance</artifactId>
-    <name>Fluss : Lake : Lance</name>
+    <name>Apache Fluss (Incubating) : Lake : Lance</name>
 
     <packaging>jar</packaging>
 

--- a/fluss-lake/fluss-lake-paimon/pom.xml
+++ b/fluss-lake/fluss-lake-paimon/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-lake-paimon</artifactId>
-    <name>Fluss : Lake : Paimon</name>
+    <name>Apache Fluss (Incubating) : Lake : Paimon</name>
 
     <packaging>jar</packaging>
 

--- a/fluss-lake/pom.xml
+++ b/fluss-lake/pom.xml
@@ -74,7 +74,7 @@
 
 
     <artifactId>fluss-lake</artifactId>
-    <name>Fluss : Lake :</name>
+    <name>Apache Fluss (Incubating) : Lake :</name>
     <modules>
         <module>fluss-lake-paimon</module>
         <module>fluss-lake-iceberg</module>

--- a/fluss-metrics/fluss-metrics-influxdb/pom.xml
+++ b/fluss-metrics/fluss-metrics-influxdb/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-metrics-influxdb</artifactId>
-    <name>Fluss : Metrics : InfluxDB</name>
+    <name>Apache Fluss (Incubating) : Metrics : InfluxDB</name>
 
     <properties>
         <influxdb3.version>1.8.0</influxdb3.version>

--- a/fluss-metrics/fluss-metrics-jmx/pom.xml
+++ b/fluss-metrics/fluss-metrics-jmx/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-metrics-jmx</artifactId>
-    <name>Fluss : Metrics : JMX</name>
+    <name>Apache Fluss (Incubating) : Metrics : JMX</name>
 
     <properties>
         <!-- required by JmxServer -->

--- a/fluss-metrics/fluss-metrics-prometheus/pom.xml
+++ b/fluss-metrics/fluss-metrics-prometheus/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-metrics-prometheus</artifactId>
-    <name>Fluss : Metrics : Prometheus</name>
+    <name>Apache Fluss (Incubating) : Metrics : Prometheus</name>
 
     <properties>
         <prometheus.version>0.8.1</prometheus.version>

--- a/fluss-metrics/pom.xml
+++ b/fluss-metrics/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-metrics</artifactId>
-    <name>Fluss : Metrics :</name>
+    <name>Apache Fluss (Incubating) : Metrics :</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/fluss-protogen/fluss-protogen-generator/pom.xml
+++ b/fluss-protogen/fluss-protogen-generator/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-protogen-generator</artifactId>
-    <name>Fluss : ProtoGen : Generator</name>
+    <name>Apache Fluss (Incubating) : ProtoGen : Generator</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/fluss-protogen/fluss-protogen-maven-plugin/pom.xml
+++ b/fluss-protogen/fluss-protogen-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-protogen-maven-plugin</artifactId>
-    <name>Fluss : ProtoGen : Maven Plugin</name>
+    <name>Apache Fluss (Incubating) : ProtoGen : Maven Plugin</name>
     <packaging>maven-plugin</packaging>
 
     <dependencies>

--- a/fluss-protogen/fluss-protogen-tests/pom.xml
+++ b/fluss-protogen/fluss-protogen-tests/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-protogen-tests</artifactId>
-    <name>Fluss : ProtoGen : Tests</name>
+    <name>Apache Fluss (Incubating) : ProtoGen : Tests</name>
 
     <dependencies>
         <dependency>

--- a/fluss-protogen/pom.xml
+++ b/fluss-protogen/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-protogen</artifactId>
-    <name>Fluss : ProtoGen :</name>
+    <name>Apache Fluss (Incubating) : ProtoGen :</name>
     <packaging>pom</packaging>
     <description>
         ProtoGen is a protobuf compatible code generator which is used to generate Java code for the
@@ -35,6 +35,15 @@
         Lightproto project to match to needs of Fluss. ProtoGen maintains a fork of Lightproto in
         the Fluss repository, because Splunk Lightproto has been archived:
         https://github.com/splunk/lightproto.
+
+        Apache Fluss is an effort undergoing incubation at The Apache Software
+        Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+        required of all newly accepted projects until a further review indicates
+        that the infrastructure, communications, and decision-making process have
+        stabilized in a manner consistent with other successful ASF projects.
+        While incubation status is not necessarily a reflection of the
+        completeness or stability of the code, it does indicate that the project
+        has yet to be fully endorsed by the ASF.
     </description>
 
     <modules>

--- a/fluss-rpc/pom.xml
+++ b/fluss-rpc/pom.xml
@@ -27,10 +27,19 @@
     </parent>
 
     <artifactId>fluss-rpc</artifactId>
-    <name>Fluss : RPC</name>
+    <name>Apache Fluss (Incubating) : RPC</name>
     <packaging>jar</packaging>
     <description>
         The Fluss RPC framework and Netty-based implementation.
+
+        Apache Fluss is an effort undergoing incubation at The Apache Software
+        Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+        required of all newly accepted projects until a further review indicates
+        that the infrastructure, communications, and decision-making process have
+        stabilized in a manner consistent with other successful ASF projects.
+        While incubation status is not necessarily a reflection of the
+        completeness or stability of the code, it does indicate that the project
+        has yet to be fully endorsed by the ASF.
     </description>
 
     <dependencies>

--- a/fluss-server/pom.xml
+++ b/fluss-server/pom.xml
@@ -29,10 +29,19 @@
 
     <artifactId>fluss-server</artifactId>
 
-    <name>Fluss : Server</name>
+    <name>Apache Fluss (Incubating) : Server</name>
     <packaging>jar</packaging>
     <description>
-        The server for Fluss
+        The server for Fluss.
+
+        Apache Fluss is an effort undergoing incubation at The Apache Software
+        Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+        required of all newly accepted projects until a further review indicates
+        that the infrastructure, communications, and decision-making process have
+        stabilized in a manner consistent with other successful ASF projects.
+        While incubation status is not necessarily a reflection of the
+        completeness or stability of the code, it does indicate that the project
+        has yet to be fully endorsed by the ASF.
     </description>
 
     <properties>

--- a/fluss-spark/fluss-spark-3.4/pom.xml
+++ b/fluss-spark/fluss-spark-3.4/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-spark-3.4_${scala.binary.version}</artifactId>
-    <name>Fluss : Engine Spark : 3.4</name>
+    <name>Apache Fluss (Incubating) : Engine Spark : 3.4</name>
 
     <properties>
         <spark.version>3.4.3</spark.version>

--- a/fluss-spark/fluss-spark-3.5/pom.xml
+++ b/fluss-spark/fluss-spark-3.5/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-spark-3.5_${scala.binary.version}</artifactId>
-    <name>Fluss : Engine Spark : 3.5</name>
+    <name>Apache Fluss (Incubating) : Engine Spark : 3.5</name>
 
     <properties>
         <spark.version>3.5.7</spark.version>

--- a/fluss-spark/fluss-spark-common/pom.xml
+++ b/fluss-spark/fluss-spark-common/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-spark-common_${scala.binary.version}</artifactId>
-    <name>Fluss : Engine Spark : Common</name>
+    <name>Apache Fluss (Incubating) : Engine Spark : Common</name>
 
     <dependencies>
         <dependency>

--- a/fluss-spark/fluss-spark-ut/pom.xml
+++ b/fluss-spark/fluss-spark-ut/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-spark-ut_${scala.binary.version}</artifactId>
-    <name>Fluss : Engine Spark : UT</name>
+    <name>Apache Fluss (Incubating) : Engine Spark : UT</name>
 
     <dependencies>
         <dependency>

--- a/fluss-spark/pom.xml
+++ b/fluss-spark/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>fluss-spark</artifactId>
-    <name>Fluss : Engine Spark :</name>
+    <name>Apache Fluss (Incubating) : Engine Spark :</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/fluss-test-coverage/pom.xml
+++ b/fluss-test-coverage/pom.xml
@@ -28,8 +28,19 @@
 
     <artifactId>fluss-test-coverage</artifactId>
     <packaging>jar</packaging>
-    <name>Fluss : Test Code Coverage</name>
-    <description>Module for aggregating code coverage across all modules.</description>
+    <name>Apache Fluss (Incubating) : Test Code Coverage</name>
+    <description>
+        Module for aggregating code coverage across all modules.
+
+        Apache Fluss is an effort undergoing incubation at The Apache Software
+        Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+        required of all newly accepted projects until a further review indicates
+        that the infrastructure, communications, and decision-making process have
+        stabilized in a manner consistent with other successful ASF projects.
+        While incubation status is not necessarily a reflection of the
+        completeness or stability of the code, it does indicate that the project
+        has yet to be fully endorsed by the ASF.
+    </description>
 
     <dependencies>
         <!-- All Fluss modules which should report code coverage -->

--- a/fluss-test-utils/pom.xml
+++ b/fluss-test-utils/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>fluss-test-utils</artifactId>
-    <name>Fluss : Test utils</name>
+    <name>Apache Fluss (Incubating) : Test utils</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,21 @@
     <artifactId>fluss</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Fluss :</name>
+    <name>Apache Fluss (Incubating)</name>
     <packaging>pom</packaging>
-    <description>The Streaming Storage for Real-Time Analytics</description>
+    <description>
+        Apache Fluss (Incubating) is a streaming storage system built for
+        real-time analytics.
+
+        Apache Fluss is an effort undergoing incubation at The Apache Software
+        Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+        required of all newly accepted projects until a further review indicates
+        that the infrastructure, communications, and decision-making process have
+        stabilized in a manner consistent with other successful ASF projects.
+        While incubation status is not necessarily a reflection of the
+        completeness or stability of the code, it does indicate that the project
+        has yet to be fully endorsed by the ASF.
+    </description>
     <url>https://github.com/apache/fluss</url>
     <inceptionYear>2025</inceptionYear>
 

--- a/tools/ci/fluss-ci-tools/pom.xml
+++ b/tools/ci/fluss-ci-tools/pom.xml
@@ -29,7 +29,7 @@
     </parent>
 
     <artifactId>fluss-ci-tools</artifactId>
-    <name>Fluss : CI : Tools</name>
+    <name>Apache Fluss (Incubating) : CI : Tools</name>
 
     <dependencies>
 


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/3376

Addresses Incubator reviewer feedback: "Maven Central - the POM descriptions don't include incubation disclaimer text." 

* Adds the ASF Incubator disclaimer to the root POM `<description>` and appends it to the 4 modules that override `<description>`,  just in case
* Renames `<name>` from `Fluss : ...` to `Apache Fluss (Incubating) : ...` across all POMs.

Effective only for future releases, already-published artifacts on Maven Central are immutable.