### PR TITLE
[docs] Fix version-replace plugin path split on Windows

### DIFF
--- a/website/src/plugins/remark-version-replace/index.js
+++ b/website/src/plugins/remark-version-replace/index.js
@@ -26,7 +26,9 @@ VERSIONS.map((version) => {
 });
 
 function getDocsVersionName(pathname) {
-    const parts = pathname.split('/');
+    // split on both POSIX ('/') and Windows ('\\') separators so the version
+    // is detected regardless of the OS the docs are built on
+    const parts = pathname.split(/[/\\]/);
     const websiteIndex = parts.lastIndexOf('website');
 
     if (websiteIndex === -1 || websiteIndex + 1 >= parts.length) return '';


### PR DESCRIPTION
### Purpose

Linked issue: close #3516

The documentation website build fails on Windows because the `remark-version-replace` plugin does not substitute version placeholders.

### Brief change log

`getDocsVersionName()` now splits the file path on both `/` and `\`, so the docs version is detected on Windows as well as on POSIX. Previously it split on `'/'` only, so on Windows (`vfile.path` uses `\`) it returned `''`, leaving `$FLUSS_VERSION$` / `$FLUSS_MAVEN_REPO_URL$` etc. unsubstituted and failing the broken-links check (~24 broken links to a literal `$FLUSS_MAVEN_REPO_URL$/...`).

### Tests

Built the website locally on Windows (`npm run clear && npm run build`): before the fix, ~24 broken links; after, 0. No change on POSIX — the character class `/[/\]/` is equivalent to `/` when the path contains no backslashes.

### Generative AI disclosure

- [x] Yes

Generated-by: Claude Code (Opus 4.8) following the guidelines
