### PR TITLE
[lake/iceberg] Fix predicate push-down for TINYINT/SMALLINT into Iceberg

### DIFF
--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/utils/FlussToIcebergPredicateConverter.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/utils/FlussToIcebergPredicateConverter.java
@@ -107,7 +107,7 @@ public class FlussToIcebergPredicateConverter implements PredicateVisitor<Expres
         public Expression visitStartsWith(FieldRef fieldRef, Object literal) {
             String fieldName = getField(fieldRef.index()).name();
             return Expressions.startsWith(
-                    fieldName, convertToIcebergLiteral(fieldRef.index(), literal).toString());
+                    fieldName, convertToIcebergLiteral(fieldRef, literal).toString());
         }
 
         @Override
@@ -125,41 +125,39 @@ public class FlussToIcebergPredicateConverter implements PredicateVisitor<Expres
         @Override
         public Expression visitLessThan(FieldRef fieldRef, Object literal) {
             String fieldName = getField(fieldRef.index()).name();
-            return Expressions.lessThan(
-                    fieldName, convertToIcebergLiteral(fieldRef.index(), literal));
+            return Expressions.lessThan(fieldName, convertToIcebergLiteral(fieldRef, literal));
         }
 
         @Override
         public Expression visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
             String fieldName = getField(fieldRef.index()).name();
             return Expressions.greaterThanOrEqual(
-                    fieldName, convertToIcebergLiteral(fieldRef.index(), literal));
+                    fieldName, convertToIcebergLiteral(fieldRef, literal));
         }
 
         @Override
         public Expression visitNotEqual(FieldRef fieldRef, Object literal) {
             String fieldName = getField(fieldRef.index()).name();
-            return Expressions.notEqual(
-                    fieldName, convertToIcebergLiteral(fieldRef.index(), literal));
+            return Expressions.notEqual(fieldName, convertToIcebergLiteral(fieldRef, literal));
         }
 
         @Override
         public Expression visitLessOrEqual(FieldRef fieldRef, Object literal) {
             String fieldName = getField(fieldRef.index()).name();
             return Expressions.lessThanOrEqual(
-                    fieldName, convertToIcebergLiteral(fieldRef.index(), literal));
+                    fieldName, convertToIcebergLiteral(fieldRef, literal));
         }
 
         @Override
         public Expression visitEqual(FieldRef fieldRef, Object literal) {
             String fieldName = getField(fieldRef.index()).name();
-            return Expressions.equal(fieldName, convertToIcebergLiteral(fieldRef.index(), literal));
+            return Expressions.equal(fieldName, convertToIcebergLiteral(fieldRef, literal));
         }
 
         @Override
         public Expression visitGreaterThan(FieldRef fieldRef, Object literal) {
             String fieldName = getField(fieldRef.index()).name();
-            Object icebergLiteral = convertToIcebergLiteral(fieldRef.index(), literal);
+            Object icebergLiteral = convertToIcebergLiteral(fieldRef, literal);
             return Expressions.greaterThan(fieldName, icebergLiteral);
         }
 
@@ -168,7 +166,7 @@ public class FlussToIcebergPredicateConverter implements PredicateVisitor<Expres
             String fieldName = getField(fieldRef.index()).name();
             List<Object> icebergLiterals =
                     literals.stream()
-                            .map(literal -> convertToIcebergLiteral(fieldRef.index(), literal))
+                            .map(literal -> convertToIcebergLiteral(fieldRef, literal))
                             .collect(Collectors.toList());
             return Expressions.in(fieldName, icebergLiterals);
         }
@@ -178,7 +176,7 @@ public class FlussToIcebergPredicateConverter implements PredicateVisitor<Expres
             String fieldName = getField(fieldRef.index()).name();
             List<Object> icebergLiterals =
                     literals.stream()
-                            .map(literal -> convertToIcebergLiteral(fieldRef.index(), literal))
+                            .map(literal -> convertToIcebergLiteral(fieldRef, literal))
                             .collect(Collectors.toList());
             return Expressions.notIn(fieldName, icebergLiterals);
         }
@@ -199,8 +197,11 @@ public class FlussToIcebergPredicateConverter implements PredicateVisitor<Expres
             return icebergSchema.columns().get(fieldIndex);
         }
 
-        private Object convertToIcebergLiteral(int fieldIndex, Object flussLiteral) {
-            return toIcebergLiteral(getField(fieldIndex), flussLiteral);
+        private Object convertToIcebergLiteral(FieldRef fieldRef, Object flussLiteral) {
+            // Pass the original Fluss field type through so IcebergConversions can reuse
+            // FlussRowAsIcebergRecord's per-Fluss-type converter directly, avoiding the lossy
+            // reverse mapping from Iceberg types back to Fluss types.
+            return toIcebergLiteral(getField(fieldRef.index()), fieldRef.type(), flussLiteral);
         }
     }
 }

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/utils/IcebergConversions.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/utils/IcebergConversions.java
@@ -21,9 +21,7 @@ import org.apache.fluss.lake.iceberg.source.FlussRowAsIcebergRecord;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.GenericRow;
 import org.apache.fluss.row.InternalRow;
-import org.apache.fluss.types.DataField;
 import org.apache.fluss.types.DataType;
-import org.apache.fluss.types.DataTypes;
 import org.apache.fluss.types.RowType;
 
 import org.apache.iceberg.PartitionField;
@@ -34,12 +32,10 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.fluss.metadata.ResolvedPartitionSpec.PARTITION_SPEC_SEPARATOR;
@@ -93,55 +89,12 @@ public class IcebergConversions {
         return expression;
     }
 
-    public static Object toIcebergLiteral(Types.NestedField field, Object flussLiteral) {
+    public static Object toIcebergLiteral(
+            Types.NestedField icebergField, DataType flussFieldType, Object flussLiteral) {
         InternalRow flussRow = GenericRow.of(flussLiteral);
         FlussRowAsIcebergRecord flussRowAsIcebergRecord =
                 new FlussRowAsIcebergRecord(
-                        Types.StructType.of(field),
-                        RowType.of(convertIcebergTypeToFlussType(field.type())),
-                        flussRow);
-        return flussRowAsIcebergRecord.get(0, field.type().typeId().javaClass());
-    }
-
-    /** Converts Iceberg data types to Fluss data types. */
-    private static DataType convertIcebergTypeToFlussType(Type icebergType) {
-        if (icebergType instanceof Types.BooleanType) {
-            return DataTypes.BOOLEAN();
-        } else if (icebergType instanceof Types.IntegerType) {
-            return DataTypes.INT();
-        } else if (icebergType instanceof Types.LongType) {
-            return DataTypes.BIGINT();
-        } else if (icebergType instanceof Types.DoubleType) {
-            return DataTypes.DOUBLE();
-        } else if (icebergType instanceof Types.TimeType) {
-            return DataTypes.TIME();
-        } else if (icebergType instanceof Types.TimestampType) {
-            Types.TimestampType timestampType = (Types.TimestampType) icebergType;
-            if (timestampType.shouldAdjustToUTC()) {
-                return DataTypes.TIMESTAMP_LTZ();
-            } else {
-                return DataTypes.TIMESTAMP();
-            }
-        } else if (icebergType instanceof Types.StringType) {
-            return DataTypes.STRING();
-        } else if (icebergType instanceof Types.DecimalType) {
-            Types.DecimalType decimalType = (Types.DecimalType) icebergType;
-            return DataTypes.DECIMAL(decimalType.precision(), decimalType.scale());
-        } else if (icebergType instanceof Types.ListType) {
-            Types.ListType listType = (Types.ListType) icebergType;
-            return DataTypes.ARRAY(convertIcebergTypeToFlussType(listType.elementType()));
-        } else if (icebergType.isStructType()) {
-            Types.StructType structType = icebergType.asStructType();
-            List<DataField> fields = new ArrayList<>();
-            for (Types.NestedField nestedField : structType.fields()) {
-                DataType fieldType = convertIcebergTypeToFlussType(nestedField.type());
-                fields.add(new DataField(nestedField.name(), fieldType));
-            }
-            return DataTypes.ROW(fields.toArray(new DataField[0]));
-        }
-
-        throw new UnsupportedOperationException(
-                "Unsupported data type conversion for Iceberg type: "
-                        + icebergType.getClass().getName());
+                        Types.StructType.of(icebergField), RowType.of(flussFieldType), flussRow);
+        return flussRowAsIcebergRecord.get(0, icebergField.type().typeId().javaClass());
     }
 }

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSourceTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSourceTest.java
@@ -66,7 +66,10 @@ class IcebergLakeSourceTest extends IcebergSourceTestBase {
             PartitionSpec.builderFor(SCHEMA).bucket("id", DEFAULT_BUCKET_NUM).build();
 
     private static final PredicateBuilder FLUSS_BUILDER =
-            new PredicateBuilder(RowType.of(DataTypes.BIGINT(), DataTypes.STRING()));
+            new PredicateBuilder(RowType.of(DataTypes.INT(), DataTypes.STRING()));
+
+    private static final PredicateBuilder FLUSS_BUILDER_TINYINT =
+            new PredicateBuilder(RowType.of(DataTypes.TINYINT(), DataTypes.STRING()));
 
     @BeforeAll
     protected static void beforeAll() {
@@ -156,5 +159,54 @@ class IcebergLakeSourceTest extends IcebergSourceTestBase {
         assertThat(filterPushDownResult.acceptedPredicates()).isEmpty();
         assertThat(filterPushDownResult.remainingPredicates().toString())
                 .isEqualTo(allFilters.toString());
+    }
+
+    @Test
+    void testWithTinyIntFilter() throws Exception {
+        TablePath tablePath = TablePath.of("fluss", "test_filters_tinyint");
+        createTable(tablePath, SCHEMA, PARTITION_SPEC);
+
+        Table table = getTable(tablePath);
+        List<Record> rows = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            rows.add(
+                    createIcebergRecord(
+                            SCHEMA,
+                            i,
+                            "name" + i,
+                            0,
+                            (long) i,
+                            OffsetDateTime.now(ZoneOffset.UTC)));
+        }
+        writeRecord(table, rows, null, 0);
+        table.refresh();
+
+        // pass Byte literal (not Integer) to exercise the Fluss TINYINT -> Iceberg int path
+        Predicate filter1 = FLUSS_BUILDER_TINYINT.greaterOrEqual(0, (byte) 2);
+        Predicate filter2 = FLUSS_BUILDER_TINYINT.lessOrEqual(0, (byte) 3);
+        List<Predicate> allFilters = Arrays.asList(filter1, filter2);
+
+        LakeSource<IcebergSplit> lakeSource = lakeStorage.createLakeSource(tablePath);
+        LakeSource.FilterPushDownResult filterPushDownResult = lakeSource.withFilters(allFilters);
+        assertThat(filterPushDownResult.acceptedPredicates()).isEqualTo(allFilters);
+        assertThat(filterPushDownResult.remainingPredicates()).isEmpty();
+
+        List<IcebergSplit> icebergSplits =
+                lakeSource.createPlanner(() -> table.currentSnapshot().snapshotId()).plan();
+        assertThat(icebergSplits).hasSize(1);
+        IcebergSplit icebergSplit = icebergSplits.get(0);
+
+        List<Row> actual = new ArrayList<>();
+        org.apache.fluss.row.InternalRow.FieldGetter[] fieldGetters =
+                org.apache.fluss.row.InternalRow.createFieldGetters(
+                        RowType.of(new IntType(), new StringType()));
+        RecordReader recordReader = lakeSource.createRecordReader(() -> icebergSplit);
+        try (CloseableIterator<LogRecord> iterator = recordReader.read()) {
+            actual.addAll(
+                    convertToFlinkRow(
+                            fieldGetters,
+                            TransformingCloseableIterator.transform(iterator, LogRecord::getRow)));
+        }
+        assertThat(actual.toString()).isEqualTo("[+I[2, name2], +I[3, name3]]");
     }
 }


### PR DESCRIPTION
## Purpose

`IcebergLakeSource#withFilters` silently drops predicates on columns whose Fluss type is not identical to its Iceberg storage type — most notably **TINYINT** and **SMALLINT** (both stored as Iceberg `int`), and also **FLOAT**, **CHAR**, **BINARY**/**BYTES**, **DATE**.

Root cause: `IcebergConversions#toIcebergLiteral` used a hand-written **Iceberg → Fluss** reverse type mapper (`convertIcebergTypeToFlussType`) to reinterpret the Fluss literal via `FlussRowAsIcebergRecord`. That mapping is:

- **lossy** — Iceberg `int` reversed to Fluss becomes `INT`, never `TINYINT`/`SMALLINT`; Iceberg `string` becomes `STRING`, never `CHAR`.
- **incomplete** — no branch for `FLOAT`, `DATE`, `BINARY`; the reverse mapper simply throws.

Concrete failure with `WHERE tinyint_col = <byte>`:

```
reversed type = INT → FlussRowAsIcebergRecord picks getInt branch
GenericRow.getInt is (Integer) fields[pos], but the value is a Byte
→ ClassCastException → predicate rejected → withFilters returns accepted=0
→ Iceberg planner receives filter=null → full scan
```

Since `LeafPredicate` (via `FieldRef#type()`) already carries the **original Fluss `DataType`**, the fix is simply to pass it through and let `FlussRowAsIcebergRecord`'s existing per-Fluss-type converter — which already covers the entire Fluss type system — handle the value, dropping the reverse mapper entirely.

## How to Reproduce

```sql
CREATE TABLE `fluss_catalog`.`fluss`.`t_all` (
  `f_boolean` BOOLEAN,
  `f_byte` TINYINT,
  `f_short` SMALLINT,
  `f_int` INT,
  `f_long` BIGINT,
  `f_string` VARCHAR(2147483647)
) WITH (
  'table.replication.factor' = '1',
  'table.datalake.format' = 'iceberg',
  'table.datalake.freshness' = '500ms',
  'table.datalake.iceberg.type' = 'hadoop',
  'table.datalake.enabled' = 'true',
  'bucket.num' = '1',
  'bootstrap.servers' = 'localhost:9123',
  'table.datalake.iceberg.warehouse' = '/tmp/iceberg'
)

INSERT INTO `fluss_catalog`.`fluss`.`t_all` VALUES
  (TRUE,  CAST(1 AS TINYINT), CAST(10 AS SMALLINT), 100, CAST(1000 AS BIGINT), 'hello'),
  (FALSE, CAST(2 AS TINYINT), CAST(20 AS SMALLINT), 200, CAST(2000 AS BIGINT), 'world'),
  (TRUE,  CAST(3 AS TINYINT), CAST(30 AS SMALLINT), 300, CAST(3000 AS BIGINT), 'fluss');

SELECT * FROM t_all WHERE f_byte = CAST(100 AS TINYINT);
```

```
[ERROR] Could not execute SQL statement. Reason:
java.lang.ClassCastException: class java.lang.Byte cannot be cast to class java.lang.Integer (java.lang.Byte and java.lang.Integer are in module java.base of loader 'bootstrap')
```

## Brief change log

- **`IcebergConversions.toIcebergLiteral`** — new signature `(NestedField icebergField, DataType flussFieldType, Object flussLiteral)`; the caller now passes the source column's original Fluss type through.
- **Removed** `IcebergConversions#convertIcebergTypeToFlussType` — the lossy reverse mapper.
- **Removed** `IcebergConversions#alignNumericLiteralToIcebergType` — a partial patch for TINYINT/SMALLINT that becomes redundant once the correct Fluss-side converter is selected.
- **`FlussToIcebergPredicateConverter#convertToIcebergLiteral`** — updated to `convertToIcebergLiteral(FieldRef fieldRef, Object literal)` and forwards `fieldRef.type()`; all 8 leaf visitor call sites (`visitEqual` / `visitNotEqual` / `visitGreater{Than,OrEqual}` / `visitLess{Than,OrEqual}` / `visitIn` / `visitNotIn` / `visitStartsWith`) updated accordingly.
- **Fixed** a latent test-side type inconsistency in `IcebergLakeSourceTest#testWithFilters`: the `FLUSS_BUILDER` used to declare column 0 as `BIGINT` for a column stored in Iceberg as `int` — this used to be masked by the reverse-mapping "self-correction". Aligned to `INT` so the test now reflects real production shape.

## Tests

- **New** `IcebergLakeSourceTest#testWithTinyIntFilter`
  - Reuses the existing `SCHEMA` / `PARTITION_SPEC` (Iceberg has no TINYINT — production tiering also stores Fluss TINYINT as Iceberg `IntegerType`, exactly what the shared schema models).
  - Adds a static `FLUSS_BUILDER_TINYINT` declaring column 0 as `DataTypes.TINYINT()`.
  - Uses **`Byte`** literals (`(byte) 2`, `(byte) 3`) — the exact shape that used to trigger the CCE.
  - Asserts both push-down (`acceptedPredicates == allFilters`, `remainingPredicates` empty) and end-to-end scan (`[+I[2, name2], +I[3, name3]]`).

## Benefit

1. We can now do the SQL correctly.

```sql
SELECT * FROM t_all WHERE f_byte = CAST(100 AS TINYINT);
```

2. We can push down to iceberg

```
explain SELECT * FROM t_all WHERE f_byte = 100;

| == Abstract Syntax Tree ==
LogicalProject(f_boolean=[$0], f_byte=[$1], f_short=[$2], f_int=[$3], f_long=[$4], f_string=[$5])
+- LogicalFilter(condition=[=(CAST($1):INTEGER, 100)])
   +- LogicalTableScan(table=[[fluss_catalog, fluss, t_all]])

== Optimized Physical Plan ==
Calc(select=[f_boolean, CAST(100:TINYINT AS TINYINT) AS f_byte, f_short, f_int, f_long, f_string], where=[=(CAST(f_byte AS INTEGER), 100)])
+- TableSourceScan(table=[[fluss_catalog, fluss, t_all, filter=[]]], fields=[f_boolean, f_byte, f_short, f_int, f_long, f_string])

== Optimized Execution Plan ==
Calc(select=[f_boolean, CAST(100 AS TINYINT) AS f_byte, f_short, f_int, f_long, f_string], where=[(CAST(f_byte AS INTEGER) = 100)])
+- TableSourceScan(table=[[fluss_catalog, fluss, t_all, filter=[]]], fields=[f_boolean, f_byte, f_short, f_int, f_long, f_string])
```
Push-down is not supported here because the parser applies a cast to the field, which is out of the scope of this PR.

```
explain SELECT * FROM t_all WHERE f_byte = CAST(100 AS TINYINT);

| == Abstract Syntax Tree ==
LogicalProject(f_boolean=[$0], f_byte=[$1], f_short=[$2], f_int=[$3], f_long=[$4], f_string=[$5])
+- LogicalFilter(condition=[=($1, 100)])
   +- LogicalTableScan(table=[[fluss_catalog, fluss, t_all]])

== Optimized Physical Plan ==
Calc(select=[f_boolean, CAST(100:TINYINT AS TINYINT) AS f_byte, f_short, f_int, f_long, f_string], where=[=(f_byte, 100:TINYINT)])
+- TableSourceScan(table=[[fluss_catalog, fluss, t_all, filter=[=(f_byte, 100:TINYINT)]]], fields=[f_boolean, f_byte, f_short, f_int, f_long, f_string])

== Optimized Execution Plan ==
Calc(select=[f_boolean, CAST(100 AS TINYINT) AS f_byte, f_short, f_int, f_long, f_string], where=[(f_byte = 100)])
+- TableSourceScan(table=[[fluss_catalog, fluss, t_all, filter=[=(f_byte, 100:TINYINT)]]], fields=[f_boolean, f_byte, f_short, f_int, f_long, f_string])
```

We can get `filter=[=(f_byte, 100:TINYINT)]` in TableSourceScan for the push down.

## API and Format

## Documentation
