### PR TITLE
[test] Stabilize CommitRemoteLogManifestITCase

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/CommitRemoteLogManifestITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/CommitRemoteLogManifestITCase.java
@@ -69,6 +69,7 @@ class CommitRemoteLogManifestITCase {
         TabletServerGateway leaderGateWay =
                 FLUSS_CLUSTER_EXTENSION.newTabletServerClientForNode(leader);
         // produce many records to trigger remote log copy.
+        long expectedRemoteLogEndOffset = 0L;
         for (int i = 0; i < 3; i++) {
             assertProduceLogResponse(
                     leaderGateWay
@@ -77,7 +78,8 @@ class CommitRemoteLogManifestITCase {
                                             tableId, 0, -1, genMemoryLogRecordsByObject(DATA1)))
                             .get(),
                     0,
-                    i * 10L);
+                    expectedRemoteLogEndOffset);
+            expectedRemoteLogEndOffset += DATA1.size();
         }
 
         // stop replicas to mock followers are out of sync
@@ -106,7 +108,7 @@ class CommitRemoteLogManifestITCase {
                         .set(
                                 ConfigOptions.REMOTE_LOG_TASK_INTERVAL_DURATION,
                                 Duration.ofMillis(1)));
-        FLUSS_CLUSTER_EXTENSION.waitUntilSomeLogSegmentsCopyToRemote(tb);
+        FLUSS_CLUSTER_EXTENSION.waitUntilRemoteLogEndOffset(tb, expectedRemoteLogEndOffset);
 
         // check only has two remote log segments for the stopped replicas
         for (int stopFollower : stopFollowers) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
@@ -715,6 +715,20 @@ public final class FlussClusterExtension
                 });
     }
 
+    /** Wait until the remote log end offset reaches the expected offset. */
+    public void waitUntilRemoteLogEndOffset(TableBucket tableBucket, long expectedEndOffset) {
+        ZooKeeperClient zkClient = getZooKeeperClient();
+        retry(
+                Duration.ofMinutes(2),
+                () -> {
+                    Optional<RemoteLogManifestHandle> remoteLogManifestHandle;
+                    remoteLogManifestHandle = zkClient.getRemoteLogManifestHandle(tableBucket);
+                    assertThat(remoteLogManifestHandle).isPresent();
+                    assertThat(remoteLogManifestHandle.get().getRemoteLogEndOffset())
+                            .isGreaterThanOrEqualTo(expectedEndOffset);
+                });
+    }
+
     public void triggerAndWaitSnapshot(TablePath tablePath) throws Exception {
         Optional<TableRegistration> table = zooKeeperClient.getTable(tablePath);
         //noinspection SimplifyOptionalCallChains (Java 8 compatibility)


### PR DESCRIPTION
### What's changed

This fixes the flaky `CommitRemoteLogManifestITCase.testDeleteOutOfSyncReplicaLogAfterCommit` by waiting until the remote log manifest end offset reaches the expected produced offset. The previous helper only waited for the remote log manifest handle to exist, which could continue before the expected remote log segments were committed.

Closes #3440