### PR TITLE
[metrics] Fix typo in scanner metric name

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -275,7 +275,7 @@ public class MetricNames {
 
     // for scanner
     public static final String SCANNER_TIME_MS_BETWEEN_POLL = "timeMsBetweenPoll";
-    public static final String SCANNER_LAST_POLL_SECONDS_AGO = "lastPoolSecondsAgo";
+    public static final String SCANNER_LAST_POLL_SECONDS_AGO = "lastPollSecondsAgo";
     public static final String SCANNER_POLL_IDLE_RATIO = "pollIdleRatio";
     public static final String SCANNER_FETCH_LATENCY_MS = "fetchLatencyMs";
     public static final String SCANNER_FETCH_RATE = "fetchRequestsPerSecond";


### PR DESCRIPTION

### Purpose

The scanner metric constant `SCANNER_LAST_POLL_SECONDS_AGO` exposes its value as `lastPoolSecondsAgo`, but i believe the intended name is `lastPollSecondsAgo` (aka "Poll", not "Pool")

###  Brief change log
Fix the string value of `MetricNames.SCANNER_LAST_POLL_SECONDS_AGO` from `lastPoolSecondsAgo` to `lastPollSecondsAgo`.

NOTE:
This changes a user-facing client scanner metric name. Existing dashboards/alerts referencing `lastPoolSecondsAgo` would need to be updated, so kinda breaking change for end users. 
Let me know if you want this PR to retain compatibiilty instead.

