### PR TITLE
[website] include maven links to specific plugins/connectors pages

### DIFF
--- a/website/docs/engine-flink/getting-started.md
+++ b/website/docs/engine-flink/getting-started.md
@@ -9,6 +9,30 @@ sidebar_position: 1
 For a quick introduction to running Flink, refer to the [Quick Start](quickstart/flink.md) guide.
 
 
+## Dependencies
+
+Apache Fluss publishes the following JARs to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss connector for Flink 2.2 | [fluss-flink-2.2-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-2.2/$FLUSS_VERSION$/fluss-flink-2.2-$FLUSS_VERSION$.jar) |
+| Fluss connector for Flink 1.20 | [fluss-flink-1.20-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar) |
+| Fluss connector for Flink 1.19 | [fluss-flink-1.19-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-1.19/$FLUSS_VERSION$/fluss-flink-1.19-$FLUSS_VERSION$.jar) |
+| Fluss connector for Flink 1.18 | [fluss-flink-1.18-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-1.18/$FLUSS_VERSION$/fluss-flink-1.18-$FLUSS_VERSION$.jar) |
+
+Maven coordinates (example for Flink 1.20):
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-flink-1.20</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
+
 ## Supported Flink Versions
 | Fluss Connector Versions | Supported Flink Versions |
 |--------------------------|--------------------------| 
@@ -55,14 +79,14 @@ tar -xzf flink-1.20.3-bin-scala_2.12.tgz
 ```
 - **Copy Fluss Flink Bundled Jar**
 
-Download [Fluss Flink Bundled jar](/downloads) and copy to the `lib` directory of your Flink home.
+Download the Fluss Flink connector JAR from the [Dependencies](#dependencies) section above and copy it to the `lib` directory of your Flink home.
 
 ```shell
 cp fluss-flink-1.20-$FLUSS_VERSION$.jar <FLINK_HOME>/lib/
 ```
 :::note
 If you use [Amazon S3](http://aws.amazon.com/s3/), [Aliyun OSS](https://www.aliyun.com/product/oss) or [HDFS(Hadoop Distributed File System)](https://hadoop.apache.org/docs/stable/) as Fluss's [remote storage](maintenance/tiered-storage/remote-storage.md),
-you should download the corresponding [Fluss filesystem jar](/downloads#filesystem-jars) and also copy it to the lib directory of your Flink home.
+you should download the corresponding Fluss filesystem JAR (see [Filesystems](../maintenance/filesystems/overview.md)) and also copy it to the lib directory of your Flink home.
 :::
 
 - **Start a local cluster**

--- a/website/docs/engine-flink/getting-started.md
+++ b/website/docs/engine-flink/getting-started.md
@@ -30,7 +30,7 @@ Maven coordinates (example for Flink 1.20):
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 
 ## Supported Flink Versions

--- a/website/docs/engine-spark/getting-started.md
+++ b/website/docs/engine-spark/getting-started.md
@@ -25,7 +25,7 @@ Maven coordinates (example for Spark 3.5):
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 
 ## Supported Spark Versions

--- a/website/docs/engine-spark/getting-started.md
+++ b/website/docs/engine-spark/getting-started.md
@@ -6,6 +6,28 @@ sidebar_position: 1
 
 # Getting Started with Spark Engine
 
+## Dependencies
+
+Apache Fluss publishes the following JARs to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss connector for Spark 3.5 (Scala 2.12) | [fluss-spark-3.5_2.12-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-spark-3.5_2.12/$FLUSS_VERSION$/fluss-spark-3.5_2.12-$FLUSS_VERSION$.jar) |
+| Fluss connector for Spark 3.4 (Scala 2.12) | [fluss-spark-3.4_2.12-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-spark-3.4_2.12/$FLUSS_VERSION$/fluss-spark-3.4_2.12-$FLUSS_VERSION$.jar) |
+
+Maven coordinates (example for Spark 3.5):
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-spark-3.5_2.12</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
+
 ## Supported Spark Versions
 | Fluss Connector Versions | Supported Spark Versions |
 |--------------------------|--------------------------|
@@ -46,7 +68,7 @@ tar -xzf spark-3.5.7-bin-hadoop3.tgz
 
 - **Copy Fluss Spark Bundled Jar**
 
-Download [Fluss Spark Bundled jar](/downloads) and copy to the `jars` directory of your Spark home.
+Download the Fluss Spark connector JAR from the [Dependencies](#dependencies) section above and copy it to the `jars` directory of your Spark home.
 
 ```shell
 cp fluss-spark-3.5_2.12-$FLUSS_VERSION$.jar <SPARK_HOME>/jars/

--- a/website/docs/install-deploy/deploying-distributed-cluster.md
+++ b/website/docs/install-deploy/deploying-distributed-cluster.md
@@ -164,7 +164,7 @@ Using Flink SQL Client to interact with Fluss.
 
 You can start a Flink standalone cluster refer to [Flink Environment Preparation](engine-flink/getting-started.md#preparation-when-using-flink-sql-client)
 
-**Note**: Make sure the [Fluss connector jar](/downloads/) already has copied to the `lib` directory of your Flink home.
+**Note**: Make sure the [Fluss Flink connector jar](../engine-flink/getting-started.md#dependencies) has already been copied to the `lib` directory of your Flink home.
 
 #### Add catalog
 

--- a/website/docs/install-deploy/deploying-local-cluster.md
+++ b/website/docs/install-deploy/deploying-local-cluster.md
@@ -60,7 +60,7 @@ Using Flink SQL Client to interact with Fluss.
 
 You can start a Flink standalone cluster refer to [Flink Environment Preparation](engine-flink/getting-started.md#preparation-when-using-flink-sql-client)
 
-**Note**: Make sure the [Fluss connector jar](/downloads/) already has copied to the `lib` directory of your Flink home.
+**Note**: Make sure the [Fluss Flink connector jar](../engine-flink/getting-started.md#dependencies) has already been copied to the `lib` directory of your Flink home.
 
 #### Add catalog
 

--- a/website/docs/install-deploy/deploying-with-docker.md
+++ b/website/docs/install-deploy/deploying-with-docker.md
@@ -334,7 +334,7 @@ to interact with Fluss.
 #### Start Flink Cluster
 You can start a Flink standalone cluster refer to [Flink Environment Preparation](engine-flink/getting-started.md#preparation-when-using-flink-sql-client)
 
-**Note**: Make sure the [Fluss connector jar](/downloads/) already has copied to the `lib` directory of your Flink home.
+**Note**: Make sure the [Fluss Flink connector jar](../engine-flink/getting-started.md#dependencies) has already been copied to the `lib` directory of your Flink home.
 ```shell
 bin/start-cluster.sh 
 ```

--- a/website/docs/install-deploy/deploying-with-helm.md
+++ b/website/docs/install-deploy/deploying-with-helm.md
@@ -742,8 +742,8 @@ _fsAzurePlugin: &fsAzurePlugin
         - sh
         - -c
         - |
-          wget -O /plugins/azure/fluss-fs-azure-0.9.jar \
-            https://repo1.maven.org/maven2/org/apache/fluss/fluss-fs-azure/0.9.0-incubating/fluss-fs-azure-0.9.0-incubating.jar
+          wget -O /plugins/azure/fluss-fs-azure-$FLUSS_VERSION$.jar \
+            $FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-fs-azure/$FLUSS_VERSION$/fluss-fs-azure-$FLUSS_VERSION$.jar
       volumeMounts:
         - name: azure-plugin
           mountPath: /plugins

--- a/website/docs/maintenance/filesystems/azure.md
+++ b/website/docs/maintenance/filesystems/azure.md
@@ -7,13 +7,33 @@ sidebar_position: 5
 
 [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs) (Azure Blob Storage) is a massively scalable and secure object storage for cloud-native workloads, archives, data lakes, HPC, and machine learning.
 
+## Dependencies
+
+Apache Fluss publishes the Azure filesystem plugin to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss Azure filesystem plugin | [fluss-fs-azure-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-fs-azure/$FLUSS_VERSION$/fluss-fs-azure-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-fs-azure</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
 ## Install Azure FS Plugin Manually
 
 Azure Blob Storage support is not included in the default Fluss distribution. To enable Azure Blob Storage support, you need to manually install the filesystem plugin into Fluss.
 
 1. **Prepare the plugin JAR**:
 
-    - Download the `fluss-fs-azure-$FLUSS_VERSION$.jar` from the [Maven Repository](https://repo1.maven.org/maven2/org/apache/fluss/fluss-fs-azure/$FLUSS_VERSION$/fluss-fs-azure-$FLUSS_VERSION$.jar).
+    - Download `fluss-fs-azure-$FLUSS_VERSION$.jar` from the [Dependencies](#dependencies) section above.
 
 2. **Place the plugin**: Place the plugin JAR file in the `${FLUSS_HOME}/plugins/azure/` directory:
    ```bash

--- a/website/docs/maintenance/filesystems/azure.md
+++ b/website/docs/maintenance/filesystems/azure.md
@@ -25,7 +25,7 @@ Maven coordinates:
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 ## Install Azure FS Plugin Manually
 

--- a/website/docs/maintenance/filesystems/gs.md
+++ b/website/docs/maintenance/filesystems/gs.md
@@ -1,0 +1,71 @@
+---
+title: Google Cloud Storage
+sidebar_position: 7
+---
+
+# Google Cloud Storage
+
+[Google Cloud Storage](https://cloud.google.com/storage) (GCS) is a managed object storage service for unstructured data, providing high availability, strong consistency, and integration with the broader Google Cloud ecosystem.
+
+## Dependencies
+
+Apache Fluss publishes the Google Cloud Storage filesystem plugin to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss Google Cloud Storage filesystem plugin | [fluss-fs-gs-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-fs-gs/$FLUSS_VERSION$/fluss-fs-gs-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-fs-gs</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
+## Install GS FS Plugin Manually
+
+Google Cloud Storage support is not included in the default Fluss distribution. To enable Google Cloud Storage support, you need to manually install the filesystem plugin into Fluss.
+
+1. **Prepare the plugin JAR**:
+
+    - Download `fluss-fs-gs-$FLUSS_VERSION$.jar` from the [Dependencies](#dependencies) section above.
+
+2. **Place the plugin**: Place the plugin JAR file in the `${FLUSS_HOME}/plugins/gs/` directory:
+   ```bash
+   mkdir -p ${FLUSS_HOME}/plugins/gs/
+   cp fluss-fs-gs-$FLUSS_VERSION$.jar ${FLUSS_HOME}/plugins/gs/
+   ```
+
+3. Restart Fluss if the cluster is already running to ensure the new plugin is loaded.
+
+## Configurations setup
+
+To enable Google Cloud Storage as remote storage, add the required configuration to Fluss' `server.yaml`. The Fluss plugin accepts both `gs.` and `fs.gs.` prefixes; entries are forwarded to the underlying `gcs-connector` with the `fs.gs.` prefix.
+
+### Service account key file
+
+```yaml
+# The dir used as remote storage of Fluss, using the gs:// URI scheme
+remote.data.dir: gs://my-fluss-bucket/path
+# Use a service account JSON key file for authentication
+fs.gs.auth.type: SERVICE_ACCOUNT_JSON_KEYFILE
+# Path to the service account JSON key file on the Fluss host
+fs.gs.auth.service.account.json.keyfile: /etc/fluss/secrets/gcs-sa.json
+```
+
+### Application Default Credentials
+
+When running on GCE, GKE, or any environment with [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) available (for example via Workload Identity), the plugin can pick up credentials automatically:
+
+```yaml
+remote.data.dir: gs://my-fluss-bucket/path
+# Defer to the GCE/GKE metadata server or ADC for credentials
+fs.gs.auth.type: APPLICATION_DEFAULT
+```
+
+Other valid values for `fs.gs.auth.type` include `COMPUTE_ENGINE`, `USER_CREDENTIALS`, `ACCESS_TOKEN_PROVIDER`, and `UNAUTHENTICATED`. See the [GCS Hadoop connector documentation](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md) for the full list of `fs.gs.*` options.

--- a/website/docs/maintenance/filesystems/gs.md
+++ b/website/docs/maintenance/filesystems/gs.md
@@ -25,7 +25,7 @@ Maven coordinates:
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 ## Install GS FS Plugin Manually
 

--- a/website/docs/maintenance/filesystems/hdfs.md
+++ b/website/docs/maintenance/filesystems/hdfs.md
@@ -7,6 +7,26 @@ sidebar_position: 2
 [HDFS (Hadoop Distributed File System)](https://hadoop.apache.org/docs/stable/) is the primary storage system used by Hadoop applications. Fluss
 supports HDFS as a remote storage.
 
+## Dependencies
+
+Apache Fluss publishes the HDFS filesystem plugin to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss HDFS filesystem plugin | [fluss-fs-hdfs-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-fs-hdfs/$FLUSS_VERSION$/fluss-fs-hdfs-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-fs-hdfs</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
 
 ## Configurations setup
 To enabled HDFS as remote storage, you need to define the hdfs path as remote storage in Fluss' `server.yaml`:

--- a/website/docs/maintenance/filesystems/hdfs.md
+++ b/website/docs/maintenance/filesystems/hdfs.md
@@ -25,7 +25,7 @@ Maven coordinates:
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 
 ## Configurations setup

--- a/website/docs/maintenance/filesystems/obs.md
+++ b/website/docs/maintenance/filesystems/obs.md
@@ -25,7 +25,7 @@ Maven coordinates:
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 ## Install OBS Plugin Manually
 

--- a/website/docs/maintenance/filesystems/obs.md
+++ b/website/docs/maintenance/filesystems/obs.md
@@ -7,13 +7,33 @@ sidebar_position: 6
 
 [HuaweiCloud Object Storage Service](https://www.huaweicloud.com/product/obs.html) (HuaweiCloud OBS) is an enterprise-grade object storage solution delivering industry-leading scalability, data durability, security, and cost-efficiency. Trusted by organizations across finance, healthcare, manufacturing, and media, OBS enables you to securely store, manage, analyze, and protect unlimited data volumes for diverse scenarios like AI training, data lakes, multi-cloud backup, and real-time media processing.
 
+## Dependencies
+
+Apache Fluss publishes the OBS filesystem plugin to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss OBS filesystem plugin | [fluss-fs-obs-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-fs-obs/$FLUSS_VERSION$/fluss-fs-obs-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-fs-obs</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
 ## Install OBS Plugin Manually
 
 HuaweiCloud OBS support is not included in the default Fluss distribution. To enable OBS support, you need to manually install the filesystem plugin into Fluss.
 
-1. **Prepare the plugin JAR**: 
+1. **Prepare the plugin JAR**:
 
-   - Download the `fluss-fs-obs-$FLUSS_VERSION$.jar` from the [Maven Repository](https://repo1.maven.org/maven2/org/apache/fluss/fluss-fs-obs/$FLUSS_VERSION$/fluss-fs-obs-$FLUSS_VERSION$.jar).
+   - Download `fluss-fs-obs-$FLUSS_VERSION$.jar` from the [Dependencies](#dependencies) section above.
    
 2. **Place the plugin**: Place the plugin JAR file in the `${FLUSS_HOME}/plugins/obs/` directory:
    ```bash

--- a/website/docs/maintenance/filesystems/oss.md
+++ b/website/docs/maintenance/filesystems/oss.md
@@ -9,6 +9,26 @@ sidebar_position: 3
 
 [Aliyun Object Storage Service](https://www.aliyun.com/product/oss) (Aliyun OSS) is widely used, particularly popular among China’s cloud users, and it provides cloud object storage for a variety of use cases.
 
+## Dependencies
+
+Apache Fluss publishes the OSS filesystem plugin to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss OSS filesystem plugin | [fluss-fs-oss-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-fs-oss/$FLUSS_VERSION$/fluss-fs-oss-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-fs-oss</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
 
 ## Configurations setup
 

--- a/website/docs/maintenance/filesystems/oss.md
+++ b/website/docs/maintenance/filesystems/oss.md
@@ -27,7 +27,7 @@ Maven coordinates:
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 
 ## Configurations setup

--- a/website/docs/maintenance/filesystems/overview.md
+++ b/website/docs/maintenance/filesystems/overview.md
@@ -30,13 +30,13 @@ Never use local file system as remote storage in production as it is not fault-t
 ## Pluggable File Systems
 The Fluss project supports the following file systems:
 
-- **[HDFS](hdfs.md)** is supported by `fluss-fs-hadoop` and registered under the `hdfs://` URI scheme.
+- **[HDFS](hdfs.md)** is supported by `fluss-fs-hadoop` and registered under the `hdfs://` URI scheme. HDFS filesystem is included in default Fluss binary distribution, so you can use it directly without manual installation.
 
-- **[Aliyun OSS](oss.md)** is supported by `fluss-fs-oss` and registered under the `oss://` URI scheme.
+- **[Aliyun OSS](oss.md)** is supported by `fluss-fs-oss` and registered under the `oss://` URI scheme. OSS filesystem is included in default Fluss binary distribution, so you can use it directly without manual installation.
 
-- **[AWS S3](s3.md)** is supported by `fluss-fs-s3` and registered under the `s3://` URI scheme.
+- **[AWS S3](s3.md)** is supported by `fluss-fs-s3` and registered under the `s3://` URI scheme. S3 filesystem is included in default Fluss binary distribution, so you can use it directly without manual installation.
 
-- **[Azure Blob Storage](azure.md)** is supported by `fluss-fs-azure` and registered under the `abfs://`,`abfss://`,`wasb://`,`wasbs://`, URI schemes.
+- **[Azure Blob Storage](azure.md)** is supported by `fluss-fs-azure` and registered under the `abfs://`,`abfss://`,`wasb://`,`wasbs://`, URI schemes. Please make sure to [manually install the OBS plugin](azure.md#install-azure-fs-plugin-manually).
 
 - **[HuaweiCloud OBS](obs.md)** is supported by `fluss-fs-obs` and registered under the `obs://` URI scheme. Please make sure to [manually install the OBS plugin](obs.md#install-obs-plugin-manually).
 

--- a/website/docs/maintenance/filesystems/s3.md
+++ b/website/docs/maintenance/filesystems/s3.md
@@ -25,7 +25,7 @@ Maven coordinates:
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 ## Configurations setup
 

--- a/website/docs/maintenance/filesystems/s3.md
+++ b/website/docs/maintenance/filesystems/s3.md
@@ -7,6 +7,26 @@ sidebar_position: 4
 
 [Amazon Simple Storage Service](http://aws.amazon.com/s3/) (Amazon S3) is cloud object storage with industry-leading scalability, data availability, security, and performance.
 
+## Dependencies
+
+Apache Fluss publishes the S3 filesystem plugin to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss S3 filesystem plugin | [fluss-fs-s3-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-fs-s3/$FLUSS_VERSION$/fluss-fs-s3-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-fs-s3</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
 ## Configurations setup
 
 To enabled S3 as remote storage, there are some required configurations that must be added to Fluss' `server.yaml`:

--- a/website/docs/maintenance/tiered-storage/lakehouse-storage.md
+++ b/website/docs/maintenance/tiered-storage/lakehouse-storage.md
@@ -16,6 +16,27 @@ by external systems such as Flink, Spark, StarRocks and others. With data tiered
 can gain much storage cost reduction and analytics performance improvement.
 
 
+## Dependencies
+
+Apache Fluss publishes the Flink-based tiering service JAR to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss Flink tiering service | [fluss-flink-tiering-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-tiering/$FLUSS_VERSION$/fluss-flink-tiering-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-flink-tiering</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
+
 ## Enable Lakehouse Storage
 
 Lakehouse Storage is disabled by default, you must enable it manually. 
@@ -59,13 +80,13 @@ Additionally, when using Paimon with HDFS, you must also configure the Fluss ser
 Then, you must start the datalake tiering service to tier Fluss's data to the lakehouse storage.
 #### Prerequisites
 - A running Flink cluster (currently only Flink is supported as the tiering backend)
-- Download [fluss-flink-tiering-$FLUSS_VERSION$.jar](https://repo1.maven.org/maven2/org/apache/fluss/fluss-flink-tiering/$FLUSS_VERSION$/fluss-flink-tiering-$FLUSS_VERSION$.jar) 
+- Download [fluss-flink-tiering-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-tiering/$FLUSS_VERSION$/fluss-flink-tiering-$FLUSS_VERSION$.jar) (see [Dependencies](#dependencies))
 
 #### Prepare required jars
-- Put [fluss-flink connector jar](/downloads) into `${FLINK_HOME}/lib`, you should choose a connector version matching your Flink version. If you're using Flink 1.20, please use [fluss-flink-1.20-$FLUSS_VERSION$.jar](https://repo1.maven.org/maven2/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar)
+- Put the Fluss Flink connector JAR into `${FLINK_HOME}/lib`; pick the version matching your Flink runtime (see [Dependencies](../../engine-flink/getting-started.md#dependencies)). For Flink 1.20, use [fluss-flink-1.20-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar).
 - If you are using [Amazon S3](http://aws.amazon.com/s3/), [Aliyun OSS](https://www.aliyun.com/product/oss) or [HDFS(Hadoop Distributed File System)](https://hadoop.apache.org/docs/stable/) as Fluss's [remote storage](maintenance/tiered-storage/remote-storage.md),
-  you should download the corresponding [Fluss filesystem jar](/downloads#filesystem-jars) and also put it into `${FLINK_HOME}/lib`
-- Put [fluss-lake-paimon jar](https://repo1.maven.org/maven2/org/apache/fluss/fluss-lake-paimon/$FLUSS_VERSION$/fluss-lake-paimon-$FLUSS_VERSION$.jar) into `${FLINK_HOME}/lib`
+  you should download the corresponding Fluss filesystem JAR (see [Filesystems](../filesystems/overview.md)) and also put it into `${FLINK_HOME}/lib`
+- Put [fluss-lake-paimon-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-lake-paimon/$FLUSS_VERSION$/fluss-lake-paimon-$FLUSS_VERSION$.jar) into `${FLINK_HOME}/lib`
 - Put [paimon-bundle jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-bundle/$PAIMON_VERSION$/paimon-bundle-$PAIMON_VERSION$.jar) into `${FLINK_HOME}/lib`
 - [Download](https://flink.apache.org/downloads/) pre-bundled Hadoop jar `flink-shaded-hadoop-2-uber-*.jar` and put into `${FLINK_HOME}/lib`
 - Put Paimon's [filesystem jar](https://paimon.apache.org/docs/$PAIMON_VERSION_SHORT$/project/download/) into `${FLINK_HOME}/lib`, if you use s3 to store paimon data, please put `paimon-s3` jar into `${FLINK_HOME}/lib`

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/formats/iceberg.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/formats/iceberg.md
@@ -30,7 +30,7 @@ Maven coordinates:
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 
 ## Configure Iceberg as LakeHouse Storage

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/formats/iceberg.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/formats/iceberg.md
@@ -12,6 +12,26 @@ To integrate Fluss with Iceberg, you must enable lakehouse storage and configure
 
 > **NOTE**: Iceberg requires JDK11 or later. Please ensure that both your Fluss deployment and the Flink cluster used for tiering services are running on JDK11+.
 
+## Dependencies
+
+Apache Fluss publishes the Iceberg lake connector to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss Iceberg lake connector | [fluss-lake-iceberg-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-lake-iceberg/$FLUSS_VERSION$/fluss-lake-iceberg-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-lake-iceberg</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
 
 ## Configure Iceberg as LakeHouse Storage
 
@@ -149,18 +169,17 @@ export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`
 Follow the dependency management guidelines below for the [Prepare required jars](maintenance/tiered-storage/lakehouse-storage.md#prepare-required-jars) step:
 
 ##### 1. Core Fluss Components
-- **Fluss Flink Connector**: Put [fluss-flink connector jar](/downloads) into `${FLINK_HOME}/lib`
-  - Choose a connector version matching your Flink version
-  - For Flink 1.20: [fluss-flink-1.20-$FLUSS_VERSION$.jar](https://repo1.maven.org/maven2/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar)
+- **Fluss Flink Connector**: Put the Fluss Flink connector JAR into `${FLINK_HOME}/lib` — see [Dependencies](../../../engine-flink/getting-started.md#dependencies) for all supported Flink versions.
+  - For Flink 1.20: [fluss-flink-1.20-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar)
 
 ##### 2. Remote Storage Support
-If you are using remote storage, download the corresponding [Fluss filesystem jar](/downloads#filesystem-jars) and place it into `${FLINK_HOME}/lib`:
-- **Amazon S3**: [fluss-fs-s3 jar](/downloads#filesystem-jars)
-- **Aliyun OSS**: [fluss-fs-oss jar](/downloads#filesystem-jars)
-- **HDFS**: [fluss-fs-hdfs jar](/downloads#filesystem-jars)
+If you are using remote storage, download the corresponding Fluss filesystem JAR and place it into `${FLINK_HOME}/lib`:
+- **Amazon S3**: see [S3 Dependencies](../../../maintenance/filesystems/s3.md#dependencies)
+- **Aliyun OSS**: see [OSS Dependencies](../../../maintenance/filesystems/oss.md#dependencies)
+- **HDFS**: see [HDFS Dependencies](../../../maintenance/filesystems/hdfs.md#dependencies)
 
 ##### 3. Iceberg Lake Connector
-- **Fluss Lake Iceberg**: Put [fluss-lake-iceberg jar](https://repo1.maven.org/maven2/org/apache/fluss/fluss-lake-iceberg/$FLUSS_VERSION$/fluss-lake-iceberg-$FLUSS_VERSION$.jar) into `${FLINK_HOME}/lib`
+- **Fluss Lake Iceberg**: Put [fluss-lake-iceberg-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-lake-iceberg/$FLUSS_VERSION$/fluss-lake-iceberg-$FLUSS_VERSION$.jar) into `${FLINK_HOME}/lib`
 
 ##### 4. Iceberg Catalog Dependencies
 Put the JARs required by your Iceberg Catalog into `${FLINK_HOME}/lib`.

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/formats/lance.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/formats/lance.md
@@ -28,7 +28,7 @@ Maven coordinates:
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 ## Configure Lance as LakeHouse Storage
 

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/formats/lance.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/formats/lance.md
@@ -10,6 +10,26 @@ sidebar_position: 3
 [Lance](https://lancedb.github.io/lance/) is a modern table format optimized for machine learning and AI applications. 
 To integrate Fluss with Lance, you must enable lakehouse storage and configure Lance as the lakehouse storage. For more details, see [Enable Lakehouse Storage](maintenance/tiered-storage/lakehouse-storage.md#enable-lakehouse-storage).
 
+## Dependencies
+
+Apache Fluss publishes the Lance lake connector to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss Lance lake connector | [fluss-lake-lance-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-lake-lance/$FLUSS_VERSION$/fluss-lake-lance-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-lake-lance</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
 ## Configure Lance as LakeHouse Storage
 
 ### Configure Lance in Cluster Configurations
@@ -53,10 +73,10 @@ Then, you must start the datalake tiering service to tier Fluss's data to Lance.
 ](maintenance/tiered-storage/lakehouse-storage.md#start-the-datalake-tiering-service). Although the example uses Paimon, the process is also applicable to Lance. 
 
 But in [Prepare required jars](maintenance/tiered-storage/lakehouse-storage.md#prepare-required-jars) step, you should follow this guidance:
-- Put [fluss-flink connector jar](/downloads) into `${FLINK_HOME}/lib`, you should choose a connector version matching your Flink version. If you're using Flink 1.20, please use [fluss-flink-1.20-$FLUSS_VERSION$.jar](https://repo1.maven.org/maven2/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar)
+- Put the Fluss Flink connector JAR into `${FLINK_HOME}/lib`; pick the connector matching your Flink version (see [Dependencies](../../../engine-flink/getting-started.md#dependencies)). For Flink 1.20, use [fluss-flink-1.20-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar).
 - If you are using [Amazon S3](http://aws.amazon.com/s3/), [Aliyun OSS](https://www.aliyun.com/product/oss) or [HDFS(Hadoop Distributed File System)](https://hadoop.apache.org/docs/stable/) as Fluss's [remote storage](maintenance/tiered-storage/remote-storage.md),
-  you should download the corresponding [Fluss filesystem jar](/downloads#filesystem-jars) and also put it into `${FLINK_HOME}/lib`
-- Put [fluss-lake-lance jar](https://repo1.maven.org/maven2/org/apache/fluss/fluss-lake-lance/$FLUSS_VERSION$/fluss-lake-lance-$FLUSS_VERSION$.jar) into `${FLINK_HOME}/lib`
+  you should download the corresponding Fluss filesystem JAR (see the [Filesystems](../../../maintenance/filesystems/overview.md) section) and also put it into `${FLINK_HOME}/lib`.
+- Put [fluss-lake-lance-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-lake-lance/$FLUSS_VERSION$/fluss-lake-lance-$FLUSS_VERSION$.jar) into `${FLINK_HOME}/lib`.
 
 Additionally, when following the [Start Datalake Tiering Service](maintenance/tiered-storage/lakehouse-storage.md#start-datalake-tiering-service) guide, make sure to use Lance-specific configurations as parameters when starting the Flink tiering job:
 ```shell

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/formats/paimon.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/formats/paimon.md
@@ -28,7 +28,7 @@ Maven coordinates:
 </dependency>
 ```
 
-Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads#verifying-downloads).
 
 ## Version Compatibility
 

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/formats/paimon.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/formats/paimon.md
@@ -10,6 +10,26 @@ sidebar_position: 1
 [Apache Paimon](https://paimon.apache.org/) innovatively combines a lake format with an LSM (Log-Structured Merge-tree) structure, bringing efficient updates into the lake architecture. 
 To integrate Fluss with Paimon, you must enable lakehouse storage and configure Paimon as the lakehouse storage. For more details, see [Enable Lakehouse Storage](maintenance/tiered-storage/lakehouse-storage.md#enable-lakehouse-storage).
 
+## Dependencies
+
+Apache Fluss publishes the Paimon lake connector to Maven Central:
+
+| Artifact | Jar |
+|----------|-----|
+| Fluss Paimon lake connector | [fluss-lake-paimon-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-lake-paimon/$FLUSS_VERSION$/fluss-lake-paimon-$FLUSS_VERSION$.jar) |
+
+Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.apache.fluss</groupId>
+  <artifactId>fluss-lake-paimon</artifactId>
+  <version>$FLUSS_VERSION$</version>
+</dependency>
+```
+
+Verify downloaded JARs against the [KEYS file](https://downloads.apache.org/incubator/fluss/KEYS) using the [verification instructions](/downloads).
+
 ## Version Compatibility
 
 | Use Case        | Required/Tested Versions                           |
@@ -104,7 +124,7 @@ For further information, refer to Paimon's [SQL Query documentation](https://pai
 #### Union Read of Data in Fluss and Paimon
 
 ##### Prerequisites
-Download the [fluss-lake-paimon-$FLUSS_VERSION$.jar](https://repo1.maven.org/maven2/org/apache/fluss/fluss-lake-paimon/$FLUSS_VERSION$/fluss-lake-paimon-$FLUSS_VERSION$.jar) and [paimon-bundle-$PAIMON_VERSION$.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-bundle/$PAIMON_VERSION$/paimon-bundle-$PAIMON_VERSION$.jar), and place it into `${FLINK_HOME}/lib`.
+Download the [fluss-lake-paimon-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-lake-paimon/$FLUSS_VERSION$/fluss-lake-paimon-$FLUSS_VERSION$.jar) and [paimon-bundle-$PAIMON_VERSION$.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-bundle/$PAIMON_VERSION$/paimon-bundle-$PAIMON_VERSION$.jar), and place it into `${FLINK_HOME}/lib`.
 
 ##### Union Read
 To read the full dataset, which includes both Fluss (fresh) and Paimon (historical) data, simply query the table without any suffix. The following example illustrates this:


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/3378

PR #3373 removed JAR download links from downloads.md per ASF graduation feedback. 

This change relocates those references to the engine/filesystem/lake doc pages where users actually need them, mirroring how Apache Paimon and Flink structure their connector docs.