### PR TITLE
[server] Ensure KV tablet dir is removed before log and surface clean…

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogManager.java
@@ -564,40 +564,52 @@ public final class LogManager extends TabletManagerBase {
                                 "Table or partition for {} has already been dropped, the residual data will be removed.",
                                 tabletDir,
                                 e);
+
+                        final Tuple2<PhysicalTablePath, TableBucket> pathAndBucket;
+                        try {
+                            pathAndBucket = FlussPaths.parseTabletDir(tabletDir);
+                        } catch (Exception parseException) {
+                            LOG.warn(
+                                    "Failed to parse tablet directory {} while removing residual data, "
+                                            + "skip the cleanup so it can be retried later.",
+                                    tabletDir,
+                                    parseException);
+                            return;
+                        }
+
+                        // Delete the corresponding KV tablet directory first and only drop the log
+                        // (the anchor of an unfinished delete) once the KV directory is confirmed
+                        // gone, so that a KV deletion failure leaves the log in place for retry.
+                        File kvTabletDir =
+                                FlussPaths.kvTabletDir(dataDir, pathAndBucket.f0, pathAndBucket.f1);
+                        if (kvTabletDir.exists()) {
+                            try {
+                                FileUtils.deleteDirectory(kvTabletDir);
+                                LOG.info("Removed residual KV tablet directory: {}", kvTabletDir);
+                            } catch (IOException kvDeleteException) {
+                                LOG.warn(
+                                        "Failed to delete residual KV tablet directory {}, keeping the "
+                                                + "log {} so the cleanup can be retried later.",
+                                        kvTabletDir,
+                                        tabletDir,
+                                        kvDeleteException);
+                                return;
+                            }
+                        }
+
                         FileUtils.deleteDirectoryQuietly(tabletDir);
 
-                        try {
-                            Tuple2<PhysicalTablePath, TableBucket> pathAndBucket =
-                                    FlussPaths.parseTabletDir(tabletDir);
+                        boolean isPartitioned = pathAndBucket.f0.getPartitionName() != null;
+                        File partitionDir = tabletDir.getParentFile();
+                        if (partitionDir != null) {
+                            deleteEmptyDirQuietly(partitionDir);
 
-                            // Also delete corresponding KV tablet directory if it exists
-                            File kvTabletDir =
-                                    FlussPaths.kvTabletDir(
-                                            dataDir, pathAndBucket.f0, pathAndBucket.f1);
-                            if (kvTabletDir.exists()) {
-                                LOG.info(
-                                        "Also removing corresponding KV tablet directory: {}",
-                                        kvTabletDir);
-                                FileUtils.deleteDirectoryQuietly(kvTabletDir);
-                            }
-
-                            boolean isPartitioned = pathAndBucket.f0.getPartitionName() != null;
-                            File partitionDir = tabletDir.getParentFile();
-                            if (partitionDir != null) {
-                                deleteEmptyDirQuietly(partitionDir);
-
-                                if (isPartitioned) {
-                                    File tableDir = partitionDir.getParentFile();
-                                    if (tableDir != null) {
-                                        deleteEmptyDirQuietly(tableDir);
-                                    }
+                            if (isPartitioned) {
+                                File tableDir = partitionDir.getParentFile();
+                                if (tableDir != null) {
+                                    deleteEmptyDirQuietly(tableDir);
                                 }
                             }
-                        } catch (Exception cleanupException) {
-                            LOG.warn(
-                                    "Failed to clean up residual KV/parent directories for {}: {}",
-                                    tabletDir,
-                                    cleanupException.getMessage());
                         }
                         return;
                     }

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -104,6 +104,7 @@ import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.server.zk.data.ZkData;
 import org.apache.fluss.types.RowType;
 import org.apache.fluss.utils.CloseableRegistry;
+import org.apache.fluss.utils.FileUtils;
 import org.apache.fluss.utils.FlussPaths;
 import org.apache.fluss.utils.IOUtils;
 import org.apache.fluss.utils.clock.Clock;
@@ -729,6 +730,36 @@ public final class Replica {
             checkNotNull(kvManager);
             kvManager.dropKv(tableBucket);
             kvTablet = null;
+        } else if (isKvTable()) {
+            // The in-memory KvTablet is not open (e.g. a follower replica), but a residual kv
+            // tablet directory may still exist on disk. Remove it so that we do not leave an
+            // orphan kv directory behind after the log is dropped.
+            File kvTabletDir =
+                    FlussPaths.kvTabletDir(logTablet.getDataDir(), physicalPath, tableBucket);
+            if (kvTabletDir.exists()) {
+                try {
+                    FileUtils.deleteDirectory(kvTabletDir);
+                    LOG.info(
+                            "Deleted residual kv tablet directory {} for bucket {} whose kv tablet "
+                                    + "was not open.",
+                            kvTabletDir,
+                            tableBucket);
+                } catch (IOException e) {
+                    // Surface the failure so the caller does not drop the log; the log is kept as
+                    // an anchor so the cleanup can be retried later.
+                    LOG.warn(
+                            "Failed to delete residual kv tablet directory {} for bucket {}, "
+                                    + "keeping the log so the cleanup can be retried later.",
+                            kvTabletDir,
+                            tableBucket,
+                            e);
+                    throw new KvStorageException(
+                            String.format(
+                                    "Failed to delete residual kv tablet directory %s for bucket %s",
+                                    kvTabletDir, tableBucket),
+                            e);
+                }
+            }
         }
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1973,6 +1973,14 @@ public class ReplicaManager implements ServerReconfigurable {
                 try {
                     FileUtils.deleteDirectory(kvTabletDir);
                 } catch (IOException e) {
+                    // Keep the log as an anchor so a coordinator retry can re-enter this method
+                    // and finish the cleanup; throwing here prevents the log from being dropped.
+                    LOG.warn(
+                            "Failed to delete orphan KV tablet directory {} for bucket {}, "
+                                    + "keeping the log so the cleanup can be retried later.",
+                            kvTabletDir,
+                            tb,
+                            e);
                     throw new KvStorageException(
                             String.format(
                                     "Failed to delete orphan KV tablet directory %s", kvTabletDir),

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LogManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LogManagerTest.java
@@ -33,6 +33,7 @@ import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.ZooKeeperExtension;
 import org.apache.fluss.server.zk.data.TableRegistration;
 import org.apache.fluss.testutils.common.AllCallbackWrapper;
+import org.apache.fluss.utils.FlussPaths;
 import org.apache.fluss.utils.clock.SystemClock;
 import org.apache.fluss.utils.concurrent.FlussScheduler;
 
@@ -242,6 +243,75 @@ final class LogManagerTest extends LogTestBase {
         assertThat(checkpoints.get(tableBucket2)).isEqualTo(log2.getRecoveryPoint());
 
         newLogManager.shutdown();
+    }
+
+    @Test
+    void testResidualKvAndLogRemovedWhenTableDropped() throws Exception {
+        initTableBuckets(null);
+        // Create the on-disk log dir and a corresponding kv tablet dir.
+        LogTablet log1 = getOrCreateLog(tablePath1, null, tableBucket1);
+        File logDir = log1.getLogDir();
+        PhysicalTablePath physicalTablePath = PhysicalTablePath.of(tablePath1);
+        File kvTabletDir = FlussPaths.kvTabletDir(tempDir, physicalTablePath, tableBucket1);
+        assertThat(kvTabletDir.mkdirs()).isTrue();
+        assertThat(logDir).exists();
+        assertThat(kvTabletDir).exists();
+
+        // Drop the table from ZK so that loadLog sees the schema is gone (residual data).
+        logManager.shutdown();
+        logManager = null;
+        zkClient.deleteTable(tablePath1);
+
+        LogManager newLogManager =
+                LogManager.create(
+                        conf,
+                        zkClient,
+                        new FlussScheduler(1),
+                        SystemClock.getInstance(),
+                        TestingMetricGroups.TABLET_SERVER_METRICS,
+                        localDiskManager);
+        newLogManager.startup();
+        logManager = newLogManager;
+
+        // Both the kv and log tablet directories should be removed.
+        assertThat(kvTabletDir).doesNotExist();
+        assertThat(logDir).doesNotExist();
+    }
+
+    @Test
+    void testLogKeptWhenResidualKvDeletionFails() throws Exception {
+        initTableBuckets(null);
+        // Create the on-disk log dir, then place a regular FILE where the kv tablet dir would be,
+        // so FileUtils.deleteDirectory fails (it is not a directory).
+        LogTablet log1 = getOrCreateLog(tablePath1, null, tableBucket1);
+        File logDir = log1.getLogDir();
+        PhysicalTablePath physicalTablePath = PhysicalTablePath.of(tablePath1);
+        File kvTabletDir = FlussPaths.kvTabletDir(tempDir, physicalTablePath, tableBucket1);
+        // The table dir already exists (created alongside the log dir); create the kv path as a
+        // regular file so FileUtils.deleteDirectory fails (it is not a directory).
+        assertThat(kvTabletDir.createNewFile()).isTrue();
+        assertThat(kvTabletDir).isFile();
+        assertThat(logDir).exists();
+
+        // Drop the table from ZK so that loadLog sees the schema is gone (residual data).
+        logManager.shutdown();
+        logManager = null;
+        zkClient.deleteTable(tablePath1);
+
+        LogManager newLogManager =
+                LogManager.create(
+                        conf,
+                        zkClient,
+                        new FlussScheduler(1),
+                        SystemClock.getInstance(),
+                        TestingMetricGroups.TABLET_SERVER_METRICS,
+                        localDiskManager);
+        newLogManager.startup();
+        logManager = newLogManager;
+
+        // KV deletion failed, so the log must be kept as an anchor for a later retry.
+        assertThat(logDir).exists();
+        assertThat(kvTabletDir).exists();
     }
 
     @ParameterizedTest

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
@@ -122,6 +122,35 @@ final class ReplicaTest extends ReplicaTestBase {
     }
 
     @Test
+    void testDeleteRemovesResidualKvDirWhenKvTabletNotOpen() throws Exception {
+        TableBucket tableBucket = new TableBucket(DATA1_TABLE_ID_PK, 1);
+        Replica kvReplica = makeKvReplica(DATA1_PHYSICAL_TABLE_PATH_PK, tableBucket);
+        makeKvReplicaAsLeader(kvReplica);
+
+        File logDir = kvReplica.getLogTablet().getLogDir();
+        File kvTabletDir =
+                kvReplica.getTabletParentDir().resolve("kv-" + tableBucket.getBucket()).toFile();
+        assertThat(kvTabletDir).exists();
+
+        // Become follower: the in-memory KvTablet is dropped (getKvTablet() == null).
+        makeKvReplicaAsFollower(kvReplica, 1);
+        assertThat(kvReplica.getKvTablet()).isNull();
+
+        // Simulate a residual on-disk kv directory left behind (e.g. a previous dropKv that did
+        // not finish), while the in-memory KvTablet is null - this is the orphan-kv condition.
+        assertThat(kvTabletDir.mkdirs()).isTrue();
+        assertThat(kvTabletDir).exists();
+        assertThat(logDir).exists();
+
+        kvReplica.delete();
+
+        // Even though the in-memory KvTablet was null, the residual kv directory must be removed
+        // (and the log removed too).
+        assertThat(kvTabletDir).doesNotExist();
+        assertThat(logDir).doesNotExist();
+    }
+
+    @Test
     void testAppendRecordsToLeader() throws Exception {
         Replica logReplica =
                 makeLogReplica(DATA1_PHYSICAL_TABLE_PATH, new TableBucket(DATA1_TABLE_ID, 1));


### PR DESCRIPTION

When cleaning residual data for a dropped table/partition during startup, delete the KV tablet directory before dropping the log, and only drop the log once the KV directory is confirmed gone. KV deletion failures are now logged (warn) instead of being silently swallowed, keeping the log as an anchor so the cleanup can be retried.

Also propagate KV deletion failures in ReplicaManager.sweepOrphanTabletDirs so the log is not dropped when orphan KV cleanup fails.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

delete kv tablet dir first, if success, then delete the log dir.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
