### PR TITLE
[test] Delete temp dir after cluster shutdown in FlussClusterExtension

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
@@ -68,6 +68,7 @@ import org.apache.fluss.server.zk.data.PartitionRegistration;
 import org.apache.fluss.server.zk.data.RemoteLogManifestHandle;
 import org.apache.fluss.server.zk.data.TableAssignment;
 import org.apache.fluss.server.zk.data.TableRegistration;
+import org.apache.fluss.utils.FileUtils;
 import org.apache.fluss.utils.clock.Clock;
 import org.apache.fluss.utils.clock.SystemClock;
 
@@ -237,10 +238,6 @@ public final class FlussClusterExtension
             rpcClient.close();
             rpcClient = null;
         }
-        if (tempDir != null) {
-            tempDir.delete();
-            tempDir = null;
-        }
         for (TabletServer tabletServer : tabletServers.values()) {
             tabletServer.close();
         }
@@ -257,6 +254,10 @@ public final class FlussClusterExtension
         if (zooKeeperServer != null) {
             zooKeeperServer.close();
             zooKeeperServer = null;
+        }
+        if (tempDir != null) {
+            FileUtils.deleteDirectoryQuietly(tempDir);
+            tempDir = null;
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3410

<!-- What is the purpose of the change -->

### Brief change log

- Move temp directory deletion in `FlussClusterExtension.close()` to after tablet servers, coordinator server, and ZooKeeper are all shut down.
- Replace `tempDir.delete()` with `FileUtils.deleteDirectoryQuietly(tempDir)` to recursively delete non-empty directories.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

- Run `./mvnw clean verify -pl fluss-server` .
- After test pass, no `fluss-testing-cluster-*` directories remain.

<!-- List UT and IT cases to verify this change -->

### API and Format

No API changes.

<!-- Does this change affect API or storage format -->

### Documentation

No documentation changes.

<!-- Does this change introduce a new feature -->
