### PR TITLE
[client] Propagate write batch failures to flush

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
@@ -375,7 +375,7 @@ public final class RecordAccumulator {
     }
 
     /** Mark all buckets as ready to send and block until to send is complete. */
-    public void awaitFlushCompletion() throws InterruptedException {
+    public void awaitFlushCompletion() throws Exception {
         try {
             // Obtain a copy of all the incomplete write request result(s) at the time of the
             // flush. We must be careful not to hold a reference to the ProduceBatch(s) so that

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
@@ -321,6 +321,7 @@ public class Sender implements Runnable {
         WriteBatch batch = readyWriteBatch.writeBatch();
         return batch.attempts() < retries
                 && !batch.isDone()
+                && batch.waitedTimeMs(System.currentTimeMillis()) < maxRequestTimeoutMs
                 && ((error.exception() instanceof RetriableException)
                         || (idempotenceManager.idempotenceEnabled()
                                 && idempotenceManager.canRetry(

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/WriteBatch.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/WriteBatch.java
@@ -219,7 +219,7 @@ public abstract class WriteBatch {
                                 e);
                     }
                 });
-        requestFuture.done();
+        requestFuture.done(exception);
     }
 
     int attempts() {
@@ -306,15 +306,20 @@ public abstract class WriteBatch {
     /** The future for this batch. */
     public static class RequestFuture {
         private final CountDownLatch latch = new CountDownLatch(1);
+        @Nullable private Exception exception;
 
         /** Mark this request as complete and unblock any threads waiting on its completion. */
-        public void done() {
+        public void done(@Nullable Exception exception) {
+            this.exception = exception;
             latch.countDown();
         }
 
         /** Await the completion of this request. */
-        public void await() throws InterruptedException {
+        public void await() throws Exception {
             latch.await();
+            if (exception != null) {
+                throw exception;
+            }
         }
     }
 }

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/WriterClient.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/WriterClient.java
@@ -164,6 +164,10 @@ public class WriterClient {
                             "Flush interrupted after %d ms. Writer may be in inconsistent state",
                             System.currentTimeMillis() - start),
                     e);
+        } catch (Exception e) {
+            throw new FlussRuntimeException(
+                    String.format("Flush failed after %d ms.", System.currentTimeMillis() - start),
+                    e);
         }
         LOG.trace(
                 "Flushed accumulated records in writer in {} ms.",

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/RecordAccumulatorTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/RecordAccumulatorTest.java
@@ -65,6 +65,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -461,6 +462,34 @@ class RecordAccumulatorTest {
         accum.awaitFlushCompletion();
         assertThat(accum.hasUnDrained()).isFalse();
         assertThat(accum.hasIncomplete()).isFalse();
+    }
+
+    @Test
+    void testAwaitFlushCompletionPropagatesBatchFailure() throws Exception {
+        IndexedRow row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
+        RecordAccumulator accum = createTestRecordAccumulator(4 * 1024, 64 * 1024);
+        accum.append(createRecord(row), writeCallback, cluster, 0, false);
+
+        accum.beginFlush();
+        CompletableFuture<Throwable> flushResult =
+                CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                accum.awaitFlushCompletion();
+                                return null;
+                            } catch (Throwable t) {
+                                return t;
+                            }
+                        });
+
+        Map<Integer, List<ReadyWriteBatch>> results =
+                accum.drain(cluster, accum.ready(cluster).readyNodes, Integer.MAX_VALUE);
+        WriteBatch batch = results.get(node1.id()).get(0).writeBatch();
+        RuntimeException expected = new RuntimeException("write failed");
+        batch.completeExceptionally(expected);
+
+        assertThat(flushResult.get(5, TimeUnit.SECONDS)).isSameAs(expected);
+        accum.deallocate(batch);
     }
 
     @Test


### PR DESCRIPTION
### Purpose

  When `WriterClient.flush()` waits for pending write batches, it relies on
  `RecordAccumulator.awaitFlushCompletion()`, which waits on each
  `WriteBatch.RequestFuture`.

  Before this change, a write batch could be completed exceptionally through
  `WriteBatch.completeExceptionally(exception)`, but `RequestFuture` only counted
  down its latch and did not keep or rethrow the exception. As a result,
  `flush()` could wait silently without surfacing the underlying write failure,
  and in retry/error paths this could look like a hang to the caller.

  I hit this when TabletServer rejected writes with `DISK_WRITE_LOCKED`.
  The writer kept retrying until request timeout, but the failure was not
  propagated through the flush waiting path, so the test appeared to hang instead
  of failing with the real write error.

  This issue is independent of `DISK_WRITE_LOCKED` itself. Any write batch that
  is completed exceptionally should be observable by callers waiting in `flush()`.

  This is related to, but different from, #1258. #1258 fixed a lost `WriteBatch`
  case where `awaitFlushCompletion()` could wait forever. This PR fixes another
  failure path: a `WriteBatch` is completed exceptionally, but the corresponding
  `RequestFuture.await()` did not propagate the batch exception.

  ### Brief change log

  - Store the batch exception in `WriteBatch.RequestFuture` when a batch completes.
  - Rethrow the stored exception from `RequestFuture.await()`.
  - Let `RecordAccumulator.awaitFlushCompletion()` propagate batch failures.
  - Wrap propagated flush failures in `WriterClient.flush()`.
  - Stop retrying retriable write errors after the request timeout has elapsed.
  - Add a unit test to verify that `awaitFlushCompletion()` observes batch failures.

  ### Tests

  - `./mvnw -pl fluss-client -DfailIfNoTests=false -Dtest=RecordAccumulatorTest#testAwaitFlushCompletionPropagatesBatchFailure test`
  - `./mvnw -pl fluss-client -am -DskipTests compile`


  ### API and Format

  No public API or storage format changes.

  ### Documentation

  No documentation changes are required.
