### PR TITLE
[lake] Reset lake filters for each pushdown

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -154,6 +154,7 @@ public class FlinkTableSource
 
     // projection push down
     @Nullable private int[] projectedFields;
+    @Nullable private int[][] lakeProjectedFields;
 
     @Nullable private GenericRowData singleRowFilter;
 
@@ -170,6 +171,8 @@ public class FlinkTableSource
     private final Map<String, String> tableOptions;
 
     @Nullable private LakeSource<LakeSplit> lakeSource;
+    private boolean lakeFiltersPushedDown;
+    private List<Predicate> lakePredicates = Collections.emptyList();
     @Nullable private Predicate logRecordBatchFilter;
 
     /** Watermark strategy that is pushed down by the Flink optimizer. */
@@ -529,7 +532,17 @@ public class FlinkTableSource
         source.singleRowFilter = singleRowFilter;
         source.modificationScanType = modificationScanType;
         source.partitionFilters = partitionFilters;
-        source.lakeSource = lakeSource;
+        source.lakeProjectedFields = lakeProjectedFields;
+        source.lakeFiltersPushedDown = lakeFiltersPushedDown;
+        source.lakePredicates = new ArrayList<>(lakePredicates);
+        if (source.lakeSource != null) {
+            if (source.lakeProjectedFields != null) {
+                source.lakeSource.withProject(source.lakeProjectedFields);
+            }
+            if (source.lakeFiltersPushedDown) {
+                source.lakeSource.withFilters(source.lakePredicates);
+            }
+        }
         source.logRecordBatchFilter = logRecordBatchFilter;
         source.watermarkStrategy = watermarkStrategy;
         // Note: availableStatsColumns is already computed in the constructor
@@ -549,6 +562,7 @@ public class FlinkTableSource
     @Override
     public void applyProjection(int[][] projectedFields, DataType producedDataType) {
         this.projectedFields = Arrays.stream(projectedFields).mapToInt(value -> value[0]).toArray();
+        this.lakeProjectedFields = projectedFields;
         this.producedDataType = producedDataType.getLogicalType();
         if (lakeSource != null) {
             lakeSource.withProject(projectedFields);
@@ -710,12 +724,16 @@ public class FlinkTableSource
             }
         }
 
+        LakeSource.FilterPushDownResult filterPushDownResult =
+                checkNotNull(lakeSource).withFilters(lakePredicates);
+        this.lakePredicates =
+                lakePredicates.isEmpty()
+                        ? Collections.emptyList()
+                        : new ArrayList<>(lakePredicates);
+        this.lakeFiltersPushedDown = true;
         if (lakePredicates.isEmpty()) {
             return;
         }
-
-        LakeSource.FilterPushDownResult filterPushDownResult =
-                checkNotNull(lakeSource).withFilters(lakePredicates);
         Set<Predicate> acceptedLakePredicates =
                 Collections.newSetFromMap(new IdentityHashMap<Predicate, Boolean>());
         acceptedLakePredicates.addAll(filterPushDownResult.acceptedPredicates());

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFilterPushDownTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFilterPushDownTest.java
@@ -22,6 +22,9 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.TableConfig;
 import org.apache.fluss.flink.FlinkConnectorOptions;
 import org.apache.fluss.flink.utils.FlinkConnectorOptionsUtils;
+import org.apache.fluss.lake.values.TestingValuesLakeSource;
+import org.apache.fluss.lake.values.TestingValuesLakeStorage;
+import org.apache.fluss.metadata.DataLakeFormat;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.predicate.Predicate;
 import org.apache.fluss.row.BinaryString;
@@ -43,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -353,6 +357,107 @@ public class FlinkTableSourceFilterPushDownTest {
             assertThat(result.getAcceptedFilters()).isEmpty();
             assertThat(result.getRemainingFilters()).isEmpty();
             assertThat(tableSource.getLogRecordBatchFilter()).isNull();
+        }
+    }
+
+    @Nested
+    class LakeSourcePushDownTests {
+        private FlinkTableSource tableSource;
+        private TablePath tablePath;
+
+        @BeforeEach
+        void setUp() {
+            RowType tableOutputType =
+                    (RowType)
+                            DataTypes.ROW(
+                                            DataTypes.FIELD("id", DataTypes.INT()),
+                                            DataTypes.FIELD("name", DataTypes.STRING()),
+                                            DataTypes.FIELD("value", DataTypes.BIGINT()))
+                                    .getLogicalType();
+
+            tablePath = TablePath.of("test_db", "test_lake_table");
+            Configuration flussConfig = new Configuration();
+            flussConfig.setString(FlinkConnectorOptions.BOOTSTRAP_SERVERS.key(), "localhost:9092");
+
+            Configuration tableConfig = new Configuration();
+            tableConfig.set(ConfigOptions.TABLE_STATISTICS_COLUMNS, "*");
+
+            FlinkConnectorOptionsUtils.StartupOptions startupOptions =
+                    new FlinkConnectorOptionsUtils.StartupOptions();
+            startupOptions.startupMode = FlinkConnectorOptions.ScanStartupMode.EARLIEST;
+
+            Map<String, String> tableOptions = Maps.newHashMap();
+            tableOptions.put(
+                    ConfigOptions.TABLE_DATALAKE_FORMAT.key(), DataLakeFormat.LANCE.toString());
+
+            tableSource =
+                    new FlinkTableSource(
+                            tablePath,
+                            flussConfig,
+                            new TableConfig(tableConfig),
+                            tableOutputType,
+                            new int[] {}, // no primary key indexes
+                            new int[] {}, // bucket key indexes
+                            new int[] {}, // partition key indexes
+                            true, // streaming
+                            startupOptions,
+                            false, // lookup async
+                            false, // insert if not exists
+                            null, // cache
+                            1000L, // scan partition discovery interval
+                            true, // is data lake enabled
+                            null, // merge engine type
+                            tableOptions,
+                            null); // lease context
+        }
+
+        @Test
+        void testCopyUsesIndependentLakeSourceWithReplayedState() {
+            int[][] project = new int[][] {new int[] {0}, new int[] {2}};
+            tableSource.applyProjection(
+                    project,
+                    DataTypes.ROW(
+                            DataTypes.FIELD("id", DataTypes.INT()),
+                            DataTypes.FIELD("value", DataTypes.BIGINT())));
+
+            FieldReferenceExpression idFieldRef =
+                    new FieldReferenceExpression("id", DataTypes.INT(), 0, 0);
+            CallExpression greaterThanCall =
+                    new CallExpression(
+                            BuiltInFunctionDefinitions.GREATER_THAN,
+                            Arrays.asList(idFieldRef, new ValueLiteralExpression(5)),
+                            DataTypes.BOOLEAN());
+
+            tableSource.applyFilters(Collections.singletonList(greaterThanCall));
+
+            TestingValuesLakeSource originalLakeSource =
+                    TestingValuesLakeStorage.getLatestLakeSource(tablePath);
+            List<Predicate> originalPredicates =
+                    originalLakeSource == null
+                            ? Collections.emptyList()
+                            : originalLakeSource.getPredicates();
+            assertThat(originalLakeSource).isNotNull();
+            assertThat(originalPredicates).hasSize(1);
+
+            FlinkTableSource copiedSource = (FlinkTableSource) tableSource.copy();
+            TestingValuesLakeSource copiedLakeSource =
+                    TestingValuesLakeStorage.getLatestLakeSource(tablePath);
+            assertThat(copiedLakeSource).isNotNull();
+            assertThat(copiedLakeSource).isNotSameAs(originalLakeSource);
+            assertThat(copiedLakeSource.getProject()).isDeepEqualTo(project);
+            assertThat(copiedLakeSource.getPredicates()).isEqualTo(originalPredicates);
+
+            CallExpression lessThanCall =
+                    new CallExpression(
+                            BuiltInFunctionDefinitions.LESS_THAN,
+                            Arrays.asList(idFieldRef, new ValueLiteralExpression(10)),
+                            DataTypes.BOOLEAN());
+
+            copiedSource.applyFilters(Collections.singletonList(lessThanCall));
+
+            assertThat(originalLakeSource.getPredicates()).isEqualTo(originalPredicates);
+            assertThat(copiedLakeSource.getPredicates()).hasSize(1);
+            assertThat(copiedLakeSource.getPredicates()).isNotEqualTo(originalPredicates);
         }
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/lake/values/TestingValuesLakeSource.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/lake/values/TestingValuesLakeSource.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.values;
+
+import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
+import org.apache.fluss.lake.source.LakeSource;
+import org.apache.fluss.lake.source.LakeSplit;
+import org.apache.fluss.lake.source.Planner;
+import org.apache.fluss.lake.source.RecordReader;
+import org.apache.fluss.predicate.Predicate;
+import org.apache.fluss.utils.CloseableIterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Testing values lake source for Flink connector tests. */
+public class TestingValuesLakeSource implements LakeSource<LakeSplit> {
+
+    private List<Predicate> predicates = Collections.emptyList();
+    private int[][] project;
+
+    @Override
+    public void withProject(int[][] project) {
+        this.project = project;
+    }
+
+    @Override
+    public void withLimit(int limit) {}
+
+    @Override
+    public FilterPushDownResult withFilters(List<Predicate> predicates) {
+        this.predicates = new ArrayList<>(predicates);
+        return FilterPushDownResult.of(predicates, Collections.emptyList());
+    }
+
+    @Override
+    public Planner<LakeSplit> createPlanner(PlannerContext context) {
+        return Collections::emptyList;
+    }
+
+    @Override
+    public RecordReader createRecordReader(ReaderContext<LakeSplit> context) {
+        return CloseableIterator::emptyIterator;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<LakeSplit> getSplitSerializer() {
+        return new SimpleVersionedSerializer<LakeSplit>() {
+            @Override
+            public int getVersion() {
+                return 0;
+            }
+
+            @Override
+            public byte[] serialize(LakeSplit obj) throws IOException {
+                return new byte[0];
+            }
+
+            @Override
+            public LakeSplit deserialize(int version, byte[] serialized) throws IOException {
+                throw new IOException("Unsupported testing split deserialization.");
+            }
+        };
+    }
+
+    public List<Predicate> getPredicates() {
+        return predicates;
+    }
+
+    public int[][] getProject() {
+        return project;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/lake/values/TestingValuesLakeStorage.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/lake/values/TestingValuesLakeStorage.java
@@ -25,8 +25,15 @@ import org.apache.fluss.lake.values.tiering.TestingValuesLakeTieringFactory;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
 import org.apache.fluss.metadata.TablePath;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /** Implementation of {@link LakeStorage} for values lake. */
 public class TestingValuesLakeStorage implements LakeStorage {
+
+    private static final Map<TablePath, TestingValuesLakeSource> LAKE_SOURCES =
+            new ConcurrentHashMap<>();
+
     @Override
     public LakeTieringFactory<?, ?> createLakeTieringFactory() {
         return new TestingValuesLakeTieringFactory();
@@ -39,6 +46,12 @@ public class TestingValuesLakeStorage implements LakeStorage {
 
     @Override
     public LakeSource<?> createLakeSource(TablePath tablePath) {
-        throw new UnsupportedOperationException("Not impl.");
+        TestingValuesLakeSource lakeSource = new TestingValuesLakeSource();
+        LAKE_SOURCES.put(tablePath, lakeSource);
+        return lakeSource;
+    }
+
+    public static TestingValuesLakeSource getLatestLakeSource(TablePath tablePath) {
+        return LAKE_SOURCES.get(tablePath);
     }
 }

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSource.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSource.java
@@ -70,6 +70,10 @@ public class IcebergLakeSource implements LakeSource<IcebergSplit> {
     public FilterPushDownResult withFilters(List<Predicate> predicates) {
         List<Predicate> unConsumedPredicates = new ArrayList<>();
         List<Predicate> consumedPredicates = new ArrayList<>();
+        if (predicates.isEmpty()) {
+            filter = null;
+            return FilterPushDownResult.of(consumedPredicates, unConsumedPredicates);
+        }
         List<Expression> converted = new ArrayList<>();
         Schema schema = getSchema(tablePath);
         for (Predicate predicate : predicates) {
@@ -82,9 +86,7 @@ public class IcebergLakeSource implements LakeSource<IcebergSplit> {
                 unConsumedPredicates.add(predicate);
             }
         }
-        if (!converted.isEmpty()) {
-            filter = converted.stream().reduce(Expressions::and).orElse(null);
-        }
+        filter = converted.stream().reduce(Expressions::and).orElse(null);
         return FilterPushDownResult.of(consumedPredicates, unConsumedPredicates);
     }
 

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSourceTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSourceTest.java
@@ -157,4 +157,64 @@ class IcebergLakeSourceTest extends IcebergSourceTestBase {
         assertThat(filterPushDownResult.remainingPredicates().toString())
                 .isEqualTo(allFilters.toString());
     }
+
+    @Test
+    void testUnacceptedFiltersClearPreviousAcceptedFilters() throws Exception {
+        TablePath tablePath = TablePath.of("fluss", "test_clear_previous_filters");
+        createTable(tablePath, SCHEMA, PARTITION_SPEC);
+
+        Table table = getTable(tablePath);
+        List<Record> rows = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            rows.add(
+                    createIcebergRecord(
+                            SCHEMA,
+                            i,
+                            "name" + i,
+                            0,
+                            (long) i,
+                            OffsetDateTime.now(ZoneOffset.UTC)));
+        }
+        writeRecord(table, rows, null, 0);
+        table.refresh();
+
+        Predicate acceptedFilter = FLUSS_BUILDER.greaterOrEqual(0, 3);
+        Predicate nonConvertibleFilter = FLUSS_BUILDER.endsWith(1, BinaryString.fromString("name"));
+
+        LakeSource<IcebergSplit> lakeSource = lakeStorage.createLakeSource(tablePath);
+        LakeSource.FilterPushDownResult filterPushDownResult =
+                lakeSource.withFilters(Collections.singletonList(acceptedFilter));
+        assertThat(filterPushDownResult.acceptedPredicates())
+                .containsExactlyInAnyOrder(acceptedFilter);
+        assertThat(readRows(lakeSource, table.currentSnapshot().snapshotId()).toString())
+                .isEqualTo("[+I[3, name3], +I[4, name4]]");
+
+        filterPushDownResult =
+                lakeSource.withFilters(Collections.singletonList(nonConvertibleFilter));
+        assertThat(filterPushDownResult.acceptedPredicates()).isEmpty();
+        assertThat(filterPushDownResult.remainingPredicates())
+                .containsExactly(nonConvertibleFilter);
+
+        assertThat(readRows(lakeSource, table.currentSnapshot().snapshotId()).toString())
+                .isEqualTo("[+I[1, name1], +I[2, name2], +I[3, name3], +I[4, name4]]");
+    }
+
+    private List<Row> readRows(LakeSource<IcebergSplit> lakeSource, long snapshotId)
+            throws Exception {
+        List<Row> actual = new ArrayList<>();
+        org.apache.fluss.row.InternalRow.FieldGetter[] fieldGetters =
+                org.apache.fluss.row.InternalRow.createFieldGetters(
+                        RowType.of(new IntType(), new StringType()));
+        for (IcebergSplit icebergSplit : lakeSource.createPlanner(() -> snapshotId).plan()) {
+            RecordReader recordReader = lakeSource.createRecordReader(() -> icebergSplit);
+            try (CloseableIterator<LogRecord> iterator = recordReader.read()) {
+                actual.addAll(
+                        convertToFlinkRow(
+                                fieldGetters,
+                                TransformingCloseableIterator.transform(
+                                        iterator, LogRecord::getRow)));
+            }
+        }
+        return actual;
+    }
 }

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/PaimonLakeSource.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/PaimonLakeSource.java
@@ -76,6 +76,10 @@ public class PaimonLakeSource implements LakeSource<PaimonSplit> {
     public FilterPushDownResult withFilters(List<Predicate> predicates) {
         List<Predicate> unConsumedPredicates = new ArrayList<>();
         List<Predicate> consumedPredicates = new ArrayList<>();
+        if (predicates.isEmpty()) {
+            predicate = null;
+            return FilterPushDownResult.of(consumedPredicates, unConsumedPredicates);
+        }
         List<org.apache.paimon.predicate.Predicate> converted = new ArrayList<>();
         RowType rowType = getRowType(tablePath);
         for (Predicate predicate : predicates) {
@@ -88,9 +92,7 @@ public class PaimonLakeSource implements LakeSource<PaimonSplit> {
                 unConsumedPredicates.add(predicate);
             }
         }
-        if (!converted.isEmpty()) {
-            predicate = PredicateBuilder.and(converted);
-        }
+        predicate = converted.isEmpty() ? null : PredicateBuilder.and(converted);
         return FilterPushDownResult.of(consumedPredicates, unConsumedPredicates);
     }
 

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/source/PaimonLakeSourceTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/source/PaimonLakeSourceTest.java
@@ -164,6 +164,68 @@ class PaimonLakeSourceTest extends PaimonSourceTestBase {
                 .isEqualTo(allFilters.toString());
     }
 
+    @Test
+    void testUnacceptedFiltersClearPreviousAcceptedFilters() throws Exception {
+        TablePath tablePath = TablePath.of("fluss", "test_clear_previous_filters");
+        createTable(tablePath, SCHEMA);
+
+        List<InternalRow> rows = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            rows.add(
+                    GenericRow.of(
+                            i,
+                            BinaryString.fromString("name" + i),
+                            0,
+                            (long) i,
+                            Timestamp.fromEpochMillis(System.currentTimeMillis())));
+        }
+        writeRecord(tablePath, rows);
+
+        Predicate acceptedFilter = FLUSS_BUILDER.greaterOrEqual(0, 3);
+        Predicate nonConvertibleFilter =
+                new LeafPredicate(
+                        new UnSupportFilterFunction(),
+                        DataTypes.INT(),
+                        0,
+                        "f1",
+                        Collections.emptyList());
+
+        LakeSource<PaimonSplit> lakeSource = lakeStorage.createLakeSource(tablePath);
+        LakeSource.FilterPushDownResult filterPushDownResult =
+                lakeSource.withFilters(Collections.singletonList(acceptedFilter));
+        assertThat(filterPushDownResult.acceptedPredicates())
+                .containsExactlyInAnyOrder(acceptedFilter);
+        assertThat(readRows(lakeSource, 1).toString()).isEqualTo("[+I[3, name3], +I[4, name4]]");
+
+        filterPushDownResult =
+                lakeSource.withFilters(Collections.singletonList(nonConvertibleFilter));
+        assertThat(filterPushDownResult.acceptedPredicates()).isEmpty();
+        assertThat(filterPushDownResult.remainingPredicates())
+                .containsExactly(nonConvertibleFilter);
+
+        assertThat(readRows(lakeSource, 1).toString())
+                .isEqualTo("[+I[1, name1], +I[2, name2], +I[3, name3], +I[4, name4]]");
+    }
+
+    private List<Row> readRows(LakeSource<PaimonSplit> lakeSource, long snapshotId)
+            throws Exception {
+        List<Row> actual = new ArrayList<>();
+        org.apache.fluss.row.InternalRow.FieldGetter[] fieldGetters =
+                org.apache.fluss.row.InternalRow.createFieldGetters(
+                        RowType.of(new IntType(), new StringType()));
+        for (PaimonSplit paimonSplit : lakeSource.createPlanner(() -> snapshotId).plan()) {
+            RecordReader recordReader = lakeSource.createRecordReader(() -> paimonSplit);
+            try (CloseableIterator<LogRecord> iterator = recordReader.read()) {
+                actual.addAll(
+                        convertToFlinkRow(
+                                fieldGetters,
+                                TransformingCloseableIterator.transform(
+                                        iterator, LogRecord::getRow)));
+            }
+        }
+        return actual;
+    }
+
     private static class UnSupportFilterFunction extends LeafFunction {
 
         @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->

Lake filter pushdown state was kept on mutable lake source instances. If a later pushdown had no convertible lake predicates, the old predicate could remain active and incorrectly filter subsequent lake reads.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Reset Paimon and Iceberg lake filters on every `withFilters` call.
  - Ensure Flink clears lake filters even when no lake predicates are convertible.
  - Recreate and replay lake pushdown state when copying `FlinkTableSource`, avoiding shared mutable lake source state between copies.
  - Add regression tests for Paimon, Iceberg, and Flink lake source copy isolation.

### Tests

<!-- List UT and IT cases to verify this change -->

- `./mvnw -pl fluss-flink/fluss-flink-common -am -Dtest='FlinkTableSourceFilterPushDownTest$LakeSourcePushDownTests' -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl fluss-flink/fluss-flink-common,fluss-lake/fluss-lake-paimon,fluss-lake/fluss-lake-iceberg -am -Dtest=FlinkTableSourceFilterPushDownTest,PaimonLakeSourceTest,IcebergLakeSourceTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
