### PR TITLE
[docs] Add Apache Polaris/Iceberg REST catalog quick-start guide

### DIFF
--- a/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
@@ -35,6 +35,8 @@ export TOKEN=$(curl -s http://<polaris-host>:8181/api/catalog/v1/oauth/tokens \
     -d 'scope=PRINCIPAL_ROLE:ALL' | jq -r '.access_token')
 ```
 
+> **NOTE**: These commands target Polaris's default realm. If your deployment uses a custom realm, add a `-H "Polaris-Realm: <your-realm>"` header to **both** the token request above and the catalog request below — otherwise they resolve against the default realm and the requests may be silently misrouted.
+
 Then create a catalog backed by your object storage:
 
 ```bash
@@ -57,6 +59,13 @@ curl -X POST http://<polaris-host>:8181/api/management/v1/catalogs \
 
 > **NOTE**: Adjust the `storageConfigInfo` to match your storage backend. Polaris supports S3, Azure, and GCS. You also need a principal with a role granting `TABLE_WRITE_DATA` on the catalog — see the [Polaris documentation](https://polaris.apache.org/) for catalog, principal, and access-control setup.
 
+#### Vended credentials vs. static keys
+
+Polaris hands storage credentials to Fluss in one of two ways, depending on your object store:
+
+- **Vended credentials (AWS S3 with STS)** — the path used throughout this guide. The catalog's `storageConfigInfo` must include a `roleArn`, and Polaris must be allowed to `AssumeRole` on it; Polaris then vends temporary, scoped credentials per request (enabled by the `X-Iceberg-Access-Delegation: vended-credentials` header in the Fluss config below). Without a `roleArn`, table operations fail with `Failed to get subscoped credentials: roleArn must not be null`.
+- **Static keys (MinIO, NooBaa, or other S3-compatible stores without STS)** — there is no role to assume. Disable credential subscoping on Polaris by setting `SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION=true`, and provide static `fs.s3a.*` keys (access key and secret) to Fluss instead of the vended-credentials header.
+
 ## Configure Fluss with Polaris
 
 ### Cluster Configuration
@@ -75,7 +84,7 @@ datalake.iceberg.header.X-Iceberg-Access-Delegation: vended-credentials
 
 Fluss strips the `datalake.iceberg.` prefix and passes the remaining properties to the Iceberg REST catalog client. The `credential` (`client_id:client_secret`) and `scope` properties configure OAuth2 client-credentials authentication; the Iceberg client derives the token endpoint from `uri` (`/v1/oauth/tokens`), which matches the Polaris endpoint. You can add any additional [Iceberg REST catalog properties](https://iceberg.apache.org/docs/1.10.1/configuration/#catalog-properties) using the same prefix.
 
-> With credential vending enabled (`X-Iceberg-Access-Delegation: vended-credentials`), Polaris returns temporary, scoped storage credentials for each table request, so Fluss does not need static object-storage credentials.
+> With credential vending enabled (`X-Iceberg-Access-Delegation: vended-credentials`), Polaris returns temporary, scoped storage credentials for each table request, so Fluss does not need static object-storage credentials. For stores without STS (e.g. MinIO), drop this header and supply static `fs.s3a.*` keys instead, as described in [Vended credentials vs. static keys](#vended-credentials-vs-static-keys) above.
 
 #### Hadoop Dependencies
 

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
@@ -64,7 +64,7 @@ curl -X POST http://<polaris-host>:8181/api/management/v1/catalogs \
 Polaris hands storage credentials to Fluss in one of two ways, depending on your object store:
 
 - **Vended credentials (AWS S3 with STS)** — the path used throughout this guide. The catalog's `storageConfigInfo` must include a `roleArn`, and Polaris must be allowed to `AssumeRole` on it; Polaris then vends temporary, scoped credentials per request (enabled by the `X-Iceberg-Access-Delegation: vended-credentials` header in the Fluss config below). Without a `roleArn`, table operations fail with `Failed to get subscoped credentials: roleArn must not be null`.
-- **Static keys (MinIO, NooBaa, or other S3-compatible stores without STS)** — there is no role to assume. Disable credential subscoping on Polaris by setting `SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION=true`, and provide static `s3.access-key-id` / `s3.secret-access-key` keys to Fluss instead of the vended-credentials header.
+- **Static keys (MinIO, NooBaa, or other S3-compatible stores without STS)** — there is no role to assume. Mark the catalog's storage config with `"stsUnavailable": true`, and provide static `s3.access-key-id`, `s3.secret-access-key`, and `client.region` to Fluss instead of the vended-credentials header. (Polaris also has a `SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION` feature flag, but it is test/dev-only — prefer `stsUnavailable` on the storage config.)
 
 ## Configure Fluss with Polaris
 
@@ -86,7 +86,7 @@ datalake.iceberg.header.X-Iceberg-Access-Delegation: vended-credentials
 
 Fluss strips the `datalake.iceberg.` prefix and passes the remaining properties to the Iceberg REST catalog client. The `io-impl` property selects Iceberg's `S3FileIO` for warehouse data access; set it explicitly, because the default `ResolvingFileIO` requires Hadoop classes that the Fluss servers' Iceberg plugin does not bundle, and the catalog otherwise fails to load. The `credential` (`client_id:client_secret`), `scope`, and `oauth2-server-uri` properties configure OAuth2 client-credentials authentication against Polaris. Setting `oauth2-server-uri` explicitly is recommended: the Iceberg client can otherwise fall back to `<uri>/v1/oauth/tokens`, but that implicit fallback is deprecated and logs a warning. You can add any additional [Iceberg REST catalog properties](https://iceberg.apache.org/docs/1.10.1/configuration/#catalog-properties) using the same prefix.
 
-> With credential vending enabled (`X-Iceberg-Access-Delegation: vended-credentials`), Polaris returns temporary, scoped storage credentials for each table request, so Fluss does not need static object-storage credentials. For stores without STS (e.g. MinIO), drop this header and supply static `s3.access-key-id` / `s3.secret-access-key` keys instead, as described in [Vended credentials vs. static keys](#vended-credentials-vs-static-keys) above.
+> With credential vending enabled (`X-Iceberg-Access-Delegation: vended-credentials`), Polaris returns temporary, scoped storage credentials for each table request, so Fluss does not need static object-storage credentials. For stores without STS (e.g. MinIO), drop this header, set `"stsUnavailable": true` on the catalog's storage config, and supply static `s3.access-key-id`, `s3.secret-access-key`, and `client.region` to Fluss instead, as described in [Vended credentials vs. static keys](#vended-credentials-vs-static-keys) above.
 
 ### Start Tiering Service
 

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
@@ -79,10 +79,11 @@ datalake.iceberg.uri: http://<polaris-host>:8181/api/catalog
 datalake.iceberg.warehouse: <catalog-name>
 datalake.iceberg.credential: <client-id>:<client-secret>
 datalake.iceberg.scope: PRINCIPAL_ROLE:ALL
+datalake.iceberg.oauth2-server-uri: http://<polaris-host>:8181/api/catalog/v1/oauth/tokens
 datalake.iceberg.header.X-Iceberg-Access-Delegation: vended-credentials
 ```
 
-Fluss strips the `datalake.iceberg.` prefix and passes the remaining properties to the Iceberg REST catalog client. The `credential` (`client_id:client_secret`) and `scope` properties configure OAuth2 client-credentials authentication; the Iceberg client derives the token endpoint from `uri` (`/v1/oauth/tokens`), which matches the Polaris endpoint. You can add any additional [Iceberg REST catalog properties](https://iceberg.apache.org/docs/1.10.1/configuration/#catalog-properties) using the same prefix.
+Fluss strips the `datalake.iceberg.` prefix and passes the remaining properties to the Iceberg REST catalog client. The `credential` (`client_id:client_secret`), `scope`, and `oauth2-server-uri` properties configure OAuth2 client-credentials authentication against Polaris. Setting `oauth2-server-uri` explicitly is recommended: the Iceberg client can otherwise fall back to `<uri>/v1/oauth/tokens`, but that implicit fallback is deprecated and logs a warning. You can add any additional [Iceberg REST catalog properties](https://iceberg.apache.org/docs/1.10.1/configuration/#catalog-properties) using the same prefix.
 
 > With credential vending enabled (`X-Iceberg-Access-Delegation: vended-credentials`), Polaris returns temporary, scoped storage credentials for each table request, so Fluss does not need static object-storage credentials. For stores without STS (e.g. MinIO), drop this header and supply static `fs.s3a.*` keys instead, as described in [Vended credentials vs. static keys](#vended-credentials-vs-static-keys) above.
 
@@ -99,6 +100,7 @@ ${FLINK_HOME}/bin/flink run /path/to/fluss-flink-tiering-$FLUSS_VERSION$.jar \
     --datalake.iceberg.warehouse <catalog-name> \
     --datalake.iceberg.credential <client-id>:<client-secret> \
     --datalake.iceberg.scope PRINCIPAL_ROLE:ALL \
+    --datalake.iceberg.oauth2-server-uri http://<polaris-host>:8181/api/catalog/v1/oauth/tokens \
     --datalake.iceberg.header.X-Iceberg-Access-Delegation vended-credentials
 ```
 

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
@@ -1,0 +1,144 @@
+---
+title: Polaris
+sidebar_position: 2
+---
+
+# Polaris
+
+## Introduction
+
+[Apache Polaris](https://polaris.apache.org/) is an open-source, fully-featured catalog for Apache Iceberg. It implements Iceberg's [REST Catalog](https://iceberg.apache.org/concepts/catalog/#decoupling-using-the-rest-catalog) interface, making Iceberg tables discoverable and queryable by any Iceberg-compatible engine, with role-based access control and credential vending built in.
+
+This guide explains how to configure Fluss to use Polaris as its Iceberg catalog. For general Iceberg integration details (table mapping, data types, limitations), see [Iceberg](../formats/iceberg.md).
+
+## How It Works
+
+When Fluss is configured with Polaris as its Iceberg REST catalog:
+
+1. Fluss creates and manages Iceberg table metadata through Polaris's REST API
+2. The [tiering service](maintenance/tiered-storage/lakehouse-storage.md#start-the-datalake-tiering-service) writes data to object storage and commits snapshots via Polaris
+3. Any Iceberg-compatible engine (Flink, Spark, Trino, StarRocks, etc.) can discover and query the tiered tables through Polaris
+
+## Prerequisites
+
+### Running Polaris Instance
+
+You need a running Polaris instance with a catalog and a principal (a `client_id` / `client_secret` pair) that can access it. The fastest way to get started is the [Polaris Quickstart](https://polaris.apache.org/), which starts Polaris and automatically creates a `quickstart_catalog` plus a `quickstart_user` principal, printing the principal's credentials in the container logs.
+
+To create a catalog manually, first obtain an access token with your root credentials:
+
+```bash
+export TOKEN=$(curl -s http://<polaris-host>:8181/api/catalog/v1/oauth/tokens \
+    -d 'grant_type=client_credentials' \
+    -d 'client_id=<root-client-id>' \
+    -d 'client_secret=<root-client-secret>' \
+    -d 'scope=PRINCIPAL_ROLE:ALL' | jq -r '.access_token')
+```
+
+Then create a catalog backed by your object storage:
+
+```bash
+curl -X POST http://<polaris-host>:8181/api/management/v1/catalogs \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "catalog": {
+        "name": "my_catalog",
+        "type": "INTERNAL",
+        "properties": { "default-base-location": "s3://my-bucket/iceberg" },
+        "storageConfigInfo": {
+          "storageType": "S3",
+          "allowedLocations": ["s3://my-bucket/iceberg"],
+          "roleArn": "<your-role-arn>"
+        }
+      }
+    }'
+```
+
+> **NOTE**: Adjust the `storageConfigInfo` to match your storage backend. Polaris supports S3, Azure, and GCS. You also need a principal with a role granting `TABLE_WRITE_DATA` on the catalog — see the [Polaris documentation](https://polaris.apache.org/) for catalog, principal, and access-control setup.
+
+## Configure Fluss with Polaris
+
+### Cluster Configuration
+
+Add the following to your `server.yaml`:
+
+```yaml
+datalake.format: iceberg
+datalake.iceberg.type: rest
+datalake.iceberg.uri: http://<polaris-host>:8181/api/catalog
+datalake.iceberg.warehouse: <catalog-name>
+datalake.iceberg.credential: <client-id>:<client-secret>
+datalake.iceberg.scope: PRINCIPAL_ROLE:ALL
+datalake.iceberg.header.X-Iceberg-Access-Delegation: vended-credentials
+```
+
+Fluss strips the `datalake.iceberg.` prefix and passes the remaining properties to the Iceberg REST catalog client. The `credential` (`client_id:client_secret`) and `scope` properties configure OAuth2 client-credentials authentication; the Iceberg client derives the token endpoint from `uri` (`/v1/oauth/tokens`), which matches the Polaris endpoint. You can add any additional [Iceberg REST catalog properties](https://iceberg.apache.org/docs/1.10.1/configuration/#catalog-properties) using the same prefix.
+
+> With credential vending enabled (`X-Iceberg-Access-Delegation: vended-credentials`), Polaris returns temporary, scoped storage credentials for each table request, so Fluss does not need static object-storage credentials.
+
+#### Hadoop Dependencies
+
+Some FileIO implementations require Hadoop classes. Place the pre-bundled Hadoop JAR into `FLUSS_HOME/plugins/iceberg/`:
+
+```bash
+wget -P ${FLUSS_HOME}/plugins/iceberg/ \
+    https://repo1.maven.org/maven2/io/trino/hadoop/hadoop-apache/3.3.5-2/hadoop-apache-3.3.5-2.jar
+```
+
+See [Iceberg - Hadoop Dependencies](../formats/iceberg.md#1-hadoop-dependencies-configuration) for alternative approaches.
+
+### Start Tiering Service
+
+Follow the [Iceberg tiering service setup](../formats/iceberg.md#start-tiering-service-to-iceberg) to prepare the required JARs and start the tiering service. Use the REST catalog parameters when launching the Flink tiering job:
+
+```bash
+${FLINK_HOME}/bin/flink run /path/to/fluss-flink-tiering-$FLUSS_VERSION$.jar \
+    --fluss.bootstrap.servers <coordinator-host>:9123 \
+    --datalake.format iceberg \
+    --datalake.iceberg.type rest \
+    --datalake.iceberg.uri http://<polaris-host>:8181/api/catalog \
+    --datalake.iceberg.warehouse <catalog-name> \
+    --datalake.iceberg.credential <client-id>:<client-secret> \
+    --datalake.iceberg.scope PRINCIPAL_ROLE:ALL \
+    --datalake.iceberg.header.X-Iceberg-Access-Delegation vended-credentials
+```
+
+## Usage Example
+
+### Create a Datalake-Enabled Table
+
+```sql title="Flink SQL"
+USE CATALOG fluss_catalog;
+
+CREATE TABLE orders (
+    `order_id` BIGINT,
+    `customer_id` INT NOT NULL,
+    `total_price` DECIMAL(15, 2),
+    `order_date` DATE,
+    `status` STRING,
+    PRIMARY KEY (`order_id`) NOT ENFORCED
+) WITH (
+    'table.datalake.enabled' = 'true',
+    'table.datalake.freshness' = '30s'
+);
+```
+
+Once the tiering service is running, Fluss automatically creates the corresponding Iceberg table in Polaris and begins tiering data.
+
+### Query Data
+
+```sql title="Flink SQL"
+SET 'execution.runtime-mode' = 'batch';
+
+-- Union read: combines fresh data in Fluss with historical data in Iceberg
+SELECT COUNT(*) FROM orders;
+```
+
+For details on union reads, streaming reads, and reading with other engines, see [Iceberg - Read Tables](../formats/iceberg.md#read-tables).
+
+## Further Reading
+
+- [Iceberg Integration](../formats/iceberg.md) - Table mapping, data types, supported catalog types, and limitations
+- [Lakehouse Storage](maintenance/tiered-storage/lakehouse-storage.md) - General tiered storage setup
+- [Apache Polaris Documentation](https://polaris.apache.org/) - Deploying and managing Polaris, catalogs, principals, and access control

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
@@ -86,17 +86,6 @@ Fluss strips the `datalake.iceberg.` prefix and passes the remaining properties 
 
 > With credential vending enabled (`X-Iceberg-Access-Delegation: vended-credentials`), Polaris returns temporary, scoped storage credentials for each table request, so Fluss does not need static object-storage credentials. For stores without STS (e.g. MinIO), drop this header and supply static `fs.s3a.*` keys instead, as described in [Vended credentials vs. static keys](#vended-credentials-vs-static-keys) above.
 
-#### Hadoop Dependencies
-
-Some FileIO implementations require Hadoop classes. Place the pre-bundled Hadoop JAR into `FLUSS_HOME/plugins/iceberg/`:
-
-```bash
-wget -P ${FLUSS_HOME}/plugins/iceberg/ \
-    https://repo1.maven.org/maven2/io/trino/hadoop/hadoop-apache/3.3.5-2/hadoop-apache-3.3.5-2.jar
-```
-
-See [Iceberg - Hadoop Dependencies](../formats/iceberg.md#1-hadoop-dependencies-configuration) for alternative approaches.
-
 ### Start Tiering Service
 
 Follow the [Iceberg tiering service setup](../formats/iceberg.md#start-tiering-service-to-iceberg) to prepare the required JARs and start the tiering service. Use the REST catalog parameters when launching the Flink tiering job:

--- a/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
+++ b/website/docs/streaming-lakehouse/integrate-data-lakes/catalogs/polaris.md
@@ -64,7 +64,7 @@ curl -X POST http://<polaris-host>:8181/api/management/v1/catalogs \
 Polaris hands storage credentials to Fluss in one of two ways, depending on your object store:
 
 - **Vended credentials (AWS S3 with STS)** — the path used throughout this guide. The catalog's `storageConfigInfo` must include a `roleArn`, and Polaris must be allowed to `AssumeRole` on it; Polaris then vends temporary, scoped credentials per request (enabled by the `X-Iceberg-Access-Delegation: vended-credentials` header in the Fluss config below). Without a `roleArn`, table operations fail with `Failed to get subscoped credentials: roleArn must not be null`.
-- **Static keys (MinIO, NooBaa, or other S3-compatible stores without STS)** — there is no role to assume. Disable credential subscoping on Polaris by setting `SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION=true`, and provide static `fs.s3a.*` keys (access key and secret) to Fluss instead of the vended-credentials header.
+- **Static keys (MinIO, NooBaa, or other S3-compatible stores without STS)** — there is no role to assume. Disable credential subscoping on Polaris by setting `SKIP_CREDENTIAL_SUBSCOPING_INDIRECTION=true`, and provide static `s3.access-key-id` / `s3.secret-access-key` keys to Fluss instead of the vended-credentials header.
 
 ## Configure Fluss with Polaris
 
@@ -75,6 +75,7 @@ Add the following to your `server.yaml`:
 ```yaml
 datalake.format: iceberg
 datalake.iceberg.type: rest
+datalake.iceberg.io-impl: org.apache.iceberg.aws.s3.S3FileIO
 datalake.iceberg.uri: http://<polaris-host>:8181/api/catalog
 datalake.iceberg.warehouse: <catalog-name>
 datalake.iceberg.credential: <client-id>:<client-secret>
@@ -83,9 +84,9 @@ datalake.iceberg.oauth2-server-uri: http://<polaris-host>:8181/api/catalog/v1/oa
 datalake.iceberg.header.X-Iceberg-Access-Delegation: vended-credentials
 ```
 
-Fluss strips the `datalake.iceberg.` prefix and passes the remaining properties to the Iceberg REST catalog client. The `credential` (`client_id:client_secret`), `scope`, and `oauth2-server-uri` properties configure OAuth2 client-credentials authentication against Polaris. Setting `oauth2-server-uri` explicitly is recommended: the Iceberg client can otherwise fall back to `<uri>/v1/oauth/tokens`, but that implicit fallback is deprecated and logs a warning. You can add any additional [Iceberg REST catalog properties](https://iceberg.apache.org/docs/1.10.1/configuration/#catalog-properties) using the same prefix.
+Fluss strips the `datalake.iceberg.` prefix and passes the remaining properties to the Iceberg REST catalog client. The `io-impl` property selects Iceberg's `S3FileIO` for warehouse data access; set it explicitly, because the default `ResolvingFileIO` requires Hadoop classes that the Fluss servers' Iceberg plugin does not bundle, and the catalog otherwise fails to load. The `credential` (`client_id:client_secret`), `scope`, and `oauth2-server-uri` properties configure OAuth2 client-credentials authentication against Polaris. Setting `oauth2-server-uri` explicitly is recommended: the Iceberg client can otherwise fall back to `<uri>/v1/oauth/tokens`, but that implicit fallback is deprecated and logs a warning. You can add any additional [Iceberg REST catalog properties](https://iceberg.apache.org/docs/1.10.1/configuration/#catalog-properties) using the same prefix.
 
-> With credential vending enabled (`X-Iceberg-Access-Delegation: vended-credentials`), Polaris returns temporary, scoped storage credentials for each table request, so Fluss does not need static object-storage credentials. For stores without STS (e.g. MinIO), drop this header and supply static `fs.s3a.*` keys instead, as described in [Vended credentials vs. static keys](#vended-credentials-vs-static-keys) above.
+> With credential vending enabled (`X-Iceberg-Access-Delegation: vended-credentials`), Polaris returns temporary, scoped storage credentials for each table request, so Fluss does not need static object-storage credentials. For stores without STS (e.g. MinIO), drop this header and supply static `s3.access-key-id` / `s3.secret-access-key` keys instead, as described in [Vended credentials vs. static keys](#vended-credentials-vs-static-keys) above.
 
 ### Start Tiering Service
 
@@ -96,6 +97,7 @@ ${FLINK_HOME}/bin/flink run /path/to/fluss-flink-tiering-$FLUSS_VERSION$.jar \
     --fluss.bootstrap.servers <coordinator-host>:9123 \
     --datalake.format iceberg \
     --datalake.iceberg.type rest \
+    --datalake.iceberg.io-impl org.apache.iceberg.aws.s3.S3FileIO \
     --datalake.iceberg.uri http://<polaris-host>:8181/api/catalog \
     --datalake.iceberg.warehouse <catalog-name> \
     --datalake.iceberg.credential <client-id>:<client-secret> \


### PR DESCRIPTION
### Purpose

Linked issue: close #3513

Adds a quick-start guide for Apache Polaris as an Iceberg REST catalog for Fluss lakehouse tiering.

### Brief change log

New page `catalogs/polaris.md`:
- Polaris as an Iceberg REST catalog — intro and how tiering commits through it
- Prerequisites: running Polaris, creating a catalog + a principal (OAuth2 client credentials)
- Fluss `server.yaml` config (`datalake.iceberg.type: rest`, `uri`, `warehouse`, `credential`, `scope`, vended-credentials header) and the tiering-service parameters
- Hadoop dependency note + usage example (datalake-enabled table + union read)

### Tests

Documentation-only. Built the Docusaurus site locally (`build_versioned_docs.sh` + `npm run build`) — no broken links. Also validated the OAuth2 + Iceberg REST flow described in the guide (token, `/v1/config`, namespace create/list) against a Polaris instance started from the official quickstart.

### Generative AI disclosure

- [x] Yes

Generated-by: Claude Code (Opus 4.8) following the guidelines
