### PR TITLE
[website] Add Security Updates table to security page

### DIFF
--- a/website/community/security.md
+++ b/website/community/security.md
@@ -12,3 +12,30 @@ If you have concerns regarding Fluss's security or discover a vulnerability or p
 In the email, specify the project name **Fluss** and include a description of the issue or potential threat. You are also encouraged to include steps to reproduce the issue. The security team and the Fluss community will get back to you after assessing and analyzing the findings.
 
 **PLEASE PAY ATTENTION** to report the security issue privately to **security@apache.org** before disclosing it publicly.
+
+## Security Updates
+
+This section lists fixed vulnerabilities in Fluss.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" width="200">CVE ID</th>
+      <th class="text-left" width="250">Affected Fluss versions</th>
+      <th class="text-left" width="550">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="https://www.cve.org/CVERecord?id=CVE-2026-49361">CVE-2026-49361</a>
+      </td>
+      <td>
+        0.8.0, 0.9.0
+      </td>
+      <td>
+        Users are advised to upgrade to Fluss 0.9.1 or later versions. See the <a href="https://lists.apache.org/thread/dccw6tj0njwtmvbftq13mw7fdhsok373">advisory</a> for details.
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary

- Add a **Security Updates** section to `website/community/security.md`, modeled after the [Flink security page](https://flink.apache.org/what-is-flink/security/), to publicly track fixed CVEs.
- Add the first entry for **[CVE-2026-49361](https://www.cve.org/CVERecord?id=CVE-2026-49361)** (Netty frame decoder memory exhaustion, affecting 0.8.0 and 0.9.0, fixed in 0.9.1), with a link to the [announcement thread](https://lists.apache.org/thread/dccw6tj0njwtmvbftq13mw7fdhsok373).

## Test plan

- [ ] Run the website locally (`npm run start` in `website/`) and confirm the table renders correctly on `/community/security`.
- [ ] Verify the CVE link, version list, and advisory link all resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)