### PR TITLE
[lake/iceberg] Fix integer overflow when converting Iceberg LocalTime to Fluss millis-of-day

### DIFF
--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergArrayAsFlussArray.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergArrayAsFlussArray.java
@@ -79,7 +79,7 @@ public class IcebergArrayAsFlussArray implements InternalArray {
             return (int) ((LocalDate) value).toEpochDay();
         }
         if (value instanceof LocalTime) {
-            return (int) ((LocalTime) value).toNanoOfDay() / 1_000_000;
+            return (int) (((LocalTime) value).toNanoOfDay() / 1_000_000);
         }
         return (Integer) value;
     }

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergRecordAsFlussRow.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergRecordAsFlussRow.java
@@ -94,7 +94,7 @@ public class IcebergRecordAsFlussRow implements InternalRow {
             return (int) ((LocalDate) value).toEpochDay();
         }
         if (value instanceof LocalTime) {
-            return (int) ((LocalTime) value).toNanoOfDay() / 1_000_000;
+            return (int) (((LocalTime) value).toNanoOfDay() / 1_000_000);
         }
         return (Integer) value;
     }

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergRecordAsFlussRowTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergRecordAsFlussRowTest.java
@@ -37,6 +37,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -203,12 +204,38 @@ class IcebergRecordAsFlussRowTest {
 
         assertThat(icebergRecordAsFlussRow.getInt(15)).isEqualTo((int) date.toEpochDay());
         assertThat(icebergRecordAsFlussRow.getInt(16))
-                .isEqualTo((int) time.toNanoOfDay() / 1_000_000);
+                .isEqualTo((int) (time.toNanoOfDay() / 1_000_000));
 
         InternalArray dateArray = icebergRecordAsFlussRow.getArray(17);
         InternalArray timeArray = icebergRecordAsFlussRow.getArray(18);
         assertThat(dateArray.getInt(0)).isEqualTo((int) date.toEpochDay());
-        assertThat(timeArray.getInt(0)).isEqualTo((int) time.toNanoOfDay() / 1_000_000);
+        assertThat(timeArray.getInt(0)).isEqualTo((int) (time.toNanoOfDay() / 1_000_000));
+    }
+
+    @Test
+    void testGetIntWithLocalTimeNearEndOfDay() {
+        // 23:59:59.999 -> 86_399_999 ms
+        LocalTime endOfDay = LocalTime.of(23, 59, 59, 999_000_000);
+        long expectedNanos = endOfDay.toNanoOfDay();
+        assertThat(expectedNanos).isGreaterThan(Integer.MAX_VALUE);
+        int expectedMillisOfDay = (int) (expectedNanos / 1_000_000L);
+        assertThat(expectedMillisOfDay).isEqualTo(86_399_999);
+
+        record.setField("id", 1L);
+        record.setField("date_field", LocalDate.of(2020, 6, 15));
+        record.setField("time_field", endOfDay);
+        record.setField("date_array", List.of(LocalDate.of(2020, 6, 15)));
+        record.setField("time_array", List.of(endOfDay));
+        record.setField("__bucket", 1);
+        record.setField("__offset", 100L);
+        record.setField("__timestamp", OffsetDateTime.now(ZoneOffset.UTC));
+
+        icebergRecordAsFlussRow.replaceIcebergRecord(record);
+
+        assertThat(icebergRecordAsFlussRow.getInt(16)).isEqualTo(expectedMillisOfDay);
+
+        InternalArray timeArray = icebergRecordAsFlussRow.getArray(18);
+        assertThat(timeArray.getInt(0)).isEqualTo(expectedMillisOfDay);
     }
 
     @Test


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

Fix an integer-overflow bug in the fluss-iceberg lake source path when reading Iceberg TIME columns (and ARRAY<TIME>).
The previous implementation in IcebergRecordAsFlussRow#getInt and IcebergArrayAsFlussArray#getInt was:

```
return (int) ((LocalTime) value).toNanoOfDay() / 1_000_000;
```
Due to Java operator precedence the (int) cast is applied before the division, casting the long returned by toNanoOfDay() (up to 86_399_999_999_999) to int, which silently overflows for any LocalTime greater than ~00:00:02.148. As a result, e.g. 09:00:00 is decoded as -1859 instead of 32_400_000

https://github.com/apache/fluss/blob/486fe0a8ae8c0677c468b94dfdfec39535453f36/fluss-common/src/main/java/org/apache/fluss/predicate/PredicateBuilder.java#L303

In PredicateBuilder handling here is correct, so we should adjusted the error part to use the corresponding method.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

Fix IcebergRecordAsFlussRow#getInt to perform the division on long and only cast the final value:

```

  return (int) (((LocalTime) value).toNanoOfDay() / 1_000_000L);
  
```

### Tests

This change is verified by the new unit tests:
* testGetIntWithLocalDateAndLocalTime — sanity test for normal values on both row and array paths.
* testGetIntWithLocalTimeNearEndOfDay — asserts toNanoOfDay() > Integer.MAX_VALUE before the conversion, then asserts that getInt returns the expected 86_399_999, proving the overflow is fixed.

### API and Format

<!-- Does this change affect API or storage format -->
No public API or storage format change.

### Documentation

<!-- Does this change introduce a new feature -->
No documentation change; behavior-only fix.