### PR TITLE
[lake/paimon] Bump Paimon version to 1.4.2

### DIFF
--- a/docker/quickstart-flink/README.md
+++ b/docker/quickstart-flink/README.md
@@ -32,7 +32,7 @@ This split keeps the regular "Quickstart with Flink" flow working out of the box
 
 The optional lakehouse directories include the Flink-side filesystem and catalog jars needed by those guides. For example:
 
-- `paimon/` includes `paimon-flink-1.20-1.3.1`, `paimon-s3-1.3.1`, and `hadoop-apache`
+- `paimon/` includes `paimon-flink-1.20-1.4.2`, `paimon-s3-1.4.2`, and `hadoop-apache`
 - `iceberg/` includes `iceberg-flink-runtime`, `hadoop-apache`, `iceberg-aws`, `iceberg-aws-bundle`, and `postgresql`
 
 ## Important Behavior

--- a/docker/quickstart-flink/prepare_build.sh
+++ b/docker/quickstart-flink/prepare_build.sh
@@ -166,15 +166,15 @@ main() {
         "508255883b984483a45ca48d5af6365d4f013bb8" \
         "hadoop-apache-3.3.5-2"
     download_jar \
-        "https://repo1.maven.org/maven2/org/apache/paimon/paimon-flink-1.20/1.3.1/paimon-flink-1.20-1.3.1.jar" \
-        "./paimon/paimon-flink-1.20-1.3.1.jar" \
+        "https://repo1.maven.org/maven2/org/apache/paimon/paimon-flink-1.20/1.4.2/paimon-flink-1.20-1.4.2.jar" \
+        "./paimon/paimon-flink-1.20-1.4.2.jar" \
         "" \
-        "paimon-flink-1.20-1.3.1"
+        "paimon-flink-1.20-1.4.2"
     download_jar \
-        "https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-s3/1.3.1/paimon-s3-1.3.1.jar" \
-        "./paimon/paimon-s3-1.3.1.jar" \
+        "https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-s3/1.4.2/paimon-s3-1.4.2.jar" \
+        "./paimon/paimon-s3-1.4.2.jar" \
         "" \
-        "paimon-s3-1.3.1"
+        "paimon-s3-1.4.2"
 
     # Iceberg-specific dependencies. These stay outside /opt/flink/lib by
     # default and are activated by init_iceberg.sh only when needed.
@@ -231,8 +231,8 @@ verify_jars() {
     local paimon_jars=(
         "fluss-lake-paimon-*.jar"
         "hadoop-apache-3.3.5-2.jar"
-        "paimon-flink-1.20-1.3.1.jar"
-        "paimon-s3-1.3.1.jar"
+        "paimon-flink-1.20-1.4.2.jar"
+        "paimon-s3-1.4.2.jar"
     )
 
     local iceberg_jars=(
@@ -309,8 +309,8 @@ show_summary() {
     echo "  - Base: Fluss S3 filesystem plugin"
     echo "  - Base: Flink Faker (v0.5.3)"
     echo "  - Paimon only: Fluss Lake Paimon connector"
-    echo "  - Paimon only: Paimon Flink 1.20 (v1.3.1)"
-    echo "  - Paimon only: Paimon S3 (v1.3.1)"
+    echo "  - Paimon only: Paimon Flink 1.20 (v1.4.2)"
+    echo "  - Paimon only: Paimon S3 (v1.4.2)"
     echo "  - Paimon only: Hadoop Apache (v3.3.5-2)"
     echo "  - Iceberg only: Fluss Lake Iceberg connector"
     echo "  - Iceberg only: Iceberg Flink runtime 1.20 (v1.10.1)"

--- a/fluss-common/src/test/java/org/apache/fluss/row/encode/paimon/PaimonKeyEncoderTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/row/encode/paimon/PaimonKeyEncoderTest.java
@@ -109,8 +109,8 @@ class PaimonKeyEncoderTest {
                 (int)
                         TypeUtils.castFromString(
                                 "09:30:00.0", org.apache.fluss.types.DataTypes.TIME()));
-        binaryRowWriter.writeBinary(9, "1234567890".getBytes());
-        binaryRowWriter.writeBinary(10, "20".getBytes());
+        binaryRowWriter.writeBinary(9, "1234567890".getBytes(), 0, "1234567890".getBytes().length);
+        binaryRowWriter.writeBinary(10, "20".getBytes(), 0, "20".getBytes().length);
         binaryRowWriter.writeString(11, BinaryString.fromString("1"));
         binaryRowWriter.writeString(12, BinaryString.fromString("hello"));
         binaryRowWriter.writeDecimal(13, Decimal.fromUnscaledLong(9, 5, 2), 5);

--- a/fluss-common/src/test/java/org/apache/fluss/row/encode/paimon/PaimonKeyEncoderTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/row/encode/paimon/PaimonKeyEncoderTest.java
@@ -109,8 +109,8 @@ class PaimonKeyEncoderTest {
                 (int)
                         TypeUtils.castFromString(
                                 "09:30:00.0", org.apache.fluss.types.DataTypes.TIME()));
-        binaryRowWriter.writeBinary(9, "1234567890".getBytes());
-        binaryRowWriter.writeBinary(10, "20".getBytes());
+        binaryRowWriter.writeBinary(9, "1234567890".getBytes(), 0, "1234567890".length());
+        binaryRowWriter.writeBinary(10, "20".getBytes(), 0, "20".length());
         binaryRowWriter.writeString(11, BinaryString.fromString("1"));
         binaryRowWriter.writeString(12, BinaryString.fromString("hello"));
         binaryRowWriter.writeDecimal(13, Decimal.fromUnscaledLong(9, 5, 2), 5);

--- a/fluss-lake/fluss-lake-paimon/pom.xml
+++ b/fluss-lake/fluss-lake-paimon/pom.xml
@@ -32,10 +32,6 @@
 
     <packaging>jar</packaging>
 
-    <properties>
-        <paimon.version>1.3.1</paimon.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.fluss</groupId>

--- a/fluss-lake/fluss-lake-paimon/pom.xml
+++ b/fluss-lake/fluss-lake-paimon/pom.xml
@@ -31,11 +31,6 @@
     <name>Apache Fluss : Lake : Paimon</name>
 
     <packaging>jar</packaging>
-
-    <properties>
-        <paimon.version>1.3.1</paimon.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.fluss</groupId>

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuper.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuper.java
@@ -493,6 +493,11 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
         }
 
         @Override
+        public String pickTempDir() {
+            return delegate.pickTempDir();
+        }
+
+        @Override
         public FileIOChannel.Enumerator createChannelEnumerator() {
             return delegate.createChannelEnumerator();
         }

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/FlussArrayAsPaimonArray.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/FlussArrayAsPaimonArray.java
@@ -21,10 +21,12 @@ import org.apache.fluss.row.TimestampLtz;
 import org.apache.fluss.row.TimestampNtz;
 
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.InternalVector;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.ArrayType;
@@ -150,12 +152,24 @@ public class FlussArrayAsPaimonArray implements InternalArray {
     }
 
     @Override
+    public Blob getBlob(int pos) {
+        throw new UnsupportedOperationException(
+                "getBlob is not supported for Fluss array currently.");
+    }
+
+    @Override
     public InternalArray getArray(int pos) {
         org.apache.fluss.row.InternalArray innerArray = flussArray.getArray(pos);
         return innerArray == null
                 ? null
                 : new FlussArrayAsPaimonArray(
                         innerArray, ((ArrayType) elementType).getElementType());
+    }
+
+    @Override
+    public InternalVector getVector(int pos) {
+        throw new UnsupportedOperationException(
+                "getVector is not supported for Fluss array currently.");
     }
 
     @Override

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/FlussRowAsPaimonRow.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/FlussRowAsPaimonRow.java
@@ -21,10 +21,12 @@ import org.apache.fluss.row.TimestampLtz;
 import org.apache.fluss.row.TimestampNtz;
 
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.InternalVector;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.ArrayType;
@@ -159,12 +161,24 @@ public class FlussRowAsPaimonRow implements InternalRow {
     }
 
     @Override
+    public Blob getBlob(int pos) {
+        throw new UnsupportedOperationException(
+                "getBlob is not support for Fluss record currently.");
+    }
+
+    @Override
     public InternalArray getArray(int pos) {
         org.apache.fluss.row.InternalArray flussArray = internalRow.getArray(pos);
         return flussArray == null
                 ? null
                 : new FlussArrayAsPaimonArray(
                         flussArray, ((ArrayType) tableRowType.getTypeAt(pos)).getElementType());
+    }
+
+    @Override
+    public InternalVector getVector(int pos) {
+        throw new UnsupportedOperationException(
+                "getVector is not support for Fluss record currently.");
     }
 
     @Override

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/PaimonLakeCommitter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/PaimonLakeCommitter.java
@@ -31,10 +31,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestCommittable;
-import org.apache.paimon.manifest.ManifestEntry;
-import org.apache.paimon.manifest.SimpleFileEntry;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableSnapshot;
 import org.apache.paimon.table.sink.CommitCallback;
@@ -287,12 +284,8 @@ public class PaimonLakeCommitter implements LakeCommitter<PaimonWriteResult, Pai
     public static class PaimonCommitCallback implements CommitCallback {
 
         @Override
-        public void call(
-                List<SimpleFileEntry> baseFiles,
-                List<ManifestEntry> deltaFiles,
-                List<IndexManifestEntry> indexFiles,
-                Snapshot snapshot) {
-            currentCommitSnapshotId.set(snapshot.id());
+        public void call(Context context) {
+            currentCommitSnapshotId.set(context.snapshot.id());
         }
 
         @Override

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/PaimonLakeCommitter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/PaimonLakeCommitter.java
@@ -31,10 +31,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestCommittable;
-import org.apache.paimon.manifest.ManifestEntry;
-import org.apache.paimon.manifest.SimpleFileEntry;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableSnapshot;
 import org.apache.paimon.table.sink.CommitCallback;
@@ -290,12 +287,8 @@ public class PaimonLakeCommitter implements LakeCommitter<PaimonWriteResult, Pai
     public static class PaimonCommitCallback implements CommitCallback {
 
         @Override
-        public void call(
-                List<SimpleFileEntry> baseFiles,
-                List<ManifestEntry> deltaFiles,
-                List<IndexManifestEntry> indexFiles,
-                Snapshot snapshot) {
-            currentCommitSnapshotId.set(snapshot.id());
+        public void call(Context context) {
+            currentCommitSnapshotId.set(context.snapshot.id());
         }
 
         @Override

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
@@ -64,6 +64,7 @@ import org.apache.paimon.data.columnar.VectorizedColumnBatch;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.BinaryType;
+import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.BooleanType;
 import org.apache.paimon.types.CharType;
 import org.apache.paimon.types.DataField;
@@ -85,6 +86,7 @@ import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.types.VariantType;
+import org.apache.paimon.types.VectorType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -479,6 +481,11 @@ public interface Arrow2PaimonVectorConverter {
         }
 
         @Override
+        public Arrow2PaimonVectorConverter visit(BlobType blobType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public Arrow2PaimonVectorConverter visit(ArrayType arrayType) {
             final Arrow2PaimonVectorConverter arrowVectorConvertor =
                     arrayType.getElementType().accept(this);
@@ -517,6 +524,11 @@ public interface Arrow2PaimonVectorConverter {
                             return columnVector;
                         }
                     };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(VectorType vectorType) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/fluss-lake/fluss-lake-paimon/src/main/resources/META-INF/NOTICE
+++ b/fluss-lake/fluss-lake-paimon/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.paimon:paimon-bundle:1.3.1
+- org.apache.paimon:paimon-bundle:1.4.2

--- a/fluss-lake/fluss-lake-paimon/src/main/resources/META-INF/NOTICE
+++ b/fluss-lake/fluss-lake-paimon/src/main/resources/META-INF/NOTICE
@@ -3,7 +3,3 @@ Copyright 2025-2026 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
-This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-- org.apache.paimon:paimon-bundle:1.4.2

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/utils/PaimonConversionsTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/utils/PaimonConversionsTest.java
@@ -66,7 +66,11 @@ class PaimonConversionsTest {
                 w -> w.writeInt(0, milliOfDay),
                 milliOfDay,
                 DataTypeRoot.TIME_WITHOUT_TIME_ZONE);
-        assertMatches(DataTypes.BYTES(), w -> w.writeBinary(0, bytes), bytes, DataTypeRoot.BYTES);
+        assertMatches(
+                DataTypes.BYTES(),
+                w -> w.writeBinary(0, bytes, 0, bytes.length),
+                bytes,
+                DataTypeRoot.BYTES);
         assertMatches(
                 DataTypes.TIMESTAMP(6),
                 w -> w.writeTimestamp(0, Timestamp.fromEpochMillis(ms, nanos), 6),

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <curator.version>5.4.0</curator.version>
         <netty.version>4.1.104.Final</netty.version>
         <arrow.version>15.0.0</arrow.version>
-        <paimon.version>1.3.1</paimon.version>
+        <paimon.version>1.4.2</paimon.version>
         <iceberg.version>1.10.1</iceberg.version>
         <hudi.version>1.1.0</hudi.version>
         <roaringbitmap.version>1.3.0</roaringbitmap.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <curator.version>5.4.0</curator.version>
         <netty.version>4.1.104.Final</netty.version>
         <arrow.version>15.0.0</arrow.version>
-        <paimon.version>1.3.1</paimon.version>
+        <paimon.version>1.4.2</paimon.version>
         <iceberg.version>1.10.1</iceberg.version>
         <hudi.version>1.1.0</hudi.version>
         <roaringbitmap.version>1.3.0</roaringbitmap.version>

--- a/website/community/how-to-release/creating-a-fluss-release.mdx
+++ b/website/community/how-to-release/creating-a-fluss-release.mdx
@@ -205,8 +205,8 @@ Next, add a new version item for the next release version in the `website/fluss-
   "fullVersion": "1.1-SNAPSHOT",
   "shortVersion": "1.1",
   "dockerVersion": "1.1-SNAPSHOT",
-  "paimonVersion": "1.3.1",
-  "paimonVersionShort": "1.3",
+  "paimonVersion": "1.4.2",
+  "paimonVersionShort": "1.4",
   "released": false
 }
 ```
@@ -219,8 +219,8 @@ Additionally, update the `fullVersion`, `shortVersion`, and `dockerVersion` fiel
     "fullVersion": "1.0.0",
     "shortVersion": "1.0",
     "dockerVersion": "1.0.0",
-    "paimonVersion": "1.3.1",
-    "paimonVersionShort": "1.3",
+    "paimonVersion": "1.4.2",
+    "paimonVersionShort": "1.4",
     "released": false
  }
 ```

--- a/website/docs/streaming-lakehouse/datalake-formats/paimon.md
+++ b/website/docs/streaming-lakehouse/datalake-formats/paimon.md
@@ -32,10 +32,10 @@ Verify downloaded JARs using the [verification instructions](/downloads#verifyin
 
 ## Version Compatibility
 
-| Use Case        | Required/Tested Versions                           |
-|-----------------|----------------------------------------------------|
-| Tiering Service | Paimon **1.3** (required)                          |
-| Union Read      | Paimon 1.1, 1.2, 1.3 (tested and verified to work) |
+| Use Case        | Required/Tested Versions                                |
+|-----------------|---------------------------------------------------------|
+| Tiering Service | Paimon **1.4** (required)                               |
+| Union Read      | Paimon 1.1, 1.2, 1.3, 1.4 (tested and verified to work) |
 
 ## Configure Paimon as LakeHouse Storage
 

--- a/website/fluss-versions.json
+++ b/website/fluss-versions.json
@@ -4,8 +4,8 @@
     "fullVersion": "1.0-SNAPSHOT",
     "shortVersion": "1.0",
     "dockerVersion": "1.0-SNAPSHOT",
-    "paimonVersion": "1.3.1",
-    "paimonVersionShort": "1.3",
+    "paimonVersion": "1.4.2",
+    "paimonVersionShort": "1.4",
     "released": false
   },
   {


### PR DESCRIPTION
### Purpose

Linked issue: close #3544


### Brief change log

1. pom.xml: Bump paimon.version from 1.3.1 to 1.4.2.
2. InternalRow / InternalArray: Add getBlob and getVector method implementations to adapt to the BLOB / VECTOR types introduced in Paimon 1.4. (Fluss does not currently support these types, so the methods throw UnsupportedOperationException.)

3. PaimonLakeCommitter: Change the CommitCallback.call method signature from (baseFiles, deltaFiles, indexFiles, snapshot) to (Context context), and clean up the unused imports accordingly.

4. Arrow2PaimonVectorConverter: Add visit(BlobType) and visit(VectorType) methods. Currently not supported.

### Tests


### API and Format


### Documentation
