### PR TITLE
[docs] Add rust/python/c++/elixir component tags

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 
   - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.
 
-  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.
+  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.
 
   - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,7 +431,7 @@ git remote add fork https://github.com/<your-username>/fluss.git
 Detailed explanation of changes and motivation.
 ```
 
-**Component tags:** `[client]`, `[server]`, `[rpc]`, `[flink]`, `[spark]`, `[docs]`, `[build]`, `[test]`
+**Component tags:** `[client]`, `[server]`, `[rpc]`, `[flink]`, `[spark]`, `[rust]`, `[python]`, `[c++]`, `[elixir]`, `[docs]`, `[build]`, `[test]`
 
 ### Pre-Push Self-Review
 

--- a/website/community/how-to-contribute/bug-reports-feature-requests.md
+++ b/website/community/how-to-contribute/bug-reports-feature-requests.md
@@ -13,7 +13,7 @@ Considerations before opening an issue:
 
 - Make sure that the issue corresponds to a genuine bug or enhancement request. Exceptions are made for typos in documentation files, which can be reported directly.
 
-- Provide a clear and descriptive title. Use component labels (such as `component=server`, `component=client`, `component=connector`, `component=docs`) to help categorize your issue and make it easier to filter and search.
+- Provide a clear and descriptive title. Use component labels (such as `component=server`, `component=client`, `component=connector`, `component=rust`, `component=docs`) to help categorize your issue and make it easier to filter and search.
 
 - Fill out the issue template to describe the problem or enhancement clearly. Please describe it such that maintainers understand the context and impact from the description, not only from reproduction steps.
 

--- a/website/community/how-to-contribute/contribute-code.md
+++ b/website/community/how-to-contribute/contribute-code.md
@@ -50,7 +50,7 @@ Considerations before opening a pull request:
 
 - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.
 
-- Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component. **Hotfixes** should be named for example `[hotfix][docs] Expand JavaDoc for PunctuatedWatermarkGenerator`.
+- Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component. **Hotfixes** should be named for example `[hotfix][docs] Expand JavaDoc for PunctuatedWatermarkGenerator`.
 
 - Fill out the pull request template to describe the changes contributed by the pull request. Please describe it such that the reviewer understands the problem and solution from the description, not only from the code. That will give reviewers the context they need to do the review.
 


### PR DESCRIPTION
As we merged fluss-rust into fluss repo, now it makes even more sense to label PRs properly, so closing this gap based on the suggestion in dev@ mailing list