### PR TITLE
[lake][paimon] Fix DV readable snapshot and offset selection

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
@@ -32,7 +32,6 @@ import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.utils.ExceptionUtils;
 import org.apache.fluss.utils.types.Tuple2;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
@@ -495,16 +494,10 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
         Set<PaimonPartitionBucket> bucketsWithoutL0 = new HashSet<>();
         Set<PaimonPartitionBucket> bucketsWithL0 = new HashSet<>();
 
-        // Scan the snapshot to get all splits including level0
-        Map<String, String> scanOptions = new HashMap<>();
-        scanOptions.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), String.valueOf(snapshot.id()));
-        // hacky: set batch scan mode to compact to make sure we can get l0 level files
-        scanOptions.put(
-                CoreOptions.BATCH_SCAN_MODE.key(), CoreOptions.BatchScanMode.COMPACT.getValue());
-
+        // Scan the snapshot to get all data files including L0 level files
         Map<BinaryRow, Map<Integer, List<ManifestEntry>>> manifestsByBucket =
                 FileStoreScan.Plan.groupByPartFiles(
-                        fileStoreTable.copy(scanOptions).store().newScan().plan().files());
+                        fileStoreTable.store().newScan().withSnapshot(snapshot).plan().files());
 
         for (Map.Entry<BinaryRow, Map<Integer, List<ManifestEntry>>> manifestsByBucketEntry :
                 manifestsByBucket.entrySet()) {

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
@@ -255,19 +255,19 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
             return null;
         }
 
-        // We keep snapshots because for a compacted snapshot, if a bucket has L0, we find the
-        // snapshot that exactly holds those L0, then use that snapshot's previous APPEND's tiered
-        // offset as the readable offset (that offset is safe to read). When the current compacted
-        // snapshot has no L0 in any bucket, we do not traverse; for any later compact we would
-        // traverse to (going backwards in time), if some bucket has L0, the snapshot that exactly
-        // holds that L0 must be after the current compacted snapshot on the timeline. So that
-        // snapshot's previous APPEND cannot be earlier than the current compacted snapshot's
-        // previous APPEND. Therefore the minimum snapshot we need to keep is the current compact's
-        // previous APPEND; set earliestSnapshotIdToKeep to it so it is not deleted. Earlier
-        // snapshots may be safely deleted.
-        if (bucketsWithL0.isEmpty()) {
-            earliestSnapshotIdToKeep = compactedSnapshotPreviousAppendSnapshot.id();
-        }
+        // The earliest snapshot we must keep is bounded by EVERY bucket's base anchor, i.e. the
+        // previous APPEND of the latest snapshot that exactly holds the L0 files of the bucket's
+        // most recent flush. A bucket's base anchor only moves forward when the bucket is flushed
+        // again; until then, a future recomputation (triggered once the bucket receives new L0)
+        // will trace back to that same anchor, so the anchor snapshot must stay retained.
+        //
+        // Buckets with L0 in the current compacted snapshot have their anchor found by the
+        // traversal below (which also derives their readable offset). Buckets without L0 take their
+        // readable offset from the latest tiered snapshot and are NOT traversed there, so their
+        // anchors are computed separately afterwards. We must not assume "no L0 in any bucket"
+        // means earlier snapshots are deletable: a bucket can be clean in the current compacted
+        // snapshot yet still be anchored to an older snapshot (it was flushed earlier and has not
+        // been flushed since).
 
         // for all buckets with l0, we need to find the latest compacted snapshot which flushed
         // the buckets, the per-bucket offset should be updated to the corresponding compacted
@@ -304,52 +304,26 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
                     continue;
                 }
                 if (!readableOffsets.containsKey(tb)) {
-                    Snapshot sourceSnapshot =
-                            findLatestSnapshotExactlyHoldingL0Files(
-                                    fileStoreTable, currentSnapshot);
-                    // it happens if there is a compacted snapshot flush l0 files for a bucket,
-                    // but the snapshot from which the compacted snapshot compact is expired
-                    // it should happen rarely, we can't determine the readable offsets for this
-                    // bucket, currently, we just return null to stop readable offset advance
-                    // if it happen, compaction should work unexpected, warn it and reminds to
-                    // increase snapshot retention
-                    if (sourceSnapshot == null) {
-                        LOG.warn(
-                                "Cannot find snapshot holding L0 files flushed by compacted snapshot {} for bucket {}, "
-                                        + "the snapshot may have been expired. Consider increasing snapshot retention.",
-                                currentSnapshot.id(),
-                                tb);
-                        return null;
-                    }
+                    // The previous APPEND of the latest snapshot that still exactly holds the L0
+                    // files flushed by currentSnapshot is this bucket's base anchor; its tiered
+                    // offset is the bucket's readable offset.
+                    Snapshot previousAppendSnapshot = findBaseAnchorAppendSnapshot(currentSnapshot);
 
-                    // we already find that for this bucket, which snapshot do the latest flush,
-                    // the offset for the previous one append snapshot should be the readable
-                    // offset
-                    Snapshot previousAppendSnapshot =
-                            sourceSnapshot.commitKind() == Snapshot.CommitKind.APPEND
-                                    ? sourceSnapshot
-                                    : findPreviousSnapshot(
-                                            sourceSnapshot.id(), Snapshot.CommitKind.APPEND);
-
-                    // Can't find previous APPEND snapshot, likely due to snapshot expiration.
-                    // This happens when the snapshot holding flushed L0 files is a COMPACT
-                    // snapshot,
-                    // and all APPEND snapshots before it have been expired.
+                    // Can't determine the base anchor, likely due to snapshot expiration: either
+                    // the snapshot holding the flushed L0 files, or all earlier APPEND snapshots,
+                    // have been expired. We can't determine this bucket's readable offset, so stop
+                    // advancing and return null.
                     //
-                    // TODO: Optimization - Store compacted snapshot offsets in Fluss
-                    // Currently, we rely on Paimon to find the previous APPEND snapshot to get its
-                    // offset. If Fluss stores offsets for all snapshots (including COMPACT
-                    // snapshots),
-                    // we could:
-                    // 1. Use the sourceSnapshot's offset directly if it's stored in Fluss
-                    // 2. Find any previous snapshot (COMPACT or APPEND) and use its offset
-                    // 3. This would make the system more resilient to snapshot expiration
+                    // TODO: Optimization - Store compacted snapshot offsets in Fluss so we don't
+                    // need to find the previous APPEND snapshot to get its offset, making this
+                    // resilient to snapshot expiration.
                     if (previousAppendSnapshot == null) {
                         LOG.warn(
-                                "Cannot find previous APPEND snapshot before snapshot {} for bucket {}. "
-                                        + "This may be due to snapshot expiration. Consider increasing paimon snapshot retention.",
-                                sourceSnapshot.id(),
-                                tb);
+                                "Cannot determine base anchor (previous APPEND) for bucket {} flushed by "
+                                        + "compacted snapshot {}. Snapshot history may have expired; "
+                                        + "consider increasing paimon snapshot retention.",
+                                tb,
+                                currentSnapshot.id());
                         return null;
                     }
 
@@ -403,6 +377,23 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
             return null;
         }
 
+        // Tighten earliestSnapshotIdToKeep using the base anchors of buckets without L0 as well.
+        // Their readable offsets come from the latest tiered snapshot, but their base was
+        // established by an earlier flush; once such a bucket receives new L0, a later
+        // recomputation traces back to that flush's anchor, so the anchor snapshot must be kept.
+        //
+        // This is best-effort: if a bucket's flush history has expired and its anchor cannot be
+        // determined, we conservatively keep all previous snapshots (KEEP_ALL_PREVIOUS) rather than
+        // risk deleting one that is still needed. We never fail the whole readable-offset advance
+        // here, since these buckets' offsets are already resolved from the latest tiered snapshot.
+        earliestSnapshotIdToKeep =
+                tightenEarliestSnapshotIdToKeepForBucketsWithoutL0(
+                        bucketsWithoutL0,
+                        flussTableBucketMapper,
+                        latestCompactedSnapshot.id(),
+                        earliestSnapshotId,
+                        earliestSnapshotIdToKeep);
+
         // we use the previous append snapshot tiered offset of the compacted snapshot as the
         // compacted snapshot tiered offsets
         LakeSnapshot tieredLakeSnapshot =
@@ -423,6 +414,112 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
                 tieredOffsets,
                 readableOffsets,
                 earliestSnapshotIdToKeep);
+    }
+
+    /**
+     * Lowers {@code earliestSnapshotIdToKeep} to also cover the base anchors of buckets that have
+     * no L0 files in the latest compacted snapshot.
+     *
+     * <p>A bucket without L0 has all of its data in base files, and its readable offset is taken
+     * from the latest tiered snapshot. However, that base was established by the bucket's most
+     * recent flush, and a later recomputation (once the bucket receives new L0) will trace back to
+     * that flush's anchor snapshot (the previous APPEND of the latest snapshot that exactly holds
+     * the flushed L0). That anchor snapshot must therefore stay retained until the bucket is
+     * flushed again.
+     *
+     * <p>This is best-effort: if a bucket's flush history has expired and its anchor cannot be
+     * determined, this conservatively returns {@link LakeCommitResult#KEEP_ALL_PREVIOUS} so that no
+     * snapshot is deleted, rather than risk deleting one that is still needed.
+     *
+     * @param bucketsWithoutL0 buckets with no L0 in the latest compacted snapshot
+     * @param flussTableBucketMapper mapper from Paimon partition-bucket to Fluss table bucket
+     * @param latestCompactedSnapshotId the latest compacted snapshot id (traversal start)
+     * @param earliestSnapshotId the earliest snapshot id still present in Paimon (traversal end)
+     * @param earliestSnapshotIdToKeep the current value computed from buckets with L0
+     * @return the tightened earliest snapshot id to keep
+     */
+    private long tightenEarliestSnapshotIdToKeepForBucketsWithoutL0(
+            Set<PaimonPartitionBucket> bucketsWithoutL0,
+            FlussTableBucketMapper flussTableBucketMapper,
+            long latestCompactedSnapshotId,
+            long earliestSnapshotId,
+            long earliestSnapshotIdToKeep)
+            throws IOException {
+        if (bucketsWithoutL0.isEmpty()) {
+            return earliestSnapshotIdToKeep;
+        }
+
+        // Only track buckets that map to a Fluss bucket; unmappable ones (e.g. a partition not in
+        // Fluss) never need recomputation and must not pin retention.
+        Set<PaimonPartitionBucket> bucketsToAnchor = new HashSet<>();
+        for (PaimonPartitionBucket bucket : bucketsWithoutL0) {
+            if (flussTableBucketMapper.toTableBucket(bucket) != null) {
+                bucketsToAnchor.add(bucket);
+            }
+        }
+        if (bucketsToAnchor.isEmpty()) {
+            return earliestSnapshotIdToKeep;
+        }
+        boolean allAnchorsResolved = true;
+
+        for (long currentSnapshotId = latestCompactedSnapshotId;
+                currentSnapshotId >= earliestSnapshotId && !bucketsToAnchor.isEmpty();
+                currentSnapshotId--) {
+            Snapshot currentSnapshot = snapshotManager.tryGetSnapshot(currentSnapshotId);
+            if (currentSnapshot == null
+                    || currentSnapshot.commitKind() != Snapshot.CommitKind.COMPACT) {
+                continue;
+            }
+            // The first flush encountered going backwards is the bucket's most recent flush.
+            for (PaimonPartitionBucket partitionBucket : getBucketsWithFlushedL0(currentSnapshot)) {
+                if (!bucketsToAnchor.remove(partitionBucket)) {
+                    continue;
+                }
+                Snapshot previousAppendSnapshot = findBaseAnchorAppendSnapshot(currentSnapshot);
+                if (previousAppendSnapshot == null) {
+                    // can't determine this bucket's base anchor; don't tighten retention
+                    allAnchorsResolved = false;
+                    continue;
+                }
+                if (earliestSnapshotIdToKeep <= 0
+                        || previousAppendSnapshot.id() < earliestSnapshotIdToKeep) {
+                    earliestSnapshotIdToKeep = previousAppendSnapshot.id();
+                }
+            }
+        }
+
+        if (!bucketsToAnchor.isEmpty()) {
+            // some bucket's most recent flush was not found within the retained snapshots
+            allAnchorsResolved = false;
+        }
+
+        return allAnchorsResolved ? earliestSnapshotIdToKeep : LakeCommitResult.KEEP_ALL_PREVIOUS;
+    }
+
+    /**
+     * Finds the base anchor APPEND snapshot for the bucket(s) whose L0 files were flushed by the
+     * given compacted snapshot.
+     *
+     * <p>The anchor is the previous APPEND of the latest snapshot that still exactly holds those
+     * flushed L0 files (see {@link PaimonDvTableUtils#findLatestSnapshotExactlyHoldingL0Files}).
+     * Its tiered offset is the bucket's readable offset, and it must stay retained until the bucket
+     * is flushed again.
+     *
+     * @param flushingCompactedSnapshot the COMPACT snapshot that flushed the bucket's L0 files
+     * @return the base anchor APPEND snapshot, or {@code null} if it cannot be determined (e.g. the
+     *     holding snapshot or all earlier APPEND snapshots have been expired)
+     */
+    @Nullable
+    private Snapshot findBaseAnchorAppendSnapshot(Snapshot flushingCompactedSnapshot)
+            throws IOException {
+        Snapshot sourceSnapshot =
+                findLatestSnapshotExactlyHoldingL0Files(fileStoreTable, flushingCompactedSnapshot);
+        if (sourceSnapshot == null) {
+            return null;
+        }
+        return sourceSnapshot.commitKind() == Snapshot.CommitKind.APPEND
+                ? sourceSnapshot
+                : findPreviousSnapshot(sourceSnapshot.id(), Snapshot.CommitKind.APPEND);
     }
 
     /**

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
@@ -113,14 +113,14 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
      *       compacted snapshot
      *   <li>For buckets without L0 files: use offsets from the latest tiered snapshot (all data is
      *       in base files, safe to advance)
-     *   <li>For buckets with L0 files:
+     *   <li>Traverse backwards through compacted snapshots once for both groups:
      *       <ol>
-     *         <li>Traverse backwards through compacted snapshots starting from the latest one
      *         <li>For each compacted snapshot, check which buckets had their L0 files flushed
      *         <li>For each flushed bucket, find the latest snapshot that exactly holds those L0
      *             files using {@link PaimonDvTableUtils#findLatestSnapshotExactlyHoldingL0Files}
      *         <li>Find the previous APPEND snapshot before that snapshot
-     *         <li>Use that APPEND snapshot's offset for the bucket
+     *         <li>Use that APPEND snapshot's offset for buckets with L0, and retain it as the base
+     *             anchor for buckets without L0
      *       </ol>
      *   <li>Return readable offsets for all buckets, allowing incremental advancement
      * </ol>
@@ -259,30 +259,30 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
         // again; until then, a future recomputation (triggered once the bucket receives new L0)
         // will trace back to that same anchor, so the anchor snapshot must stay retained.
         //
-        // Buckets with L0 in the current compacted snapshot have their anchor found by the
-        // traversal below (which also derives their readable offset). Buckets without L0 take their
-        // readable offset from the latest tiered snapshot and are NOT traversed there, so their
-        // anchors are computed separately afterwards. We must not assume "no L0 in any bucket"
-        // means earlier snapshots are deletable: a bucket can be clean in the current compacted
-        // snapshot yet still be anchored to an older snapshot (it was flushed earlier and has not
-        // been flushed since).
+        // The traversal below handles both groups in one pass. Buckets with L0 also derive their
+        // readable offset from the anchor. Buckets without L0 already use the latest tiered offset,
+        // but still need their anchor retained until their next flush.
 
-        // for all buckets with l0, we need to find the latest compacted snapshot which flushed
-        // the buckets, the per-bucket offset should be updated to the corresponding compacted
-        // snapshot offsets
+        // Buckets with L0 need both their base anchor and its offset. Buckets without L0 only need
+        // their base anchor retained.
         Set<PaimonPartitionBucket> allBucketsToAdvance = new HashSet<>(bucketsWithL0);
+        Set<PaimonPartitionBucket> bucketsWithoutL0ToAnchor = new HashSet<>();
+        for (PaimonPartitionBucket bucket : bucketsWithoutL0) {
+            if (flussTableBucketMapper.toTableBucket(bucket) != null) {
+                bucketsWithoutL0ToAnchor.add(bucket);
+            }
+        }
 
         // Cache LakeSnapshot by snapshot ID to avoid repeated getLakeSnapshot RPCs when many
         // buckets share the same snapshot.
         Map<Long, LakeSnapshot> lakeSnapshotBySnapshotId = new HashMap<>();
 
         long earliestSnapshotId = checkNotNull(snapshotManager.earliestSnapshotId());
-        // From latestCompacted forward traverse compacted snapshots
+        // Traverse compacted snapshots backwards from the latest one.
         for (long currentSnapshotId = latestCompactedSnapshot.id();
                 currentSnapshotId >= earliestSnapshotId;
                 currentSnapshotId--) {
-            // no any buckets to advance, break directly
-            if (allBucketsToAdvance.isEmpty()) {
+            if (allBucketsToAdvance.isEmpty() && bucketsWithoutL0ToAnchor.isEmpty()) {
                 break;
             }
             Snapshot currentSnapshot = snapshotManager.tryGetSnapshot(currentSnapshotId);
@@ -292,8 +292,16 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
             }
             // Get buckets flushed by current compacted snapshot
             Set<PaimonPartitionBucket> flushedBuckets = getBucketsWithFlushedL0(currentSnapshot);
-            // For each flushed bucket, if offset not set yet, set it
+            Snapshot previousAppendSnapshot = null;
+            boolean baseAnchorLookedUp = false;
             for (PaimonPartitionBucket partitionBucket : flushedBuckets) {
+                boolean shouldAdvance = allBucketsToAdvance.contains(partitionBucket);
+                // The first flush encountered going backwards is the bucket's most recent flush.
+                boolean shouldAnchorOnly = bucketsWithoutL0ToAnchor.remove(partitionBucket);
+                if (!shouldAdvance && !shouldAnchorOnly) {
+                    continue;
+                }
+
                 TableBucket tb = flussTableBucketMapper.toTableBucket(partitionBucket);
                 if (tb == null) {
                     // can't map such paimon bucket to fluss,just ignore
@@ -301,21 +309,14 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
                     allBucketsToAdvance.remove(partitionBucket);
                     continue;
                 }
-                if (!readableOffsets.containsKey(tb)) {
-                    // The previous APPEND of the latest snapshot that still exactly holds the L0
-                    // files flushed by currentSnapshot is this bucket's base anchor; its tiered
-                    // offset is the bucket's readable offset.
-                    Snapshot previousAppendSnapshot = findBaseAnchorAppendSnapshot(currentSnapshot);
 
-                    // Can't determine the base anchor, likely due to snapshot expiration: either
-                    // the snapshot holding the flushed L0 files, or all earlier APPEND snapshots,
-                    // have been expired. We can't determine this bucket's readable offset, so stop
-                    // advancing and return null.
-                    //
-                    // TODO: Optimization - Store compacted snapshot offsets in Fluss so we don't
-                    // need to find the previous APPEND snapshot to get its offset, making this
-                    // resilient to snapshot expiration.
-                    if (previousAppendSnapshot == null) {
+                if (!baseAnchorLookedUp) {
+                    previousAppendSnapshot = findBaseAnchorAppendSnapshot(currentSnapshot);
+                    baseAnchorLookedUp = true;
+                }
+
+                if (previousAppendSnapshot == null) {
+                    if (shouldAdvance) {
                         LOG.warn(
                                 "Cannot determine base anchor (previous APPEND) for bucket {} flushed by "
                                         + "compacted snapshot {}. Snapshot history may have expired; "
@@ -324,31 +325,35 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
                                 currentSnapshot.id());
                         return null;
                     }
+                    // Retaining older Fluss offset metadata cannot recover expired Paimon history.
+                    continue;
+                }
 
-                    // Track the minimum previousAppendSnapshot ID
-                    // This snapshot will be accessed via getLakeSnapshot, so we need to keep it
-                    if (earliestSnapshotIdToKeep <= 0
-                            || previousAppendSnapshot.id() < earliestSnapshotIdToKeep) {
-                        earliestSnapshotIdToKeep = previousAppendSnapshot.id();
-                    }
+                if (earliestSnapshotIdToKeep <= 0
+                        || previousAppendSnapshot.id() < earliestSnapshotIdToKeep) {
+                    earliestSnapshotIdToKeep = previousAppendSnapshot.id();
+                }
 
-                    long snapshotId = previousAppendSnapshot.id();
-                    LakeSnapshot lakeSnapshot =
-                            getOrFetchLakeSnapshot(snapshotId, lakeSnapshotBySnapshotId);
-                    if (lakeSnapshot == null) {
-                        return null;
-                    }
-                    Long offset = lakeSnapshot.getTableBucketsOffset().get(tb);
-                    if (offset != null) {
-                        readableOffsets.put(tb, offset);
-                        allBucketsToAdvance.remove(partitionBucket);
-                    } else {
-                        LOG.error(
-                                "Could not find offset for bucket {} in snapshot {}, skip advancing readable snapshot.",
-                                tb,
-                                snapshotId);
-                        return null;
-                    }
+                if (!shouldAdvance) {
+                    continue;
+                }
+
+                long snapshotId = previousAppendSnapshot.id();
+                LakeSnapshot lakeSnapshot =
+                        getOrFetchLakeSnapshot(snapshotId, lakeSnapshotBySnapshotId);
+                if (lakeSnapshot == null) {
+                    return null;
+                }
+                Long offset = lakeSnapshot.getTableBucketsOffset().get(tb);
+                if (offset != null) {
+                    readableOffsets.put(tb, offset);
+                    allBucketsToAdvance.remove(partitionBucket);
+                } else {
+                    LOG.error(
+                            "Could not find offset for bucket {} in snapshot {}, skip advancing readable snapshot.",
+                            tb,
+                            snapshotId);
+                    return null;
                 }
             }
         }
@@ -375,22 +380,13 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
             return null;
         }
 
-        // Tighten earliestSnapshotIdToKeep using the base anchors of buckets without L0 as well.
-        // Their readable offsets come from the latest tiered snapshot, but their base was
-        // established by an earlier flush; once such a bucket receives new L0, a later
-        // recomputation traces back to that flush's anchor, so the anchor snapshot must be kept.
-        //
-        // This is best-effort: if a bucket's flush history has expired and its anchor cannot be
-        // determined, we conservatively keep all previous snapshots (KEEP_ALL_PREVIOUS) rather than
-        // risk deleting one that is still needed. We never fail the whole readable-offset advance
-        // here, since these buckets' offsets are already resolved from the latest tiered snapshot.
-        earliestSnapshotIdToKeep =
-                tightenEarliestSnapshotIdToKeepForBucketsWithoutL0(
-                        bucketsWithoutL0,
-                        flussTableBucketMapper,
-                        latestCompactedSnapshot.id(),
-                        earliestSnapshotId,
-                        earliestSnapshotIdToKeep);
+        // The base anchor of every resolved bucket is at or before the latest compacted
+        // snapshot's previous APPEND. If no bucket provided a bound, use that APPEND as the
+        // fallback. It is fetched from Fluss below before the result is returned.
+        if (earliestSnapshotIdToKeep <= 0
+                || compactedSnapshotPreviousAppendSnapshot.id() < earliestSnapshotIdToKeep) {
+            earliestSnapshotIdToKeep = compactedSnapshotPreviousAppendSnapshot.id();
+        }
 
         // we use the previous append snapshot tiered offset of the compacted snapshot as the
         // compacted snapshot tiered offsets
@@ -412,86 +408,6 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
                 tieredOffsets,
                 readableOffsets,
                 earliestSnapshotIdToKeep);
-    }
-
-    /**
-     * Lowers {@code earliestSnapshotIdToKeep} to also cover the base anchors of buckets that have
-     * no L0 files in the latest compacted snapshot.
-     *
-     * <p>A bucket without L0 has all of its data in base files, and its readable offset is taken
-     * from the latest tiered snapshot. However, that base was established by the bucket's most
-     * recent flush, and a later recomputation (once the bucket receives new L0) will trace back to
-     * that flush's anchor snapshot (the previous APPEND of the latest snapshot that exactly holds
-     * the flushed L0). That anchor snapshot must therefore stay retained until the bucket is
-     * flushed again.
-     *
-     * <p>This is best-effort: if a bucket's flush history has expired and its anchor cannot be
-     * determined, this conservatively returns {@link LakeCommitResult#KEEP_ALL_PREVIOUS} so that no
-     * snapshot is deleted, rather than risk deleting one that is still needed.
-     *
-     * @param bucketsWithoutL0 buckets with no L0 in the latest compacted snapshot
-     * @param flussTableBucketMapper mapper from Paimon partition-bucket to Fluss table bucket
-     * @param latestCompactedSnapshotId the latest compacted snapshot id (traversal start)
-     * @param earliestSnapshotId the earliest snapshot id still present in Paimon (traversal end)
-     * @param earliestSnapshotIdToKeep the current value computed from buckets with L0
-     * @return the tightened earliest snapshot id to keep
-     */
-    private long tightenEarliestSnapshotIdToKeepForBucketsWithoutL0(
-            Set<PaimonPartitionBucket> bucketsWithoutL0,
-            FlussTableBucketMapper flussTableBucketMapper,
-            long latestCompactedSnapshotId,
-            long earliestSnapshotId,
-            long earliestSnapshotIdToKeep)
-            throws IOException {
-        if (bucketsWithoutL0.isEmpty()) {
-            return earliestSnapshotIdToKeep;
-        }
-
-        // Only track buckets that map to a Fluss bucket; unmappable ones (e.g. a partition not in
-        // Fluss) never need recomputation and must not pin retention.
-        Set<PaimonPartitionBucket> bucketsToAnchor = new HashSet<>();
-        for (PaimonPartitionBucket bucket : bucketsWithoutL0) {
-            if (flussTableBucketMapper.toTableBucket(bucket) != null) {
-                bucketsToAnchor.add(bucket);
-            }
-        }
-        if (bucketsToAnchor.isEmpty()) {
-            return earliestSnapshotIdToKeep;
-        }
-        boolean allAnchorsResolved = true;
-
-        for (long currentSnapshotId = latestCompactedSnapshotId;
-                currentSnapshotId >= earliestSnapshotId && !bucketsToAnchor.isEmpty();
-                currentSnapshotId--) {
-            Snapshot currentSnapshot = snapshotManager.tryGetSnapshot(currentSnapshotId);
-            if (currentSnapshot == null
-                    || currentSnapshot.commitKind() != Snapshot.CommitKind.COMPACT) {
-                continue;
-            }
-            // The first flush encountered going backwards is the bucket's most recent flush.
-            for (PaimonPartitionBucket partitionBucket : getBucketsWithFlushedL0(currentSnapshot)) {
-                if (!bucketsToAnchor.remove(partitionBucket)) {
-                    continue;
-                }
-                Snapshot previousAppendSnapshot = findBaseAnchorAppendSnapshot(currentSnapshot);
-                if (previousAppendSnapshot == null) {
-                    // can't determine this bucket's base anchor; don't tighten retention
-                    allAnchorsResolved = false;
-                    continue;
-                }
-                if (earliestSnapshotIdToKeep <= 0
-                        || previousAppendSnapshot.id() < earliestSnapshotIdToKeep) {
-                    earliestSnapshotIdToKeep = previousAppendSnapshot.id();
-                }
-            }
-        }
-
-        if (!bucketsToAnchor.isEmpty()) {
-            // some bucket's most recent flush was not found within the retained snapshots
-            allAnchorsResolved = false;
-        }
-
-        return allAnchorsResolved ? earliestSnapshotIdToKeep : LakeCommitResult.KEEP_ALL_PREVIOUS;
     }
 
     /**

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
@@ -253,19 +253,19 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
             return null;
         }
 
-        // We keep snapshots because for a compacted snapshot, if a bucket has L0, we find the
-        // snapshot that exactly holds those L0, then use that snapshot's previous APPEND's tiered
-        // offset as the readable offset (that offset is safe to read). When the current compacted
-        // snapshot has no L0 in any bucket, we do not traverse; for any later compact we would
-        // traverse to (going backwards in time), if some bucket has L0, the snapshot that exactly
-        // holds that L0 must be after the current compacted snapshot on the timeline. So that
-        // snapshot's previous APPEND cannot be earlier than the current compacted snapshot's
-        // previous APPEND. Therefore the minimum snapshot we need to keep is the current compact's
-        // previous APPEND; set earliestSnapshotIdToKeep to it so it is not deleted. Earlier
-        // snapshots may be safely deleted.
-        if (bucketsWithL0.isEmpty()) {
-            earliestSnapshotIdToKeep = compactedSnapshotPreviousAppendSnapshot.id();
-        }
+        // The earliest snapshot we must keep is bounded by EVERY bucket's base anchor, i.e. the
+        // previous APPEND of the latest snapshot that exactly holds the L0 files of the bucket's
+        // most recent flush. A bucket's base anchor only moves forward when the bucket is flushed
+        // again; until then, a future recomputation (triggered once the bucket receives new L0)
+        // will trace back to that same anchor, so the anchor snapshot must stay retained.
+        //
+        // Buckets with L0 in the current compacted snapshot have their anchor found by the
+        // traversal below (which also derives their readable offset). Buckets without L0 take their
+        // readable offset from the latest tiered snapshot and are NOT traversed there, so their
+        // anchors are computed separately afterwards. We must not assume "no L0 in any bucket"
+        // means earlier snapshots are deletable: a bucket can be clean in the current compacted
+        // snapshot yet still be anchored to an older snapshot (it was flushed earlier and has not
+        // been flushed since).
 
         // for all buckets with l0, we need to find the latest compacted snapshot which flushed
         // the buckets, the per-bucket offset should be updated to the corresponding compacted
@@ -302,52 +302,26 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
                     continue;
                 }
                 if (!readableOffsets.containsKey(tb)) {
-                    Snapshot sourceSnapshot =
-                            findLatestSnapshotExactlyHoldingL0Files(
-                                    fileStoreTable, currentSnapshot);
-                    // it happens if there is a compacted snapshot flush l0 files for a bucket,
-                    // but the snapshot from which the compacted snapshot compact is expired
-                    // it should happen rarely, we can't determine the readable offsets for this
-                    // bucket, currently, we just return null to stop readable offset advance
-                    // if it happen, compaction should work unexpected, warn it and reminds to
-                    // increase snapshot retention
-                    if (sourceSnapshot == null) {
-                        LOG.warn(
-                                "Cannot find snapshot holding L0 files flushed by compacted snapshot {} for bucket {}, "
-                                        + "the snapshot may have been expired. Consider increasing snapshot retention.",
-                                currentSnapshot.id(),
-                                tb);
-                        return null;
-                    }
+                    // The previous APPEND of the latest snapshot that still exactly holds the L0
+                    // files flushed by currentSnapshot is this bucket's base anchor; its tiered
+                    // offset is the bucket's readable offset.
+                    Snapshot previousAppendSnapshot = findBaseAnchorAppendSnapshot(currentSnapshot);
 
-                    // we already find that for this bucket, which snapshot do the latest flush,
-                    // the offset for the previous one append snapshot should be the readable
-                    // offset
-                    Snapshot previousAppendSnapshot =
-                            sourceSnapshot.commitKind() == Snapshot.CommitKind.APPEND
-                                    ? sourceSnapshot
-                                    : findPreviousSnapshot(
-                                            sourceSnapshot.id(), Snapshot.CommitKind.APPEND);
-
-                    // Can't find previous APPEND snapshot, likely due to snapshot expiration.
-                    // This happens when the snapshot holding flushed L0 files is a COMPACT
-                    // snapshot,
-                    // and all APPEND snapshots before it have been expired.
+                    // Can't determine the base anchor, likely due to snapshot expiration: either
+                    // the snapshot holding the flushed L0 files, or all earlier APPEND snapshots,
+                    // have been expired. We can't determine this bucket's readable offset, so stop
+                    // advancing and return null.
                     //
-                    // TODO: Optimization - Store compacted snapshot offsets in Fluss
-                    // Currently, we rely on Paimon to find the previous APPEND snapshot to get its
-                    // offset. If Fluss stores offsets for all snapshots (including COMPACT
-                    // snapshots),
-                    // we could:
-                    // 1. Use the sourceSnapshot's offset directly if it's stored in Fluss
-                    // 2. Find any previous snapshot (COMPACT or APPEND) and use its offset
-                    // 3. This would make the system more resilient to snapshot expiration
+                    // TODO: Optimization - Store compacted snapshot offsets in Fluss so we don't
+                    // need to find the previous APPEND snapshot to get its offset, making this
+                    // resilient to snapshot expiration.
                     if (previousAppendSnapshot == null) {
                         LOG.warn(
-                                "Cannot find previous APPEND snapshot before snapshot {} for bucket {}. "
-                                        + "This may be due to snapshot expiration. Consider increasing paimon snapshot retention.",
-                                sourceSnapshot.id(),
-                                tb);
+                                "Cannot determine base anchor (previous APPEND) for bucket {} flushed by "
+                                        + "compacted snapshot {}. Snapshot history may have expired; "
+                                        + "consider increasing paimon snapshot retention.",
+                                tb,
+                                currentSnapshot.id());
                         return null;
                     }
 
@@ -401,6 +375,23 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
             return null;
         }
 
+        // Tighten earliestSnapshotIdToKeep using the base anchors of buckets without L0 as well.
+        // Their readable offsets come from the latest tiered snapshot, but their base was
+        // established by an earlier flush; once such a bucket receives new L0, a later
+        // recomputation traces back to that flush's anchor, so the anchor snapshot must be kept.
+        //
+        // This is best-effort: if a bucket's flush history has expired and its anchor cannot be
+        // determined, we conservatively keep all previous snapshots (KEEP_ALL_PREVIOUS) rather than
+        // risk deleting one that is still needed. We never fail the whole readable-offset advance
+        // here, since these buckets' offsets are already resolved from the latest tiered snapshot.
+        earliestSnapshotIdToKeep =
+                tightenEarliestSnapshotIdToKeepForBucketsWithoutL0(
+                        bucketsWithoutL0,
+                        flussTableBucketMapper,
+                        latestCompactedSnapshot.id(),
+                        earliestSnapshotId,
+                        earliestSnapshotIdToKeep);
+
         // we use the previous append snapshot tiered offset of the compacted snapshot as the
         // compacted snapshot tiered offsets
         LakeSnapshot tieredLakeSnapshot =
@@ -421,6 +412,112 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
                 tieredOffsets,
                 readableOffsets,
                 earliestSnapshotIdToKeep);
+    }
+
+    /**
+     * Lowers {@code earliestSnapshotIdToKeep} to also cover the base anchors of buckets that have
+     * no L0 files in the latest compacted snapshot.
+     *
+     * <p>A bucket without L0 has all of its data in base files, and its readable offset is taken
+     * from the latest tiered snapshot. However, that base was established by the bucket's most
+     * recent flush, and a later recomputation (once the bucket receives new L0) will trace back to
+     * that flush's anchor snapshot (the previous APPEND of the latest snapshot that exactly holds
+     * the flushed L0). That anchor snapshot must therefore stay retained until the bucket is
+     * flushed again.
+     *
+     * <p>This is best-effort: if a bucket's flush history has expired and its anchor cannot be
+     * determined, this conservatively returns {@link LakeCommitResult#KEEP_ALL_PREVIOUS} so that no
+     * snapshot is deleted, rather than risk deleting one that is still needed.
+     *
+     * @param bucketsWithoutL0 buckets with no L0 in the latest compacted snapshot
+     * @param flussTableBucketMapper mapper from Paimon partition-bucket to Fluss table bucket
+     * @param latestCompactedSnapshotId the latest compacted snapshot id (traversal start)
+     * @param earliestSnapshotId the earliest snapshot id still present in Paimon (traversal end)
+     * @param earliestSnapshotIdToKeep the current value computed from buckets with L0
+     * @return the tightened earliest snapshot id to keep
+     */
+    private long tightenEarliestSnapshotIdToKeepForBucketsWithoutL0(
+            Set<PaimonPartitionBucket> bucketsWithoutL0,
+            FlussTableBucketMapper flussTableBucketMapper,
+            long latestCompactedSnapshotId,
+            long earliestSnapshotId,
+            long earliestSnapshotIdToKeep)
+            throws IOException {
+        if (bucketsWithoutL0.isEmpty()) {
+            return earliestSnapshotIdToKeep;
+        }
+
+        // Only track buckets that map to a Fluss bucket; unmappable ones (e.g. a partition not in
+        // Fluss) never need recomputation and must not pin retention.
+        Set<PaimonPartitionBucket> bucketsToAnchor = new HashSet<>();
+        for (PaimonPartitionBucket bucket : bucketsWithoutL0) {
+            if (flussTableBucketMapper.toTableBucket(bucket) != null) {
+                bucketsToAnchor.add(bucket);
+            }
+        }
+        if (bucketsToAnchor.isEmpty()) {
+            return earliestSnapshotIdToKeep;
+        }
+        boolean allAnchorsResolved = true;
+
+        for (long currentSnapshotId = latestCompactedSnapshotId;
+                currentSnapshotId >= earliestSnapshotId && !bucketsToAnchor.isEmpty();
+                currentSnapshotId--) {
+            Snapshot currentSnapshot = snapshotManager.tryGetSnapshot(currentSnapshotId);
+            if (currentSnapshot == null
+                    || currentSnapshot.commitKind() != Snapshot.CommitKind.COMPACT) {
+                continue;
+            }
+            // The first flush encountered going backwards is the bucket's most recent flush.
+            for (PaimonPartitionBucket partitionBucket : getBucketsWithFlushedL0(currentSnapshot)) {
+                if (!bucketsToAnchor.remove(partitionBucket)) {
+                    continue;
+                }
+                Snapshot previousAppendSnapshot = findBaseAnchorAppendSnapshot(currentSnapshot);
+                if (previousAppendSnapshot == null) {
+                    // can't determine this bucket's base anchor; don't tighten retention
+                    allAnchorsResolved = false;
+                    continue;
+                }
+                if (earliestSnapshotIdToKeep <= 0
+                        || previousAppendSnapshot.id() < earliestSnapshotIdToKeep) {
+                    earliestSnapshotIdToKeep = previousAppendSnapshot.id();
+                }
+            }
+        }
+
+        if (!bucketsToAnchor.isEmpty()) {
+            // some bucket's most recent flush was not found within the retained snapshots
+            allAnchorsResolved = false;
+        }
+
+        return allAnchorsResolved ? earliestSnapshotIdToKeep : LakeCommitResult.KEEP_ALL_PREVIOUS;
+    }
+
+    /**
+     * Finds the base anchor APPEND snapshot for the bucket(s) whose L0 files were flushed by the
+     * given compacted snapshot.
+     *
+     * <p>The anchor is the previous APPEND of the latest snapshot that still exactly holds those
+     * flushed L0 files (see {@link PaimonDvTableUtils#findLatestSnapshotExactlyHoldingL0Files}).
+     * Its tiered offset is the bucket's readable offset, and it must stay retained until the bucket
+     * is flushed again.
+     *
+     * @param flushingCompactedSnapshot the COMPACT snapshot that flushed the bucket's L0 files
+     * @return the base anchor APPEND snapshot, or {@code null} if it cannot be determined (e.g. the
+     *     holding snapshot or all earlier APPEND snapshots have been expired)
+     */
+    @Nullable
+    private Snapshot findBaseAnchorAppendSnapshot(Snapshot flushingCompactedSnapshot)
+            throws IOException {
+        Snapshot sourceSnapshot =
+                findLatestSnapshotExactlyHoldingL0Files(fileStoreTable, flushingCompactedSnapshot);
+        if (sourceSnapshot == null) {
+            return null;
+        }
+        return sourceSnapshot.commitKind() == Snapshot.CommitKind.APPEND
+                ? sourceSnapshot
+                : findPreviousSnapshot(sourceSnapshot.id(), Snapshot.CommitKind.APPEND);
     }
 
     /**

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetriever.java
@@ -32,7 +32,6 @@ import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.utils.ExceptionUtils;
 import org.apache.fluss.utils.types.Tuple2;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.manifest.FileKind;
@@ -493,16 +492,10 @@ public class DvTableReadableSnapshotRetriever implements AutoCloseable {
         Set<PaimonPartitionBucket> bucketsWithoutL0 = new HashSet<>();
         Set<PaimonPartitionBucket> bucketsWithL0 = new HashSet<>();
 
-        // Scan the snapshot to get all splits including level0
-        Map<String, String> scanOptions = new HashMap<>();
-        scanOptions.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), String.valueOf(snapshot.id()));
-        // hacky: set batch scan mode to compact to make sure we can get l0 level files
-        scanOptions.put(
-                CoreOptions.BATCH_SCAN_MODE.key(), CoreOptions.BatchScanMode.COMPACT.getValue());
-
+        // Scan the snapshot to get all data files including L0 level files
         Map<BinaryRow, Map<Integer, List<ManifestEntry>>> manifestsByBucket =
                 FileStoreScan.Plan.groupByPartFiles(
-                        fileStoreTable.copy(scanOptions).store().newScan().plan().files());
+                        fileStoreTable.store().newScan().withSnapshot(snapshot).plan().files());
 
         for (Map.Entry<BinaryRow, Map<Integer, List<ManifestEntry>>> manifestsByBucketEntry :
                 manifestsByBucket.entrySet()) {

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetrieverTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetrieverTest.java
@@ -732,9 +732,12 @@ class DvTableReadableSnapshotRetrieverTest {
         assertThat(readableSnapshotAndOffsets.getReadableOffsets())
                 .isEqualTo(expectedReadableOffsets);
 
-        // After compact 13, all buckets have no L0 in the compacted snapshot, we only need
-        // to keep the previous append snapshot 12
-        assertThat(readableSnapshotAndOffsets.getEarliestSnapshotIdToKeep()).isEqualTo(snapshot12);
+        // All buckets have no L0 in the compacted snapshot, but each bucket's base is anchored to
+        // the previous APPEND of its most recent flush: partition0/bucket0 -> snapshot6 (flushed at
+        // s7, never flushed since), partition1/bucket0 -> snapshot9, partition0/bucket1 ->
+        // snapshot12. The earliest snapshot we must keep is the minimum of these anchors
+        // (snapshot6), since a future recomputation for partition0/bucket0 would trace back to it.
+        assertThat(readableSnapshotAndOffsets.getEarliestSnapshotIdToKeep()).isEqualTo(snapshot6);
     }
 
     private long latestSnapshot(FileStoreTable fileStoreTable) {

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetrieverTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/utils/DvTableReadableSnapshotRetrieverTest.java
@@ -24,6 +24,7 @@ import org.apache.fluss.client.admin.Admin;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.FlussRuntimeException;
+import org.apache.fluss.exception.LakeTableSnapshotNotExistException;
 import org.apache.fluss.flink.tiering.committer.FlussTableLakeSnapshotCommitter;
 import org.apache.fluss.lake.committer.LakeCommitResult;
 import org.apache.fluss.metadata.PartitionInfo;
@@ -41,6 +42,7 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.options.ExpireConfig;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.junit.jupiter.api.AfterEach;
@@ -65,6 +67,7 @@ import static org.apache.fluss.lake.paimon.utils.PaimonTestUtils.CompactHelper;
 import static org.apache.fluss.lake.paimon.utils.PaimonTestUtils.writeAndCommitData;
 import static org.apache.fluss.server.utils.LakeStorageUtils.extractLakeProperties;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Unit test for {@link DvTableReadableSnapshotRetriever} using real Paimon tables. */
 class DvTableReadableSnapshotRetrieverTest {
@@ -429,6 +432,61 @@ class DvTableReadableSnapshotRetrieverTest {
                 .as(
                         "Compacted snapshot 13 is already in ZK, should skip recomputation and return null")
                 .isNull();
+    }
+
+    @Test
+    void testRetentionAdvancesWhenColdBucketAnchorsExpire() throws Exception {
+        int bucket0 = 0;
+        int bucket1 = 1;
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "test_dv_expired_anchor_retention");
+        tableId = createDvTable(tablePath, 2);
+        FileStoreTable fileStoreTable = getPaimonTable(tablePath);
+        CompactHelper compactHelper = new CompactHelper(fileStoreTable, compactionTempDir);
+
+        TableBucket tb0 = new TableBucket(tableId, bucket0);
+        TableBucket tb1 = new TableBucket(tableId, bucket1);
+        Map<TableBucket, Long> tieredOffsets = new HashMap<>();
+        tieredOffsets.put(tb0, 3L);
+        tieredOffsets.put(tb1, 3L);
+
+        // Bucket0 is flushed first, so its anchor will expire before bucket1's anchor.
+        Map<Integer, List<GenericRow>> initialRows = new HashMap<>();
+        initialRows.put(bucket0, generateRows(bucket0, 0, 3));
+        initialRows.put(bucket1, generateRows(bucket1, 0, 3));
+        long snapshot1 = writeAndCommitData(fileStoreTable, initialRows);
+        commitSnapshot(tableId, tablePath, snapshot1, tieredOffsets, null);
+        compactHelper.compactBucket(bucket0).commit();
+        long snapshot2 = latestSnapshot(fileStoreTable);
+
+        long snapshot3 =
+                writeAndCommitData(
+                        fileStoreTable,
+                        Collections.singletonMap(bucket1, generateRows(bucket1, 3, 6)));
+        tieredOffsets.put(tb1, 6L);
+        commitSnapshot(tableId, tablePath, snapshot3, tieredOffsets, null);
+        compactHelper.compactBucket(bucket1).commit();
+        long snapshot4 = latestSnapshot(fileStoreTable);
+
+        fileStoreTable
+                .newExpireSnapshots()
+                .config(ExpireConfig.builder().snapshotRetainMax(3).build())
+                .expire();
+        assertThat(fileStoreTable.snapshotManager().earliestSnapshotId()).isEqualTo(snapshot2);
+
+        // Bucket0's flush is expired, while bucket1 still resolves to snapshot3. The unresolved
+        // bucket must not discard bucket1's retention bound.
+        long snapshot5 = writeAndCommitData(fileStoreTable, Collections.emptyMap());
+        DvTableReadableSnapshotRetriever.ReadableSnapshotResult result =
+                retrieveReadableSnapshotAndOffsets(tablePath, fileStoreTable, snapshot5);
+        assertThat(result).isNotNull();
+        assertThat(result.getReadableSnapshotId()).isEqualTo(snapshot4);
+        assertThat(result.getEarliestSnapshotIdToKeep()).isEqualTo(snapshot3);
+        commitSnapshot(tableId, tablePath, snapshot5, tieredOffsets, result);
+        assertThatThrownBy(() -> flussAdmin.getLakeSnapshot(tablePath, snapshot1).get())
+                .rootCause()
+                .isInstanceOf(LakeTableSnapshotNotExistException.class);
+        assertThat(flussAdmin.getLakeSnapshot(tablePath, snapshot3).get().getSnapshotId())
+                .isEqualTo(snapshot3);
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [x] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: Codex (GPT-6) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #2121 (follow-up; already closed). Related PR: #3396.

<!-- What is the purpose of the change -->

This PR fixes **Bug 1 (scanning the wrong snapshot)**, including keeping its offsets consistent with the selected COMPACT. **Bug 2 is intentionally deferred.** The file-store scan ignores the table-level snapshot options, so it currently classifies buckets using the latest snapshot rather than the intended COMPACT.

After recovery, Fluss may also have registered a newer APPEND without registering the preceding COMPACT. For example, s1 APPEND contains bucket0 up to offset 3; s2 compacts it; recovered s3 APPEND advances bucket0 to 6 and introduces bucket1. Retrieving s2 after another APPEND must return and register `{bucket0: 3}`, without taking offset 6 or bucket1 from s3.

**Bug 2 (premature deletion of historical APPEND offsets) is deferred.** If a bucket receives new L0 files after its previous flush's APPEND metadata has been deleted, readable-snapshot advancement can pause while tiering continues. It can recover after the affected bucket's new L0 is flushed and all required snapshot offsets are available. APPENDs alone, or compaction of other buckets, do not guarantee recovery; a rarely flushed bucket can remain stalled for a long time. The regression test covers a pause followed by recovery after flushing the affected bucket.

Retaining historical APPENDs for buckets without L0 would prevent the premature deletion in Bug 2. A cold bucket or historical partition can consequently hold the table-wide retention boundary far back while its flush history remains available. Fluss retains every snapshot metadata entry from that boundary onward, so this can retain substantially more history than the individual required snapshots. We are deferring that retention change until we have an approach that also avoids excessive retention for cold buckets and historical partitions. During a Bug 2 stall, the existing `KEEP_ALL_PREVIOUS` fallback can also accumulate metadata; this PR does not resolve that tradeoff.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- Select the COMPACT explicitly with `FileStoreScan.withSnapshot(snapshot)`.
- Read no-L0 offsets from the APPEND immediately preceding that COMPACT; preserve offsets for buckets whose files were removed, and resolve buckets with L0 from their flush history.
- Register the readable snapshot's complete offset maps without merging offsets from a newer APPEND. Ordinary tiered APPEND commits continue merging incremental bucket updates.
- Update the existing scenario to assert Bug 2's pause and recovery, and add a regression for snapshot/offset pairing after APPEND recovery.

### Tests

<!-- List UT and IT cases to verify this change -->

Passed on JDK 11 (16 tests, no failures or skips):

- `DvTableReadableSnapshotRetrieverTest` (3 tests): incremental offsets, Bug 2 pause/recovery, partitioned tables, and recovered APPEND offset pairing.
- `FlussTableLakeSnapshotCommitterTest` (5 tests).
- `TieringCommitOperatorTest` (6 tests).
- `FlinkUnionReadDvTableITCase` (2 tests): non-partitioned and partitioned union reads.

```sh
./mvnw -pl fluss-lake/fluss-lake-paimon -am spotless:apply test \
  -Dtest=DvTableReadableSnapshotRetrieverTest,FlussTableLakeSnapshotCommitterTest,TieringCommitOperatorTest,FlinkUnionReadDvTableITCase \
  -Dsurefire.failIfNoSpecifiedTests=false
./mvnw spotless:check validate
```

Checkstyle, Spotless, and license validation passed. The full repository `clean verify` suite was not run.

### API and Format

<!-- Does this change affect API or storage format -->

No public API or storage format changes. Uses the existing `ignorePreviousTableOffsets` request field for complete readable-snapshot offset maps.

### Documentation

<!-- Does this change introduce a new feature -->

No new feature. Updated code comments to describe snapshot-specific offsets and the existing retention limitation.
