### PR TITLE
[lake/lance] Add tests for Decimal and Timestamp(LTZ) conversions

### DIFF
--- a/fluss-lake/fluss-lake-lance/src/test/java/org/apache/fluss/lake/lance/utils/ArrowDataConverterTest.java
+++ b/fluss-lake/fluss-lake-lance/src/test/java/org/apache/fluss/lake/lance/utils/ArrowDataConverterTest.java
@@ -20,11 +20,15 @@ package org.apache.fluss.lake.lance.utils;
 import org.apache.fluss.lake.lance.tiering.ShadedArrowBatchWriter;
 import org.apache.fluss.row.GenericArray;
 import org.apache.fluss.row.GenericRow;
+import org.apache.fluss.row.TimestampLtz;
 import org.apache.fluss.types.DataTypes;
 import org.apache.fluss.types.RowType;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -32,6 +36,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -191,6 +197,99 @@ class ArrowDataConverterTest {
                 assertThat((Float) values2.get(0)).isEqualTo(7.0f);
                 assertThat((Float) values2.get(1)).isEqualTo(8.0f);
                 assertThat((Float) values2.get(2)).isEqualTo(9.0f);
+            }
+        }
+    }
+
+    @Test
+    void testConvertDecimalColumn() {
+        RowType rowType = DataTypes.ROW(DataTypes.FIELD("amount", DataTypes.DECIMAL(20, 4)));
+        Schema nonShadedSchema = LanceArrowUtils.toArrowSchema(rowType);
+
+        BigDecimal[] data = {
+            new BigDecimal("1234567890.1234"),
+            new BigDecimal("-9876543210.9876"),
+            new BigDecimal("0.0001")
+        };
+
+        try (ShadedArrowBatchWriter writer = new ShadedArrowBatchWriter(shadedAllocator, rowType)) {
+            for (BigDecimal value : data) {
+                GenericRow row = new GenericRow(1);
+                row.setField(0, org.apache.fluss.row.Decimal.fromBigDecimal(value, 20, 4));
+                writer.writeRow(row);
+            }
+            writer.finish();
+
+            try (VectorSchemaRoot nonShadedRoot =
+                    ArrowDataConverter.convertToNonShaded(
+                            writer.getShadedRoot(), nonShadedAllocator, nonShadedSchema)) {
+                assertThat(nonShadedRoot.getRowCount()).isEqualTo(data.length);
+                DecimalVector vector = (DecimalVector) nonShadedRoot.getVector("amount");
+                for (int i = 0; i < data.length; i++) {
+                    // BigDecimal.compareTo ignores scale representation but preserves value.
+                    assertThat(vector.getObject(i)).isEqualByComparingTo(data[i]);
+                }
+            }
+        }
+    }
+
+    @Test
+    void testConvertTimestampLtzMillisColumn() {
+        RowType rowType = DataTypes.ROW(DataTypes.FIELD("event_time", DataTypes.TIMESTAMP_LTZ(3)));
+        Schema nonShadedSchema = LanceArrowUtils.toArrowSchema(rowType);
+
+        long[] millis = {1_700_000_000_000L, 1_700_000_001_000L, 1_700_000_002_500L};
+
+        try (ShadedArrowBatchWriter writer = new ShadedArrowBatchWriter(shadedAllocator, rowType)) {
+            for (long ms : millis) {
+                GenericRow row = new GenericRow(1);
+                row.setField(0, TimestampLtz.fromEpochMillis(ms));
+                writer.writeRow(row);
+            }
+            writer.finish();
+
+            try (VectorSchemaRoot nonShadedRoot =
+                    ArrowDataConverter.convertToNonShaded(
+                            writer.getShadedRoot(), nonShadedAllocator, nonShadedSchema)) {
+                assertThat(nonShadedRoot.getRowCount()).isEqualTo(millis.length);
+                TimeStampMilliVector vector =
+                        (TimeStampMilliVector) nonShadedRoot.getVector("event_time");
+                for (int i = 0; i < millis.length; i++) {
+                    assertThat(vector.get(i)).isEqualTo(millis[i]);
+                }
+            }
+        }
+    }
+
+    @Test
+    void testConvertTimestampLtzMicrosColumn() {
+        RowType rowType = DataTypes.ROW(DataTypes.FIELD("event_time", DataTypes.TIMESTAMP_LTZ(6)));
+        Schema nonShadedSchema = LanceArrowUtils.toArrowSchema(rowType);
+
+        long[] millis = {1_700_000_000_000L, 1_700_000_000_123L};
+        int[] nanoOfMillis = {456_000, 789_000};
+
+        try (ShadedArrowBatchWriter writer = new ShadedArrowBatchWriter(shadedAllocator, rowType)) {
+            for (int i = 0; i < millis.length; i++) {
+                GenericRow row = new GenericRow(1);
+                row.setField(
+                        0,
+                        TimestampLtz.fromInstant(
+                                Instant.ofEpochMilli(millis[i]).plusNanos(nanoOfMillis[i])));
+                writer.writeRow(row);
+            }
+            writer.finish();
+
+            try (VectorSchemaRoot nonShadedRoot =
+                    ArrowDataConverter.convertToNonShaded(
+                            writer.getShadedRoot(), nonShadedAllocator, nonShadedSchema)) {
+                assertThat(nonShadedRoot.getRowCount()).isEqualTo(millis.length);
+                TimeStampMicroVector vector =
+                        (TimeStampMicroVector) nonShadedRoot.getVector("event_time");
+                for (int i = 0; i < millis.length; i++) {
+                    long expectedMicros = millis[i] * 1_000L + nanoOfMillis[i] / 1_000L;
+                    assertThat(vector.get(i)).isEqualTo(expectedMicros);
+                }
             }
         }
     }

--- a/fluss-lake/fluss-lake-lance/src/test/java/org/apache/fluss/lake/lance/utils/LanceArrowUtilsTest.java
+++ b/fluss-lake/fluss-lake-lance/src/test/java/org/apache/fluss/lake/lance/utils/LanceArrowUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.fluss.lake.lance.utils;
 import org.apache.fluss.types.DataTypes;
 import org.apache.fluss.types.RowType;
 
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -297,5 +298,69 @@ class LanceArrowUtilsTest {
         assertThat(tagsChildren).hasSize(1);
         assertThat(tagsChildren.get(0).getName()).isEqualTo("element");
         assertThat(tagsChildren.get(0).getType()).isEqualTo(ArrowType.Utf8.INSTANCE);
+    }
+
+    @Test
+    void testToArrowSchemaWithDecimal() {
+        RowType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("small_dec", DataTypes.DECIMAL(9, 2)),
+                        DataTypes.FIELD("large_dec", DataTypes.DECIMAL(20, 4)));
+
+        Schema schema = LanceArrowUtils.toArrowSchema(rowType);
+
+        Field smallField = schema.findField("small_dec");
+        assertThat(smallField.getType()).isInstanceOf(ArrowType.Decimal.class);
+        ArrowType.Decimal smallDec = (ArrowType.Decimal) smallField.getType();
+        assertThat(smallDec.getPrecision()).isEqualTo(9);
+        assertThat(smallDec.getScale()).isEqualTo(2);
+
+        Field largeField = schema.findField("large_dec");
+        assertThat(largeField.getType()).isInstanceOf(ArrowType.Decimal.class);
+        ArrowType.Decimal largeDec = (ArrowType.Decimal) largeField.getType();
+        assertThat(largeDec.getPrecision()).isEqualTo(20);
+        assertThat(largeDec.getScale()).isEqualTo(4);
+    }
+
+    @Test
+    void testToArrowSchemaWithTimestampLtz() {
+        RowType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("ts_sec", DataTypes.TIMESTAMP_LTZ(0)),
+                        DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP_LTZ(3)),
+                        DataTypes.FIELD("ts_us", DataTypes.TIMESTAMP_LTZ(6)),
+                        DataTypes.FIELD("ts_ns", DataTypes.TIMESTAMP_LTZ(9)));
+
+        Schema schema = LanceArrowUtils.toArrowSchema(rowType);
+
+        assertThat(((ArrowType.Timestamp) schema.findField("ts_sec").getType()).getUnit())
+                .isEqualTo(TimeUnit.SECOND);
+        assertThat(((ArrowType.Timestamp) schema.findField("ts_ms").getType()).getUnit())
+                .isEqualTo(TimeUnit.MILLISECOND);
+        assertThat(((ArrowType.Timestamp) schema.findField("ts_us").getType()).getUnit())
+                .isEqualTo(TimeUnit.MICROSECOND);
+        assertThat(((ArrowType.Timestamp) schema.findField("ts_ns").getType()).getUnit())
+                .isEqualTo(TimeUnit.NANOSECOND);
+    }
+
+    @Test
+    void testToArrowSchemaWithTimestampNtz() {
+        RowType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("ts_sec", DataTypes.TIMESTAMP(0)),
+                        DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP(3)),
+                        DataTypes.FIELD("ts_us", DataTypes.TIMESTAMP(6)),
+                        DataTypes.FIELD("ts_ns", DataTypes.TIMESTAMP(9)));
+
+        Schema schema = LanceArrowUtils.toArrowSchema(rowType);
+
+        assertThat(((ArrowType.Timestamp) schema.findField("ts_sec").getType()).getUnit())
+                .isEqualTo(TimeUnit.SECOND);
+        assertThat(((ArrowType.Timestamp) schema.findField("ts_ms").getType()).getUnit())
+                .isEqualTo(TimeUnit.MILLISECOND);
+        assertThat(((ArrowType.Timestamp) schema.findField("ts_us").getType()).getUnit())
+                .isEqualTo(TimeUnit.MICROSECOND);
+        assertThat(((ArrowType.Timestamp) schema.findField("ts_ns").getType()).getUnit())
+                .isEqualTo(TimeUnit.NANOSECOND);
     }
 }


### PR DESCRIPTION

Extend Lance test coverage for Decimal and Timestamp/TimestampLtz mappings on both the Fluss RowType -> non-shaded Arrow schema layer (`LanceArrowUtils`) and the shaded -> non-shaded `VectorSchemaRoot` copy layer (`ArrowDataConverter`):

- **`LanceArrowUtilsTest`**: assert Arrow type for `DECIMAL(9,2)` / `DECIMAL(20,4)` including precision and scale round-trip; assert `TimeUnit` selection for `TIMESTAMP_LTZ(0/3/6/9)` and `TIMESTAMP(0/3/6/9)`.
- **`ArrowDataConverterTest`**: end-to-end conversion of `DECIMAL(20,4)` values through `ShadedArrowBatchWriter` into a non-shaded `DecimalVector`, and `TIMESTAMP_LTZ(3)` / `TIMESTAMP_LTZ(6)` columns into `TimeStampMilliVector` and `TimeStampMicroVector` respectively, including sub-millisecond precision truncation semantics.

These types are common in financial and event-time workloads; adding explicit coverage guards against future regressions in the Lance tiering path.

## Purpose

Lance tiering already handles `DECIMAL`, `TIMESTAMP` and `TIMESTAMP_LTZ` in production code, but the existing unit tests did not directly exercise:

1. The precision/scale round-trip for `DECIMAL` on the shaded -> non-shaded schema mapping,
2. The `TimeUnit` selection rules (SECOND / MILLISECOND / MICROSECOND / NANOSECOND) for `TIMESTAMP` and `TIMESTAMP_LTZ` at every supported precision (`0/3/6/9`),
3. The end-to-end value conversion from Fluss `Decimal` / `TimestampLtz` through `ShadedArrowBatchWriter` into the corresponding non-shaded Arrow vectors (including sub-millisecond truncation for `TIMESTAMP_LTZ(3)` and microsecond preservation for `TIMESTAMP_LTZ(6)`).

This PR closes that gap so that any future refactor of `LanceArrowUtils` or `ArrowDataConverter` will surface regressions on these two commonly-used-in-production types immediately.

Linked issue: close #xxx

## Brief change log

Test-only change. No production code is touched.

- `LanceArrowUtilsTest`: add three tests (+65 lines)
  - `testToArrowSchemaWithDecimal` — asserts `ArrowType.Decimal(9,2)` and `ArrowType.Decimal(20,4)` are produced for the corresponding Fluss types.
  - `testToArrowSchemaWithTimestampLtz` — asserts `TIMESTAMP_LTZ(0/3/6/9)` maps to Arrow `Timestamp` with `SECOND` / `MILLISECOND` / `MICROSECOND` / `NANOSECOND`.
  - `testToArrowSchemaWithTimestampNtz` — same coverage for `TIMESTAMP(0/3/6/9)` (no time zone).
- `ArrowDataConverterTest`: add three tests (+104 lines)
  - `testConvertDecimalColumn` — writes three `DECIMAL(20,4)` values (positive / negative / very small) via `ShadedArrowBatchWriter`, converts to a non-shaded `VectorSchemaRoot`, and verifies each value using `BigDecimal.compareTo` on `DecimalVector#getObject`.
  - `testConvertTimestampLtzMillisColumn` — writes three `TIMESTAMP_LTZ(3)` values built with `TimestampLtz.fromEpochMillis` and asserts round-trip via `TimeStampMilliVector#get`.
  - `testConvertTimestampLtzMicrosColumn` — writes `TIMESTAMP_LTZ(6)` values with sub-millisecond components (`Instant.ofEpochMilli(...).plusNanos(...)`) and asserts the expected microsecond value in `TimeStampMicroVector` (i.e. `millis * 1_000 + nanoOfMillis / 1_000`), locking in the truncation semantics.

## Tests

New tests are the deliverable of this PR. Verified locally:

- `./mvnw -pl fluss-lake/fluss-lake-lance test -Dspotless.check.skip` — all Lance tests pass, including the 6 new ones.
- `./mvnw -pl fluss-lake/fluss-lake-lance checkstyle:check` — 0 violations.

No production behavior change; existing tests are unchanged.

## API and Format

None. This PR only adds tests under `src/test/java`. There are no changes to public Java API, table properties, wire format, or on-disk / Lance dataset format.

## Documentation

None. Test-only change; no user-facing documentation impact.