### PR TITLE
[test] fix flaky testRebalanceWithRemoteLog

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/RebalanceManagerITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/RebalanceManagerITCase.java
@@ -311,7 +311,7 @@ public class RebalanceManagerITCase {
                     0,
                     baseOffset + i * 10L);
         }
-        FLUSS_CLUSTER_EXTENSION.waitUntilSomeLogSegmentsCopyToRemote(
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllLogSegmentsCopyToRemote(
                 new TableBucket(tb.getTableId(), 0));
     }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
@@ -715,6 +715,32 @@ public final class FlussClusterExtension
                 });
     }
 
+    /**
+     * Wait until all log segments (non-active) copy to remote. This method waits until the remote
+     * log end offset reaches the base offset of the active segment.
+     */
+    public void waitUntilAllLogSegmentsCopyToRemote(TableBucket tableBucket) {
+        retry(
+                Duration.ofMinutes(2),
+                () -> {
+                    int leader = waitAndGetLeader(tableBucket);
+                    TabletServer tabletServer = getTabletServerById(leader);
+                    ReplicaManager.HostedReplica hostedReplica =
+                            tabletServer.getReplicaManager().getReplica(tableBucket);
+                    assertThat(hostedReplica).isInstanceOf(ReplicaManager.OnlineReplica.class);
+                    Replica replica = ((ReplicaManager.OnlineReplica) hostedReplica).getReplica();
+                    long activeSegmentBaseOffset =
+                            replica.getLogTablet().activeLogSegment().getBaseOffset();
+                    assertThat(
+                                    tabletServer
+                                            .getReplicaManager()
+                                            .getRemoteLogManager()
+                                            .remoteLogTablet(tableBucket)
+                                            .getRemoteLogEndOffset())
+                            .hasValue(activeSegmentBaseOffset);
+                });
+    }
+
     public void triggerAndWaitSnapshot(TablePath tablePath) throws Exception {
         Optional<TableRegistration> table = zooKeeperClient.getTable(tablePath);
         //noinspection SimplifyOptionalCallChains (Java 8 compatibility)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3385 

<!-- What is the purpose of the change -->
The test captures the remote log segment count, then asserts it's unchanged after rebalance.
But, `produceRecordsAndWaitRemoteLogCopy()` does not ensure that all log segments have been copied to remote, so the `remoteLogSize`(captured count) is non-deterministic.

### Brief change log
- Add `FlussClusterExtension#waitUntilAllLogSegmentsCopyToRemote()`, which waits until the remote log end offset reaches the active segment's base offset (i.e. all non-active segments are copied to remote).
- Uses `waitUntilAllLogSegmentsCopyToRemote()` instead of `waitUntilSomeLogSegmentsCopyToRemote()`, so the captured segment count is stable.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

Ran `RebalanceManagerITCase.testRebalanceWithRemoteLog` 100 times
- Before fix: 9 / 100 failed
- After fix: 0 / 100 failed