### PR TITLE
[lake] Stabilize Paimon tiering IT

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/testutils/FlinkPaimonTieringTestBase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/testutils/FlinkPaimonTieringTestBase.java
@@ -64,7 +64,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -450,13 +449,25 @@ public abstract class FlinkPaimonTieringTestBase {
 
     protected void checkDataInPaimonPrimaryKeyTable(
             TablePath tablePath, List<InternalRow> expectedRows) throws Exception {
-        Iterator<org.apache.paimon.data.InternalRow> paimonRowIterator =
-                getPaimonRowCloseableIterator(tablePath);
-        for (InternalRow expectedRow : expectedRows) {
-            org.apache.paimon.data.InternalRow row = paimonRowIterator.next();
-            assertThat(row.getInt(0)).isEqualTo(expectedRow.getInt(0));
-            assertThat(row.getString(1).toString()).isEqualTo(expectedRow.getString(1).toString());
-        }
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    try (CloseableIterator<org.apache.paimon.data.InternalRow> paimonRowIterator =
+                            getPaimonRowCloseableIterator(tablePath)) {
+                        Map<Integer, String> actualRows = new HashMap<>();
+                        while (paimonRowIterator.hasNext()) {
+                            org.apache.paimon.data.InternalRow row = paimonRowIterator.next();
+                            actualRows.put(row.getInt(0), row.getString(1).toString());
+                        }
+
+                        Map<Integer, String> expectedRowsByKey = new HashMap<>();
+                        for (InternalRow expectedRow : expectedRows) {
+                            expectedRowsByKey.put(
+                                    expectedRow.getInt(0), expectedRow.getString(1).toString());
+                        }
+                        assertThat(actualRows).isEqualTo(expectedRowsByKey);
+                    }
+                });
     }
 
     protected CloseableIterator<org.apache.paimon.data.InternalRow> getPaimonRowCloseableIterator(
@@ -475,24 +486,30 @@ public abstract class FlinkPaimonTieringTestBase {
 
     protected void checkFlussOffsetsInSnapshot(
             TablePath tablePath, Map<TableBucket, Long> expectedOffsets) throws Exception {
-        FileStoreTable table =
-                (FileStoreTable)
-                        getPaimonCatalog()
-                                .getTable(
-                                        Identifier.create(
-                                                tablePath.getDatabaseName(),
-                                                tablePath.getTableName()));
-        Snapshot snapshot = table.snapshotManager().latestSnapshot();
-        assertThat(snapshot).isNotNull();
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    FileStoreTable table =
+                            (FileStoreTable)
+                                    getPaimonCatalog()
+                                            .getTable(
+                                                    Identifier.create(
+                                                            tablePath.getDatabaseName(),
+                                                            tablePath.getTableName()));
+                    Snapshot snapshot = table.snapshotManager().latestSnapshot();
+                    assertThat(snapshot).isNotNull();
 
-        String offsetFile = snapshot.properties().get(FLUSS_LAKE_SNAP_BUCKET_OFFSET_PROPERTY);
-        Map<TableBucket, Long> recordedOffsets =
-                new LakeTable(
-                                new LakeTable.LakeSnapshotMetadata(
-                                        // don't care about snapshot id
-                                        -1, new FsPath(offsetFile), null))
-                        .getOrReadLatestTableSnapshot()
-                        .getBucketLogEndOffset();
-        assertThat(recordedOffsets).isEqualTo(expectedOffsets);
+                    String offsetFile =
+                            snapshot.properties().get(FLUSS_LAKE_SNAP_BUCKET_OFFSET_PROPERTY);
+                    assertThat(offsetFile).isNotNull();
+                    Map<TableBucket, Long> recordedOffsets =
+                            new LakeTable(
+                                            new LakeTable.LakeSnapshotMetadata(
+                                                    // don't care about snapshot id
+                                                    -1, new FsPath(offsetFile), null))
+                                    .getOrReadLatestTableSnapshot()
+                                    .getBucketLogEndOffset();
+                    assertThat(recordedOffsets).isEqualTo(expectedOffsets);
+                });
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/tiering/PaimonTieringITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/tiering/PaimonTieringITCase.java
@@ -68,6 +68,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.fluss.testutils.DataTestUtils.row;
+import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT case for tiering tables to paimon. */
@@ -496,19 +497,39 @@ class PaimonTieringITCase extends FlinkPaimonTieringTestBase {
     private void checkDataInPaimonAppendOnlyTable(
             TablePath tablePath, List<InternalRow> expectedRows, long startingOffset)
             throws Exception {
-        Iterator<org.apache.paimon.data.InternalRow> paimonRowIterator =
-                getPaimonRowCloseableIterator(tablePath);
-        Iterator<InternalRow> flussRowIterator = expectedRows.iterator();
-        while (paimonRowIterator.hasNext()) {
-            org.apache.paimon.data.InternalRow row = paimonRowIterator.next();
-            InternalRow flussRow = flussRowIterator.next();
-            assertThat(row.getInt(0)).isEqualTo(flussRow.getInt(0));
-            assertThat(row.getString(1).toString()).isEqualTo(flussRow.getString(1).toString());
-            // system columns are always the last three: __bucket, __offset, __timestamp
-            int offsetIndex = row.getFieldCount() - 2;
-            assertThat(row.getLong(offsetIndex)).isEqualTo(startingOffset++);
-        }
-        assertThat(flussRowIterator.hasNext()).isFalse();
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    try (CloseableIterator<org.apache.paimon.data.InternalRow> paimonRowIterator =
+                            getPaimonRowCloseableIterator(tablePath)) {
+                        List<String> actualRows = new ArrayList<>();
+                        while (paimonRowIterator.hasNext()) {
+                            org.apache.paimon.data.InternalRow row = paimonRowIterator.next();
+                            // system columns are always the last three:
+                            // __bucket, __offset, __timestamp
+                            int offsetIndex = row.getFieldCount() - 2;
+                            actualRows.add(
+                                    row.getInt(0)
+                                            + "|"
+                                            + row.getString(1).toString()
+                                            + "|"
+                                            + row.getLong(offsetIndex));
+                        }
+
+                        List<String> expectedPaimonRows = new ArrayList<>();
+                        long offset = startingOffset;
+                        for (InternalRow flussRow : expectedRows) {
+                            expectedPaimonRows.add(
+                                    flussRow.getInt(0)
+                                            + "|"
+                                            + flussRow.getString(1).toString()
+                                            + "|"
+                                            + offset++);
+                        }
+                        assertThat(actualRows)
+                                .containsExactlyInAnyOrderElementsOf(expectedPaimonRows);
+                    }
+                });
     }
 
     private void checkDataInPaimonAppendOnlyPartitionedTable(
@@ -517,19 +538,41 @@ class PaimonTieringITCase extends FlinkPaimonTieringTestBase {
             List<InternalRow> expectedRows,
             long startingOffset)
             throws Exception {
-        Iterator<org.apache.paimon.data.InternalRow> paimonRowIterator =
-                getPaimonRowCloseableIterator(tablePath, partitionSpec);
-        Iterator<InternalRow> flussRowIterator = expectedRows.iterator();
-        while (paimonRowIterator.hasNext()) {
-            org.apache.paimon.data.InternalRow row = paimonRowIterator.next();
-            InternalRow flussRow = flussRowIterator.next();
-            assertThat(row.getInt(0)).isEqualTo(flussRow.getInt(0));
-            assertThat(row.getString(1).toString()).isEqualTo(flussRow.getString(1).toString());
-            assertThat(row.getString(2).toString()).isEqualTo(flussRow.getString(2).toString());
-            // the idx 3 is __bucket, so use 4
-            assertThat(row.getLong(4)).isEqualTo(startingOffset++);
-        }
-        assertThat(flussRowIterator.hasNext()).isFalse();
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    try (CloseableIterator<org.apache.paimon.data.InternalRow> paimonRowIterator =
+                            getPaimonRowCloseableIterator(tablePath, partitionSpec)) {
+                        List<String> actualRows = new ArrayList<>();
+                        while (paimonRowIterator.hasNext()) {
+                            org.apache.paimon.data.InternalRow row = paimonRowIterator.next();
+                            // the idx 3 is __bucket, so use 4
+                            actualRows.add(
+                                    row.getInt(0)
+                                            + "|"
+                                            + row.getString(1).toString()
+                                            + "|"
+                                            + row.getString(2).toString()
+                                            + "|"
+                                            + row.getLong(4));
+                        }
+
+                        List<String> expectedPaimonRows = new ArrayList<>();
+                        long offset = startingOffset;
+                        for (InternalRow flussRow : expectedRows) {
+                            expectedPaimonRows.add(
+                                    flussRow.getInt(0)
+                                            + "|"
+                                            + flussRow.getString(1).toString()
+                                            + "|"
+                                            + flussRow.getString(2).toString()
+                                            + "|"
+                                            + offset++);
+                        }
+                        assertThat(actualRows)
+                                .containsExactlyInAnyOrderElementsOf(expectedPaimonRows);
+                    }
+                });
     }
 
     private CloseableIterator<org.apache.paimon.data.InternalRow> getPaimonRowCloseableIterator(


### PR DESCRIPTION
## Summary
- Make Paimon tiering data checks retry until tiered snapshots become visible.
- Compare Paimon scan results without depending on physical row order while still validating offsets.

Fixes #3445

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 11) ./mvnw -pl fluss-lake/fluss-lake-paimon -am -Dtest=PaimonTieringITCase#testTiering -DfailIfNoTests=false test
- JAVA_HOME=$(/usr/libexec/java_home -v 11) ./mvnw spotless:check -pl fluss-lake/fluss-lake-paimon
