### PR TITLE
[flink] Fix limit pushdown for lake union read

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -332,7 +332,8 @@ public class FlinkTableSource
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
         // handle single row filter scan
-        if (singleRowFilter != null || limit > 0 || selectRowCount) {
+        boolean useFlussOnlyLimitScan = limit > 0 && !shouldReadLakeInFullMode();
+        if (singleRowFilter != null || useFlussOnlyLimitScan || selectRowCount) {
             Collection<RowData> results;
             if (singleRowFilter != null) {
                 results =
@@ -343,7 +344,7 @@ public class FlinkTableSource
                                 tableOutputType,
                                 primaryKeyIndexes,
                                 projectedFields);
-            } else if (limit > 0) {
+            } else if (useFlussOnlyLimitScan) {
                 results =
                         PushdownUtils.limitScan(
                                 tablePath, flussConfig, tableOutputType, projectedFields, limit);
@@ -459,6 +460,11 @@ public class FlinkTableSource
                 }
             };
         }
+    }
+
+    private boolean shouldReadLakeInFullMode() {
+        return lakeSource != null
+                && startupOptions.startupMode == FlinkConnectorOptions.ScanStartupMode.FULL;
     }
 
     @Override

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadLogTableITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadLogTableITCase.java
@@ -335,6 +335,74 @@ class FlinkUnionReadLogTableITCase extends FlinkUnionReadTestBase {
         jobClient.cancel().get();
     }
 
+    @Test
+    void testLimitReadLogTablePartitionFromPaimon() throws Exception {
+        JobClient jobClient = buildTieringJob(execEnv);
+        try {
+            String tableName = "limit_expired_partition_logTable";
+            TablePath tablePath = TablePath.of(DEFAULT_DB, tableName);
+            long tableId =
+                    createLogTable(
+                            tablePath,
+                            DEFAULT_BUCKET_NUM,
+                            true,
+                            Collections.emptyMap(),
+                            Collections.emptyMap());
+            Map<Long, String> partitionNameByIds = waitUntilPartitions(tablePath);
+
+            List<InternalRow> rows = new ArrayList<>();
+            for (String partitionName : partitionNameByIds.values()) {
+                for (int i = 0; i < 3; i++) {
+                    rows.add(row(i, "value_" + i, partitionName));
+                }
+            }
+            writeRows(tablePath, rows, true);
+
+            waitUntilBucketSynced(tablePath, tableId, DEFAULT_BUCKET_NUM, true);
+
+            Long partitionToDropId = partitionNameByIds.keySet().iterator().next();
+            String partitionToDropName = partitionNameByIds.get(partitionToDropId);
+            List<String> expectedRowsInExpiredPartition = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                expectedRowsInExpiredPartition.add(
+                        Row.of(i, "value_" + i, partitionToDropName).toString());
+            }
+
+            admin.dropPartition(
+                            tablePath,
+                            new PartitionSpec(Collections.singletonMap("c", partitionToDropName)),
+                            false)
+                    .get();
+            retry(
+                    Duration.ofSeconds(60),
+                    () -> {
+                        List<PartitionInfo> remainingPartitions =
+                                admin.listPartitionInfos(tablePath).get();
+                        assertThat(remainingPartitions.size()).isEqualTo(1);
+                    });
+
+            List<String> actual =
+                    CollectionUtil.iteratorToList(
+                                    batchTEnv
+                                            .executeSql(
+                                                    "select * from "
+                                                            + tableName
+                                                            + " where c = '"
+                                                            + partitionToDropName
+                                                            + "' LIMIT 2")
+                                            .collect())
+                            .stream()
+                            .map(Row::toString)
+                            .collect(Collectors.toList());
+            assertThat(actual)
+                    .as("LIMIT should still read expired partition data from Paimon")
+                    .hasSize(2)
+                    .containsOnlyElementsOf(expectedRowsInExpiredPartition);
+        } finally {
+            jobClient.cancel().get();
+        }
+    }
+
     private long prepareLogTable(
             TablePath tablePath, int bucketNum, boolean isPartitioned, List<Row> flinkRows)
             throws Exception {

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadLogTableITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadLogTableITCase.java
@@ -397,7 +397,8 @@ class FlinkUnionReadLogTableITCase extends FlinkUnionReadTestBase {
             assertThat(actual)
                     .as("LIMIT should still read expired partition data from Paimon")
                     .hasSize(2)
-                    .containsOnlyElementsOf(expectedRowsInExpiredPartition);
+                    .doesNotHaveDuplicates()
+                    .isSubsetOf(expectedRowsInExpiredPartition);
         } finally {
             jobClient.cancel().get();
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->

`LIMIT` pushdown previously always used the Fluss-only limit scan path. For datalake-enabled FULL scans, this skipped the lake source, so union reads could miss records that had already been tiered to the lake.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Avoid the Fluss-only limit scan path when a FULL scan needs to read from the lake.
  - Let the normal Flink source path perform lake + Fluss union reads in that case.
  - Add a Paimon IT covering `LIMIT` reads from an expired Fluss partition whose data still exists in Paimon.

### Tests

<!-- List UT and IT cases to verify this change -->

  - `./mvnw -pl fluss-flink/fluss-flink-common,fluss-lake/fluss-lake-paimon -am -DskipTests -DfailIfNoTests=false test-compile`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
