### PR TITLE
[test] Fix disk usage collector test

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/storage/DiskUsageCollectorTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/storage/DiskUsageCollectorTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.data.Offset.offset;
 
 /** Test for {@link DiskUsageCollector}. */
 class DiskUsageCollectorTest {
@@ -55,7 +56,7 @@ class DiskUsageCollectorTest {
         DiskUsageCollector oneDir = new DiskUsageCollector(Collections.singletonList(dataDir1));
 
         // both directories share the same FileStore -> result should match a single-dir collector
-        assertThat(twoDirs.collect()).isEqualTo(oneDir.collect());
+        assertThat(twoDirs.collect()).isCloseTo(oneDir.collect(), offset(1e-6));
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

Fix a flaky assertion in `DiskUsageCollectorTest#testMultipleDirsOnSameFileStoreDeduplicated`.

The test creates two collectors over the same underlying `FileStore` and expects the collected disk usage to match. Since the two collectors sample usage sequentially, the values can differ by a tiny floating-point amount and make the test flaky.

### Brief change log

- Use AssertJ `isCloseTo(..., offset(1e-6))` instead of exact equality for disk usage comparison.
- Keep the test semantics unchanged: multiple directories on the same `FileStore` should still be deduplicated.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
