### PR TITLE
[client] Initialize lake comparator before merge read

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/batch/LakeSnapshotAndLogSplitScanner.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/batch/LakeSnapshotAndLogSplitScanner.java
@@ -54,6 +54,7 @@ public class LakeSnapshotAndLogSplitScanner implements BatchScanner {
     private final @Nullable List<LakeSplit> lakeSplits;
     private Comparator<InternalRow> rowComparator;
     private List<CloseableIterator<LogRecord>> lakeRecordIterators = new ArrayList<>();
+    private boolean lakeRecordIteratorsInitialized;
     private final LakeSource<LakeSplit> lakeSource;
 
     private final int[] pkIndexes;
@@ -155,16 +156,7 @@ public class LakeSnapshotAndLogSplitScanner implements BatchScanner {
     @Override
     public CloseableIterator<InternalRow> pollBatch(Duration timeout) throws IOException {
         if (logScanFinished) {
-            if (lakeRecordIterators.isEmpty()) {
-                if (lakeSplits == null || lakeSplits.isEmpty()) {
-                    lakeRecordIterators = Collections.emptyList();
-                } else {
-                    for (LakeSplit lakeSplit : lakeSplits) {
-                        lakeRecordIterators.add(
-                                lakeSource.createRecordReader(() -> lakeSplit).read());
-                    }
-                }
-            }
+            initializeLakeRecordIterators();
             if (currentSortMergeReader == null) {
                 currentSortMergeReader =
                         new SortMergeReader(
@@ -179,30 +171,39 @@ public class LakeSnapshotAndLogSplitScanner implements BatchScanner {
             }
             return currentSortMergeReader.readBatch();
         } else {
-            if (lakeRecordIterators.isEmpty()) {
-                List<RecordReader> recordReaders = new ArrayList<>();
-                if (lakeSplits == null || lakeSplits.isEmpty()) {
-                    // pass null split to get rowComparator
-                    recordReaders.add(lakeSource.createRecordReader(() -> null));
-                } else {
-                    for (LakeSplit lakeSplit : lakeSplits) {
-                        recordReaders.add(lakeSource.createRecordReader(() -> lakeSplit));
-                    }
-                }
-                for (RecordReader reader : recordReaders) {
-                    if (reader instanceof SortedRecordReader) {
-                        rowComparator = ((SortedRecordReader) reader).order();
-                    } else {
-                        throw new UnsupportedOperationException(
-                                "lake records must instance of sorted view.");
-                    }
-                    lakeRecordIterators.add(reader.read());
-                }
+            initializeLakeRecordIterators();
+            if (logRows == null) {
                 logRows = new TreeMap<>(rowComparator);
             }
             pollLogRecords(timeout);
             return CloseableIterator.wrap(Collections.emptyIterator());
         }
+    }
+
+    private void initializeLakeRecordIterators() throws IOException {
+        if (lakeRecordIteratorsInitialized) {
+            return;
+        }
+
+        List<RecordReader> recordReaders = new ArrayList<>();
+        if (lakeSplits == null || lakeSplits.isEmpty()) {
+            // pass null split to get rowComparator
+            recordReaders.add(lakeSource.createRecordReader(() -> null));
+        } else {
+            for (LakeSplit lakeSplit : lakeSplits) {
+                recordReaders.add(lakeSource.createRecordReader(() -> lakeSplit));
+            }
+        }
+        for (RecordReader reader : recordReaders) {
+            if (reader instanceof SortedRecordReader) {
+                rowComparator = ((SortedRecordReader) reader).order();
+            } else {
+                throw new UnsupportedOperationException(
+                        "lake records must instance of sorted view.");
+            }
+            lakeRecordIterators.add(reader.read());
+        }
+        lakeRecordIteratorsInitialized = true;
     }
 
     private void pollLogRecords(Duration timeout) {


### PR DESCRIPTION
### Purpose

Linked issue: close #3405

When `LakeSnapshotAndLogSplitScanner` starts with the log scan already finished, it can construct `SortMergeReader` before initializing the lake snapshot row comparator. With multiple lake snapshot iterators, this can pass a null comparator into the merge priority queue and fail with an NPE.

This change makes the scanner initialize lake readers and the sorted lake comparator through the same path regardless of whether log scanning finishes before the first poll.

### Brief change log

- Add a shared lake reader initialization method in `LakeSnapshotAndLogSplitScanner`.
- Initialize `rowComparator` from `SortedRecordReader.order()` before constructing `SortMergeReader` in both log-finished and log-polling paths.
- Guard lake reader initialization with an explicit boolean instead of relying on iterator list emptiness.

### Tests

- `./mvnw -pl fluss-client spotless:apply`
- Not run: unit/integration tests, per requester instruction.

### API and Format

No public API, RPC, or storage format changes.

### Documentation

No documentation changes. This is a bug fix.

Generated-by: Codex following https://github.com/apache/fluss/blob/main/AGENTS.md
