### PR TITLE
[build] CI build test on Java 17 and 21 (#203 Phase 3)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,36 @@ jobs:
         run: |
           mvn -T 1C -B clean install -DskipTests -Pjava8
 
+  compile-on-jdk17:
+    name: "Compile Java 17"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build
+        run: |
+          mvn -T 1C -B clean install -DskipTests -Dspotless.check.skip=true
+
+  compile-on-jdk21:
+    name: "Compile Java 21"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Build
+        run: |
+          mvn -T 1C -B clean install -DskipTests -Dspotless.check.skip=true
+
   build-on-jdk11:
     name: "Java 11"
     uses: ./.github/workflows/ci-template.yaml

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -32,3 +32,15 @@ jobs:
     with:
       java-version: "8"
       maven-parameters: "-Pjava8"
+  build-on-jdk17:
+    name: "Java 17"
+    uses: ./.github/workflows/ci-template.yaml
+    with:
+      java-version: "17"
+      maven-parameters: "-Dspotless.check.skip=true"
+  build-on-jdk21:
+    name: "Java 21"
+    uses: ./.github/workflows/ci-template.yaml
+    with:
+      java-version: "21"
+      maven-parameters: "-Dspotless.check.skip=true"

--- a/fluss-docgen/website/docs/_configs/_partial_config.mdx
+++ b/fluss-docgen/website/docs/_configs/_partial_config.mdx
@@ -1,0 +1,359 @@
+{/* This file is auto-generated. Do not edit directly. */}
+
+## Acl Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `acl.notification.expiration-time` | `15 min` | Duration | The duration for which ACL notifications are valid before they expire. This configuration determines the time window during which an ACL notification is considered active. After this duration, the notification will no longer be valid and will be discarded. The default value is 15 minutes. This setting is important to ensure that ACL changes are propagated in a timely manner and do not remain active longer than necessary. |
+
+## Advertised Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `advertised.listeners` | `none` | String | The externally advertised address and port for client connections. Required in distributed environments when the bind address is not publicly reachable. Format matches `bind.listeners` (listener_name://host:port). Defaults to the value of `bind.listeners` if not explicitly configured. |
+
+## Allow Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `allow.create.log.tables` | `true` | Boolean | Whether to allow creation of log tables. When set to false, attempts to create log tables (tables without primary key) will be rejected. The default value is true. |
+| `allow.create.kv.tables` | `true` | Boolean | Whether to allow creation of kv tables (primary key tables). When set to false, attempts to create kv tables (tables with primary key) will be rejected. The default value is true. |
+
+## Authorizer Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `authorizer.enabled` | `false` | Boolean | Specifies whether to enable the authorization feature. If enabled, access control is enforced based on the authorization rules defined in the configuration. If disabled, all operations and resources are accessible to all users. |
+| `authorizer.type` | `default` | String | Specifies the type of authorizer to be used for access control. This value corresponds to the identifier of the authorization plugin. The default value is `default`, which indicates the built-in authorizer implementation. Custom authorizers can be implemented by providing a matching plugin identifier. |
+
+## Auto-partition Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `auto-partition.check.interval` | `10 min` | Duration | The interval of auto partition check. The default value is 10 minutes. |
+
+## Bind Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `bind.listeners` | `none` | String | The network address and port to which the server binds for accepting connections. This defines the interface and port where the server will listen for incoming requests. The format is `listener_name://host:port`, and multiple addresses can be specified, separated by commas. Use `0.0.0.0` for the `host` to bind to all available interfaces which is dangerous on production and not suggested for production usage. The `listener_name` serves as an identifier for the address in the configuration. For example, `internal.listener.name` specifies the address used for internal server communication. If multiple addresses are configured, ensure that the `listener_name` values are unique. |
+
+## Bootstrap Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `bootstrap.servers` | `none` | String | A list of host/port pairs to use for establishing the initial connection to the Fluss cluster. The list should be in the form host1:port1,host2:port2,.... Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down)  |
+
+## Client Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `client.id` | `(empty)` | String | An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging. |
+| `client.connect-timeout` | `2 min` | Duration | The Netty client connect timeout. |
+| `client.writer.buffer.memory-size` | `64 mb` | MemorySize | The total bytes of memory the writer can use to buffer internal rows. |
+| `client.writer.buffer.page-size` | `128 kb` | MemorySize | Size of every page in memory buffers (`client.writer.buffer.memory-size`). |
+| `client.writer.buffer.per-request-memory-size` | `16 mb` | MemorySize | The minimum number of bytes that will be allocated by the writer rounded down to the closes multiple of client.writer.buffer.page-sizeIt must be greater than or equal to client.writer.buffer.page-size. This option allows to allocate memory in batches to have better CPU-cached friendliness due to contiguous segments. |
+| `client.writer.buffer.wait-timeout` | `9223372036 s` | Duration | Defines how long the writer will block when waiting for segments to become available. |
+| `client.writer.batch-size` | `2 mb` | MemorySize | The writer or walBuilder will attempt to batch records together into one batch for the same bucket. This helps performance on both the client and the server. |
+| `client.writer.dynamic-batch-size.enabled` | `true` | Boolean | Controls whether the client writer dynamically adjusts the batch size based on actual write throughput. Enabled by default. With dynamic batch sizing enabled, the writer adapts memory allocation per batch according to historical write sizes for the target table or partition. This ensures better memory utilization and performance under varying throughput conditions. The dynamic batch size is bounded: it will not exceed `client.writer.batch-size`, nor fall below `client.writer.buffer.page-size`.When disabled, the writer uses a fixed batch size (`client.writer.batch-size`) for all batches, this may lead to frequent memory waits and suboptimal write performance if the incoming data rate is inconsistent across partitions. |
+| `client.writer.batch-timeout` | `0 s` | Duration | The writer groups ay rows that arrive in between request sends into a single batched request. Normally this occurs only under load when rows arrive faster than they can be sent out. However in some circumstances the writer may want toreduce the number of requests even under moderate load. This setting accomplishes this by adding a small amount of artificial delay, that is, rather than immediately sending out a row, the writer will wait for up to the given delay to allow other records to be sent so that the sends can be batched together. This can be thought of as analogous to Nagle's algorithm in TCP. This setting gives the upper bound on the delay for batching: once we get client.writer.batch-size worth of rows for a bucket it will be sent immediately regardless of this setting, however if we have fewer than this many bytes accumulated for this bucket we will delay for the specified time waiting for more records to show up. |
+| `client.writer.bucket.no-key-assigner` | `STICKY` | NoKeyAssigner | The bucket assigner for no key table. For table with bucket key or primary key, we choose a bucket based on a hash of the key. For these table without bucket key and primary key, we can use this option to specify bucket assigner, the candidate assigner is [ROUND_ROBIN, STICKY], the default assigner is STICKY. ROUND_ROBIN: this strategy will assign the bucket id for the input row by round robin. STICKY: this strategy will assign new bucket id only if the batch changed in record accumulator, otherwise the bucket id will be the same as the front record. |
+| `client.writer.acks` | `all` | String | The number of acknowledgments the writer requires the leader to have received before considering a request complete. This controls the durability of records that are sent. The following settings are allowed: acks=0: If set to 0, then the writer will not wait for any acknowledgment from the server at all. No guarantee can be mode that the server has received the record in this case. acks=1: This will mean the leader will write the record to its local log but will respond without awaiting full acknowledge the record but before the followers have replicated it then the record will be lost. acks=-1 (all): This will mean the leader will wait for the full ser of in-sync replicas to acknowledge the record. This guarantees that the record will not be lost as long as at least one in-sync replica remains alive, This is the strongest available guarantee. |
+| `client.writer.request-max-size` | `10 mb` | MemorySize | The maximum size of a request in bytes. This setting will limit the number of record batches the writer will send in a single request to avoid sending huge requests. Note that this retry is no different than if the writer resent the row upon receiving the error. |
+| `client.writer.retries` | `2147483647` | Integer | Setting a value greater than zero will cause the client to resend any record whose send fails with a potentially transient error. |
+| `client.writer.enable-idempotence` | `true` | Boolean | Enable idempotence for the writer. When idempotence is enabled, the writer will ensure that exactly one copy of each record is written in the stream. When idempotence is disabled, the writer retries due to server failures, etc., may write duplicates of the retried record in the stream. Note that enabling writer idempotence requires client.writer.retries to be greater than 0, and client.writer.acks must be `all`. Writer idempotence is enabled by default if no conflicting config are set. If conflicting config are set and writer idempotence is not explicitly enabled, idempotence is disabled. If idempotence is explicitly enabled and conflicting config are set, a ConfigException is thrown |
+| `client.writer.max-inflight-requests-per-bucket` | `5` | Integer | The maximum number of unacknowledged requests per bucket for writer. This configuration can work only if client.writer.enable-idempotence is set to true. When the number of inflight requests per bucket exceeds this setting, the writer will wait for the inflight requests to complete before sending out new requests. |
+| `client.writer.dynamic-create-partition.enabled` | `true` | Boolean | Whether enable dynamic create partition for client writer. Enable by default. Dynamic partition strategy refers to creating partitions based on the data being written for partitioned table if the wrote partition don't exists. |
+| `client.request-timeout` | `30 s` | Duration | The timeout for a request to complete. If user set the write ack to -1, this timeout is the max time that delayed write try to complete. The default setting is 30 seconds. |
+| `client.scanner.log.check-crc` | `true` | Boolean | Automatically check the CRC3 of the read records for LogScanner. This ensures no on-the-wire or on-disk corruption to the messages occurred. This check adds some overhead, so it may be disabled in cases seeking extreme performance. |
+| `client.scanner.log.max-poll-records` | `500` | Integer | The maximum number of records returned in a single call to poll() for LogScanner. Note that this config doesn't impact the underlying fetching behavior. The Scanner will cache the records from each fetch request and returns them incrementally from each poll. |
+| `client.security.protocol` | `PLAINTEXT` | String | The authentication protocol used to authenticate the client. |
+| `client.security.enable-plugin-discovery` | `false` | Boolean | When set to true, the client will additionally discover authentication plugins from the configured plugins/ folder via the PluginManager, in addition to the default classpath. This is useful for standalone tools or scripts that run outside the server JVM but still need to load authentication plugins shipped in plugins/. |
+| `client.scanner.log.fetch.max-bytes` | `16 mb` | MemorySize | The maximum amount of data the server should return for a fetch request from client. Records are fetched in batches, and if the first record batch in the first non-empty bucket of the fetch is larger than this value, the record batch will still be returned to ensure that the fetch can make progress. As such, this is not a absolute maximum. |
+| `client.scanner.log.fetch.max-bytes-for-bucket` | `1 mb` | MemorySize | The maximum amount of data the server should return for a table bucket in fetch request from client. Records are fetched in batches, the max bytes size is config by this option. |
+| `client.scanner.log.fetch.wait-max-time` | `0 s` | Duration | The maximum time to wait for enough bytes to be available for a fetch log request from client to response. |
+| `client.scanner.log.fetch.min-bytes` | `1 bytes` | MemorySize | The minimum bytes expected for each fetch log request from client to response. If not enough bytes, wait up to client.scanner.log.fetch.wait-max-time time to return. |
+| `client.scanner.kv.fetch.max-bytes` | `4 mb` | MemorySize | The maximum amount of data the server should return per kv scan request when performing a full primary key table scan. Records are streamed in batches; the server may cap this value via 'kv.scanner.max-batch-size'. |
+| `client.lookup.queue-size` | `25600` | Integer | The maximum number of pending lookup operations. |
+| `client.lookup.max-batch-size` | `128` | Integer | The maximum batch size of merging lookup operations to one lookup request. |
+| `client.lookup.max-inflight-requests` | `128` | Integer | The maximum number of unacknowledged lookup requests for lookup operations. |
+| `client.lookup.batch-timeout` | `0 s` | Duration | The maximum time to wait for the lookup batch to full, if this timeout is reached, the lookup batch will be closed to send. |
+| `client.lookup.max-retries` | `2147483647` | Integer | Setting a value greater than zero will cause the client to resend any lookup request that fails with a potentially transient error. |
+| `client.scanner.remote-log.prefetch-num` | `4` | Integer | The number of remote log segments to keep in local temp file for LogScanner, which download from remote storage. The default setting is 4. |
+| `client.scanner.io.tmpdir` | `/tmp/fluss` | String | Local directory that is used by client for storing the data files (like kv snapshot, log segment files) to read temporarily |
+| `client.remote-file.download-thread-num` | `3` | Integer | The number of threads the client uses to download remote files. |
+| `client.filesystem.security.token.renewal.backoff` | `1 hours` | Duration | The time period how long to wait before retrying to obtain new security tokens for filesystem after a failure. |
+| `client.filesystem.security.token.renewal.time-ratio` | `0.75` | Double | Ratio of the token's expiration time when new credentials for access filesystem should be re-obtained. |
+| `client.metrics.enabled` | `false` | Boolean | Enable metrics for client. When metrics is enabled, the client will collect metrics and report by the JMX metrics reporter. |
+| `client.security.sasl.mechanism` | `PLAIN` | String | SASL mechanism to use for authentication.Currently, we only support plain. |
+| `client.security.sasl.jaas.config` | `none` | String | JAAS configuration string for the client. This option is retained for backward compatibility only. Since only SASL/PLAIN is currently supported, only PlainLoginModule is accepted. Prefer using 'client.security.sasl.username' and 'client.security.sasl.password' directly. Example: org.apache.fluss.security.auth.sasl.plain.PlainLoginModule required username="admin" password="admin-secret"; |
+| `client.security.sasl.username` | `none` | String | The password to use for client-side SASL JAAS authentication. This is used when the client connects to the Fluss cluster with SASL authentication enabled. If not provided, the username will be read from the JAAS configuration string specified by `client.security.sasl.jaas.config`. |
+| `client.security.sasl.password` | `none` | String | The username to use for client-side SASL JAAS authentication. This is used when the client connects to the Fluss cluster with SASL authentication enabled. If not provided, the password will be read from the JAAS configuration string specified by `client.security.sasl.jaas.config`. |
+
+## Coordinator Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `coordinator.lifecycle-throttler.inflight-timeout` | `3 min` | Duration | The timeout for an in-flight drop event in the coordinator's TableLifecycleThrottler. If a drop event has been admitted but the corresponding completion callback has not arrived within this timeout, the throttler abandons tracking of that drop and continues admitting the next pending drop. |
+| `coordinator.lifecycle-throttler.timeout-check-interval` | `1 min` | Duration | The periodic interval at which the coordinator's TableLifecycleThrottler scans in-flight drops for timeouts. |
+| `coordinator.host` | `none` | String | The config parameter defining the network address to connect to for communication with the coordinator server. If the coordinator server is used as a bootstrap server (discover all the servers in the cluster), the value of this config option should be a static hostname or address.This option is deprecated. Please use bind.listeners instead, which provides a more flexible configuration for multiple ports |
+| `coordinator.port` | `9123` | String | The config parameter defining the network port to connect to for communication with the coordinator server. Like coordinator.host, if the coordinator server is used as a bootstrap server (discover all the servers in the cluster), the value of this config option should be a static port. Otherwise, the value can be set to "0" for a dynamic service name resolution. The value accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both.This option is deprecated. Please use bind.listeners instead, which provides a more flexible configuration for multiple ports |
+| `coordinator.io-pool.size` | `10` | Integer | The size of the IO thread pool to run blocking operations for coordinator server. This includes discard unnecessary snapshot files. Increase this value if you experience slow unnecessary snapshot files clean. The default value is 10. This option is deprecated. Please use server.io-pool.size instead. |
+| `coordinator.producer-offsets.ttl` | `24 hours` | Duration | The TTL (time-to-live) for producer offsets. Producer offsets older than this TTL will be automatically cleaned up by the coordinator server. Default is 24 hours. |
+| `coordinator.producer-offsets.cleanup-interval` | `1 hours` | Duration | The interval for cleaning up expired producer offsets and orphan files in remote storage. Default is 1 hour. |
+
+## Data Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `data.dir` | `/tmp/fluss-data` | String | This configuration controls the directory where fluss will store its data. The default value is /tmp/fluss-data |
+| `data.dirs` | `none` | String | A comma-separated list of local directories used by TabletServer to store local log, kv, checkpoints, and other node-local files. If configured, this option takes precedence over `data.dir`. If not configured, `data.dir` is used as the only local data directory. |
+
+## Datalake Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `datalake.enabled` | `none` | String | Whether the Fluss cluster is ready to create and manage lakehouse tables. If unset, Fluss keeps the legacy behavior where configuring `datalake.format` also enables lakehouse tables. If set to `false`, Fluss pre-binds the lake format for newly created tables but does not allow lakehouse tables yet. If set to `true`, Fluss fully enables lakehouse tables. When this option is explicitly set to `true`, `datalake.format` must also be configured. |
+| `datalake.format` | `none` | String | The datalake format used by Fluss as lakehouse storage. Currently, supported formats are Paimon, Iceberg, and Lance. In the future, more kinds of data lake format will be supported, such as DeltaLake or Hudi. |
+
+## Default Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `default.bucket.number` | `1` | Integer | The default number of buckets for a table in Fluss cluster. It's a cluster-level parameter, and all the tables without specifying bucket number in the cluster will use the value as the bucket number. |
+| `default.replication.factor` | `1` | Integer | The default replication factor for the log of a table in Fluss cluster. It's a cluster-level parameter, and all the tables without specifying replication factor in the cluster will use the value as replication factor. |
+
+## Internal Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `internal.listener.name` | `FLUSS` | String | The listener for server internal communication. |
+
+## Kafka Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `kafka.enabled` | `false` | Boolean | Whether enable fluss kafka. Disabled by default. When this option is set to true, the fluss kafka will be enabled. |
+| `kafka.listener.names` | `[KAFKA]` | ArrayList | The listener names for Kafka wire protocol communication. Support multiple listener names, separated by comma. |
+| `kafka.database` | `kafka` | String | The database for fluss kafka. The default database is `kafka`. |
+| `kafka.connection.max-idle-time` | `1 min` | Duration | Close kafka idle connections after the given time specified by this config. |
+
+## Kv Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `kv.scanner.ttl` | `10 min` | Duration | The time-to-live for an idle KV scanner session on the server. A scanner that has not received a request within this duration will be automatically expired and its resources released. The default value is 10 minutes. |
+| `kv.scanner.expiration-interval` | `30 s` | Duration | How often the TTL evictor runs to close idle scanner sessions. The default value is 30 seconds. |
+| `kv.scanner.max-per-bucket` | `8` | Integer | Maximum number of concurrent scanner sessions per bucket. Exceeding this limit returns TOO_MANY_SCANNERS. The default value is 8. |
+| `kv.scanner.max-per-server` | `200` | Integer | Maximum number of concurrent scanner sessions per tablet server. Exceeding this limit returns TOO_MANY_SCANNERS. The default value is 200. |
+| `kv.scanner.max-batch-size` | `10 mb` | MemorySize | Server-side cap on the per-batch payload size for KV full-scan responses. The effective batch size is min(client-requested batch_size_bytes, this value). Protects the tablet server from out-of-memory if a client passes an excessively large batch size. The default value is 10mb. |
+| `kv.snapshot.interval` | `10 min` | Duration | The interval to perform periodic snapshot for kv data. The default setting is 10 minutes. |
+| `kv.snapshot.scheduler-thread-num` | `1` | Integer | The number of threads that the server uses to schedule snapshot kv data for all the replicas in the server. |
+| `kv.snapshot.transfer-thread-num` | `4` | Integer | The number of threads the server uses to transfer (download and upload) kv snapshot files. This option is deprecated. Please use server.io-pool.size instead. |
+| `kv.snapshot.num-retained` | `2` | Integer | The maximum number of completed snapshots to retain. |
+| `kv.snapshot.lease.expiration-check-interval` | `10 min` | Duration | The interval to check the expiration of kv snapshot lease. The default setting is 10 minutes. |
+| `kv.rocksdb.thread.num` | `2` | Integer | The maximum number of concurrent background flush and compaction jobs (per bucket of table). The default value is `2`. |
+| `kv.rocksdb.files.open` | `-1` | Integer | The maximum number of open files (per  bucket of table) that can be used by the DB, `-1` means no limit. The default value is `-1`. |
+| `kv.rocksdb.log.max-file-size` | `25 mb` | MemorySize | The maximum size of RocksDB's file used for information logging. If the log files becomes larger than this, a new file will be created. If 0, all logs will be written to one log file. The default maximum file size is `25MB`.  |
+| `kv.rocksdb.log.file-num` | `4` | Integer | The maximum number of files RocksDB should keep for information logging (Default setting: 4). |
+| `kv.rocksdb.log.dir` | `none` | String | The directory for RocksDB's information logging files. If empty (Fluss default setting), log files will be in the same directory as the Fluss log. If non-empty, this directory will be used and the data directory's absolute path will be used as the prefix of the log file name. If setting this option as a non-existing location, e.g `/dev/null`, RocksDB will then create the log under its own database folder as before. |
+| `kv.rocksdb.log.level` | `INFO_LEVEL` | InfoLogLevel | The specified information logging level for RocksDB. Candidate log level is [DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL, NUM_INFO_LOG_LEVELS]. If unset, Fluss will use INFO_LEVEL. Note: RocksDB info logs will not be written to the Fluss's tablet server logs and there is no rolling strategy, unless you configure kv.rocksdb.log.dir, kv.rocksdb.log.max-file-size, and kv.rocksdb.log.file-num accordingly. Without a rolling strategy, it may lead to uncontrolled disk space usage if configured with increased log levels! There is no need to modify the RocksDB log level, unless for troubleshooting RocksDB. |
+| `kv.rocksdb.write-batch-size` | `2 mb` | MemorySize | The max size of the consumed memory for RocksDB batch write, will flush just based on item count if this config set to 0. |
+| `kv.rocksdb.shared-rate-limiter.bytes-per-sec` | `9223372036854775807 bytes` | MemorySize | The shared rate limit in bytes per second for RocksDB flush and compaction operations across all RocksDB instances in the TabletServer. All KV tablets share a single global RateLimiter to prevent disk IO from being saturated. The RateLimiter is always enabled. The default value is Long.MAX_VALUE (effectively unlimited). Set to a lower value (e.g., 100MB) to limit the rate. |
+| `kv.rocksdb.compaction.style` | `LEVEL` | CompactionStyle | The specified compaction style for DB. Candidate compaction style is LEVEL, FIFO, UNIVERSAL or NONE, and Fluss chooses `LEVEL` as default style. |
+| `kv.rocksdb.compaction.level.use-dynamic-size` | `false` | Boolean | If true, RocksDB will pick target size of each level dynamically. From an empty DB, RocksDB would make last level the base level, which means merging L0 data into the last level, until it exceeds max_bytes_for_level_base. And then repeat this process for second last level and so on. The default value is `false`. For more information, please refer to  https://github.com/facebook/rocksdb/wiki/Leveled-Compaction#level_compaction_dynamic_level_bytes-is-trueRocksDB's doc. |
+| `kv.rocksdb.compression.per.level` | `[LZ4, LZ4, LZ4, LZ4, LZ4, ZSTD, ZSTD]` | ArrayList | A comma-separated list of Compression Type. Different levels can have different compression policies. In many cases, lower levels use fast compression algorithms, while higher levels with more data use slower but more effective compression algorithms. The N th element in the List corresponds to the compression type of the level N-1When `kv.rocksdb.compaction.level.use-dynamic-size` is true, compression_per_level[0] still determines L0, but other elements are based on the base level and may not match the level seen in the info log. Note: If the List size is smaller than the level number, the undefined lower level uses the last Compression Type in the List. The optional values include NO, SNAPPY, LZ4, ZSTD. For more information about compression type, please refer to doc https://github.com/facebook/rocksdb/wiki/Compression. The default value is ‘LZ4,LZ4,LZ4,LZ4,LZ4,ZSTD,ZSTD’, indicates there is lz4 compaction of level0 and level4，ZSTD compaction algorithm is used from level5 to level6. LZ4 is a lightweight compression algorithm so it usually strikes a good balance between space and CPU usage.  ZSTD is more space save than LZ4, but it is more CPU-intensive. Different machines deploy compaction modes according to CPU and I/O resources. The default value is for the scenario that CPU resources are adequate. If you find the IO pressure of the system is not big when writing a lot of data, but CPU resources are inadequate, you can exchange I/O resources for CPU resources and change the compaction mode to `NO,NO,NO,LZ4,LZ4,ZSTD,ZSTD`.  |
+| `kv.rocksdb.compaction.level.target-file-size-base` | `64 mb` | MemorySize | The target file size for compaction, which determines a level-1 file size. The default value is `64MB`. |
+| `kv.rocksdb.compaction.level.max-size-level-base` | `256 mb` | MemorySize | The upper-bound of the total size of level base files in bytes. The default value is `256MB`. |
+| `kv.rocksdb.writebuffer.size` | `64 mb` | MemorySize | The amount of data built up in memory (backed by an unsorted log on disk) before converting to a sorted on-disk files. The default writebuffer size is `64MB`. |
+| `kv.rocksdb.writebuffer.count` | `2` | Integer | The maximum number of write buffers that are built up in memory. The default value is `2`. |
+| `kv.rocksdb.writebuffer.number-to-merge` | `1` | Integer | The minimum number of write buffers that will be merged together before writing to storage. The default value is `1`. |
+| `kv.rocksdb.block.blocksize` | `4 kb` | MemorySize | The approximate size (in bytes) of user data packed per block. The default blocksize is `4KB`. |
+| `kv.rocksdb.block.metadata-blocksize` | `4 kb` | MemorySize | Approximate size of partitioned metadata packed per block. Currently applied to indexes block when partitioned index/filters option is enabled. The default blocksize is `4KB`. |
+| `kv.rocksdb.block.cache-size` | `8 mb` | MemorySize | The amount of the cache for data blocks in RocksDB. The default block-cache size is `8MB`. |
+| `kv.rocksdb.use-bloom-filter` | `true` | Boolean | If true, every newly created SST file will contain a Bloom filter. It is enabled by default. |
+| `kv.rocksdb.bloom-filter.bits-per-key` | `10.0` | Double | Bits per key that bloom filter will use, this only take effect when bloom filter is used. The default value is 10.0. |
+| `kv.rocksdb.bloom-filter.block-based-mode` | `false` | Boolean | If true, RocksDB will use block-based filter instead of full filter, this only take effect when bloom filter is used. The default value is `false`. |
+| `kv.rocksdb.block.cache-index-and-filter-blocks` | `false` | Boolean | If true, index and filter blocks will be stored in block cache, together with all other data blocks. This helps to limit memory usage so that the total memory used by RocksDB is bounded by block cache size. The default value is `false`. |
+| `kv.rocksdb.block.cache-index-and-filter-blocks-with-high-priority` | `false` | Boolean | If true and cache_index_and_filter_blocks is enabled, index and filter blocks will be stored with high priority in block cache, making them less likely to be evicted than data blocks. The default value is `false`. |
+| `kv.rocksdb.block.pin-l0-filter-and-index-blocks-in-cache` | `false` | Boolean | If true and cache_index_and_filter_blocks is enabled, L0 index and filter blocks will be pinned in block cache and will not be evicted. This helps avoid performance degradation due to cache misses on L0 index/filter blocks. The default value is `false`. |
+| `kv.rocksdb.block.pin-top-level-index-and-filter` | `false` | Boolean | If true, the top-level index of partitioned index/filter blocks will be pinned in block cache and will not be evicted. The default value is `false`. |
+| `kv.recover.log-record-batch.max-size` | `16 mb` | MemorySize | The max fetch size for fetching log to apply to kv during recovering kv. |
+| `kv.recover.remote-log.prefetch-num` | `4` | Integer | The maximum number of remote log segments that can be downloaded but not yet consumed during KV recovery. A larger value overlaps more remote storage downloads with consumption, at the cost of extra local disk usage. Setting to 1 keeps the historical behavior (one-step prefetch). |
+| `kv.recover.remote-log.download-threads` | `3` | Integer | The number of threads used to download remote log segments during KV recovery. Should be less than or equal to 'kv.recover.remote-log.prefetch-num'. |
+
+## Lake Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `lake.tiering.auto-expire-snapshot` | `false` | Boolean | If true, snapshot expiration will be triggered automatically when tiering service commits to the datalake, even if Key: 'table.datalake.auto-expire-snapshot' , default: false (fallback keys: []) is false. |
+
+## Log Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `log.segment.file-size` | `1 gb` | MemorySize | This configuration controls the segment file size for the log. Retention and cleaning is always done a file at a time so a larger segment size means fewer files but less granular control over retention. |
+| `log.index.file-size` | `10 mb` | MemorySize | This configuration controls the size of the index that maps offsets to file positions. We preallocate this index file and shrink it only after log rolls. You generally should not need to change this setting. |
+| `log.index.interval-size` | `4 kb` | MemorySize | This setting controls how frequently fluss adds an index entry to its offset index. The default setting ensures that we index a message roughly every 4096 bytes. More indexing allows reads to jump closer to the exact position in the log but makes the index larger. You probably don't need to change this. |
+| `log.file-preallocate` | `false` | Boolean | True if we should preallocate the file on disk when creating a new log segment. |
+| `log.flush.interval-messages` | `9223372036854775807` | Long | This setting allows specifying an interval at which we will force a fsync of data written to the log. For example if this was set to 1, we would fsync after every message; if it were 5 we would fsync after every five messages. |
+| `log.replica.high-watermark.checkpoint-interval` | `5 s` | Duration | The frequency with which the high watermark is saved out to disk. The default setting is 5 seconds. |
+| `log.replica.max-lag-time` | `30 s` | Duration | If a follower replica hasn't sent any fetch log requests or hasn't consumed up the leaders log end offset for at least this time, the leader will remove the follower replica form isr |
+| `log.replica.write-operation-purge-number` | `1000` | Integer | The purge number (in number of requests) of the write operation manager, the default value is 1000. |
+| `log.replica.fetch-operation-purge-number` | `1000` | Integer | The purge number (in number of requests) of the fetch log operation manager, the default value is 1000. |
+| `log.replica.fetcher-number` | `1` | Integer | Number of fetcher threads used to replicate log records from each source tablet server. The total number of fetchers on each tablet server is bound by this parameter multiplied by the number of tablet servers in the cluster. Increasing this value can increase the degree of I/O parallelism in the follower and leader tablet server at the cost of higher CPU and memory utilization. |
+| `log.replica.fetch.backoff-interval` | `1 s` | Duration | The amount of time to sleep when fetch bucket error occurs. |
+| `log.replica.fetch.max-bytes` | `16 mb` | MemorySize | The maximum amount of data the server should return for a fetch request from follower. Records are fetched in batches, and if the first record batch in the first non-empty bucket of the fetch is larger than this value, the record batch will still be returned to ensure that the fetch can make progress. As such, this is not a absolute maximum. Note that the fetcher performs multiple fetches in parallel. |
+| `log.replica.fetch.max-bytes-for-bucket` | `1 mb` | MemorySize | The maximum amount of data the server should return for a table bucket in fetch request from follower. Records are fetched in batches, the max bytes size is config by this option. |
+| `log.replica.fetch.wait-max-time` | `0 s` | Duration | The maximum time to wait for enough bytes to be available for a fetch log request from follower to response. This value should always be less than the `log.replica.max-lag-time` at all times to prevent frequent shrinking of ISR for low throughput tables |
+| `log.replica.fetch.min-bytes` | `1 bytes` | MemorySize | The minimum bytes expected for each fetch log request from follower to response. If not enough bytes, wait up to log.replica.fetch.wait-max-time time to return. |
+| `log.replica.min-in-sync-replicas-number` | `1` | Integer | When a writer set `client.writer.acks` to all (-1), this configuration specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. If this minimum cannot be met, then the writer will raise an exception (NotEnoughReplicas). when used together, this config and `client.writer.acks` allow you to enforce greater durability guarantees. A typical scenario would be to create a table with a replication factor of 3. set this conf to 2, and write with acks = -1. This will ensure that the writer raises an exception if a majority of replicas don't receive a write. |
+
+## Max Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `max.partition.num` | `1000` | Integer | Limits the maximum number of partitions that can be created for a partitioned table to avoid creating too many partitions. |
+| `max.bucket.num` | `128000` | Integer | The maximum number of buckets that can be created for a table.The default value is 128000 |
+
+## Metrics Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `metrics.reporters` | `none` | String | An optional list of reporter names. If configured, only reporters whose name matches in the list will be started |
+| `metrics.reporter.prometheus.port` | `9249` | String | The port the Prometheus reporter listens on.In order to be able to run several instances of the reporter on one host (e.g. when one TabletServer is colocated with the CoordinatorServer) it is advisable to use a port range like 9250-9260. |
+| `metrics.reporter.prometheus-push.host-url` | `none` | String | The PushGateway server host URL including scheme, host name, and port. |
+| `metrics.reporter.prometheus-push.job-name` | `none` | String | The job name under which metrics will be pushed |
+| `metrics.reporter.prometheus-push.random-job-name-suffix` | `true` | Boolean | Specifies whether a random suffix should be appended to the job name. This is useful when multiple instances of the reporter are running on the same host. |
+| `metrics.reporter.prometheus-push.delete-on-shutdown` | `true` | Boolean | Specifies whether to delete metrics from the PushGateway on shutdown. Fluss will try its best to delete the metrics but this is not guaranteed. |
+| `metrics.reporter.prometheus-push.grouping-key` | `none` | String | Specifies the grouping key which is the group and global labels of all metrics. The label name and value are separated by '=', and labels are separated by ';', e.g., k1=v1;k2=v2. |
+| `metrics.reporter.prometheus-push.push-interval` | `10 s` | Duration | The interval of pushing metrics to Prometheus PushGateway. |
+| `metrics.reporter.jmx.port` | `none` | String | The port for the JMXServer that JMX clients can connect to. If not set, the JMXServer won't start. In order to be able to run several instances of the reporter on one host (e.g. when one TabletServer is colocated with the CoordinatorServer) it is advisable to use a port range like 9990-9999. |
+| `metrics.reporter.influxdb.version` | `v3` | String | The InfluxDB version to connect to. Supported values are 'v2' and 'v3'. For InfluxDB v2, the 'org' configuration is required; for InfluxDB v3, it is not needed. |
+| `metrics.reporter.influxdb.host-url` | `none` | String | The InfluxDB server host URL including scheme, host name, and port. |
+| `metrics.reporter.influxdb.bucket` | `none` | String | The InfluxDB bucket/database name. |
+| `metrics.reporter.influxdb.org` | `none` | String | The InfluxDB organization name. Required for InfluxDB v2, not needed for InfluxDB v3. |
+| `metrics.reporter.influxdb.token` | `none` | String | The InfluxDB authentication token. |
+| `metrics.reporter.influxdb.push-interval` | `10 s` | Duration | The interval of reporting metrics to InfluxDB. |
+
+## Netty Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `netty.server.num-network-threads` | `3` | Integer | The number of threads that the server uses for receiving requests from the network and sending responses to the network. |
+| `netty.server.num-worker-threads` | `8` | Integer | The number of threads that the server uses for processing requests, which may include disk and remote I/O. |
+| `netty.server.max-queued-requests` | `500` | Integer | The number of queued requests allowed for worker threads, before blocking the I/O threads. |
+| `netty.server.max-request-size` | `100 mb` | MemorySize | The maximum size of a single request that the server can receive. This limits the maximum frame length at the Netty pipeline level to protect the server from malicious clients sending oversized requests that could exhaust server memory. |
+| `netty.connection.max-idle-time` | `10 min` | Duration | Close idle connections after the given time specified by this config. |
+| `netty.client.num-network-threads` | `4` | Integer | The number of threads that the client uses for sending requests to the network and receiving responses from network. The default value is 4 |
+| `netty.client.allocator.heap-buffer-first` | `true` | Boolean | Whether to allocate heap buffer first for the netty client. If set to false, direct buffer will be used first, which requires sufficient off-heap memory to be available. By default, inner clients (server-to-server) use false and non-inner clients (external) use true. |
+
+## Plugin Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `plugin.classloader.parent-first-patterns.default` | `[java., org.apache.fluss., javax.annotation., org.apache.hadoop., core-site, org.slf4j, org.apache.log4j, org.apache.logging, org.apache.commons.logging, ch.qos.logback]` | ArrayList | A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the plugin parent ClassLoader first. A pattern is a simple prefix that is checked  against the fully qualified class name. This setting should generally not be modified. To add another  pattern we recommend to use "plugin.classloader.parent-first-patterns.additional" instead. |
+| `plugin.classloader.parent-first-patterns.additional` | `[]` | ArrayList | A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the plugin parent ClassLoader first. A pattern is a simple prefix that is checked  against the fully qualified class name. These patterns are appended to "plugin.classloader.parent-first-patterns.default". |
+
+## Remote Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `remote.data.dir` | `none` | String | The directory used for storing the kv snapshot data files and remote log for log tiered storage in a Fluss supported filesystem. When upgrading to `remote.data.dirs`, please ensure this value is placed as the first entry in the new configuration.For new clusters, it is recommended to use `remote.data.dirs` instead. If `remote.data.dirs` is configured, this value will be ignored. |
+| `remote.data.dirs` | `[]` | ArrayList | A comma-separated list of directories in Fluss supported filesystems for storing the kv snapshot data files and remote log files of tables/partitions. If configured, when a new table or a new partition is created, one of the directories from this list will be selected according to the strategy specified by `remote.data.dirs.strategy` (`ROUND_ROBIN` by default). If not configured, the system uses `remote.data.dir` as the sole remote data directory for all data. |
+| `remote.data.dirs.strategy` | `ROUND_ROBIN` | RemoteDataDirStrategy | The strategy for selecting the remote data directory from `remote.data.dirs`. The candidate strategies are: [ROUND_ROBIN, WEIGHTED_ROUND_ROBIN], the default strategy is ROUND_ROBIN. ROUND_ROBIN: this strategy employs a round-robin approach to select one from the available remote directories. WEIGHTED_ROUND_ROBIN: this strategy selects one of the available remote directories based on the weights configured in `remote.data.dirs.weights`. |
+| `remote.data.dirs.weights` | `[]` | ArrayList | The weights of the remote data directories. This is a list of weights corresponding to the `remote.data.dirs` in the same order. When `remote.data.dirs.strategy` is set to `WEIGHTED_ROUND_ROBIN`, this must be configured, and its size must be equal to `remote.data.dirs`; otherwise, it will be ignored. |
+| `remote.fs.write-buffer-size` | `4 kb` | MemorySize | The default size of the write buffer for writing the local files to remote file systems. |
+| `remote.log.task-interval-duration` | `1 min` | Duration | Interval at which remote log manager runs the scheduled tasks like copy segments, clean up remote log segments, delete local log segments etc. If the value is set to 0, it means that the remote log storage is disabled. |
+| `remote.log.task-max-upload-segments` | `5` | Integer | The maximum number of log segments to upload to remote storage per tiering task execution. This limits the upload batch size to prevent overwhelming the remote storage when there is a large backlog of segments to upload. |
+| `remote.log.index-file-cache-size` | `1 gb` | MemorySize | The size of the space allocated per local data directory to store index files fetched from remote storage in the local storage. |
+| `remote.log-manager.thread-pool-size` | `4` | Integer | Size of the thread pool used in scheduling tasks to copy segments, fetch remote log indexes and clean up remote log segments. |
+| `remote.log.data-transfer-thread-num` | `4` | Integer | The number of threads the server uses to transfer (download and upload) remote log file can be  data file, index file and remote log metadata file. This option is deprecated. Please use server.io-pool.size instead. |
+
+## Security Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `security.sasl.enabled.mechanisms` | `none` | String |  |
+| `security.protocol.map` | `{}` | EmptyMap | A map defining the authentication protocol for each listener. The format is `listenerName1:protocol1,listenerName2:protocol2`, e.g., `INTERNAL:PLAINTEXT,CLIENT:GSSAPI`. Each listener can be associated with a specific authentication protocol. Listeners not included in the map will use PLAINTEXT by default, which does not require authentication. |
+
+## Server Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `server.io-pool.size` | `10` | Integer | The size of the IO thread pool to run blocking operations for both coordinator and tablet servers. This includes discard unnecessary snapshot files, transfer kv snapshot files, and transfer remote log files. Increase this value if you experience slow IO operations. The default value is 10. |
+| `server.data-disk.write-limit-ratio` | `0.85` | Double | Reject writes when the tablet server data disk usage exceeds this ratio. Writes resume after the usage drops below (ratio - 0.10). Set to 1.0 to disable the disk-usage protection entirely. The valid range is (0.1, 1.0]. |
+| `server.data-disk.check-interval` | `30 s` | Duration | The interval at which the tablet server samples the local data disk usage for the write-protection state machine. A shorter interval narrows the time window during which writes can still flow in after the disk crosses the limit ratio, at the cost of slightly more frequent statvfs calls (which are in-memory and cheap). The default 30s is suitable for typical write workloads. |
+| `server.writer-id.expiration-time` | `168 hours` | Duration | The time that the tablet server will wait without receiving any write request from a client before expiring the related status. The default value is 7 days. |
+| `server.writer-id.expiration-check-interval` | `10 min` | Duration | The interval at which to remove writer ids that have expired due to server.writer-id.expiration-time passing. The default value is 10 minutes. |
+| `server.background.threads` | `10` | Integer | The number of threads to use for various background processing tasks. |
+| `server.buffer.memory-size` | `256 mb` | MemorySize | The total bytes of memory the server can use, e.g, buffer write-ahead-log rows. |
+| `server.buffer.page-size` | `128 kb` | MemorySize | Size of every page in memory buffers (`server.buffer.memory-size`). |
+| `server.buffer.per-request-memory-size` | `16 mb` | MemorySize | The minimum number of bytes that will be allocated by the writer rounded down to the closes multiple of server.buffer.page-sizeIt must be greater than or equal to server.buffer.page-size. This option allows to allocate memory in batches to have better CPU-cached friendliness due to contiguous segments. |
+| `server.buffer.wait-timeout` | `9223372036 s` | Duration | Defines how long the buffer pool will block when waiting for segments to become available. |
+
+## Super Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `super.users` | `none` | String | A semicolon-separated list of superusers who have unrestricted access to all operations and resources. Note that the delimiter is semicolon since SSL user names may contain comma, and each super user should be specified in the format `principal_type:principal_name`, e.g., `User:admin;User:bob`. This configuration is critical for defining administrative privileges in the system. |
+
+## Table Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `table.replication.factor` | `none` | String | The replication factor for the log of the new table. When it's not set, Fluss will use the cluster's default replication factor configured by default.replication.factor. It should be a positive number and not larger than the number of tablet servers in the Fluss cluster. A value larger than the number of tablet servers in Fluss cluster will result in an error when the new table is created. |
+| `table.log.format` | `ARROW` | LogFormat | The format of the log records in log store. The default value is `arrow`. The supported formats are `arrow`, `indexed` and `compacted`. |
+| `table.log.arrow.compression.type` | `ZSTD` | ArrowCompressionType | The compression type of the log records if the log format is set to `ARROW`. The candidate compression type is [NONE, LZ4_FRAME, ZSTD] |
+| `table.log.arrow.compression.zstd.level` | `3` | Integer | The compression level of ZSTD for the log records if the log format is set to `ARROW` and the compression type is set to `ZSTD`. The valid range is 1 to 22. |
+| `table.kv.format` | `COMPACTED` | KvFormat | The format of the kv records in kv store. The default value is `compacted`. The supported formats are `compacted` and `indexed`. |
+| `table.kv.format-version` | `none` | String | The version of the kv format. Automatically set by the coordinator during table creation if not configured by users. Note: The datalake encoding and bucketing strategy mentioned below only takes effect when 'datalake.format' is configured at cluster level. Version Behaviors: (1) Version 1: Tables created before 'table.kv.format-version' was introduced are treated as version 1. Uses datalake's encoder (e.g., Paimon/Iceberg) for both primary key and bucket key encoding. This may not support prefix lookup properly because some datalake encoders (like Paimon) don't guarantee that encoded bucket key bytes are a prefix of encoded primary key bytes. (2) Version 2 (current): New tables use Fluss's default encoder for primary key encoding when bucket key differs from primary key, which ensures proper prefix lookup support. When bucket key equals primary key (default bucket key), it still uses datalake's encoder for optimization (encoded bytes can be reused for bucket calculation). Bucket key encoding always uses datalake's encoder to align with datalake bucket calculation. |
+| `table.kv.standby-replica.enabled` | `none` | String | Whether to enable standby replicas for primary key tables. Standby replicas maintain recent KV snapshots for fast leader promotion. Automatically set to true by the coordinator during table creation for new PK tables. Tables created before this option was introduced are treated as disabled. Can be dynamically enabled via ALTER TABLE. |
+| `table.auto-partition.enabled` | `false` | Boolean | Whether enable auto partition for the table. Disable by default. When auto partition is enabled, the partitions of the table will be created automatically. |
+| `table.auto-partition.key` | `none` | String | This configuration defines the time-based partition key to be used for auto-partitioning when a table is partitioned with multiple keys. Auto-partitioning utilizes a time-based partition key to handle partitions automatically, including creating new ones and removing outdated ones, by comparing the time value of the partition with the current system time. In the case of a table using multiple partition keys (such as a composite partitioning strategy), this feature determines which key should serve as the primary time dimension for making auto-partitioning decisions.And If the table has only one partition key, this config is not necessary. Otherwise, it must be specified. |
+| `table.auto-partition.time-unit` | `DAY` | AutoPartitionTimeUnit | The time granularity for auto created partitions. The default value is `DAY`. Valid values are `HOUR`, `DAY`, `MONTH`, `QUARTER`, `YEAR`. If the value is `HOUR`, the partition format for auto created is yyyyMMddHH. If the value is `DAY`, the partition format for auto created is yyyyMMdd. If the value is `MONTH`, the partition format for auto created is yyyyMM. If the value is `QUARTER`, the partition format for auto created is yyyyQ. If the value is `YEAR`, the partition format for auto created is yyyy. |
+| `table.auto-partition.time-zone` | `Etc/UTC` | String | The time zone for auto partitions, which is by default the same as the system time zone. |
+| `table.auto-partition.num-precreate` | `2` | Integer | The number of partitions to pre-create for auto created partitions in each check for auto partition. For example, if the current check time is 2024-11-11 and the value is configured as 3, then partitions 20241111, 20241112, 20241113 will be pre-created. If any one partition exists, it'll skip creating the partition. The default value is 2, which means 2 partitions will be pre-created. If the `table.auto-partition.time-unit` is `DAY`(default), one precreated partition is for today and another one is for tomorrow.For a partition table with multiple partition keys, pre-create is unsupported and will be set to 0 automatically when creating table if it is not explicitly specified. |
+| `table.auto-partition.num-retention` | `7` | Integer | The number of history partitions to retain for auto created partitions in each check for auto partition. For example, if the current check time is 2024-11-11, time-unit is DAY, and the value is configured as 3, then the history partitions 20241108, 20241109, 20241110 will be retained. The partitions earlier than 20241108 will be deleted. The default value is 7. |
+| `table.log.ttl` | `168 hours` | Duration | The time to live for log segments. The configuration controls the maximum time we will retain a log before we will delete old segments to free up space. If set to -1, the log will not be deleted. |
+| `table.log.tiered.local-segments` | `2` | Integer | The number of log segments to retain in local for each table when log tiered storage is enabled. It must be greater that 0. The default is 2. |
+| `table.datalake.enabled` | `false` | Boolean | Whether enable lakehouse storage for the table. Disabled by default. When this option is set to ture and the datalake tiering service is up, the table will be tiered and compacted into datalake format stored on lakehouse storage. |
+| `table.datalake.format` | `none` | String | The data lake format of the table specifies the tiered Lakehouse storage format. Currently, supported formats are `paimon`, `iceberg`, and `lance`. In the future, more kinds of data lake format will be supported, such as DeltaLake or Hudi. Once the `table.datalake.format` property is configured, Fluss adopts the key encoding and bucketing strategy used by the corresponding data lake format. This ensures consistency in key encoding and bucketing, enabling seamless **Union Read** functionality across Fluss and Lakehouse. The `table.datalake.format` can be pre-defined before enabling `table.datalake.enabled`. This allows the data lake feature to be dynamically enabled on the table without requiring table recreation. If `table.datalake.format` is not explicitly set during table creation, the table will default to the format specified by the `datalake.format` configuration in the Fluss cluster. |
+| `table.datalake.freshness` | `3 min` | Duration | It defines the maximum amount of time that the datalake table's content should lag behind updates to the Fluss table. Based on this target freshness, the Fluss service automatically moves data from the Fluss table and updates to the datalake table, so that the data in the datalake table is kept up to date within this target. If the data does not need to be as fresh, you can specify a longer target freshness time to reduce costs. |
+| `table.datalake.auto-compaction` | `false` | Boolean | If true, compaction will be triggered automatically when tiering service writes to the datalake. It is disabled by default. |
+| `table.datalake.auto-expire-snapshot` | `false` | Boolean | If true, snapshot expiration will be triggered automatically when tiering service commits to the datalake. It is disabled by default. |
+| `table.merge-engine` | `none` | String | Defines the merge engine for the primary key table. By default, primary key table doesn't have merge engine. The supported merge engines are `first_row`, `versioned`, and `aggregation`. The `first_row` merge engine will keep the first row of the same primary key. The `versioned` merge engine will keep the row with the largest version of the same primary key. The `aggregation` merge engine will aggregate rows with the same primary key using field-level aggregate functions. |
+| `table.merge-engine.versioned.ver-column` | `none` | String | The column name of the version column for the `versioned` merge engine. If the merge engine is set to `versioned`, the version column must be set. |
+| `table.delete.behavior` | `ALLOW` | DeleteBehavior | Defines the delete behavior for the primary key table. The supported delete behaviors are `allow`, `ignore`, and `disable`. The `allow` behavior allows normal delete operations (default for default merge engine). The `ignore` behavior silently skips delete requests without error. The `disable` behavior rejects delete requests with a clear error message. For tables with FIRST_ROW, VERSIONED, or AGGREGATION merge engines, this option defaults to `ignore`. Note: For AGGREGATION merge engine, when set to `allow`, delete operations will remove the entire record. |
+| `table.auto-increment.cache-size` | `100000` | Long | The cache size of auto-increment IDs fetched from the distributed counter each time. This value determines the length of the locally cached ID segment. Default: 100000. A larger cache size may cause significant auto-increment ID gaps, especially when unused cached ID segments are discarded due to TabletServer restarts or abnormal terminations. Conversely, a smaller cache size increases the frequency of ID fetch requests to the distributed counter, introducing extra network overhead and reducing write throughput and performance. |
+| `table.changelog.image` | `FULL` | ChangelogImage | Defines the changelog image mode for the primary key table. This configuration is inspired by similar settings in database systems like MySQL's binlog_row_image and PostgreSQL's replica identity. The supported modes are `FULL` (default) and `WAL`. The `FULL` mode produces both UPDATE_BEFORE and UPDATE_AFTER records for update operations, capturing complete information about updates and allowing tracking of previous values. The `WAL` mode does not produce UPDATE_BEFORE records. Only INSERT, UPDATE_AFTER (and DELETE if allowed) records are emitted. When WAL mode is enabled, the default merge engine is used (no merge engine configured), updates are full row updates (not partial update), and there is no auto-increment column, an optimization is applied to skip looking up old values, and in this case INSERT operations are converted to UPDATE_AFTER events. This mode reduces storage and transmission costs but loses the ability to track previous values. This option only affects primary key tables. |
+| `table.statistics.columns` | `none` | String | Configures column-level statistics collection for the table. By default this option is not set and no column statistics are collected. The value '*' means collect statistics for all supported columns. A comma-separated list of column names means collect statistics only for the specified columns. Supported types include: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT, DOUBLE, STRING, CHAR, DECIMAL, DATE, TIME, TIMESTAMP, and TIMESTAMP_LTZ. Example: 'id,name,timestamp' to collect statistics only for specified columns. Note: enabling column statistics requires the V1 batch format. Downstream consumers must be upgraded to Fluss v1.0+ before enabling this option, as older versions cannot parse the extended batch format. |
+
+## Tablet-server Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `tablet-server.host` | `none` | String | The external address of the network interface where the TabletServer is exposed. Because different TabletServer need different values for this option, usually it is specified in an additional non-shared TabletServer-specific config file.This option is deprecated. Please use bind.listeners instead, which provides a more flexible configuration for multiple ports |
+| `tablet-server.port` | `0` | String | The external RPC port where the TabletServer is exposed.This option is deprecated. Please use bind.listeners instead, which provides a more flexible configuration for multiple ports |
+| `tablet-server.id` | `none` | String | The id for the tablet server. |
+| `tablet-server.rack` | `none` | String | The rack for the tabletServer. This will be used in rack aware bucket assignment for fault tolerance. Examples: `RACK1`, `cn-hangzhou-server10` |
+| `tablet-server.controlled-shutdown.max-retries` | `3` | Integer | The maximum number of retries for controlled shutdown of the tablet server. During controlled shutdown, the tablet server attempts to transfer leadership of its buckets to other servers. If the transfer fails, it will retry up to this number of times before proceeding with shutdown. The default value is 3. |
+| `tablet-server.controlled-shutdown.retry-interval` | `1 s` | Duration | The interval between retries during controlled shutdown of the tablet server. When controlled shutdown fails to transfer bucket leadership, the tablet server will wait for this duration before attempting the next retry. The default value is 1000 milliseconds (1 second). |
+
+## Zookeeper Configurations
+
+| Key | Default | Type | Description |
+| :--- | :--- | :--- | :--- |
+| `zookeeper.address` | `none` | String | The ZooKeeper address to use, when running Fluss with ZooKeeper. |
+| `zookeeper.path.root` | `/fluss` | String | The root path under which Fluss stores its entries in ZooKeeper. |
+| `zookeeper.client.max-inflight-requests` | `100` | Integer | The maximum number of unacknowledged requests the client will send to ZooKeeper before blocking. |
+| `zookeeper.client.session-timeout` | `1 min` | Duration | Defines the session timeout for the ZooKeeper session. |
+| `zookeeper.client.connection-timeout` | `15 s` | Duration | Defines the connection timeout for ZooKeeper. |
+| `zookeeper.client.retry-wait` | `5 s` | Duration | Defines the pause between consecutive retries. |
+| `zookeeper.client.max-retry-attempts` | `3` | Integer | Defines the number of connection retries before the client gives up. |
+| `zookeeper.client.tolerate-suspended-connections` | `false` | Boolean | Defines whether a suspended ZooKeeper connection will be treated as an error that causes the leader information to be invalidated or not. In case you set this option to , Fluss will wait until a ZooKeeper connection is marked as lost before it revokes the leadership of components. This has the effect that Fluss is more resilient against temporary connection instabilities at the cost of running more likely into timing issues with ZooKeeper. |
+| `zookeeper.client.ensemble-tracker` | `true` | Boolean | Defines whether Curator should enable ensemble tracker. This can be useful in certain scenarios in which CuratorFramework is accessing to ZK clusters via load balancer or Virtual IPs. Default Curator EnsembleTracking logic watches CuratorEventType.GET_CONFIG events and changes ZooKeeper connection string. It is not desired behaviour when ZooKeeper is running under the Virtual IPs. Under certain configurations EnsembleTracking can lead to setting of ZooKeeper connection string with unresolvable hostnames. |
+| `zookeeper.client.config-path` | `none` | String | The file path from which the ZooKeeper client reads its configuration. This allows each ZooKeeper client instance to load its own configuration file, instead of relying on shared JVM-level environment settings. This enables fine-grained control over ZooKeeper client behavior. |
+| `zookeeper.client.max-buffer-size` | `104857600` | Integer | The maximum buffer size (in bytes) for ZooKeeper client. This corresponds to the jute.maxbuffer property. Default is 100MB to match the RPC frame length limit. |
+
+

--- a/fluss-lake/fluss-lake-hudi/pom.xml
+++ b/fluss-lake/fluss-lake-hudi/pom.xml
@@ -70,6 +70,14 @@
         </dependency>
 
         <dependency>
+            <!-- Hudi's Flink bundle references hadoop-client-api shaded classes
+                 (org.apache.hadoop.shaded.*); supply their runtime at test scope -->
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+            <version>${fluss.hadoop.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${fluss.hadoop.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
             --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
             --add-opens=java.base/sun.security.action=ALL-UNNAMED
             --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+            --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED
             -Djdk.reflect.useDirectMethodHandle=false
             -Dio.netty.tryReflectionSetAccessible=true
         </extraJavaTestArgs>


### PR DESCRIPTION
## Purpose

Phase 3 of #203: CI build-test coverage for Java 17 and Java 21 (default and release stay Java 11; no `target.java.version` is changed). As @wuchong noted when closing #114, building on 17/21 largely works already — this PR adds the missing CI coverage from the Phase-3 checklist, plus the two test-level fixes that running the suite on 17/21 surfaces.

## Changes

- `pom.xml`: add `--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED` to the existing `extraJavaTestArgs` block — `JMXServer$JmxRegistry` extends the JDK-internal `sun.rmi.registry.RegistryImpl`, which JDK 17+ strong encapsulation rejects (`IllegalAccessError: superclass access check failed`; JDK 8/11 only warn). Without it the whole `fluss-server` suite errors on 17/21. Harmless on 8/11 thanks to the existing `-XX:+IgnoreUnrecognizedVMOptions`.
- `fluss-lake/fluss-lake-hudi/pom.xml`: add `org.apache.hadoop:hadoop-client-runtime` at **test** scope — Hudi's Flink bundle references hadoop-client-api shaded classes (`org.apache.hadoop.shaded.com.ctc.wstx.*`); without the runtime jar `HudiLakeCatalogTest` can fail with `NoClassDefFoundError` depending on which StAX provider wins. Verified green on 11 and 21 with the dependency.
- `ci.yaml`: add `compile-on-jdk17` / `compile-on-jdk21` (compile-only, mirroring `compile-on-jdk8`) so every PR proves the build on 17/21 cheaply.
- `nightly.yaml`: add full `build-on-jdk17` / `build-on-jdk21` test runs via `ci-template`.

## Spotless

The 17/21 jobs pass `-Dspotless.check.skip=true`, following the precedent #204 established for the Java 8 leg: google-java-format 1.15.0 cannot run on JDK 21 (`JCTree$JCImport.getQualifiedIdentifier` `NoSuchMethodError`), and gjf versions that support 21 require a Java 17 runtime — no gjf version spans 11 and 21, so the format check stays on the default-JDK jobs until Phase 4.

## A linkage hazard worth a maintainer decision (not changed here)

The build uses `maven.compiler.source`/`target`, not `release`. Compiling on JDK 17/21 therefore links against newer JDK APIs even with target 11 — we reproduced jars built on 21 crashing on a Java 11 runtime with `NoSuchMethodError: java.nio.MappedByteBuffer.duplicate()` (covariant override added in JDK 13). If artifacts may ever be built on 17/21, `maven.compiler.release=11` is the fix; we left it out because it interacts with the `java8` profile (javac 8 has no `--release`) and deserves your preferred treatment.

## Verification (local, Temurin 11/17/21)

- `mvn -T 1C clean install -DskipTests`: green on 11, 17 (both pristine) and 21 (with the spotless skip).
- Full-reactor `mvn test` on 17 and 21: identical outcomes to the Java 11 baseline run, with `fluss-server` (1048 tests) green on all three after the `--add-exports` fix, and `HudiLakeCatalogTest` green on 11/21 after the dependency fix.
- Pre-existing, JDK-independent: `fluss-fs-hdfs` fails test discovery identically on 11/17/21 under a plain `mvn test` (it needs the staged `-Ptest-*` invocation); `fluss-spark-ut`'s 2-minute lake-sync waits time out under our shared-load environment — the added nightly jobs on clean runners are the right adjudicator for it.
