### PR TITLE
[server] Support plugin discovery for client authentication

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -1291,6 +1291,18 @@ public class ConfigOptions {
                     .withDescription(
                             "The authentication protocol used to authenticate the client.");
 
+    public static final ConfigOption<Boolean> CLIENT_SECURITY_ENABLE_PLUGIN_DISCOVERY =
+            key("client.security.enable-plugin-discovery")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "When set to true, the client will additionally discover "
+                                    + "authentication plugins from the configured plugins/ folder "
+                                    + "via the PluginManager, in addition to the default classpath. "
+                                    + "This is useful for standalone tools or scripts that run outside "
+                                    + "the server JVM but still need to load authentication plugins "
+                                    + "shipped in plugins/.");
+
     public static final ConfigOption<MemorySize> CLIENT_SCANNER_LOG_FETCH_MAX_BYTES =
             key("client.scanner.log.fetch.max-bytes")
                     .memoryType()

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/AuthenticationFactory.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/AuthenticationFactory.java
@@ -68,8 +68,15 @@ public class AuthenticationFactory {
             Configuration configuration) {
         String clientAuthenticateProtocol =
                 configuration.getString(ConfigOptions.CLIENT_SECURITY_PROTOCOL);
+        PluginManager pluginManager = null;
+        if (configuration.getBoolean(ConfigOptions.CLIENT_SECURITY_ENABLE_PLUGIN_DISCOVERY)) {
+            pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
+        }
         ClientAuthenticationPlugin authenticatorPlugin =
-                discoverPlugin(clientAuthenticateProtocol, ClientAuthenticationPlugin.class, null);
+                discoverPlugin(
+                        clientAuthenticateProtocol,
+                        ClientAuthenticationPlugin.class,
+                        pluginManager);
         return () -> authenticatorPlugin.createClientAuthenticator(configuration);
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/tools/ClusterHealthReadinessCheck.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tools/ClusterHealthReadinessCheck.java
@@ -19,6 +19,7 @@ package org.apache.fluss.server.tools;
 
 import org.apache.fluss.cluster.ServerNode;
 import org.apache.fluss.cluster.ServerType;
+import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.UnsupportedVersionException;
 import org.apache.fluss.metrics.registry.MetricRegistryImpl;
@@ -230,6 +231,9 @@ public final class ClusterHealthReadinessCheck {
         if (authString == null || authString.trim().isEmpty()) {
             return conf;
         }
+        // Enable plugin discovery so the client authenticator can discover authentication
+        // plugins shipped in the server's plugins/ directory.
+        conf.setBoolean(ConfigOptions.CLIENT_SECURITY_ENABLE_PLUGIN_DISCOVERY, true);
         for (String pair : authString.split(";")) {
             String trimmed = pair.trim();
             if (trimmed.isEmpty()) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3473 

<!-- What is the purpose of the change -->

When standalone tools (e.g. readiness probe) run outside the server
JVM, they cannot find authentication plugins shipped in the plugins/
directory because `loadClientAuthenticatorSupplier` only uses `ServiceLoader`
on the lib/ classpath.

Add a config option 'client.security.enable-plugin-discovery' (default
false) that enables PluginManager-based discovery from the plugins/
folder. The readiness probe enables this automatically when auth
parameters are provided.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
