### PR TITLE
[FLUSS-3415][client] Add per-scanner dimension for scanner metrics

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/metrics/ScannerMetricGroup.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/metrics/ScannerMetricGroup.java
@@ -32,6 +32,7 @@ import org.apache.fluss.metrics.groups.AbstractMetricGroup;
 import org.apache.fluss.rpc.metrics.ClientMetricGroup;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.fluss.metrics.utils.MetricGroupUtils.makeScope;
 
@@ -41,8 +42,10 @@ public class ScannerMetricGroup extends AbstractMetricGroup {
 
     private static final String NAME = "scanner";
     private static final int WINDOW_SIZE = 1024;
+    private static final AtomicLong NEXT_SCANNER_ID = new AtomicLong();
 
     private final TablePath tablePath;
+    private final String scannerId;
 
     private final Counter fetchRequestCount;
     private final Histogram bytesPerRequest;
@@ -61,6 +64,7 @@ public class ScannerMetricGroup extends AbstractMetricGroup {
     public ScannerMetricGroup(ClientMetricGroup parent, TablePath tablePath) {
         super(parent.getMetricRegistry(), makeScope(parent, NAME), parent);
         this.tablePath = tablePath;
+        this.scannerId = Long.toString(NEXT_SCANNER_ID.getAndIncrement());
 
         fetchRequestCount = new ThreadSafeSimpleCounter();
         meter(MetricNames.SCANNER_FETCH_RATE, new MeterView(fetchRequestCount));
@@ -131,5 +135,6 @@ public class ScannerMetricGroup extends AbstractMetricGroup {
     protected final void putVariables(Map<String, String> variables) {
         variables.put("database", tablePath.getDatabaseName());
         variables.put("table", tablePath.getTableName());
+        variables.put("scanner_id", scannerId);
     }
 }

--- a/fluss-client/src/test/java/org/apache/fluss/client/metrics/TestingScannerMetricGroup.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/metrics/TestingScannerMetricGroup.java
@@ -18,7 +18,14 @@
 package org.apache.fluss.client.metrics;
 
 import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.rpc.metrics.ClientMetricGroup;
 import org.apache.fluss.rpc.metrics.TestingClientMetricGroup;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** The testing metric group for scanner. */
 public class TestingScannerMetricGroup extends ScannerMetricGroup {
@@ -31,5 +38,25 @@ public class TestingScannerMetricGroup extends ScannerMetricGroup {
 
     public static TestingScannerMetricGroup newInstance() {
         return new TestingScannerMetricGroup();
+    }
+
+    @Test
+    void testScannerMetricGroupContainsScannerIdDimension() {
+        ClientMetricGroup clientMetricGroup = TestingClientMetricGroup.newInstance();
+        ScannerMetricGroup scannerMetricGroup1 =
+                new ScannerMetricGroup(clientMetricGroup, TABLE_PATH);
+        ScannerMetricGroup scannerMetricGroup2 =
+                new ScannerMetricGroup(clientMetricGroup, TABLE_PATH);
+        Map<String, String> variables1 = scannerMetricGroup1.getAllVariables();
+        Map<String, String> variables2 = scannerMetricGroup2.getAllVariables();
+        assertThat(variables1)
+                .containsEntry("database", "db")
+                .containsEntry("table", "table")
+                .containsKey("scanner_id");
+        assertThat(variables2)
+                .containsEntry("database", "db")
+                .containsEntry("table", "table")
+                .containsKey("scanner_id");
+        assertThat(variables1.get("scanner_id")).isNotEqualTo("scanner_id");
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3415 

<!-- What is the purpose of the change -->

### Brief change log
Add scanner_id in ScannerMetricGroup, make sure when two or more LogScanners run against the same database and table in the same client process, client could report right metric value.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

Add `TestingScannerMetricGroup.testScannerMetricGroupContainsScannerIdDimension`

<!-- List UT and IT cases to verify this change -->

### API and Format
no
<!-- Does this change affect API or storage format -->

### Documentation
no
<!-- Does this change introduce a new feature -->
