### PR TITLE
[rust] chore: bump Arrow stack to 59

### DIFF
--- a/fluss-rust/Cargo.lock
+++ b/fluss-rust/Cargo.lock
@@ -92,9 +92,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrow"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+checksum = "ffaaa3e009861fd829d0a24dd6f115aa8e4634324bb092147d43baafe69ca4a7"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "3ac95125e1d71c4a252b5a9c729aef111e80418f08aaa6dbabd1ba66918247fc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "0c60c79628e9a97cb90d7a0dc3e944f216a902f837d4ecabc14d524bddbbc137"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -137,7 +137,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "6026f638c400e9878c1b1cc05c3cfd46fbf381285916ab408678701c1df46c1a"
 dependencies = [
  "bytes",
  "half",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "c82c236c3caf8df5664284f3f1fbe89938852163998c3fdbf37e84ac220445e9"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
+checksum = "12714e5fb7954159af1e26d4e0d37108bcf1a2ad5ee5c5bf02a944d564d588b7"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "7bd568aa70c4ec5947027b0d5caee94877433b661a0bb9e8ddceeeb5f0c9b1ab"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "e57ee4d470eab1a021bc4b63fa2b2c15d572892bf227b0a982d3b755a6c662b5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -222,15 +222,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+checksum = "38f47e0e7a284e1f3707a780dc8cd5451b1614e9e398ea2d9ca03c7a2fe9a9ed"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap 2.13.1",
@@ -246,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "a79cf73ad2eba8686ec2aa9bbf8671208e509025f166afc040cedbd94ffe4983"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -259,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-pyarrow"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18c442b4c266aaf3d7f7dd40fd7ae058cef7f113b00ff0cd8256e1e218ec544"
+checksum = "b9e66bd74e4a47c6df9a2af16d9cca97e37cdfe5b3207d5e3558646e07957a27"
 dependencies = [
  "arrow-array",
  "arrow-data",
@@ -271,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+checksum = "cea0f7d8ed6182f14952761e2c0f989852d5aa334fcbc49f73a9f2247c25b879"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -284,18 +285,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "80b3e786a0dd9103acd583a6fb486dbf2f3268466cc0bd571dcf34cef231c1f1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "067a67e0361f6c31f4a7248759f36ca4ca71b187a941ed4d49da1c7d3d4db624"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -307,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "99bc95847f3ff62a2b03d6f8ce2e3e78f01362060549a2a311898dd442f6256d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1427,6 +1428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,15 +1776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,9 +2036,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -2066,15 +2064,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "metrics"
@@ -2546,28 +2535,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
+checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -2576,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "python3-dll-a",
  "target-lexicon",
@@ -2586,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2596,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2608,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3980,12 +3967,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/fluss-rust/Cargo.toml
+++ b/fluss-rust/Cargo.toml
@@ -34,7 +34,7 @@ members = ["crates/fluss", "crates/fluss-test-cluster", "crates/examples", "bind
 fluss = { package = "fluss-rs", version = "1.0.0", path = "crates/fluss", features = ["storage-all"] }
 tokio = { version = "1.44.2", features = ["full"] }
 clap = { version = "4.5.37", features = ["derive"] }
-arrow = { version = "57.0.0", features = ["ipc_compression", "ffi"] }
+arrow = { version = "59.0.0", features = ["ipc_compression", "ffi"] }
 bigdecimal = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/fluss-rust/bindings/python/Cargo.toml
+++ b/fluss-rust/bindings/python/Cargo.toml
@@ -27,14 +27,14 @@ name = "fluss"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.26.0", features = ["extension-module", "generate-import-lib"] }
+pyo3 = { version = "0.28.0", features = ["extension-module", "generate-import-lib"] }
 fluss = { workspace = true, features = ["storage-all"] }
 tokio = { workspace = true }
 arrow = { workspace = true }
-arrow-pyarrow = "57.0.0"
-arrow-schema = "57.0.0"
-arrow-array = "57.0.0"
-pyo3-async-runtimes = { version = "0.26.0", features = ["tokio-runtime"] }
+arrow-pyarrow = "59.0.0"
+arrow-schema = "59.0.0"
+arrow-array = "59.0.0"
+pyo3-async-runtimes = { version = "0.28.0", features = ["tokio-runtime"] }
 jiff = { workspace = true }
 bigdecimal = "0.4"
 indexmap = "2"

--- a/fluss-rust/bindings/python/src/config.rs
+++ b/fluss-rust/bindings/python/src/config.rs
@@ -19,7 +19,7 @@ use crate::*;
 use pyo3::types::PyDict;
 
 /// Configuration for Fluss client
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct Config {
     inner: fcore::config::Config,

--- a/fluss-rust/bindings/python/src/error.rs
+++ b/fluss-rust/bindings/python/src/error.rs
@@ -26,7 +26,7 @@ use pyo3::prelude::*;
 const CLIENT_ERROR_CODE: i32 = -2;
 
 /// Fluss errors
-#[pyclass(extends=PyException)]
+#[pyclass(extends=PyException, from_py_object)]
 #[derive(Debug, Clone)]
 pub struct FlussError {
     #[pyo3(get)]

--- a/fluss-rust/bindings/python/src/lib.rs
+++ b/fluss-rust/bindings/python/src/lib.rs
@@ -56,7 +56,7 @@ static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
 ///   OffsetSpec.earliest()
 ///   OffsetSpec.latest()
 ///   OffsetSpec.timestamp(ts)
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct OffsetSpec {
     pub(crate) inner: fcore::rpc::message::OffsetSpec,

--- a/fluss-rust/bindings/python/src/metadata.rs
+++ b/fluss-rust/bindings/python/src/metadata.rs
@@ -20,7 +20,7 @@ use pyo3::types::PyDict;
 use std::collections::HashMap;
 
 /// Represents the type of change for a record in a log
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ChangeType {
     /// Append-only operation
@@ -71,7 +71,7 @@ impl ChangeType {
 }
 
 /// Represents a table path with database and table name
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct TablePath {
     database_name: String,
@@ -260,7 +260,7 @@ impl TableDistribution {
 }
 
 /// Table descriptor containing schema and metadata
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct TableDescriptor {
     __tbl_desc: fcore::metadata::TableDescriptor,
@@ -363,7 +363,7 @@ impl TableDescriptor {
 }
 
 /// Information about a Fluss table
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct TableInfo {
     __table_info: fcore::metadata::TableInfo,
@@ -479,7 +479,7 @@ impl TableInfo {
 }
 
 /// Represents a lake snapshot with snapshot ID and table bucket offsets
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct LakeSnapshot {
     snapshot_id: i64,
@@ -487,7 +487,7 @@ pub struct LakeSnapshot {
 }
 
 /// Represents a table bucket with table ID, partition ID, and bucket ID
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Eq, Hash, PartialEq, Clone)]
 pub struct TableBucket {
     table_id: i64,
@@ -665,7 +665,7 @@ impl LakeSnapshot {
 }
 
 /// Descriptor for a Fluss database (comment and custom properties)
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct DatabaseDescriptor {
     __descriptor: fcore::metadata::DatabaseDescriptor,

--- a/fluss-rust/bindings/python/src/table.rs
+++ b/fluss-rust/bindings/python/src/table.rs
@@ -238,7 +238,7 @@ impl ScanRecords {
             ));
         }
         // Try slice
-        if let Ok(slice) = key.downcast::<PySlice>() {
+        if let Ok(slice) = key.cast::<PySlice>() {
             let indices = slice.indices(self.total_count as isize)?;
             let mut result: Vec<Py<ScanRecord>> = Vec::new();
             let mut i = indices.start;
@@ -1364,11 +1364,11 @@ fn python_value_to_datum(value: &Bound<PyAny>, data_type: &DataType) -> PyResult
             Ok(v.into())
         }
         DataType::Bytes(_) | DataType::Binary(_) => {
-            // Efficient extraction: downcast to specific type and use bulk copy.
+            // Efficient extraction: cast to specific type and use bulk copy.
             // PyBytes::as_bytes() and PyByteArray::to_vec() are O(n) bulk copies of the underlying data.
-            if let Ok(bytes) = value.downcast::<PyBytes>() {
+            if let Ok(bytes) = value.cast::<PyBytes>() {
                 Ok(bytes.as_bytes().to_vec().into())
-            } else if let Ok(bytearray) = value.downcast::<PyByteArray>() {
+            } else if let Ok(bytearray) = value.cast::<PyByteArray>() {
                 Ok(bytearray.to_vec().into())
             } else {
                 Err(FlussError::new_err(format!(
@@ -1392,7 +1392,7 @@ fn python_value_to_datum(value: &Bound<PyAny>, data_type: &DataType) -> PyResult
                     get_type_name(value)
                 )));
             }
-            let seq = value.downcast::<PySequence>().map_err(|_| {
+            let seq = value.cast::<PySequence>().map_err(|_| {
                 FlussError::new_err(format!(
                     "Expected sequence for Array column, got {}",
                     get_type_name(value)
@@ -1480,7 +1480,7 @@ fn python_value_to_datum(value: &Bound<PyAny>, data_type: &DataType) -> PyResult
 fn python_map_pairs<'py>(
     value: &Bound<'py, PyAny>,
 ) -> PyResult<Vec<(Bound<'py, PyAny>, Bound<'py, PyAny>)>> {
-    if let Ok(dict) = value.downcast::<PyDict>() {
+    if let Ok(dict) = value.cast::<PyDict>() {
         return Ok(dict.iter().collect());
     }
     if value.is_instance_of::<PyString>() {
@@ -1489,7 +1489,7 @@ fn python_map_pairs<'py>(
             get_type_name(value)
         )));
     }
-    let seq = value.downcast::<PySequence>().map_err(|_| {
+    let seq = value.cast::<PySequence>().map_err(|_| {
         FlussError::new_err(format!(
             "Expected dict or sequence of (key, value) pairs for Map column, got {}",
             get_type_name(value)
@@ -1499,7 +1499,7 @@ fn python_map_pairs<'py>(
     let mut pairs = Vec::with_capacity(len);
     for i in 0..len {
         let entry = seq.get_item(i)?;
-        let pair = entry.downcast::<PySequence>().map_err(|_| {
+        let pair = entry.cast::<PySequence>().map_err(|_| {
             FlussError::new_err("Map entries must be (key, value) pairs".to_string())
         })?;
         if pair.len()? != 2 {
@@ -1941,7 +1941,7 @@ static UTC_EPOCH: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 fn get_decimal_type(py: Python) -> PyResult<Bound<PyType>> {
     let ty = DECIMAL_TYPE.get_or_try_init(py, || -> PyResult<_> {
         let decimal_mod = py.import("decimal")?;
-        let decimal_ty = decimal_mod.getattr("Decimal")?.downcast_into::<PyType>()?;
+        let decimal_ty = decimal_mod.getattr("Decimal")?.cast_into::<PyType>()?;
         Ok(decimal_ty.unbind())
     })?;
     Ok(ty.bind(py).clone())
@@ -1955,8 +1955,8 @@ fn get_utc_timezone(py: Python) -> PyResult<Bound<PyTzInfo>> {
         let utc = timezone.getattr("utc")?;
         Ok(utc.unbind())
     })?;
-    // Downcast to PyTzInfo for use with PyDateTime::new()
-    Ok(tz.bind(py).clone().downcast_into::<PyTzInfo>()?)
+    // Cast to PyTzInfo for use with PyDateTime::new()
+    Ok(tz.bind(py).clone().cast_into::<PyTzInfo>()?)
 }
 
 /// Get the cached UTC epoch datetime, creating it once per interpreter.
@@ -2013,13 +2013,13 @@ fn python_decimal_to_datum(
 /// Convert Python datetime.date to Datum::Date.
 fn python_date_to_datum(value: &Bound<PyAny>) -> PyResult<fcore::row::Datum<'static>> {
     // Reject datetime.datetime (subclass of date) - use timestamp columns for those
-    if value.downcast::<PyDateTime>().is_ok() {
+    if value.cast::<PyDateTime>().is_ok() {
         return Err(FlussError::new_err(
             "Expected datetime.date, got datetime.datetime. Use a TIMESTAMP column for datetime values.",
         ));
     }
 
-    let date = value.downcast::<PyDate>().map_err(|_| {
+    let date = value.cast::<PyDate>().map_err(|_| {
         FlussError::new_err(format!(
             "Expected datetime.date, got {}",
             get_type_name(value)
@@ -2048,7 +2048,7 @@ fn python_date_to_datum(value: &Bound<PyAny>) -> PyResult<fcore::row::Datum<'sta
 /// Sub-millisecond precision (microseconds not divisible by 1000) will raise an error
 /// to prevent silent data loss and ensure fail-fast behavior.
 fn python_time_to_datum(value: &Bound<PyAny>) -> PyResult<fcore::row::Datum<'static>> {
-    let time = value.downcast::<PyTime>().map_err(|_| {
+    let time = value.cast::<PyTime>().map_err(|_| {
         FlussError::new_err(format!(
             "Expected datetime.time, got {}",
             get_type_name(value)
@@ -2107,7 +2107,7 @@ fn python_datetime_to_timestamp_ltz(value: &Bound<PyAny>) -> PyResult<fcore::row
 /// For clarity, tz-aware datetimes are rejected - use TimestampLtz for those.
 fn extract_datetime_components_ntz(value: &Bound<PyAny>) -> PyResult<(i64, i32)> {
     // Try PyDateTime first
-    if let Ok(dt) = value.downcast::<PyDateTime>() {
+    if let Ok(dt) = value.cast::<PyDateTime>() {
         // Reject tz-aware datetime for NTZ - it's ambiguous what the user wants
         let tzinfo = dt.getattr("tzinfo")?;
         if !tzinfo.is_none() {
@@ -2137,7 +2137,7 @@ fn extract_datetime_components_ntz(value: &Bound<PyAny>) -> PyResult<(i64, i32)>
 
     // Try to_pydatetime() for objects that support it
     if let Ok(py_dt) = value.call_method0("to_pydatetime") {
-        if let Ok(dt) = py_dt.downcast::<PyDateTime>() {
+        if let Ok(dt) = py_dt.cast::<PyDateTime>() {
             let tzinfo = dt.getattr("tzinfo")?;
             if !tzinfo.is_none() {
                 return Err(FlussError::new_err(
@@ -2159,7 +2159,7 @@ fn extract_datetime_components_ntz(value: &Bound<PyAny>) -> PyResult<(i64, i32)>
 /// For naive datetimes, assumes UTC. For aware datetimes, converts to UTC.
 fn extract_datetime_components_ltz(value: &Bound<PyAny>) -> PyResult<(i64, i32)> {
     // Try PyDateTime first
-    if let Ok(dt) = value.downcast::<PyDateTime>() {
+    if let Ok(dt) = value.cast::<PyDateTime>() {
         // Check if timezone-aware
         let tzinfo = dt.getattr("tzinfo")?;
         if tzinfo.is_none() {
@@ -2180,7 +2180,7 @@ fn extract_datetime_components_ltz(value: &Bound<PyAny>) -> PyResult<(i64, i32)>
 
     // Try to_pydatetime()
     if let Ok(py_dt) = value.call_method0("to_pydatetime") {
-        if let Ok(dt) = py_dt.downcast::<PyDateTime>() {
+        if let Ok(dt) = py_dt.cast::<PyDateTime>() {
             let tzinfo = dt.getattr("tzinfo")?;
             if tzinfo.is_none() {
                 return datetime_to_epoch_millis_as_utc(dt);
@@ -2234,7 +2234,7 @@ fn datetime_to_epoch_millis_utc_aware(dt: &Bound<'_, PyDateTime>) -> PyResult<(i
 
     // Compute delta = dt - epoch (this handles timezone conversion correctly)
     let delta = dt.call_method1("__sub__", (epoch,))?;
-    let delta = delta.downcast::<PyDelta>()?;
+    let delta = delta.cast::<PyDelta>()?;
 
     // Extract components using integer arithmetic
     let days = delta.get_days() as i64;

--- a/fluss-rust/crates/fluss/Cargo.toml
+++ b/fluss-rust/crates/fluss/Cargo.toml
@@ -44,7 +44,7 @@ integration_tests = []
 
 [dependencies]
 arrow = { workspace = true }
-arrow-schema = "57.0.0"
+arrow-schema = "59.0.0"
 bitvec = "1"
 byteorder = "1.5"
 futures = "0.3"


### PR DESCRIPTION
### Purpose
Updates the Rust Arrow dependency family under `fluss-rust/` to 59.0.0 and keeps the direct Arrow crates aligned across core and Python bindings. This is the replacement for apache/fluss-rust#656 after the Rust repo was merged into apache/fluss.

Supersedes the Dependabot-only `arrow-schema` bump in #3583, which leaves split Arrow versions behind.

### Brief change log
- Bump arrow, arrow-schema, arrow-array, and arrow-pyarrow to 59.0.0.
- Bump PyO3 / pyo3-async-runtimes to 0.28 to satisfy arrow-pyarrow 59.
- Replace deprecated PyO3 downcast APIs and make pyclass FromPyObject behavior explicit.

### Tests
- cargo fmt --all
- cargo tree -p fluss_python --edges normal | rg -n 'arrow|pyo3'\n- cargo build --workspace --all-targets --exclude fluss_python --exclude fluss-cpp --exclude fluss_nif\n- cargo build -p fluss_python\n- cargo clippy --all-targets --workspace -- -D warnings\n- cargo test --all-targets --workspace --exclude fluss_python --exclude fluss-cpp --exclude fluss_nif\n- cargo doc --workspace --no-deps --exclude fluss_python\n- cargo build -p fluss-cpp -p fluss_nif\n\nNote: `fluss-cpp` build/doc/clippy emitted the existing non-fatal macOS `/usr/bin/ar: illegal option -- D` build-script warning locally.