### PR TITLE
[lake/lance] Add byte-based flush threshold to LanceLakeWriter

### DIFF
--- a/fluss-lake/fluss-lake-lance/src/main/java/org/apache/fluss/lake/lance/LanceConfig.java
+++ b/fluss-lake/fluss-lake-lance/src/main/java/org/apache/fluss/lake/lance/LanceConfig.java
@@ -36,6 +36,7 @@ public class LanceConfig implements Serializable {
     private static final String max_rows_per_group = "max_rows_per_group";
     private static final String max_bytes_per_file = "max_bytes_per_file";
     private static final String batch_size = "batch_size";
+    private static final String max_bytes_per_batch = "max_bytes_per_batch";
     private static final String warehouse = "warehouse";
 
     private final Map<String, String> options;
@@ -75,6 +76,31 @@ public class LanceConfig implements Serializable {
             return Integer.parseInt(options.get(batch_size));
         }
         return 512;
+    }
+
+    /**
+     * Returns the byte-based flush threshold for the tiering writer.
+     *
+     * <p>When a row-batch's underlying Arrow off-heap allocation reaches (or exceeds) this many
+     * bytes, {@link org.apache.fluss.lake.lance.tiering.LanceLakeWriter} will flush the batch as a
+     * new Lance fragment even if {@link #getBatchSize(LanceConfig)} rows have not yet been
+     * accumulated. This lets operators cap peak memory when rows are wide, and increase throughput
+     * when rows are very narrow.
+     *
+     * <p>A value of {@code 0} (the default) disables byte-based flushing and preserves the
+     * historical row-count-only behavior.
+     */
+    public static long getMaxBytesPerBatch(LanceConfig config) {
+        Map<String, String> options = config.getOptions();
+        if (options.containsKey(max_bytes_per_batch)) {
+            long v = Long.parseLong(options.get(max_bytes_per_batch));
+            if (v < 0) {
+                throw new IllegalArgumentException(
+                        "'max_bytes_per_batch' must be non-negative, but was " + v);
+            }
+            return v;
+        }
+        return 0L;
     }
 
     public Map<String, String> getOptions() {

--- a/fluss-lake/fluss-lake-lance/src/main/java/org/apache/fluss/lake/lance/tiering/LanceLakeWriter.java
+++ b/fluss-lake/fluss-lake-lance/src/main/java/org/apache/fluss/lake/lance/tiering/LanceLakeWriter.java
@@ -47,6 +47,7 @@ public class LanceLakeWriter implements LakeWriter<LanceWriteResult> {
     private final Schema nonShadedSchema;
     private final RowType rowType;
     private final int batchSize;
+    private final long maxBytesPerBatch;
     private final String datasetUri;
     private final WriteParams writeParams;
 
@@ -63,6 +64,7 @@ public class LanceLakeWriter implements LakeWriter<LanceWriteResult> {
                         writerInitContext.tablePath().getTableName());
 
         this.batchSize = LanceConfig.getBatchSize(config);
+        this.maxBytesPerBatch = LanceConfig.getMaxBytesPerBatch(config);
         this.datasetUri = config.getDatasetUri();
         this.writeParams = LanceConfig.genWriteParamsFromConfig(config);
         this.rowType = writerInitContext.tableInfo().getRowType();
@@ -83,10 +85,25 @@ public class LanceLakeWriter implements LakeWriter<LanceWriteResult> {
     public void write(LogRecord record) throws IOException {
         arrowWriter.writeRow(record.getRow());
 
-        if (arrowWriter.getRecordsCount() >= batchSize) {
+        if (shouldFlush()) {
             List<FragmentMetadata> fragments = flush();
             allFragments.addAll(fragments);
         }
+    }
+
+    private boolean shouldFlush() {
+        int recordsCount = arrowWriter.getRecordsCount();
+        if (recordsCount >= batchSize) {
+            return true;
+        }
+        if (maxBytesPerBatch > 0
+                && arrowWriter.getShadedRoot().getFieldVectors().stream()
+                                .mapToLong(v -> v.getBufferSizeFor(recordsCount))
+                                .sum()
+                        >= maxBytesPerBatch) {
+            return true;
+        }
+        return false;
     }
 
     private List<FragmentMetadata> flush() throws IOException {

--- a/fluss-lake/fluss-lake-lance/src/test/java/org/apache/fluss/lake/lance/LanceConfigTest.java
+++ b/fluss-lake/fluss-lake-lance/src/test/java/org/apache/fluss/lake/lance/LanceConfigTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.lance;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link LanceConfig}. */
+class LanceConfigTest {
+
+    @Test
+    void testGetBatchSizeDefault() {
+        Map<String, String> cluster = new HashMap<>();
+        cluster.put("warehouse", "/tmp/lance");
+        LanceConfig config = LanceConfig.from(cluster, Collections.emptyMap(), "db", "t");
+        assertThat(LanceConfig.getBatchSize(config)).isEqualTo(512);
+    }
+
+    @Test
+    void testGetBatchSizeOverride() {
+        Map<String, String> cluster = new HashMap<>();
+        cluster.put("warehouse", "/tmp/lance");
+        Map<String, String> tableProps = new HashMap<>();
+        tableProps.put("batch_size", "128");
+        LanceConfig config = LanceConfig.from(cluster, tableProps, "db", "t");
+        assertThat(LanceConfig.getBatchSize(config)).isEqualTo(128);
+    }
+
+    @Test
+    void testGetMaxBytesPerBatchDefault() {
+        Map<String, String> cluster = new HashMap<>();
+        cluster.put("warehouse", "/tmp/lance");
+        LanceConfig config = LanceConfig.from(cluster, Collections.emptyMap(), "db", "t");
+        assertThat(LanceConfig.getMaxBytesPerBatch(config)).isZero();
+    }
+
+    @Test
+    void testGetMaxBytesPerBatchOverride() {
+        Map<String, String> cluster = new HashMap<>();
+        cluster.put("warehouse", "/tmp/lance");
+        Map<String, String> tableProps = new HashMap<>();
+        tableProps.put("max_bytes_per_batch", "1048576");
+        LanceConfig config = LanceConfig.from(cluster, tableProps, "db", "t");
+        assertThat(LanceConfig.getMaxBytesPerBatch(config)).isEqualTo(1_048_576L);
+    }
+
+    @Test
+    void testGetMaxBytesPerBatchZeroExplicit() {
+        Map<String, String> cluster = new HashMap<>();
+        cluster.put("warehouse", "/tmp/lance");
+        Map<String, String> tableProps = new HashMap<>();
+        tableProps.put("max_bytes_per_batch", "0");
+        LanceConfig config = LanceConfig.from(cluster, tableProps, "db", "t");
+        assertThat(LanceConfig.getMaxBytesPerBatch(config)).isZero();
+    }
+
+    @Test
+    void testGetMaxBytesPerBatchNegativeRejected() {
+        Map<String, String> cluster = new HashMap<>();
+        cluster.put("warehouse", "/tmp/lance");
+        Map<String, String> tableProps = new HashMap<>();
+        tableProps.put("max_bytes_per_batch", "-1");
+        LanceConfig config = LanceConfig.from(cluster, tableProps, "db", "t");
+        assertThatThrownBy(() -> LanceConfig.getMaxBytesPerBatch(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be non-negative");
+    }
+
+    @Test
+    void testGetMaxBytesPerBatchInvalidRejected() {
+        Map<String, String> cluster = new HashMap<>();
+        cluster.put("warehouse", "/tmp/lance");
+        Map<String, String> tableProps = new HashMap<>();
+        tableProps.put("max_bytes_per_batch", "not-a-number");
+        LanceConfig config = LanceConfig.from(cluster, tableProps, "db", "t");
+        assertThatThrownBy(() -> LanceConfig.getMaxBytesPerBatch(config))
+                .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    void testMissingWarehouseRejected() {
+        assertThatThrownBy(
+                        () ->
+                                LanceConfig.from(
+                                        Collections.emptyMap(), Collections.emptyMap(), "db", "t"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("warehouse");
+    }
+}


### PR DESCRIPTION

Introduce a new `max_bytes_per_batch` Lance table property (default `0`, meaning disabled) that lets the tiering writer flush a batch as soon as its underlying Arrow off-heap allocation reaches the configured number of bytes, in addition to the existing `batch_size` row-count threshold.

**Motivation:**

- With very wide rows (long strings, large binary/vector columns) the row-count threshold under-flushes, driving peak allocator memory too high.
- With very narrow rows the row-count threshold over-flushes and produces many tiny fragments, hurting Lance read performance.

**Behavior:**

- `batch_size` semantics are preserved (defaults to `512` rows).
- `max_bytes_per_batch` defaults to `0`, which fully preserves the previous row-count-only behavior — no change for existing tables.
- When `max_bytes_per_batch > 0`, `LanceLakeWriter` flushes as soon as *either* the row count reaches `batch_size` *or* the accumulated Arrow field-vector buffer size for the current row count reaches `max_bytes_per_batch`, whichever comes first.
- Negative values are rejected at config parse time with `IllegalArgumentException`.

## Purpose

Give operators a byte-oriented knob to control when `LanceLakeWriter` flushes an in-flight row batch to Lance, in addition to the existing row-count threshold. A fixed row-count threshold works poorly across mixed workloads (see Motivation). This aligns Lance tiering with how Iceberg/Paimon writers already expose byte-based flush controls, and bounds peak allocator memory during tiering.

Linked issue: close #xxx

## Brief change log

- `LanceConfig`: introduce the `max_bytes_per_batch` option and a `getMaxBytesPerBatch(config)` helper. Default is `0` (disabled). Negative values are rejected with `IllegalArgumentException`.
- `LanceLakeWriter`: add a `maxBytesPerBatch` field and extract a `shouldFlush()` helper called from `write()`. `shouldFlush()` returns true when the row count reaches `batch_size`, or (when `maxBytesPerBatch > 0`) when the buffer size reported by `VectorSchemaRoot#getBufferSizeFor(recordsCount)` reaches `maxBytesPerBatch`. Uses `getBufferSizeFor(recordsCount)` rather than `getValueCount()` so the check is valid before `finish()` has propagated the row count to the vectors.
- Add `LanceConfigTest` with 8 test methods covering default / override / zero-explicit / negative / invalid / missing-warehouse paths for both `batch_size` and `max_bytes_per_batch`.

## Tests

- New `LanceConfigTest` (8 tests) covers all parsing branches for the two thresholds.
- Existing `LanceTieringTest`, `LanceArrowUtilsTest`, and `ArrowDataConverterTest` continue to pass unchanged.
- Full module run: `./mvnw -pl fluss-lake/fluss-lake-lance clean test -Dspotless.check.skip` — 27/27 pass.
- Checkstyle: `./mvnw -pl fluss-lake/fluss-lake-lance checkstyle:check` — 0 violations.

## API and Format

- No public Java API changes.
- New table property `max_bytes_per_batch` on Lance-tiered tables. Default `0` (disabled) keeps existing tables' behavior identical, so this change is backward compatible.
- `batch_size` semantics are preserved (default `512` rows).
- No wire format, on-disk format, or Lance dataset format changes.

## Documentation

- The new property is documented via inline Javadoc on `LanceConfig#getMaxBytesPerBatch`, describing its default, its interaction with `batch_size`, and the sizing rationale (wide-row memory cap vs. narrow-row fragmentation).
- No user-facing site docs update is bundled here since the Lance tiering config surface is not yet documented on the Fluss site; a follow-up docs PR can pick this up together with other Lance properties.
