### PR TITLE
[lake] Fix DvTableReadableSnapshotRetriever scanning wrong snapshot

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
@@ -32,7 +32,6 @@ import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.utils.ExceptionUtils;
 import org.apache.fluss.utils.types.Tuple2;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
@@ -495,16 +494,10 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
         Set<PaimonPartitionBucket> bucketsWithoutL0 = new HashSet<>();
         Set<PaimonPartitionBucket> bucketsWithL0 = new HashSet<>();
 
-        // Scan the snapshot to get all splits including level0
-        Map<String, String> scanOptions = new HashMap<>();
-        scanOptions.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), String.valueOf(snapshot.id()));
-        // hacky: set batch scan mode to compact to make sure we can get l0 level files
-        scanOptions.put(
-                CoreOptions.BATCH_SCAN_MODE.key(), CoreOptions.BatchScanMode.COMPACT.getValue());
-
+        // Scan the snapshot to get all data files including L0 level files
         Map<BinaryRow, Map<Integer, List<ManifestEntry>>> manifestsByBucket =
                 FileStoreScan.Plan.groupByPartFiles(
-                        fileStoreTable.copy(scanOptions).store().newScan().plan().files());
+                        fileStoreTable.store().newScan().withSnapshot(snapshot).plan().files());
 
         for (Map.Entry<BinaryRow, Map<Integer, List<ManifestEntry>>> manifestsByBucketEntry :
                 manifestsByBucket.entrySet()) {


### PR DESCRIPTION
## Summary
- `getBucketsWithoutL0AndWithL0()` passed `SCAN_SNAPSHOT_ID` and `BATCH_SCAN_MODE` via table options to `store().newScan()`, but these options are only consumed by table-level scans (`DataTableBatchScan`), not by store-level scans (`AbstractFileStoreScan`). This means the scan always hit the latest snapshot instead of the specified one.
- Fix by using the direct `.withSnapshot(snapshot)` API on `FileStoreScan`, consistent with `getBucketsWithFlushedL0()` in the same file.
- Remove unused `CoreOptions` import.

## Test Plan
- Existing tests cover the affected code paths (`DvTableReadableSnapshotRetrieverTest`, `FlinkUnionReadDvTableITCase`)
- The behavioral change is that the scan now correctly targets the specified snapshot instead of always scanning the latest one

🤖 Generated with [Claude Code](https://claude.com/claude-code)