### PR TITLE
[server] Allow altering datalake auto-compaction before lake enabled

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
@@ -48,6 +48,7 @@ public class FlussConfigUtils {
                 Arrays.asList(
                         ConfigOptions.TABLE_DATALAKE_ENABLED.key(),
                         ConfigOptions.TABLE_DATALAKE_FRESHNESS.key(),
+                        ConfigOptions.TABLE_DATALAKE_AUTO_COMPACTION.key(),
                         ConfigOptions.TABLE_TIERED_LOG_LOCAL_SEGMENTS.key(),
                         ConfigOptions.TABLE_AUTO_PARTITION_NUM_RETENTION.key(),
                         ConfigOptions.TABLE_STATISTICS_COLUMNS.key(),

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/TableDescriptorValidation.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/TableDescriptorValidation.java
@@ -179,6 +179,15 @@ public class TableDescriptorValidation {
                             ConfigOptions.TABLE_KV_STANDBY_REPLICA_ENABLED.key()));
         }
 
+        if (tableKeysToChange.contains(ConfigOptions.TABLE_DATALAKE_AUTO_COMPACTION.key())
+                && currentConfig.isDataLakeEnabled()) {
+            throw new InvalidAlterTableException(
+                    String.format(
+                            "The option '%s' cannot be altered when '%s' is enabled.",
+                            ConfigOptions.TABLE_DATALAKE_AUTO_COMPACTION.key(),
+                            ConfigOptions.TABLE_DATALAKE_ENABLED.key()));
+        }
+
         if (!currentConfig.getDataLakeFormat().isPresent()) {
             List<String> datalakeKeys =
                     tableKeysToChange.stream()

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/LakeTableManagerITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/LakeTableManagerITCase.java
@@ -20,6 +20,7 @@ package org.apache.fluss.server.coordinator;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.cluster.AlterConfigOpType;
+import org.apache.fluss.exception.InvalidAlterTableException;
 import org.apache.fluss.exception.TableAlreadyExistException;
 import org.apache.fluss.metadata.DataLakeFormat;
 import org.apache.fluss.metadata.Schema;
@@ -234,6 +235,95 @@ class LakeTableManagerITCase {
                 .isFalse();
 
         // cleanup
+        adminGateway.dropTable(newDropTableRequest(db1, tb1, false)).get();
+        adminGateway.dropDatabase(newDropDatabaseRequest(db1, false, true)).get();
+    }
+
+    @Test
+    void testAlterDatalakeAutoCompactionOnlyWhenLakeDisabled() throws Exception {
+        AdminGateway adminGateway = getAdminGateway();
+
+        String db1 = "test_alter_datalake_auto_compaction_db";
+        String tb1 = "tb1";
+        TablePath tablePath = TablePath.of(db1, tb1);
+        adminGateway.createDatabase(newCreateDatabaseRequest(db1, false)).get();
+
+        Map<String, String> initialProperties = new HashMap<>();
+        initialProperties.put(ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "false");
+        adminGateway
+                .createTable(
+                        newCreateTableRequest(
+                                tablePath, newPkTable().withProperties(initialProperties), false))
+                .get();
+
+        Map<String, String> setProperties = new HashMap<>();
+        setProperties.put(ConfigOptions.TABLE_DATALAKE_AUTO_COMPACTION.key(), "true");
+        adminGateway
+                .alterTable(
+                        newAlterTableRequest(
+                                tablePath,
+                                setProperties,
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                false))
+                .get();
+
+        TableDescriptor disabledLakeTableDescriptor =
+                TableDescriptor.fromJsonBytes(
+                        adminGateway
+                                .getTableInfo(newGetTableInfoRequest(tablePath))
+                                .get()
+                                .getTableJson());
+        assertThat(
+                        disabledLakeTableDescriptor
+                                .getProperties()
+                                .get(ConfigOptions.TABLE_DATALAKE_AUTO_COMPACTION.key()))
+                .isEqualTo("true");
+
+        Map<String, String> enableLakeProperties = new HashMap<>();
+        enableLakeProperties.put(ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "true");
+        adminGateway
+                .alterTable(
+                        newAlterTableRequest(
+                                tablePath,
+                                enableLakeProperties,
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                false))
+                .get();
+
+        Map<String, String> resetProperties = new HashMap<>();
+        resetProperties.put(ConfigOptions.TABLE_DATALAKE_AUTO_COMPACTION.key(), "false");
+        assertThatThrownBy(
+                        () ->
+                                adminGateway
+                                        .alterTable(
+                                                newAlterTableRequest(
+                                                        tablePath,
+                                                        resetProperties,
+                                                        Collections.emptyList(),
+                                                        Collections.emptyList(),
+                                                        false))
+                                        .get())
+                .cause()
+                .isInstanceOf(InvalidAlterTableException.class)
+                .hasMessage(
+                        "The option '%s' cannot be altered when '%s' is enabled.",
+                        ConfigOptions.TABLE_DATALAKE_AUTO_COMPACTION.key(),
+                        ConfigOptions.TABLE_DATALAKE_ENABLED.key());
+
+        TableDescriptor tableDescriptorAfterFailedAlter =
+                TableDescriptor.fromJsonBytes(
+                        adminGateway
+                                .getTableInfo(newGetTableInfoRequest(tablePath))
+                                .get()
+                                .getTableJson());
+        assertThat(
+                        tableDescriptorAfterFailedAlter
+                                .getProperties()
+                                .get(ConfigOptions.TABLE_DATALAKE_AUTO_COMPACTION.key()))
+                .isEqualTo("true");
+
         adminGateway.dropTable(newDropTableRequest(db1, tb1, false)).get();
         adminGateway.dropDatabase(newDropDatabaseRequest(db1, false, true)).get();
     }


### PR DESCRIPTION
## Summary
- Allow table.datalake.auto-compaction to be altered before datalake is enabled.
- Reject changing table.datalake.auto-compaction after table.datalake.enabled=true.
- Add coordinator IT coverage for the allowed and rejected alter paths.

## Test Plan
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@11/11.0.24/libexec/openjdk.jdk/Contents/Home ./mvnw -pl fluss-server -am -Dtest=LakeTableManagerITCase#testAlterDatalakeAutoCompactionOnlyWhenLakeDisabled -DfailIfNoTests=false test