### PR TITLE
[lake/hudi] Add Flink union read test base for Hudi

### DIFF
--- a/fluss-lake/fluss-lake-hudi/src/test/java/org/apache/fluss/lake/hudi/flink/FlinkUnionReadTestBase.java
+++ b/fluss-lake/fluss-lake-hudi/src/test/java/org/apache/fluss/lake/hudi/flink/FlinkUnionReadTestBase.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.hudi.flink;
+
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.lake.hudi.testutils.FlinkHudiTieringTestBase;
+import org.apache.fluss.server.testutils.FlussClusterExtension;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import javax.annotation.Nullable;
+
+import static org.apache.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
+
+/** Base class for Hudi union read tests. */
+public class FlinkUnionReadTestBase extends FlinkHudiTieringTestBase {
+
+    @RegisterExtension
+    public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
+            FlussClusterExtension.builder()
+                    .setClusterConf(initConfig())
+                    .setNumOfTabletServers(3)
+                    .build();
+
+    protected static final int DEFAULT_BUCKET_NUM = 1;
+    StreamTableEnvironment batchTEnv;
+    StreamTableEnvironment streamTEnv;
+
+    @BeforeAll
+    protected static void beforeAll() {
+        FlinkHudiTieringTestBase.beforeAll(FLUSS_CLUSTER_EXTENSION.getClientConfig());
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        super.beforeEach();
+        buildBatchTEnv();
+        buildStreamTEnv();
+    }
+
+    @Override
+    protected FlussClusterExtension getFlussClusterExtension() {
+        return FLUSS_CLUSTER_EXTENSION;
+    }
+
+    protected StreamTableEnvironment buildStreamTEnv(@Nullable String savepointPath) {
+        Configuration conf = new Configuration();
+        if (savepointPath != null) {
+            conf.setString("execution.savepoint.path", savepointPath);
+            execEnv.configure(conf);
+        }
+        String bootstrapServers = String.join(",", clientConf.get(ConfigOptions.BOOTSTRAP_SERVERS));
+        streamTEnv = StreamTableEnvironment.create(execEnv, EnvironmentSettings.inStreamingMode());
+        streamTEnv.executeSql(
+                String.format(
+                        "create catalog %s with ('type' = 'fluss', '%s' = '%s')",
+                        CATALOG_NAME, BOOTSTRAP_SERVERS.key(), bootstrapServers));
+        streamTEnv.executeSql("use catalog " + CATALOG_NAME);
+        streamTEnv.executeSql("use " + DEFAULT_DB);
+        return streamTEnv;
+    }
+
+    private void buildStreamTEnv() {
+        buildStreamTEnv(null);
+    }
+
+    public void buildBatchTEnv() {
+        String bootstrapServers = String.join(",", clientConf.get(ConfigOptions.BOOTSTRAP_SERVERS));
+        batchTEnv = StreamTableEnvironment.create(execEnv, EnvironmentSettings.inBatchMode());
+        batchTEnv.executeSql(
+                String.format(
+                        "create catalog %s with ('type' = 'fluss', '%s' = '%s')",
+                        CATALOG_NAME, BOOTSTRAP_SERVERS.key(), bootstrapServers));
+        batchTEnv.executeSql("use catalog " + CATALOG_NAME);
+        batchTEnv.executeSql("use " + DEFAULT_DB);
+    }
+}

--- a/fluss-lake/fluss-lake-hudi/src/test/java/org/apache/fluss/lake/hudi/testutils/FlinkHudiTieringTestBase.java
+++ b/fluss-lake/fluss-lake-hudi/src/test/java/org/apache/fluss/lake/hudi/testutils/FlinkHudiTieringTestBase.java
@@ -72,10 +72,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -321,6 +323,14 @@ public abstract class FlinkHudiTieringTestBase {
         return getFlussClusterExtension().waitAndGetLeaderReplica(tableBucket);
     }
 
+    protected void assertReplicaStatus(Map<TableBucket, Long> expectedLogEndOffset) {
+        for (Map.Entry<TableBucket, Long> expectedLogEndOffsetEntry :
+                expectedLogEndOffset.entrySet()) {
+            assertReplicaStatus(
+                    expectedLogEndOffsetEntry.getKey(), expectedLogEndOffsetEntry.getValue());
+        }
+    }
+
     protected void assertReplicaStatus(TableBucket tb, long expectedLogEndOffset) {
         retry(
                 Duration.ofMinutes(1),
@@ -330,6 +340,30 @@ public abstract class FlinkHudiTieringTestBase {
                             .isGreaterThanOrEqualTo(0);
                     assertThat(replica.getLakeLogEndOffset()).isEqualTo(expectedLogEndOffset);
                 });
+    }
+
+    protected void waitUntilBucketSynced(
+            TablePath tablePath, long tableId, int bucketCount, boolean isPartitioned) {
+        Set<TableBucket> tableBuckets = new HashSet<>();
+        if (isPartitioned) {
+            Map<Long, String> partitionById = waitUntilPartitions(tablePath);
+            for (Long partitionId : partitionById.keySet()) {
+                for (int i = 0; i < bucketCount; i++) {
+                    tableBuckets.add(new TableBucket(tableId, partitionId, i));
+                }
+            }
+        } else {
+            for (int i = 0; i < bucketCount; i++) {
+                tableBuckets.add(new TableBucket(tableId, i));
+            }
+        }
+        waitUntilBucketsSynced(tableBuckets);
+    }
+
+    protected void waitUntilBucketsSynced(Set<TableBucket> tableBuckets) {
+        for (TableBucket tableBucket : tableBuckets) {
+            waitUntilBucketSynced(tableBucket);
+        }
     }
 
     protected void waitUntilBucketSynced(TableBucket tb) {


### PR DESCRIPTION
### Purpose

  Linked issue: N/A

  This PR adds the shared Flink union read test base for Hudi, preparing follow-up IT cases for validating Hudi tiering union reads from lake snapshots and Fluss logs.

### Brief change log

  - Add `FlinkUnionReadTestBase` for Hudi union read tests.
  - Initialize batch and streaming `StreamTableEnvironment` with the Fluss catalog.
  - Support rebuilding the streaming table environment from a savepoint path.
  - Add reusable Hudi tiering test helpers for waiting bucket sync and asserting replica lake offsets.

### Tests

  - `spotless:apply`
  - `mvn -pl fluss-lake/fluss-lake-hudi -am -DskipITs -Dcheckstyle.skip=true -DfailIfNoTests=false test-compile`
  - `git diff --check`

### API and Format

  No public API or storage format changes. This is test-only infrastructure.

### Documentation

  No documentation changes are needed.