### PR TITLE
fix broken path

### DIFF
--- a/website/docs/streaming-lakehouse/integrate-data-lakes/iceberg.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/iceberg.md
@@ -169,14 +169,14 @@ export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`
 Follow the dependency management guidelines below for the [Prepare required jars](maintenance/tiered-storage/lakehouse-storage.md#prepare-required-jars) step:
 
 ##### 1. Core Fluss Components
-- **Fluss Flink Connector**: Put the Fluss Flink connector JAR into `${FLINK_HOME}/lib` — see [Dependencies](../../../engine-flink/getting-started.md#dependencies) for all supported Flink versions.
+- **Fluss Flink Connector**: Put the Fluss Flink connector JAR into `${FLINK_HOME}/lib` — see [Dependencies](../../engine-flink/getting-started.md#dependencies) for all supported Flink versions.
   - For Flink 1.20: [fluss-flink-1.20-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar)
 
 ##### 2. Remote Storage Support
 If you are using remote storage, download the corresponding Fluss filesystem JAR and place it into `${FLINK_HOME}/lib`:
-- **Amazon S3**: see [S3 Dependencies](../../../maintenance/filesystems/s3.md#dependencies)
-- **Aliyun OSS**: see [OSS Dependencies](../../../maintenance/filesystems/oss.md#dependencies)
-- **HDFS**: see [HDFS Dependencies](../../../maintenance/filesystems/hdfs.md#dependencies)
+- **Amazon S3**: see [S3 Dependencies](../../maintenance/filesystems/s3.md#dependencies)
+- **Aliyun OSS**: see [OSS Dependencies](../../maintenance/filesystems/oss.md#dependencies)
+- **HDFS**: see [HDFS Dependencies](../../maintenance/filesystems/hdfs.md#dependencies)
 
 ##### 3. Iceberg Lake Connector
 - **Fluss Lake Iceberg**: Put [fluss-lake-iceberg-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-lake-iceberg/$FLUSS_VERSION$/fluss-lake-iceberg-$FLUSS_VERSION$.jar) into `${FLINK_HOME}/lib`

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/lance.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/lance.md
@@ -73,9 +73,9 @@ Then, you must start the datalake tiering service to tier Fluss's data to Lance.
 ](maintenance/tiered-storage/lakehouse-storage.md#start-the-datalake-tiering-service). Although the example uses Paimon, the process is also applicable to Lance. 
 
 But in [Prepare required jars](maintenance/tiered-storage/lakehouse-storage.md#prepare-required-jars) step, you should follow this guidance:
-- Put the Fluss Flink connector JAR into `${FLINK_HOME}/lib`; pick the connector matching your Flink version (see [Dependencies](../../../engine-flink/getting-started.md#dependencies)). For Flink 1.20, use [fluss-flink-1.20-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar).
+- Put the Fluss Flink connector JAR into `${FLINK_HOME}/lib`; pick the connector matching your Flink version (see [Dependencies](../../engine-flink/getting-started.md#dependencies)). For Flink 1.20, use [fluss-flink-1.20-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-flink-1.20/$FLUSS_VERSION$/fluss-flink-1.20-$FLUSS_VERSION$.jar).
 - If you are using [Amazon S3](http://aws.amazon.com/s3/), [Aliyun OSS](https://www.aliyun.com/product/oss) or [HDFS(Hadoop Distributed File System)](https://hadoop.apache.org/docs/stable/) as Fluss's [remote storage](maintenance/tiered-storage/remote-storage.md),
-  you should download the corresponding Fluss filesystem JAR (see the [Filesystems](../../../maintenance/filesystems/overview.md) section) and also put it into `${FLINK_HOME}/lib`.
+  you should download the corresponding Fluss filesystem JAR (see the [Filesystems](../../maintenance/filesystems/overview.md) section) and also put it into `${FLINK_HOME}/lib`.
 - Put [fluss-lake-lance-$FLUSS_VERSION$.jar]($FLUSS_MAVEN_REPO_URL$/org/apache/fluss/fluss-lake-lance/$FLUSS_VERSION$/fluss-lake-lance-$FLUSS_VERSION$.jar) into `${FLINK_HOME}/lib`.
 
 Additionally, when following the [Start Datalake Tiering Service](maintenance/tiered-storage/lakehouse-storage.md#start-datalake-tiering-service) guide, make sure to use Lance-specific configurations as parameters when starting the Flink tiering job:


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

  - Fixes 6 broken relative links in `iceberg.md` and `lance.md`      
  - Links used `../../../` but source files are only 2 levels deep under `website/docs/`, escaping
   the docs root.                                                                                 
  - Corrected to `../../`.
                                                                                                  
  ## Why this matters         
                                                                      
  - `build_versioned_docs.sh` clones `release-0.9` into `versioned_docs/version-0.9/` for every CI
  run, so these broken links currently fail website builds on every PR, not just PRs touching    
  docs.           
  

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
