### PR TITLE
[server] Require new leader ack for leader-only rebalance

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -1612,13 +1612,13 @@ public class CoordinatorEventProcessor implements EventProcessor {
                             planForBucket.getOriginReplicas(), planForBucket.getNewReplicas());
             try {
                 if (planForBucket.isLeaderChanged() && !reassignment.isBeingReassigned()) {
+                    if (!isSuccessfulLeaderOnlyRebalanceResponseFromNewLeader(
+                            notifyLeaderAndIsrResultForBucket, responseServerId, planForBucket)) {
+                        return;
+                    }
                     LeaderAndIsr leaderAndIsr = zooKeeperClient.getLeaderAndIsr(tableBucket).get();
                     int currentLeader = leaderAndIsr.leader();
-                    if (canCompleteLeaderOnlyRebalanceTask(
-                            notifyLeaderAndIsrResultForBucket,
-                            responseServerId,
-                            planForBucket,
-                            currentLeader)) {
+                    if (currentLeader == planForBucket.getNewLeader()) {
                         // leader action finish.
                         rebalanceManager.finishRebalanceTask(
                                 tableBucket, RebalanceStatus.COMPLETED);
@@ -1667,14 +1667,12 @@ public class CoordinatorEventProcessor implements EventProcessor {
     }
 
     @VisibleForTesting
-    static boolean canCompleteLeaderOnlyRebalanceTask(
+    static boolean isSuccessfulLeaderOnlyRebalanceResponseFromNewLeader(
             NotifyLeaderAndIsrResultForBucket notifyLeaderAndIsrResultForBucket,
             int responseServerId,
-            RebalancePlanForBucket planForBucket,
-            int currentLeader) {
+            RebalancePlanForBucket planForBucket) {
         return notifyLeaderAndIsrResultForBucket.succeeded()
-                && responseServerId == planForBucket.getNewLeader()
-                && currentLeader == planForBucket.getNewLeader();
+                && responseServerId == planForBucket.getNewLeader();
     }
 
     /**

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -1187,7 +1187,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
         // server to acknowledge the leader change before proceeding to the next migration.
         for (NotifyLeaderAndIsrResultForBucket notifyLeaderAndIsrResultForBucket :
                 notifyLeaderAndIsrResultForBuckets) {
-            tryToCompleteRebalanceTask(notifyLeaderAndIsrResultForBucket.getTableBucket());
+            tryToCompleteRebalanceTask(notifyLeaderAndIsrResultForBucket, serverId);
         }
     }
 
@@ -1600,7 +1600,10 @@ public class CoordinatorEventProcessor implements EventProcessor {
     }
 
     /** try to finish rebalance tasks after receive notify leader and isr response. */
-    private void tryToCompleteRebalanceTask(TableBucket tableBucket) {
+    private void tryToCompleteRebalanceTask(
+            NotifyLeaderAndIsrResultForBucket notifyLeaderAndIsrResultForBucket,
+            int responseServerId) {
+        TableBucket tableBucket = notifyLeaderAndIsrResultForBucket.getTableBucket();
         RebalancePlanForBucket planForBucket =
                 rebalanceManager.getRebalancePlanForBucket(tableBucket);
         if (planForBucket != null) {
@@ -1611,21 +1614,17 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 if (planForBucket.isLeaderChanged() && !reassignment.isBeingReassigned()) {
                     LeaderAndIsr leaderAndIsr = zooKeeperClient.getLeaderAndIsr(tableBucket).get();
                     int currentLeader = leaderAndIsr.leader();
-                    if (currentLeader == planForBucket.getNewLeader()) {
+                    if (canCompleteLeaderOnlyRebalanceTask(
+                            notifyLeaderAndIsrResultForBucket,
+                            responseServerId,
+                            planForBucket,
+                            currentLeader)) {
                         // leader action finish.
                         rebalanceManager.finishRebalanceTask(
                                 tableBucket, RebalanceStatus.COMPLETED);
                     }
-                } else {
-                    boolean isReassignmentComplete =
-                            isReassignmentComplete(tableBucket, reassignment);
-                    if (isReassignmentComplete) {
-                        LOG.info(
-                                "Target replicas {} have all caught up with the leader for reassigning bucket {}",
-                                reassignment.getTargetReplicas(),
-                                tableBucket);
-                        onBucketReassignment(tableBucket, reassignment, true);
-                    }
+                } else if (notifyLeaderAndIsrResultForBucket.succeeded()) {
+                    tryToCompleteReassignmentTask(tableBucket, reassignment);
                 }
             } catch (Exception e) {
                 LOG.error(
@@ -1633,6 +1632,49 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 rebalanceManager.finishRebalanceTask(tableBucket, RebalanceStatus.FAILED);
             }
         }
+    }
+
+    private void tryToCompleteRebalanceTaskOnLeaderAndIsrChange(TableBucket tableBucket) {
+        RebalancePlanForBucket planForBucket =
+                rebalanceManager.getRebalancePlanForBucket(tableBucket);
+        if (planForBucket != null) {
+            ReplicaReassignment reassignment =
+                    ReplicaReassignment.build(
+                            planForBucket.getOriginReplicas(), planForBucket.getNewReplicas());
+            if (planForBucket.isLeaderChanged() && !reassignment.isBeingReassigned()) {
+                return;
+            }
+            try {
+                tryToCompleteReassignmentTask(tableBucket, reassignment);
+            } catch (Exception e) {
+                LOG.error(
+                        "Failed to complete the reassignment for table bucket {}", tableBucket, e);
+                rebalanceManager.finishRebalanceTask(tableBucket, RebalanceStatus.FAILED);
+            }
+        }
+    }
+
+    private void tryToCompleteReassignmentTask(
+            TableBucket tableBucket, ReplicaReassignment reassignment) throws Exception {
+        boolean isReassignmentComplete = isReassignmentComplete(tableBucket, reassignment);
+        if (isReassignmentComplete) {
+            LOG.info(
+                    "Target replicas {} have all caught up with the leader for reassigning bucket {}",
+                    reassignment.getTargetReplicas(),
+                    tableBucket);
+            onBucketReassignment(tableBucket, reassignment, true);
+        }
+    }
+
+    @VisibleForTesting
+    static boolean canCompleteLeaderOnlyRebalanceTask(
+            NotifyLeaderAndIsrResultForBucket notifyLeaderAndIsrResultForBucket,
+            int responseServerId,
+            RebalancePlanForBucket planForBucket,
+            int currentLeader) {
+        return notifyLeaderAndIsrResultForBucket.succeeded()
+                && responseServerId == planForBucket.getNewLeader()
+                && currentLeader == planForBucket.getNewLeader();
     }
 
     /**
@@ -1926,7 +1968,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
         newLeaderAndIsrList.forEach(coordinatorContext::putBucketLeaderAndIsr);
 
         // First, try to judge whether the bucket is in rebalance task when isr change.
-        newLeaderAndIsrList.keySet().forEach(this::tryToCompleteRebalanceTask);
+        newLeaderAndIsrList.keySet().forEach(this::tryToCompleteRebalanceTaskOnLeaderAndIsrChange);
 
         // TODO update metadata for all alive tablet servers.
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
@@ -1728,13 +1728,13 @@ class CoordinatorEventProcessorTest {
         // Set up controlled gateways that capture NotifyLeaderAndIsr calls.
         // Gateways start in pass-through mode for table creation, then switch
         // to controlled mode to verify sequential leader migration.
-        ConcurrentLinkedDeque<CompletableFuture<Void>> pendingTriggers =
+        ConcurrentLinkedDeque<ControlledNotifyTrigger> pendingTriggers =
                 new ConcurrentLinkedDeque<>();
         int[] servers = zookeeperClient.getSortedTabletServerList();
         Map<Integer, TabletServerGateway> gateways = new HashMap<>();
         ControlledNotifyGateway[] controlledGateways = new ControlledNotifyGateway[servers.length];
         for (int i = 0; i < servers.length; i++) {
-            ControlledNotifyGateway gw = new ControlledNotifyGateway(pendingTriggers);
+            ControlledNotifyGateway gw = new ControlledNotifyGateway(servers[i], pendingTriggers);
             gateways.put(servers[i], gw);
             controlledGateways[i] = gw;
         }
@@ -1828,6 +1828,102 @@ class CoordinatorEventProcessorTest {
         verifyIsr(tb0, 1, Arrays.asList(0, 1, 2));
         verifyIsr(tb1, 2, Arrays.asList(0, 1, 2));
         verifyIsr(tb2, 1, Arrays.asList(0, 1, 2));
+    }
+
+    @Test
+    void testLeaderOnlyRebalanceCompletionRequiresSuccessfulResponseFromNewLeader() {
+        TableBucket tableBucket = new TableBucket(1L, 0);
+        RebalancePlanForBucket planForBucket =
+                new RebalancePlanForBucket(
+                        tableBucket, 0, 1, Arrays.asList(0, 1, 2), Arrays.asList(1, 0, 2));
+        NotifyLeaderAndIsrResultForBucket successResult =
+                new NotifyLeaderAndIsrResultForBucket(tableBucket);
+        NotifyLeaderAndIsrResultForBucket failedResult =
+                new NotifyLeaderAndIsrResultForBucket(
+                        tableBucket, new ApiError(Errors.UNKNOWN_SERVER_ERROR, "failed"));
+
+        assertThat(
+                        CoordinatorEventProcessor.canCompleteLeaderOnlyRebalanceTask(
+                                successResult, 1, planForBucket, 1))
+                .isTrue();
+        assertThat(
+                        CoordinatorEventProcessor.canCompleteLeaderOnlyRebalanceTask(
+                                successResult, 0, planForBucket, 1))
+                .isFalse();
+        assertThat(
+                        CoordinatorEventProcessor.canCompleteLeaderOnlyRebalanceTask(
+                                failedResult, 1, planForBucket, 1))
+                .isFalse();
+        assertThat(
+                        CoordinatorEventProcessor.canCompleteLeaderOnlyRebalanceTask(
+                                successResult, 1, planForBucket, 0))
+                .isFalse();
+    }
+
+    @Test
+    void testLeaderOnlyRebalanceIgnoresSuccessResponseFromOldLeader() throws Exception {
+        ConcurrentLinkedDeque<ControlledNotifyTrigger> pendingTriggers =
+                new ConcurrentLinkedDeque<>();
+        int[] servers = zookeeperClient.getSortedTabletServerList();
+        Map<Integer, TabletServerGateway> gateways = new HashMap<>();
+        ControlledNotifyGateway[] controlledGateways = new ControlledNotifyGateway[servers.length];
+        for (int i = 0; i < servers.length; i++) {
+            ControlledNotifyGateway gw = new ControlledNotifyGateway(servers[i], pendingTriggers);
+            gateways.put(servers[i], gw);
+            controlledGateways[i] = gw;
+        }
+        testCoordinatorChannelManager.setGateways(gateways);
+
+        TablePath t1 = TablePath.of(defaultDatabase, "test_leader_rebalance_wait_new_leader");
+        Map<Integer, BucketAssignment> bucketAssignments = new HashMap<>();
+        bucketAssignments.put(0, BucketAssignment.of(0, 1, 2));
+        TableAssignment tableAssignment = new TableAssignment(bucketAssignments);
+        long t1Id =
+                metadataManager.createTable(t1, remoteDataDir, TEST_TABLE, tableAssignment, false);
+
+        TableBucket tb0 = new TableBucket(t1Id, 0);
+
+        verifyIsr(tb0, 0, Arrays.asList(0, 1, 2));
+
+        for (ControlledNotifyGateway gw : controlledGateways) {
+            gw.enableControlMode();
+        }
+        pendingTriggers.clear();
+
+        Map<TableBucket, RebalancePlanForBucket> rebalancePlan = new HashMap<>();
+        rebalancePlan.put(
+                tb0,
+                new RebalancePlanForBucket(
+                        tb0, 0, 1, Arrays.asList(0, 1, 2), Arrays.asList(1, 0, 2)));
+
+        eventProcessor
+                .getRebalanceManager()
+                .registerRebalance(
+                        "rebalance-wait-new-leader-response",
+                        rebalancePlan,
+                        RebalanceStatus.NOT_STARTED);
+
+        retry(
+                Duration.ofMinutes(1),
+                () -> assertThat(hasPendingNotifyTrigger(pendingTriggers, 0)).isTrue());
+        retry(
+                Duration.ofMinutes(1),
+                () -> assertThat(hasPendingNotifyTrigger(pendingTriggers, 1)).isTrue());
+        assertThat(countInProgressRebalanceTasks(tb0)).isEqualTo(1);
+
+        completePendingNotifyTrigger(pendingTriggers, 0);
+        fromCtx(ctx -> null);
+
+        assertThat(countInProgressRebalanceTasks(tb0)).isEqualTo(1);
+        assertThat(eventProcessor.getRebalanceManager().hasInProgressRebalance()).isTrue();
+
+        completePendingNotifyTrigger(pendingTriggers, 1);
+        retry(
+                Duration.ofMinutes(1),
+                () ->
+                        assertThat(eventProcessor.getRebalanceManager().hasInProgressRebalance())
+                                .isFalse());
+        verifyIsr(tb0, 1, Arrays.asList(0, 1, 2));
     }
 
     private void verifyIsr(TableBucket tb, int expectedLeader, List<Integer> expectedIsr)
@@ -2231,11 +2327,34 @@ class CoordinatorEventProcessorTest {
     }
 
     private static void drainPendingNotifyTriggers(
-            ConcurrentLinkedDeque<CompletableFuture<Void>> pendingTriggers) {
-        CompletableFuture<Void> trigger;
+            ConcurrentLinkedDeque<ControlledNotifyTrigger> pendingTriggers) {
+        ControlledNotifyTrigger trigger;
         while ((trigger = pendingTriggers.poll()) != null) {
             trigger.complete(null);
         }
+    }
+
+    private static boolean hasPendingNotifyTrigger(
+            ConcurrentLinkedDeque<ControlledNotifyTrigger> pendingTriggers, int responseServerId) {
+        for (ControlledNotifyTrigger trigger : pendingTriggers) {
+            if (trigger.getResponseServerId() == responseServerId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void completePendingNotifyTrigger(
+            ConcurrentLinkedDeque<ControlledNotifyTrigger> pendingTriggers, int responseServerId) {
+        for (ControlledNotifyTrigger trigger : pendingTriggers) {
+            if (trigger.getResponseServerId() == responseServerId) {
+                assertThat(pendingTriggers.remove(trigger)).isTrue();
+                trigger.complete(null);
+                return;
+            }
+        }
+        throw new AssertionError(
+                "No pending NotifyLeaderAndIsr response for server " + responseServerId);
     }
 
     private int countInProgressRebalanceTasks(TableBucket... buckets) {
@@ -2275,10 +2394,14 @@ class CoordinatorEventProcessorTest {
      */
     private static class ControlledNotifyGateway extends TestTabletServerGateway {
         private volatile boolean controlMode = false;
-        private final ConcurrentLinkedDeque<CompletableFuture<Void>> pendingTriggers;
+        private final int responseServerId;
+        private final ConcurrentLinkedDeque<ControlledNotifyTrigger> pendingTriggers;
 
-        ControlledNotifyGateway(ConcurrentLinkedDeque<CompletableFuture<Void>> pendingTriggers) {
+        ControlledNotifyGateway(
+                int responseServerId,
+                ConcurrentLinkedDeque<ControlledNotifyTrigger> pendingTriggers) {
             super(false, Collections.emptySet());
+            this.responseServerId = responseServerId;
             this.pendingTriggers = pendingTriggers;
         }
 
@@ -2295,9 +2418,30 @@ class CoordinatorEventProcessorTest {
             // Build the proper success response using parent's logic.
             NotifyLeaderAndIsrResponse response = super.notifyLeaderAndIsr(request).join();
             // Return a future that completes only when the test releases the trigger.
-            CompletableFuture<Void> trigger = new CompletableFuture<>();
+            ControlledNotifyTrigger trigger = new ControlledNotifyTrigger(responseServerId);
             pendingTriggers.add(trigger);
-            return trigger.thenApply(v -> response);
+            return trigger.getFuture().thenApply(v -> response);
+        }
+    }
+
+    private static class ControlledNotifyTrigger {
+        private final int responseServerId;
+        private final CompletableFuture<Void> future = new CompletableFuture<>();
+
+        ControlledNotifyTrigger(int responseServerId) {
+            this.responseServerId = responseServerId;
+        }
+
+        int getResponseServerId() {
+            return responseServerId;
+        }
+
+        CompletableFuture<Void> getFuture() {
+            return future;
+        }
+
+        void complete(Void value) {
+            future.complete(value);
         }
     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
@@ -1831,7 +1831,7 @@ class CoordinatorEventProcessorTest {
     }
 
     @Test
-    void testLeaderOnlyRebalanceCompletionRequiresSuccessfulResponseFromNewLeader() {
+    void testLeaderOnlyRebalanceCompletionCheckRequiresSuccessfulResponseFromNewLeader() {
         TableBucket tableBucket = new TableBucket(1L, 0);
         RebalancePlanForBucket planForBucket =
                 new RebalancePlanForBucket(
@@ -1843,20 +1843,19 @@ class CoordinatorEventProcessorTest {
                         tableBucket, new ApiError(Errors.UNKNOWN_SERVER_ERROR, "failed"));
 
         assertThat(
-                        CoordinatorEventProcessor.canCompleteLeaderOnlyRebalanceTask(
-                                successResult, 1, planForBucket, 1))
+                        CoordinatorEventProcessor
+                                .isSuccessfulLeaderOnlyRebalanceResponseFromNewLeader(
+                                        successResult, 1, planForBucket))
                 .isTrue();
         assertThat(
-                        CoordinatorEventProcessor.canCompleteLeaderOnlyRebalanceTask(
-                                successResult, 0, planForBucket, 1))
+                        CoordinatorEventProcessor
+                                .isSuccessfulLeaderOnlyRebalanceResponseFromNewLeader(
+                                        successResult, 0, planForBucket))
                 .isFalse();
         assertThat(
-                        CoordinatorEventProcessor.canCompleteLeaderOnlyRebalanceTask(
-                                failedResult, 1, planForBucket, 1))
-                .isFalse();
-        assertThat(
-                        CoordinatorEventProcessor.canCompleteLeaderOnlyRebalanceTask(
-                                successResult, 1, planForBucket, 0))
+                        CoordinatorEventProcessor
+                                .isSuccessfulLeaderOnlyRebalanceResponseFromNewLeader(
+                                        failedResult, 1, planForBucket))
                 .isFalse();
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3555 

<!-- What is the purpose of the change -->

Leader-only rebalance previously completed once the current leader matched
the target leader after any `NotifyLeaderAndIsr` response for the bucket. Since
`NotifyLeaderAndIsr` is sent to multiple replicas, this could complete the task
before the new leader acknowledged the request.

Pass the bucket result and response server id into the completion check, and
only complete leader-only rebalance when the result succeeded and the response
came from the target new leader. Keep LeaderAndIsr change handling from
directly completing leader-only rebalance tasks.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
