### PR TITLE
[flink] Fail fast on batch virtual log table reads

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkTableFactory.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkTableFactory.java
@@ -322,6 +322,15 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
         FlinkConnectorOptionsUtils.validateTableSourceOptions(tableOptions);
     }
 
+    private static void validateVirtualLogTableRuntimeMode(
+            String virtualTableSuffix, boolean isStreamingMode) {
+        if (!isStreamingMode) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "%s virtual tables only support streaming mode.", virtualTableSuffix));
+        }
+    }
+
     /** Creates a ChangelogFlinkTableSource for $changelog virtual tables. */
     private DynamicTableSource createChangelogTableSource(
             Context context, ObjectIdentifier tableIdentifier, String tableName) {
@@ -333,6 +342,7 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
         boolean isStreamingMode =
                 context.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
                         == RuntimeExecutionMode.STREAMING;
+        validateVirtualLogTableRuntimeMode(FlinkCatalog.CHANGELOG_TABLE_SUFFIX, isStreamingMode);
 
         // tableOutputType includes metadata columns: [_change_type, _log_offset, _commit_timestamp,
         // data_cols...]
@@ -395,6 +405,7 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
         boolean isStreamingMode =
                 context.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
                         == RuntimeExecutionMode.STREAMING;
+        validateVirtualLogTableRuntimeMode(FlinkCatalog.BINLOG_TABLE_SUFFIX, isStreamingMode);
 
         // tableOutputType: [_change_type, _log_offset, _commit_timestamp, before ROW<...>, after
         // ROW<...>]

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
@@ -245,11 +245,9 @@ abstract class FlinkTableFactoryTest {
     private ResolvedSchema createBinlogSchema() {
         return new ResolvedSchema(
                 Arrays.asList(
-                        Column.physical(
-                                "_change_type", DataTypes.STRING().notNull()),
+                        Column.physical("_change_type", DataTypes.STRING().notNull()),
                         Column.physical("_log_offset", DataTypes.BIGINT().notNull()),
-                        Column.physical(
-                                "_commit_timestamp", DataTypes.TIMESTAMP_LTZ(3).notNull()),
+                        Column.physical("_commit_timestamp", DataTypes.TIMESTAMP_LTZ(3).notNull()),
                         Column.physical(
                                 "before",
                                 DataTypes.ROW(
@@ -289,11 +287,7 @@ abstract class FlinkTableFactoryTest {
             Map<String, String> options,
             Map<String, String> enrichmentOptions) {
         return createTableSource(
-                OBJECT_IDENTIFIER,
-                schema,
-                options,
-                enrichmentOptions,
-                new Configuration());
+                OBJECT_IDENTIFIER, schema, options, enrichmentOptions, new Configuration());
     }
 
     private static DynamicTableSource createTableSource(

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
@@ -23,7 +23,9 @@ import org.apache.fluss.flink.source.FlinkTableSource;
 import org.apache.fluss.flink.source.lookup.FlinkAsyncLookupFunction;
 import org.apache.fluss.flink.source.lookup.FlinkLookupFunction;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.ValidationException;
@@ -70,6 +72,12 @@ abstract class FlinkTableFactoryTest {
 
     public static final ObjectIdentifier OBJECT_IDENTIFIER =
             ObjectIdentifier.of("default", "default", "t1");
+
+    public static final ObjectIdentifier CHANGELOG_TABLE_IDENTIFIER =
+            ObjectIdentifier.of("default", "default", "t1" + FlinkCatalog.CHANGELOG_TABLE_SUFFIX);
+
+    public static final ObjectIdentifier BINLOG_TABLE_IDENTIFIER =
+            ObjectIdentifier.of("default", "default", "t1" + FlinkCatalog.BINLOG_TABLE_SUFFIX);
 
     @Test
     void testTableSourceOptions() {
@@ -180,6 +188,36 @@ abstract class FlinkTableFactoryTest {
     }
 
     @Test
+    void testVirtualLogTableSourceDoesNotSupportBatchMode() {
+        ResolvedSchema schema = createBasicSchema();
+        Map<String, String> properties = getBasicOptions();
+        Configuration configuration = new Configuration();
+        configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+
+        assertThatThrownBy(
+                        () ->
+                                createTableSource(
+                                        CHANGELOG_TABLE_IDENTIFIER,
+                                        schema,
+                                        properties,
+                                        Collections.emptyMap(),
+                                        configuration))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("$changelog virtual tables only support streaming mode.");
+
+        assertThatThrownBy(
+                        () ->
+                                createTableSource(
+                                        BINLOG_TABLE_IDENTIFIER,
+                                        createBinlogSchema(),
+                                        properties,
+                                        Collections.emptyMap(),
+                                        configuration))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("$binlog virtual tables only support streaming mode.");
+    }
+
+    @Test
     void testSink() {
         ResolvedSchema schema = createBasicSchema();
         Map<String, String> properties = getBasicOptionsWithBucketKey();
@@ -204,6 +242,30 @@ abstract class FlinkTableFactoryTest {
                 UniqueConstraint.primaryKey("PK_first_third", Arrays.asList("first", "third")));
     }
 
+    private ResolvedSchema createBinlogSchema() {
+        return new ResolvedSchema(
+                Arrays.asList(
+                        Column.physical(
+                                "_change_type", DataTypes.STRING().notNull()),
+                        Column.physical("_log_offset", DataTypes.BIGINT().notNull()),
+                        Column.physical(
+                                "_commit_timestamp", DataTypes.TIMESTAMP_LTZ(3).notNull()),
+                        Column.physical(
+                                "before",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("first", DataTypes.STRING().notNull()),
+                                        DataTypes.FIELD("second", DataTypes.INT()),
+                                        DataTypes.FIELD("third", DataTypes.STRING().notNull()))),
+                        Column.physical(
+                                "after",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("first", DataTypes.STRING().notNull()),
+                                        DataTypes.FIELD("second", DataTypes.INT()),
+                                        DataTypes.FIELD("third", DataTypes.STRING().notNull())))),
+                Collections.emptyList(),
+                null);
+    }
+
     private static Map<String, String> getBasicOptions() {
         Map<String, String> options = new HashMap<>();
         options.put("connector", "fluss");
@@ -226,10 +288,24 @@ abstract class FlinkTableFactoryTest {
             ResolvedSchema schema,
             Map<String, String> options,
             Map<String, String> enrichmentOptions) {
+        return createTableSource(
+                OBJECT_IDENTIFIER,
+                schema,
+                options,
+                enrichmentOptions,
+                new Configuration());
+    }
+
+    private static DynamicTableSource createTableSource(
+            ObjectIdentifier objectIdentifier,
+            ResolvedSchema schema,
+            Map<String, String> options,
+            Map<String, String> enrichmentOptions,
+            Configuration configuration) {
         FlinkTableFactory tableFactory = createFlinkTableFactory();
         FactoryUtil.DefaultDynamicTableContext context =
                 new FactoryUtil.DefaultDynamicTableContext(
-                        OBJECT_IDENTIFIER,
+                        objectIdentifier,
                         new ResolvedCatalogTable(
                                 CatalogTable.of(
                                         Schema.newBuilder().fromResolvedSchema(schema).build(),
@@ -240,7 +316,7 @@ abstract class FlinkTableFactoryTest {
                                         options),
                                 schema),
                         enrichmentOptions,
-                        new Configuration(),
+                        configuration,
                         Thread.currentThread().getContextClassLoader(),
                         false);
         return tableFactory.createDynamicTableSource(context);

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/BinlogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/BinlogVirtualTableITCase.java
@@ -131,6 +131,15 @@ abstract class BinlogVirtualTableITCase {
 
     // init table environment from savepointPath
     private StreamTableEnvironment initTableEnvironment(@Nullable String savepointPath) {
+        return initTableEnvironment(savepointPath, EnvironmentSettings.inStreamingMode());
+    }
+
+    private StreamTableEnvironment initBatchTableEnvironment() {
+        return initTableEnvironment(null, EnvironmentSettings.inBatchMode());
+    }
+
+    private StreamTableEnvironment initTableEnvironment(
+            @Nullable String savepointPath, EnvironmentSettings environmentSettings) {
         org.apache.flink.configuration.Configuration conf =
                 new org.apache.flink.configuration.Configuration();
         if (savepointPath != null) {
@@ -140,8 +149,7 @@ abstract class BinlogVirtualTableITCase {
                 StreamExecutionEnvironment.getExecutionEnvironment(conf);
         execEnv.setParallelism(1);
         execEnv.enableCheckpointing(1000);
-        StreamTableEnvironment tEnv =
-                StreamTableEnvironment.create(execEnv, EnvironmentSettings.inStreamingMode());
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, environmentSettings);
         String bootstrapServers = String.join(",", clientConf.get(ConfigOptions.BOOTSTRAP_SERVERS));
         // crate catalog using sql
         tEnv.executeSql(
@@ -225,6 +233,22 @@ abstract class BinlogVirtualTableITCase {
         // $binlog should fail for log tables
         assertThatThrownBy(() -> tEnv.executeSql("DESCRIBE log_table$binlog").collect())
                 .hasMessageContaining("only supported for primary key tables");
+    }
+
+    @Test
+    public void testBatchReadBinlogTableFailsFast() throws Exception {
+        tEnv.executeSql(
+                "CREATE TABLE batch_binlog_test ("
+                        + "  id INT NOT NULL,"
+                        + "  name STRING,"
+                        + "  PRIMARY KEY (id) NOT ENFORCED"
+                        + ") WITH ('bucket.num' = '1')");
+
+        tEnv = initBatchTableEnvironment();
+
+        assertThatThrownBy(() -> tEnv.explainSql("SELECT * FROM batch_binlog_test$binlog"))
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+                .hasRootCauseMessage("$binlog virtual tables only support streaming mode.");
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
@@ -64,6 +64,7 @@ import static org.apache.fluss.flink.utils.FlinkTestBase.writeRows;
 import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.apache.fluss.testutils.common.CommonTestUtils.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Integration test for $changelog virtual table functionality. */
 abstract class ChangelogVirtualTableITCase {
@@ -128,6 +129,15 @@ abstract class ChangelogVirtualTableITCase {
 
     // init table environment from savepointPath
     private StreamTableEnvironment initTableEnvironment(@Nullable String savepointPath) {
+        return initTableEnvironment(savepointPath, EnvironmentSettings.inStreamingMode());
+    }
+
+    private StreamTableEnvironment initBatchTableEnvironment() {
+        return initTableEnvironment(null, EnvironmentSettings.inBatchMode());
+    }
+
+    private StreamTableEnvironment initTableEnvironment(
+            @Nullable String savepointPath, EnvironmentSettings environmentSettings) {
         org.apache.flink.configuration.Configuration conf =
                 new org.apache.flink.configuration.Configuration();
         if (savepointPath != null) {
@@ -137,8 +147,7 @@ abstract class ChangelogVirtualTableITCase {
                 StreamExecutionEnvironment.getExecutionEnvironment(conf);
         execEnv.setParallelism(1);
         execEnv.enableCheckpointing(1000);
-        StreamTableEnvironment tEnv =
-                StreamTableEnvironment.create(execEnv, EnvironmentSettings.inStreamingMode());
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, environmentSettings);
         String bootstrapServers = String.join(",", clientConf.get(ConfigOptions.BOOTSTRAP_SERVERS));
         // crate catalog using sql
         tEnv.executeSql(
@@ -237,6 +246,22 @@ abstract class ChangelogVirtualTableITCase {
                                 + "  `tags` ARRAY<VARCHAR(2147483647)>\n"
                                 // with options contains random properties, skip checking
                                 + ")");
+    }
+
+    @Test
+    public void testBatchReadChangelogTableFailsFast() throws Exception {
+        tEnv.executeSql(
+                "CREATE TABLE batch_changelog_test ("
+                        + "  id INT NOT NULL,"
+                        + "  name STRING,"
+                        + "  PRIMARY KEY (id) NOT ENFORCED"
+                        + ") WITH ('bucket.num' = '1')");
+
+        tEnv = initBatchTableEnvironment();
+
+        assertThatThrownBy(() -> tEnv.explainSql("SELECT * FROM batch_changelog_test$changelog"))
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+                .hasRootCauseMessage("$changelog virtual tables only support streaming mode.");
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->

Linked issue: close #3144

Batch reads on `$binlog` and `$changelog` virtual tables could pass source creation and fail later in the source coordinator with an internal lake-source error. These virtual log tables are currently log-only and only support streaming mode.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Reject batch runtime mode in `$binlog` and `$changelog` table source creation.
  - Return a clear `UnsupportedOperationException` before job submission.
  - Add factory and planner-path tests for both virtual table types.

### Tests

<!-- List UT and IT cases to verify this change -->

  - `mvn -B -ntp -Dskip.on.java8=true -DfailIfNoTests=false -pl fluss-flink/fluss-flink-1.20 -am -Dtest=Flink120TableFactoryTest test`
  - `mvn -B -ntp -Dskip.on.java8=true -DfailIfNoTests=false -pl fluss-flink/fluss-flink-1.20 -am -Dtest=Flink120BinlogVirtualTableITCase,Flink120ChangelogVirtualTableITCase test`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
