### PR TITLE
[server] Keep flushedLogOffset monotonic to fix row count after failover

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/KvTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/KvTablet.java
@@ -687,7 +687,9 @@ public final class KvTablet {
                     } else {
                         try {
                             int rowCountDiff = kvPreWriteBuffer.flush(exclusiveUpToLogOffset);
-                            flushedLogOffset = exclusiveUpToLogOffset;
+                            if (exclusiveUpToLogOffset > flushedLogOffset) {
+                                flushedLogOffset = exclusiveUpToLogOffset;
+                            }
                             if (rowCount != ROW_COUNT_DISABLED) {
                                 // row count is enabled, we update the row count after flush.
                                 long currentRowCount = rowCount;

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
@@ -59,6 +59,7 @@ import org.apache.fluss.server.kv.rocksdb.RocksDBStatistics;
 import org.apache.fluss.server.kv.rowmerger.RowMerger;
 import org.apache.fluss.server.kv.scan.OpenScanResult;
 import org.apache.fluss.server.kv.scan.ScannerContext;
+import org.apache.fluss.server.kv.snapshot.TabletState;
 import org.apache.fluss.server.log.FetchIsolation;
 import org.apache.fluss.server.log.LogAppendInfo;
 import org.apache.fluss.server.log.LogTablet;
@@ -1857,6 +1858,40 @@ class KvTabletTest {
         kvTablet.putAsLeader(updateBatch, null);
         kvTablet.flush(Long.MAX_VALUE, NOPErrorHandler.INSTANCE);
         assertThat(kvTablet.getRowCount()).isEqualTo(12);
+
+        kvTablet.close();
+    }
+
+    @Test
+    void testFlushDoesNotRegressFlushedLogOffset() throws Exception {
+        initLogTabletAndKvTablet(DATA1_SCHEMA_PK, new HashMap<>());
+
+        List<KvRecord> inserts = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            inserts.add(kvRecordFactory.ofRecord("key" + i, new Object[] {i, "val" + i}));
+        }
+        kvTablet.putAsLeader(kvRecordBatchFactory.ofRecords(inserts), null);
+
+        List<KvRecord> deletes = new ArrayList<>();
+        for (int i = 1; i <= 2; i++) {
+            deletes.add(kvRecordFactory.ofRecord("key" + i, null));
+        }
+        kvTablet.putAsLeader(kvRecordBatchFactory.ofRecords(deletes), null);
+
+        long highOffset = logTablet.localLogEndOffset();
+        kvTablet.flush(highOffset, NOPErrorHandler.INSTANCE);
+        TabletState stateAfterHighFlush = kvTablet.getTabletState();
+        assertThat(stateAfterHighFlush.getFlushedLogOffset()).isEqualTo(highOffset);
+        assertThat(stateAfterHighFlush.getRowCount()).isEqualTo(3L);
+        assertThat(kvTablet.getRowCount()).isEqualTo(3);
+
+        long lowOffset = highOffset - 2;
+        kvTablet.flush(lowOffset, NOPErrorHandler.INSTANCE);
+        TabletState stateAfterLowFlush = kvTablet.getTabletState();
+
+        assertThat(stateAfterLowFlush.getFlushedLogOffset()).isEqualTo(highOffset);
+        assertThat(stateAfterLowFlush.getRowCount()).isEqualTo(3L);
+        assertThat(kvTablet.getRowCount()).isEqualTo(3);
 
         kvTablet.close();
     }


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3386

<!-- What is the purpose of the change -->
`FlussAdminITCase.testGetTableStatsForPrimaryKeyTableWithFailover` is a flaky test(`expected: 170 but was: 160`).

The root cause is `flushedLogOffset = exclusiveUpToLogOffset` in `KvTablet#flush`, which does not keep `flushedLogOffset` monotonically increasing.

When `flush` is called with an `exclusiveUpToLogOffset` lower than the current `flushedLogOffset`, `flushedLogOffset` is rolled back to that lower value, while `rowCount` is not. As a result, the `(flushedLogOffset, rowCount)` pair becomes inconsistent.

During failover, a kv snapshot can capture this inconsistent pair, and recovery then replays the log from the stale offset and double-counts the already-applied deletes, under-reporting the row count

### Brief change log

- `KvTablet#flush` now only advanced `flushedLogOffset` when `exclusiveUpToLogOffset` is greater than current value.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
