### PR TITLE
[fs] Mask S3 delegation token access keys in logs

### DIFF
--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
@@ -107,14 +107,14 @@ public class S3DelegationTokenProvider {
             } else {
                 LOG.info(
                         "Obtaining session credentials via GetSessionToken with access key: {}",
-                        accessKey);
+                        S3TokenLogUtils.maskAccessKey(accessKey));
                 GetSessionTokenResult result = stsClient.getSessionToken();
                 credentials = result.getCredentials();
             }
 
             LOG.info(
                     "Session credentials obtained successfully with access key: {} expiration: {}",
-                    credentials.getAccessKeyId(),
+                    S3TokenLogUtils.maskAccessKey(credentials.getAccessKeyId()),
                     credentials.getExpiration());
 
             return new ObtainedSecurityToken(

--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenReceiver.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenReceiver.java
@@ -89,7 +89,7 @@ public class S3DelegationTokenReceiver implements SecurityTokenReceiver {
 
         LOG.info(
                 "Session credentials updated successfully with access key: {}.",
-                credentials.getAccessKeyId());
+                S3TokenLogUtils.maskAccessKey(credentials.getAccessKeyId()));
     }
 
     public static Credentials getCredentials() {

--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3TokenLogUtils.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3TokenLogUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.s3.token;
+
+import javax.annotation.Nullable;
+
+/** Utilities for logging S3 delegation token values safely. */
+final class S3TokenLogUtils {
+
+    private static final int ACCESS_KEY_VISIBLE_PREFIX_LENGTH = 3;
+    private static final String ACCESS_KEY_MASK = "******";
+
+    private S3TokenLogUtils() {}
+
+    @Nullable
+    static String maskAccessKey(@Nullable String accessKey) {
+        if (accessKey == null) {
+            return null;
+        }
+        if (accessKey.length() <= ACCESS_KEY_VISIBLE_PREFIX_LENGTH) {
+            return ACCESS_KEY_MASK;
+        }
+        return accessKey.substring(0, ACCESS_KEY_VISIBLE_PREFIX_LENGTH) + ACCESS_KEY_MASK;
+    }
+}

--- a/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3TokenLogUtilsTest.java
+++ b/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3TokenLogUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.s3.token;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link S3TokenLogUtils}. */
+class S3TokenLogUtilsTest {
+
+    @Test
+    void testMaskAccessKeyWithNull() {
+        assertThat(S3TokenLogUtils.maskAccessKey(null)).isNull();
+    }
+
+    @Test
+    void testMaskAccessKeyHidesShortValues() {
+        assertThat(S3TokenLogUtils.maskAccessKey("A")).isEqualTo("******");
+        assertThat(S3TokenLogUtils.maskAccessKey("AS7")).isEqualTo("******");
+    }
+
+    @Test
+    void testMaskAccessKeyKeepsPrefixForLongValues() {
+        String accessKey = "AS7124FSDFER";
+
+        assertThat(S3TokenLogUtils.maskAccessKey(accessKey))
+                .isEqualTo("AS7******")
+                .doesNotContain(accessKey);
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1989

The S3 delegation token provider and receiver logged full access key IDs when obtaining or updating temporary session credentials. This exposed credential identifiers in logs, while the log only needs enough information to confirm which key path is being used.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- Add a package-local S3 token log utility to keep a short access-key prefix and mask the rest.
- Mask access key IDs in S3 delegation token provider and receiver logs.
- Add unit tests for null, short, and normal access key values.

### Tests

<!-- List UT and IT cases to verify this change -->

- `mvn -pl fluss-filesystems/fluss-fs-s3 -am -Dtest=S3TokenLogUtilsTest -DfailIfNoTests=false clean test`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
