### PR TITLE
[docs] Add PrometheusPushGateway and InfluxDB to Metrics Storage in overview

### DIFF
--- a/website/docs/install-deploy/overview.md
+++ b/website/docs/install-deploy/overview.md
@@ -129,6 +129,8 @@ We have listed them in the table below the figure.
             <td>
                <li>[JMX](maintenance/observability/metric-reporters.md#jmx)</li>
                <li>[Prometheus](maintenance/observability/metric-reporters.md#prometheus)</li>
+               <li>[PrometheusPushGateway](maintenance/observability/metric-reporters.md#prometheuspushgateway)</li>
+               <li>[InfluxDB](maintenance/observability/metric-reporters.md#influxdb)</li>
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION

## Purpose

The **Metrics Storage** section in the deployment overview page (`website/docs/install-deploy/overview.md`) only lists `JMX` and `Prometheus`, but Fluss actually supports 4 metric reporters as documented in `website/docs/maintenance/observability/metric-reporters.md`:

- JMX (pull)
- Prometheus (pull)
- PrometheusPushGateway (push)
- InfluxDB (push, supports v2/v3)

This PR adds the two missing reporters (`PrometheusPushGateway` and `InfluxDB`) to the Metrics Storage row in the deployment overview table so that the documentation is consistent with the actual supported reporters.

## Brief change log

- Add `PrometheusPushGateway` link to Metrics Storage in `website/docs/install-deploy/overview.md`.
- Add `InfluxDB` link to Metrics Storage in `website/docs/install-deploy/overview.md`.

## Tests


## API and Format

No API/format changes.

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **docs**
