### PR TITLE
[flink] Gate single-row lookup pushdown on partition liveness

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/getter/PartitionGetter.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/getter/PartitionGetter.java
@@ -59,6 +59,10 @@ public class PartitionGetter {
     }
 
     public String getPartition(InternalRow row) {
+        return getResolvedPartitionSpec(row).getPartitionName();
+    }
+
+    public ResolvedPartitionSpec getResolvedPartitionSpec(InternalRow row) {
         List<String> partitionValues = new ArrayList<>();
         for (int i = 0; i < partitionFieldGetters.size(); i++) {
             InternalRow.FieldGetter partitionFieldGetter = partitionFieldGetters.get(i);
@@ -68,8 +72,6 @@ public class PartitionGetter {
             partitionValues.add(
                     PartitionUtils.convertValueOfType(partitionValue, dataType.getTypeRoot()));
         }
-        ResolvedPartitionSpec resolvedPartitionSpec =
-                new ResolvedPartitionSpec(partitionKeys, partitionValues);
-        return resolvedPartitionSpec.getPartitionName();
+        return new ResolvedPartitionSpec(partitionKeys, partitionValues);
     }
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -24,6 +24,7 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.StatisticsColumnsConfig;
 import org.apache.fluss.config.TableConfig;
 import org.apache.fluss.flink.FlinkConnectorOptions;
+import org.apache.fluss.flink.row.FlinkAsFlussRow;
 import org.apache.fluss.flink.source.deserializer.RowDataDeserializationSchema;
 import org.apache.fluss.flink.source.lookup.FlinkAsyncLookupFunction;
 import org.apache.fluss.flink.source.lookup.FlinkLookupFunction;
@@ -46,7 +47,6 @@ import org.apache.fluss.predicate.PartitionPredicateVisitor;
 import org.apache.fluss.predicate.Predicate;
 import org.apache.fluss.predicate.PredicateBuilder;
 import org.apache.fluss.predicate.PredicateVisitor;
-import org.apache.fluss.row.GenericRow;
 import org.apache.fluss.types.DataTypeChecks;
 import org.apache.fluss.types.RowType;
 
@@ -105,7 +105,6 @@ import java.util.Set;
 import static org.apache.fluss.flink.utils.LakeSourceUtils.createLakeSource;
 import static org.apache.fluss.flink.utils.PredicateConverter.convertToFlussPredicate;
 import static org.apache.fluss.flink.utils.PushdownUtils.ValueConversion.FLINK_INTERNAL_VALUE;
-import static org.apache.fluss.flink.utils.PushdownUtils.ValueConversion.FLUSS_INTERNAL_VALUE;
 import static org.apache.fluss.flink.utils.PushdownUtils.extractFieldEquals;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
@@ -599,7 +598,7 @@ public class FlinkTableSource
             // if not all primary key fields are in condition, fall through to
             // try partition filter pushdown for partitioned PK tables
             if (visitedPkFields.equals(primaryKeyTypes.keySet())
-                    && lookupCoversAllData(filters, primaryKeyTypes)) {
+                    && lookupCoversAllData(lookupRow)) {
                 singleRowFilter = lookupRow;
                 // FLINK-38635: return all filters as remaining for scan vs lookup safety net
                 return Result.of(acceptedFilters, filters);
@@ -894,34 +893,23 @@ public class FlinkTableSource
         return projection;
     }
 
-    private boolean lookupCoversAllData(
-            List<ResolvedExpression> filters, Map<Integer, LogicalType> primaryKeyTypes) {
+    private boolean lookupCoversAllData(GenericRowData lookupRow) {
         if (!isDataLakeEnabled || !isPartitioned()) {
             return true;
         }
-        return PushdownUtils.partitionExists(
-                tablePath, flussConfig, resolveLookupPartition(filters, primaryKeyTypes));
-    }
-
-    private PartitionSpec resolveLookupPartition(
-            List<ResolvedExpression> filters, Map<Integer, LogicalType> primaryKeyTypes) {
-        List<FieldEqual> keyEquals =
-                extractFieldEquals(
-                        filters,
-                        primaryKeyTypes,
-                        new ArrayList<>(),
-                        new ArrayList<>(),
-                        FLUSS_INTERNAL_VALUE);
-        int[] keyRowProjection = getKeyRowProjection();
-        GenericRow keyRow = new GenericRow(primaryKeyIndexes.length);
-        for (FieldEqual keyEqual : keyEquals) {
-            keyRow.setField(keyRowProjection[keyEqual.fieldIndex], keyEqual.equalValue);
-        }
+        // TODO: drop this gate once FIP-28 lets the lookup path read expired partitions from the
+        // lake; then always push the single-row lookup down instead of falling back to a scan.
+        // Partition keys are a subset of the primary key, so the partition resolves from lookupRow.
         RowType flussRowType = FlinkConversions.toFlussRowType(tableOutputType);
-        List<String> partitionKeys = flussRowType.project(partitionKeyIndexes).getFieldNames();
-        return new PartitionGetter(flussRowType.project(primaryKeyIndexes), partitionKeys)
-                .getResolvedPartitionSpec(keyRow)
-                .toPartitionSpec();
+        PartitionGetter partitionGetter =
+                new PartitionGetter(
+                        flussRowType.project(primaryKeyIndexes),
+                        flussRowType.project(partitionKeyIndexes).getFieldNames());
+        PartitionSpec partitionSpec =
+                partitionGetter
+                        .getResolvedPartitionSpec(new FlinkAsFlussRow(lookupRow))
+                        .toPartitionSpec();
+        return PushdownUtils.partitionExists(tablePath, flussConfig, partitionSpec);
     }
 
     @VisibleForTesting

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -18,6 +18,7 @@
 package org.apache.fluss.flink.source;
 
 import org.apache.fluss.client.initializer.OffsetsInitializer;
+import org.apache.fluss.client.table.getter.PartitionGetter;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.StatisticsColumnsConfig;
@@ -38,12 +39,14 @@ import org.apache.fluss.lake.source.LakeSplit;
 import org.apache.fluss.metadata.ChangelogImage;
 import org.apache.fluss.metadata.DeleteBehavior;
 import org.apache.fluss.metadata.MergeEngineType;
+import org.apache.fluss.metadata.PartitionSpec;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.predicate.CompoundPredicate;
 import org.apache.fluss.predicate.PartitionPredicateVisitor;
 import org.apache.fluss.predicate.Predicate;
 import org.apache.fluss.predicate.PredicateBuilder;
 import org.apache.fluss.predicate.PredicateVisitor;
+import org.apache.fluss.row.GenericRow;
 import org.apache.fluss.types.DataTypeChecks;
 import org.apache.fluss.types.RowType;
 
@@ -102,6 +105,7 @@ import java.util.Set;
 import static org.apache.fluss.flink.utils.LakeSourceUtils.createLakeSource;
 import static org.apache.fluss.flink.utils.PredicateConverter.convertToFlussPredicate;
 import static org.apache.fluss.flink.utils.PushdownUtils.ValueConversion.FLINK_INTERNAL_VALUE;
+import static org.apache.fluss.flink.utils.PushdownUtils.ValueConversion.FLUSS_INTERNAL_VALUE;
 import static org.apache.fluss.flink.utils.PushdownUtils.extractFieldEquals;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
@@ -594,7 +598,8 @@ public class FlinkTableSource
 
             // if not all primary key fields are in condition, fall through to
             // try partition filter pushdown for partitioned PK tables
-            if (visitedPkFields.equals(primaryKeyTypes.keySet())) {
+            if (visitedPkFields.equals(primaryKeyTypes.keySet())
+                    && lookupCoversAllData(filters, primaryKeyTypes)) {
                 singleRowFilter = lookupRow;
                 // FLINK-38635: return all filters as remaining for scan vs lookup safety net
                 return Result.of(acceptedFilters, filters);
@@ -887,6 +892,36 @@ public class FlinkTableSource
             projection[primaryKeyIndexes[i]] = i;
         }
         return projection;
+    }
+
+    private boolean lookupCoversAllData(
+            List<ResolvedExpression> filters, Map<Integer, LogicalType> primaryKeyTypes) {
+        if (!isDataLakeEnabled || !isPartitioned()) {
+            return true;
+        }
+        return PushdownUtils.partitionExists(
+                tablePath, flussConfig, resolveLookupPartition(filters, primaryKeyTypes));
+    }
+
+    private PartitionSpec resolveLookupPartition(
+            List<ResolvedExpression> filters, Map<Integer, LogicalType> primaryKeyTypes) {
+        List<FieldEqual> keyEquals =
+                extractFieldEquals(
+                        filters,
+                        primaryKeyTypes,
+                        new ArrayList<>(),
+                        new ArrayList<>(),
+                        FLUSS_INTERNAL_VALUE);
+        int[] keyRowProjection = getKeyRowProjection();
+        GenericRow keyRow = new GenericRow(primaryKeyIndexes.length);
+        for (FieldEqual keyEqual : keyEquals) {
+            keyRow.setField(keyRowProjection[keyEqual.fieldIndex], keyEqual.equalValue);
+        }
+        RowType flussRowType = FlinkConversions.toFlussRowType(tableOutputType);
+        List<String> partitionKeys = flussRowType.project(partitionKeyIndexes).getFieldNames();
+        return new PartitionGetter(flussRowType.project(primaryKeyIndexes), partitionKeys)
+                .getResolvedPartitionSpec(keyRow)
+                .toPartitionSpec();
     }
 
     @VisibleForTesting

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/PushdownUtils.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/PushdownUtils.java
@@ -31,6 +31,7 @@ import org.apache.fluss.exception.UnsupportedVersionException;
 import org.apache.fluss.flink.source.lookup.FlinkLookupFunction;
 import org.apache.fluss.flink.source.lookup.LookupNormalizer;
 import org.apache.fluss.metadata.PartitionInfo;
+import org.apache.fluss.metadata.PartitionSpec;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.metadata.TableStats;
@@ -329,6 +330,16 @@ public class PushdownUtils {
             }
 
             return flinkRows;
+        } catch (Exception e) {
+            throw new FlussRuntimeException(e);
+        }
+    }
+
+    public static boolean partitionExists(
+            TablePath tablePath, Configuration flussConfig, PartitionSpec partitionSpec) {
+        try (Connection connection = ConnectionFactory.createConnection(flussConfig);
+                Admin flussAdmin = connection.getAdmin()) {
+            return !flussAdmin.listPartitionInfos(tablePath, partitionSpec).get().isEmpty();
         } catch (Exception e) {
             throw new FlussRuntimeException(e);
         }

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadPrimaryKeyTableITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadPrimaryKeyTableITCase.java
@@ -1123,63 +1123,74 @@ class FlinkUnionReadPrimaryKeyTableITCase extends FlinkUnionReadTestBase {
     void testPointLookupOnExpiredPartitionReadsFromLake() throws Exception {
         JobClient jobClient = buildTieringJob(execEnv);
 
-        String tableName = "point_lookup_expired_partition_pk_table";
-        TablePath tablePath = TablePath.of(DEFAULT_DB, tableName);
-        Map<TableBucket, Long> bucketLogEndOffset = new HashMap<>();
-        Function<String, List<InternalRow>> rowGenerator =
-                (partition) ->
-                        Arrays.asList(
-                                row(3, "string", partition), row(30, "another_string", partition));
-        long tableId =
-                prepareSimplePKTable(
-                        tablePath, DEFAULT_BUCKET_NUM, true, rowGenerator, bucketLogEndOffset);
+        boolean tieringCancelled = false;
+        try {
+            String tableName = "point_lookup_expired_partition_pk_table";
+            TablePath tablePath = TablePath.of(DEFAULT_DB, tableName);
+            Map<TableBucket, Long> bucketLogEndOffset = new HashMap<>();
+            Function<String, List<InternalRow>> rowGenerator =
+                    (partition) ->
+                            Arrays.asList(
+                                    row(3, "string", partition),
+                                    row(30, "another_string", partition));
+            long tableId =
+                    prepareSimplePKTable(
+                            tablePath, DEFAULT_BUCKET_NUM, true, rowGenerator, bucketLogEndOffset);
 
-        waitUntilBucketSynced(tablePath, tableId, DEFAULT_BUCKET_NUM, true);
+            waitUntilBucketSynced(tablePath, tableId, DEFAULT_BUCKET_NUM, true);
 
-        Map<Long, String> partitionNameByIds = waitUntilPartitions(tablePath);
-        assertThat(partitionNameByIds.size()).isGreaterThanOrEqualTo(2);
+            Map<Long, String> partitionNameByIds = waitUntilPartitions(tablePath);
+            assertThat(partitionNameByIds.size()).isGreaterThanOrEqualTo(2);
 
-        // stop tiering so the read is served from the lake snapshot
-        jobClient.cancel().get();
+            // stop tiering so the read is served from the lake snapshot; the per-job MiniCluster
+            // shuts down with the job, so cancel exactly once
+            jobClient.cancel().get();
+            tieringCancelled = true;
 
-        Iterator<String> partitionIterator = partitionNameByIds.values().iterator();
-        String expiredPartition = partitionIterator.next();
-        String livePartition = partitionIterator.next();
+            Iterator<String> partitionIterator = partitionNameByIds.values().iterator();
+            String expiredPartition = partitionIterator.next();
+            String livePartition = partitionIterator.next();
 
-        admin.dropPartition(
-                        tablePath,
-                        new PartitionSpec(Collections.singletonMap("c3", expiredPartition)),
-                        false)
-                .get();
-        retry(
-                Duration.ofSeconds(60),
-                () ->
-                        assertThat(admin.listPartitionInfos(tablePath).get())
-                                .noneMatch(p -> expiredPartition.equals(p.getPartitionName())));
+            admin.dropPartition(
+                            tablePath,
+                            new PartitionSpec(Collections.singletonMap("c3", expiredPartition)),
+                            false)
+                    .get();
+            retry(
+                    Duration.ofSeconds(60),
+                    () ->
+                            assertThat(admin.listPartitionInfos(tablePath).get())
+                                    .noneMatch(p -> expiredPartition.equals(p.getPartitionName())));
 
-        List<String> expiredResult =
-                collectBatchRows(
-                        batchTEnv
-                                .executeSql(
-                                        String.format(
-                                                "select * from %s where c1 = 3 and c3 = '%s'",
-                                                tableName, expiredPartition))
-                                .collect());
-        assertThat(expiredResult)
-                .as("point query on a lake-only (expired) partition must read from the lake")
-                .containsExactly(String.format("+I[3, string, %s]", expiredPartition));
+            List<String> expiredResult =
+                    collectBatchRows(
+                            batchTEnv
+                                    .executeSql(
+                                            String.format(
+                                                    "select * from %s where c1 = 3 and c3 = '%s'",
+                                                    tableName, expiredPartition))
+                                    .collect());
+            assertThat(expiredResult)
+                    .as("point query on a lake-only (expired) partition must read from the lake")
+                    .containsExactly(String.format("+I[3, string, %s]", expiredPartition));
 
-        List<String> liveResult =
-                collectBatchRows(
-                        batchTEnv
-                                .executeSql(
-                                        String.format(
-                                                "select * from %s where c1 = 3 and c3 = '%s'",
-                                                tableName, livePartition))
-                                .collect());
-        assertThat(liveResult)
-                .as("point query on a live partition must still return its row")
-                .containsExactly(String.format("+I[3, string, %s]", livePartition));
+            List<String> liveResult =
+                    collectBatchRows(
+                            batchTEnv
+                                    .executeSql(
+                                            String.format(
+                                                    "select * from %s where c1 = 3 and c3 = '%s'",
+                                                    tableName, livePartition))
+                                    .collect());
+            assertThat(liveResult)
+                    .as("point query on a live partition must still return its row")
+                    .containsExactly(String.format("+I[3, string, %s]", livePartition));
+        } finally {
+            // only cancel here if setup failed before the intended cancel above
+            if (!tieringCancelled) {
+                jobClient.cancel().get();
+            }
+        }
     }
 
     @Test

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadPrimaryKeyTableITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadPrimaryKeyTableITCase.java
@@ -1120,6 +1120,69 @@ class FlinkUnionReadPrimaryKeyTableITCase extends FlinkUnionReadTestBase {
     }
 
     @Test
+    void testPointLookupOnExpiredPartitionReadsFromLake() throws Exception {
+        JobClient jobClient = buildTieringJob(execEnv);
+
+        String tableName = "point_lookup_expired_partition_pk_table";
+        TablePath tablePath = TablePath.of(DEFAULT_DB, tableName);
+        Map<TableBucket, Long> bucketLogEndOffset = new HashMap<>();
+        Function<String, List<InternalRow>> rowGenerator =
+                (partition) ->
+                        Arrays.asList(
+                                row(3, "string", partition), row(30, "another_string", partition));
+        long tableId =
+                prepareSimplePKTable(
+                        tablePath, DEFAULT_BUCKET_NUM, true, rowGenerator, bucketLogEndOffset);
+
+        waitUntilBucketSynced(tablePath, tableId, DEFAULT_BUCKET_NUM, true);
+
+        Map<Long, String> partitionNameByIds = waitUntilPartitions(tablePath);
+        assertThat(partitionNameByIds.size()).isGreaterThanOrEqualTo(2);
+
+        // stop tiering so the read is served from the lake snapshot
+        jobClient.cancel().get();
+
+        Iterator<String> partitionIterator = partitionNameByIds.values().iterator();
+        String expiredPartition = partitionIterator.next();
+        String livePartition = partitionIterator.next();
+
+        admin.dropPartition(
+                        tablePath,
+                        new PartitionSpec(Collections.singletonMap("c3", expiredPartition)),
+                        false)
+                .get();
+        retry(
+                Duration.ofSeconds(60),
+                () ->
+                        assertThat(admin.listPartitionInfos(tablePath).get())
+                                .noneMatch(p -> expiredPartition.equals(p.getPartitionName())));
+
+        List<String> expiredResult =
+                collectBatchRows(
+                        batchTEnv
+                                .executeSql(
+                                        String.format(
+                                                "select * from %s where c1 = 3 and c3 = '%s'",
+                                                tableName, expiredPartition))
+                                .collect());
+        assertThat(expiredResult)
+                .as("point query on a lake-only (expired) partition must read from the lake")
+                .containsExactly(String.format("+I[3, string, %s]", expiredPartition));
+
+        List<String> liveResult =
+                collectBatchRows(
+                        batchTEnv
+                                .executeSql(
+                                        String.format(
+                                                "select * from %s where c1 = 3 and c3 = '%s'",
+                                                tableName, livePartition))
+                                .collect());
+        assertThat(liveResult)
+                .as("point query on a live partition must still return its row")
+                .containsExactly(String.format("+I[3, string, %s]", livePartition));
+    }
+
+    @Test
     void testPartitionFilterOnPartitionedTableInBatch() throws Exception {
         // first of all, start tiering
         JobClient jobClient = buildTieringJob(execEnv);


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/3443

A full-PK point query on a lake-enabled partitioned table returns empty when the partition was expired from Fluss but still lives in the lake and the lookup pushdown skips the union scan. 
Gate the lookup on partition liveness, fall back to the scan otherwise.