### PR TITLE
[flink] Preserve offsets for empty tiering buckets

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/committer/TieringCommitOperator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/committer/TieringCommitOperator.java
@@ -232,7 +232,7 @@ public class TieringCommitOperator<WriteResult, Committable>
 
             Map<TableBucket, Long> logEndOffsets = new HashMap<>();
             Map<TableBucket, Long> logMaxTieredTimestamps = new HashMap<>();
-            for (TableBucketWriteResult<WriteResult> writeResult : nonEmptyResults) {
+            for (TableBucketWriteResult<WriteResult> writeResult : committableWriteResults) {
                 TableBucket tableBucket = writeResult.tableBucket();
                 logEndOffsets.put(tableBucket, writeResult.logEndOffset());
                 logMaxTieredTimestamps.put(tableBucket, writeResult.maxTimestamp());

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/committer/TieringCommitOperatorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/committer/TieringCommitOperatorTest.java
@@ -246,6 +246,7 @@ class TieringCommitOperatorTest extends FlinkTestBase {
                         numberOfWriteResults));
 
         Map<TableBucket, Long> expectedLogEndOffsets = new HashMap<>();
+        expectedLogEndOffsets.put(new TableBucket(tableId, 0), 3L);
         expectedLogEndOffsets.put(new TableBucket(tableId, 1), 1L);
         expectedLogEndOffsets.put(new TableBucket(tableId, 2), 2L);
         verifyLakeSnapshot(tablePath1, tableId, 1, expectedLogEndOffsets);


### PR DESCRIPTION
## What is changed

Fixes #3413.

This change keeps lake writes limited to non-empty bucket write results, but collects committed Fluss log offsets and max tiered timestamps from all completed bucket write results in a mixed commit round. That preserves offsets for buckets that only advanced through an empty materialized batch while another bucket produced lake data in the same commit.

The existing empty-write-result test now asserts that the empty bucket offset is included in the committed lake snapshot metadata.

## Why

Before this change, `TieringCommitOperator` built the `logEndOffsets` map from only non-empty write results. In a mixed commit, empty-batch buckets with `writeResult() == null` were filtered out, so their completed log offsets were not committed even though the commit round had lake data to publish.

## Tests

- Red/green verified `TieringCommitOperatorTest#testCommitMeetsEmptyWriteResult`; before the production change it failed because bucket 0 offset was missing from the committed snapshot.
- `mvn -s <empty-settings> -pl fluss-flink/fluss-flink-common -am -Dtest=TieringCommitOperatorTest#testCommitMeetsEmptyWriteResult -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -s <empty-settings> -pl fluss-flink/fluss-flink-common -am -Dtest=TieringCommitOperatorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

I used an empty temporary Maven settings file locally to avoid a private mirror configured in my user Maven settings.

## AI assistance

This PR was prepared with assistance from OpenAI Codex. I reviewed the change and verified the tests above.
