### PR TITLE
[client] Add log read preference for remote-first fetch

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/LogFetcher.java
@@ -52,6 +52,7 @@ import org.apache.fluss.rpc.messages.PbFetchLogRespForBucket;
 import org.apache.fluss.rpc.messages.PbFetchLogRespForTable;
 import org.apache.fluss.rpc.protocol.ApiError;
 import org.apache.fluss.rpc.protocol.Errors;
+import org.apache.fluss.rpc.protocol.FetchLogReadPreference;
 import org.apache.fluss.rpc.util.PredicateMessageUtils;
 import org.apache.fluss.shaded.arrow.org.apache.arrow.memory.ChunkedAllocationManager;
 import org.apache.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
@@ -109,6 +110,7 @@ public class LogFetcher implements Closeable {
     private final LogFetchCollector logFetchCollector;
     private final ArrowLogFetchCollector arrowLogFetchCollector;
     private final RemoteLogDownloader remoteLogDownloader;
+    private final FetchLogReadPreference readPreference;
 
     @GuardedBy("this")
     private final Set<Integer> nodesWithPendingFetchRequests;
@@ -166,6 +168,7 @@ public class LogFetcher implements Closeable {
         this.arrowLogFetchCollector =
                 new ArrowLogFetchCollector(tablePath, logScannerStatus, conf, metadataUpdater);
         this.scannerMetricGroup = scannerMetricGroup;
+        this.readPreference = conf.get(ConfigOptions.CLIENT_SCANNER_LOG_READ_PREFERENCE);
         this.remoteLogDownloader =
                 new RemoteLogDownloader(tablePath, conf, remoteFileDownloader, scannerMetricGroup);
         remoteLogDownloader.start();
@@ -562,7 +565,8 @@ public class LogFetcher implements Closeable {
                                         .setFollowerServerId(-1)
                                         .setMaxBytes(maxFetchBytes)
                                         .setMinBytes(minFetchBytes)
-                                        .setMaxWaitMs(maxFetchWaitMs);
+                                        .setMaxWaitMs(maxFetchWaitMs)
+                                        .setReadPreference(readPreference.value());
                         PbFetchLogReqForTable reqForTable =
                                 new PbFetchLogReqForTable().setTableId(finalTableId);
                         if (readContext.isProjectionPushDowned()) {

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetcherTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetcherTest.java
@@ -23,6 +23,7 @@ import org.apache.fluss.client.metadata.TestingMetadataUpdater;
 import org.apache.fluss.client.metrics.TestingScannerMetricGroup;
 import org.apache.fluss.client.table.scanner.RemoteFileDownloader;
 import org.apache.fluss.cluster.BucketLocation;
+import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.NotLeaderOrFollowerException;
 import org.apache.fluss.metadata.PhysicalTablePath;
@@ -32,9 +33,12 @@ import org.apache.fluss.rpc.entity.FetchLogResultForBucket;
 import org.apache.fluss.rpc.messages.FetchLogRequest;
 import org.apache.fluss.rpc.messages.FetchLogResponse;
 import org.apache.fluss.rpc.protocol.ApiError;
+import org.apache.fluss.rpc.protocol.FetchLogReadPreference;
 import org.apache.fluss.server.entity.FetchReqInfo;
 import org.apache.fluss.server.tablet.TestTabletServerGateway;
+import org.apache.fluss.utils.IOUtils;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -68,24 +72,29 @@ public class LogFetcherTest {
     @BeforeEach
     public void setup() {
         metadataUpdater = initializeMetadataUpdater();
+        logFetcher = createLogFetcher(new Configuration());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        IOUtils.closeQuietly(logFetcher);
+    }
+
+    private LogFetcher createLogFetcher(Configuration conf) {
         ClientSchemaGetter clientSchemaGetter =
                 new TestingClientSchemaGetter(
-                        DATA1_TABLE_PATH,
-                        new SchemaInfo(DATA1_SCHEMA, 0),
-                        metadataUpdater,
-                        new Configuration());
+                        DATA1_TABLE_PATH, new SchemaInfo(DATA1_SCHEMA, 0), metadataUpdater, conf);
         LogScannerStatus logScannerStatus = initializeLogScannerStatus();
-        logFetcher =
-                new LogFetcher(
-                        DATA1_TABLE_INFO,
-                        null,
-                        null,
-                        logScannerStatus,
-                        new Configuration(),
-                        metadataUpdater,
-                        TestingScannerMetricGroup.newInstance(),
-                        new RemoteFileDownloader(1),
-                        clientSchemaGetter);
+        return new LogFetcher(
+                DATA1_TABLE_INFO,
+                null,
+                null,
+                logScannerStatus,
+                conf,
+                metadataUpdater,
+                TestingScannerMetricGroup.newInstance(),
+                new RemoteFileDownloader(1),
+                clientSchemaGetter);
     }
 
     @Test
@@ -109,6 +118,31 @@ public class LogFetcherTest {
         // When NotLeaderOrFollowerException is received, the bucketLocation will be removed from
         // metadata updater to trigger get the latest bucketLocation in next fetch round.
         assertThat(metadataUpdater.getBucketLocation(tb1)).isNotPresent();
+    }
+
+    @Test
+    void testPrepareFetchLogRequestWithReadPreference() throws Exception {
+        Map<Integer, FetchLogRequest> defaultRequestMap = logFetcher.prepareFetchLogRequests();
+        FetchLogRequest defaultRequest = defaultRequestMap.get(1);
+        assertThat(defaultRequest.hasReadPreference()).isTrue();
+        assertThat(defaultRequest.getReadPreference())
+                .isEqualTo(FetchLogReadPreference.LOCAL_FIRST.value());
+
+        Configuration remoteFirstConf = new Configuration();
+        remoteFirstConf.setString(
+                ConfigOptions.CLIENT_SCANNER_LOG_READ_PREFERENCE.key(),
+                FetchLogReadPreference.REMOTE_FIRST.toString());
+        LogFetcher remoteFirstFetcher = createLogFetcher(remoteFirstConf);
+        try {
+            Map<Integer, FetchLogRequest> remoteFirstRequestMap =
+                    remoteFirstFetcher.prepareFetchLogRequests();
+            FetchLogRequest remoteFirstRequest = remoteFirstRequestMap.get(1);
+            assertThat(remoteFirstRequest.hasReadPreference()).isTrue();
+            assertThat(remoteFirstRequest.getReadPreference())
+                    .isEqualTo(FetchLogReadPreference.REMOTE_FIRST.value());
+        } finally {
+            remoteFirstFetcher.close();
+        }
     }
 
     private LogScannerStatus initializeLogScannerStatus() {

--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -26,6 +26,7 @@ import org.apache.fluss.metadata.DeleteBehavior;
 import org.apache.fluss.metadata.KvFormat;
 import org.apache.fluss.metadata.LogFormat;
 import org.apache.fluss.metadata.MergeEngineType;
+import org.apache.fluss.rpc.protocol.FetchLogReadPreference;
 import org.apache.fluss.utils.ArrayUtils;
 
 import java.lang.reflect.Field;
@@ -1524,6 +1525,13 @@ public class ConfigOptions {
                     .withDescription(
                             "The number of remote log segments to keep in local temp file for LogScanner, "
                                     + "which download from remote storage. The default setting is 4.");
+
+    public static final ConfigOption<FetchLogReadPreference> CLIENT_SCANNER_LOG_READ_PREFERENCE =
+            key("client.scanner.log.read-preference")
+                    .enumType(FetchLogReadPreference.class)
+                    .defaultValue(FetchLogReadPreference.LOCAL_FIRST)
+                    .withDescription(
+                            "The read preference for LogScanner. Supported values are local-first and remote-first.");
 
     public static final ConfigOption<String> CLIENT_SCANNER_IO_TMP_DIR =
             key("client.scanner.io.tmpdir")

--- a/fluss-common/src/main/java/org/apache/fluss/rpc/protocol/FetchLogReadPreference.java
+++ b/fluss-common/src/main/java/org/apache/fluss/rpc/protocol/FetchLogReadPreference.java
@@ -17,14 +17,13 @@
 
 package org.apache.fluss.rpc.protocol;
 
-import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.annotation.PublicEvolving;
 
 /** Read preference for fetch log requests. */
-@Internal
+@PublicEvolving
 public enum FetchLogReadPreference {
     LOCAL_FIRST(0, "local-first"),
     REMOTE_FIRST(1, "remote-first");
-
     private final int value;
     private final String name;
 

--- a/fluss-common/src/main/java/org/apache/fluss/rpc/protocol/FetchLogReadPreference.java
+++ b/fluss-common/src/main/java/org/apache/fluss/rpc/protocol/FetchLogReadPreference.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.rpc.protocol;
+
+import org.apache.fluss.annotation.Internal;
+
+/** Read preference for fetch log requests. */
+@Internal
+public enum FetchLogReadPreference {
+    LOCAL_FIRST(0, "local-first"),
+    REMOTE_FIRST(1, "remote-first");
+
+    private final int value;
+    private final String name;
+
+    FetchLogReadPreference(int value, String name) {
+        this.value = value;
+        this.name = name;
+    }
+
+    public int value() {
+        return value;
+    }
+
+    public static FetchLogReadPreference from(int value) {
+        for (FetchLogReadPreference preference : values()) {
+            if (preference.value == value) {
+                return preference;
+            }
+        }
+        return LOCAL_FIRST;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSource.java
@@ -45,8 +45,10 @@ import org.apache.flink.streaming.api.graph.StreamGraphHasherV2;
 import java.nio.charset.StandardCharsets;
 
 import static org.apache.fluss.config.ConfigOptions.CLIENT_SCANNER_IO_TMP_DIR;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SCANNER_LOG_READ_PREFERENCE;
 import static org.apache.fluss.flink.tiering.source.TieringSourceOptions.POLL_TIERING_TABLE_INTERVAL;
 import static org.apache.fluss.flink.utils.FlinkConnectorOptionsUtils.getClientScannerIoTmpDir;
+import static org.apache.fluss.rpc.protocol.FetchLogReadPreference.REMOTE_FIRST;
 
 /**
  * The flink source implementation for tiering data from Fluss to downstream lake.
@@ -112,10 +114,13 @@ public class TieringSource<WriteResult>
             SourceReaderContext sourceReaderContext) {
         FutureCompletingBlockingQueue<RecordsWithSplitIds<TableBucketWriteResult<WriteResult>>>
                 elementsQueue = new FutureCompletingBlockingQueue<>();
-        flussConf.set(
+        Configuration tieringReaderConf = new Configuration(flussConf);
+        tieringReaderConf.set(
                 CLIENT_SCANNER_IO_TMP_DIR,
-                getClientScannerIoTmpDir(flussConf, sourceReaderContext.getConfiguration()));
-        Connection connection = ConnectionFactory.createConnection(flussConf);
+                getClientScannerIoTmpDir(
+                        tieringReaderConf, sourceReaderContext.getConfiguration()));
+        tieringReaderConf.set(CLIENT_SCANNER_LOG_READ_PREFERENCE, REMOTE_FIRST);
+        Connection connection = ConnectionFactory.createConnection(tieringReaderConf);
         return new TieringSourceReader<>(
                 elementsQueue, sourceReaderContext, connection, lakeTieringFactory);
     }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/FlinkTieringTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/FlinkTieringTestBase.java
@@ -173,6 +173,15 @@ class FlinkTieringTestBase {
         return TestingValuesLake.getResults(tablePath.toString());
     }
 
+    protected TieringJobScope startTieringJob(StreamExecutionEnvironment execEnv) throws Exception {
+        return new TieringJobScope(buildTieringJob(execEnv));
+    }
+
+    protected TieringJobScope startTieringJob(
+            StreamExecutionEnvironment execEnv, Configuration lakeTieringConfig) throws Exception {
+        return new TieringJobScope(buildTieringJob(execEnv, lakeTieringConfig));
+    }
+
     protected JobClient buildTieringJob(StreamExecutionEnvironment execEnv) throws Exception {
         return buildTieringJob(execEnv, new Configuration());
     }
@@ -189,5 +198,35 @@ class FlinkTieringTestBase {
                         lakeTieringConfig,
                         DataLakeFormat.LANCE.toString())
                 .build();
+    }
+
+    /**
+     * A try-with-resources scope that starts a tiering job and cancels it when closed.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * try (TieringJobScope tiering = startTieringJob(execEnv)) {
+     *     assertReplicaStatus(tableBucket, expectedLogEndOffset);
+     * }
+     * }</pre>
+     */
+    protected static final class TieringJobScope implements AutoCloseable {
+
+        private final JobClient jobClient;
+
+        private TieringJobScope(JobClient jobClient) {
+            this.jobClient = jobClient;
+        }
+
+        /** Returns the underlying Flink job client. */
+        public JobClient client() {
+            return jobClient;
+        }
+
+        @Override
+        public void close() throws Exception {
+            jobClient.cancel().get();
+        }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringITCase.java
@@ -34,15 +34,11 @@ import org.apache.fluss.types.DataTypes;
 import org.apache.fluss.utils.ExceptionUtils;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -56,7 +52,6 @@ import static org.apache.fluss.testutils.common.CommonTestUtils.waitValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** The IT case for tiering. */
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 abstract class TieringITCase extends FlinkTieringTestBase {
 
     @BeforeAll
@@ -79,7 +74,6 @@ abstract class TieringITCase extends FlinkTieringTestBase {
     }
 
     @Test
-    @Order(1)
     void testTieringReachMaxDuration() throws Exception {
         TablePath logTablePath = TablePath.of("fluss", "logtable");
         createTable(logTablePath, false);
@@ -105,9 +99,7 @@ abstract class TieringITCase extends FlinkTieringTestBase {
 
         // set tiering duration to a small value for testing purpose
         Configuration lakeTieringConfig = new Configuration();
-        JobClient jobClient = buildTieringJob(execEnv, lakeTieringConfig);
-
-        try {
+        try (TieringJobScope ignored = startTieringJob(execEnv, lakeTieringConfig)) {
             // verify the tiered records is less than the table total record to
             // make sure tiering is forced to complete when reach max duration
             LakeSnapshot logTableLakeSnapshot = waitLakeSnapshot(logTablePath);
@@ -119,13 +111,10 @@ abstract class TieringITCase extends FlinkTieringTestBase {
             LakeSnapshot pkTableLakeSnapshot = waitLakeSnapshot(pkTablePath);
             tieredRecords = countTieredRecords(pkTableLakeSnapshot);
             assertThat(tieredRecords).isLessThan(recordCount);
-        } finally {
-            jobClient.cancel().get();
         }
     }
 
     @Test
-    @Order(2)
     void testTieringReadsRemoteFirstAndSwitchesToLocalTail() throws Exception {
         TablePath tablePath = TablePath.of("fluss", "remote_first_log_table");
         Schema schema =
@@ -163,8 +152,7 @@ abstract class TieringITCase extends FlinkTieringTestBase {
 
         long localBytesOutBefore =
                 replica.tableMetrics().getServerMetricGroup().bytesOut().getCount();
-        JobClient jobClient = buildTieringJob(execEnv);
-        try {
+        try (TieringJobScope ignored = startTieringJob(execEnv)) {
             assertReplicaStatus(tableBucket, expectedRows.size());
             assertRows(tablePath, expectedRows);
 
@@ -172,8 +160,6 @@ abstract class TieringITCase extends FlinkTieringTestBase {
                     replica.tableMetrics().getServerMetricGroup().bytesOut().getCount()
                             - localBytesOutBefore;
             assertThat(localBytesOut).isEqualTo(localTailBytes);
-        } finally {
-            jobClient.cancel().get();
         }
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringITCase.java
@@ -22,10 +22,14 @@ import org.apache.fluss.client.metadata.LakeSnapshot;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.LakeTableSnapshotNotExistException;
 import org.apache.fluss.metadata.Schema;
+import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.BinaryString;
 import org.apache.fluss.row.GenericRow;
 import org.apache.fluss.row.InternalRow;
+import org.apache.fluss.server.log.FetchIsolation;
+import org.apache.fluss.server.log.LogTablet;
+import org.apache.fluss.server.replica.Replica;
 import org.apache.fluss.types.DataTypes;
 import org.apache.fluss.utils.ExceptionUtils;
 
@@ -35,7 +39,10 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -44,10 +51,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.apache.fluss.testutils.common.CommonTestUtils.waitValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** The IT case for tiering. */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 abstract class TieringITCase extends FlinkTieringTestBase {
 
     @BeforeAll
@@ -70,6 +79,7 @@ abstract class TieringITCase extends FlinkTieringTestBase {
     }
 
     @Test
+    @Order(1)
     void testTieringReachMaxDuration() throws Exception {
         TablePath logTablePath = TablePath.of("fluss", "logtable");
         createTable(logTablePath, false);
@@ -110,7 +120,86 @@ abstract class TieringITCase extends FlinkTieringTestBase {
             tieredRecords = countTieredRecords(pkTableLakeSnapshot);
             assertThat(tieredRecords).isLessThan(recordCount);
         } finally {
-            jobClient.cancel();
+            jobClient.cancel().get();
+        }
+    }
+
+    @Test
+    @Order(2)
+    void testTieringReadsRemoteFirstAndSwitchesToLocalTail() throws Exception {
+        TablePath tablePath = TablePath.of("fluss", "remote_first_log_table");
+        Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.STRING())
+                        .build();
+        long tableId = createTable(tablePath, schema);
+        TableBucket tableBucket = new TableBucket(tableId, 0);
+
+        int remoteRecordCount = 4;
+        List<InternalRow> expectedRows = createRows(0, remoteRecordCount);
+        writeRows(tablePath, expectedRows, true);
+
+        Replica replica = getLeaderReplica(tableBucket);
+        LogTablet logTablet = replica.getLogTablet();
+        logTablet.roll(Optional.empty());
+
+        FLUSS_CLUSTER_EXTENSION.waitUntilSomeLogSegmentsCopyToRemote(tableBucket);
+        retry(
+                Duration.ofMinutes(1),
+                () -> assertThat(logTablet.canFetchFromRemoteLog(remoteRecordCount - 1L)).isTrue());
+
+        List<InternalRow> localTailRows = createRows(remoteRecordCount, 2);
+        expectedRows.addAll(localTailRows);
+        writeRows(tablePath, localTailRows, true);
+
+        assertThat(logTablet.canFetchFromRemoteLog(remoteRecordCount)).isFalse();
+        assertThat(logTablet.localLogStartOffset()).isZero();
+        assertThat(logTablet.localLogEndOffset()).isEqualTo(expectedRows.size());
+
+        int allLocalBytes = readLocalBytes(logTablet, 0L);
+        int localTailBytes = readLocalBytes(logTablet, remoteRecordCount);
+        assertThat(localTailBytes).isPositive().isLessThan(allLocalBytes);
+
+        long localBytesOutBefore =
+                replica.tableMetrics().getServerMetricGroup().bytesOut().getCount();
+        JobClient jobClient = buildTieringJob(execEnv);
+        try {
+            assertReplicaStatus(tableBucket, expectedRows.size());
+            assertRows(tablePath, expectedRows);
+
+            long localBytesOut =
+                    replica.tableMetrics().getServerMetricGroup().bytesOut().getCount()
+                            - localBytesOutBefore;
+            assertThat(localBytesOut).isEqualTo(localTailBytes);
+        } finally {
+            jobClient.cancel().get();
+        }
+    }
+
+    private List<InternalRow> createRows(int start, int count) {
+        List<InternalRow> rows = new ArrayList<>();
+        for (int i = start; i < start + count; i++) {
+            rows.add(GenericRow.of(i, BinaryString.fromString("v" + i)));
+        }
+        return rows;
+    }
+
+    private int readLocalBytes(LogTablet logTablet, long offset) throws Exception {
+        return logTablet
+                .read(offset, Integer.MAX_VALUE, FetchIsolation.LOG_END, true, null, null)
+                .getRecords()
+                .sizeInBytes();
+    }
+
+    private void assertRows(TablePath tablePath, List<InternalRow> expectedRows) {
+        List<InternalRow> actualRows = getValuesRecords(tablePath);
+        assertThat(actualRows).hasSameSizeAs(expectedRows);
+        for (int i = 0; i < expectedRows.size(); i++) {
+            InternalRow actual = actualRows.get(i);
+            InternalRow expected = expectedRows.get(i);
+            assertThat(actual.getInt(0)).isEqualTo(expected.getInt(0));
+            assertThat(actual.getString(1)).isEqualTo(expected.getString(1));
         }
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringITCase.java
@@ -100,17 +100,15 @@ abstract class TieringITCase extends FlinkTieringTestBase {
         // set tiering duration to a small value for testing purpose
         Configuration lakeTieringConfig = new Configuration();
         try (TieringJobScope ignored = startTieringJob(execEnv, lakeTieringConfig)) {
-            // verify the tiered records is less than the table total record to
-            // make sure tiering is forced to complete when reach max duration
-            LakeSnapshot logTableLakeSnapshot = waitLakeSnapshot(logTablePath);
-            long tieredRecords = countTieredRecords(logTableLakeSnapshot);
-            assertThat(tieredRecords).isLessThan(recordCount);
+            // Wait until all records are tiered, then verify that max duration forced tiering to
+            // complete in multiple snapshots.
+            LakeSnapshot logTableLakeSnapshot = waitUntilFullyTiered(logTablePath, recordCount);
+            assertThat(countTieredRecords(logTableLakeSnapshot)).isEqualTo(recordCount);
+            assertThat(logTableLakeSnapshot.getSnapshotId()).isGreaterThan(0L);
 
-            // verify the tiered records is less than the table total record to
-            // make sure tiering is forced to complete when reach max duration
-            LakeSnapshot pkTableLakeSnapshot = waitLakeSnapshot(pkTablePath);
-            tieredRecords = countTieredRecords(pkTableLakeSnapshot);
-            assertThat(tieredRecords).isLessThan(recordCount);
+            LakeSnapshot pkTableLakeSnapshot = waitUntilFullyTiered(pkTablePath, recordCount);
+            assertThat(countTieredRecords(pkTableLakeSnapshot)).isEqualTo(recordCount);
+            assertThat(pkTableLakeSnapshot.getSnapshotId()).isGreaterThan(0L);
         }
     }
 
@@ -195,11 +193,14 @@ abstract class TieringITCase extends FlinkTieringTestBase {
                 .sum();
     }
 
-    private LakeSnapshot waitLakeSnapshot(TablePath tablePath) {
+    private LakeSnapshot waitUntilFullyTiered(TablePath tablePath, long expectedRecordCount) {
         return waitValue(
                 () -> {
                     try {
-                        return Optional.of(admin.getLatestLakeSnapshot(tablePath).get());
+                        LakeSnapshot lakeSnapshot = admin.getLatestLakeSnapshot(tablePath).get();
+                        return countTieredRecords(lakeSnapshot) == expectedRecordCount
+                                ? Optional.of(lakeSnapshot)
+                                : Optional.empty();
                     } catch (Exception e) {
                         if (ExceptionUtils.stripExecutionException(e)
                                 instanceof LakeTableSnapshotNotExistException) {
@@ -209,7 +210,7 @@ abstract class TieringITCase extends FlinkTieringTestBase {
                     }
                 },
                 Duration.ofSeconds(30),
-                "Fail to wait for one round of tiering finish for table " + tablePath);
+                "Fail to wait for tiering to finish for table " + tablePath);
     }
 
     private void createTable(TablePath tablePath, boolean isPrimaryKeyTable) throws Exception {

--- a/fluss-flink/fluss-flink-tiering/src/test/java/org/apache/fluss/flink/tiering/TieringFailoverITCase.java
+++ b/fluss-flink/fluss-flink-tiering/src/test/java/org/apache/fluss/flink/tiering/TieringFailoverITCase.java
@@ -28,7 +28,6 @@ import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.types.DataTypes;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
-import org.apache.flink.core.execution.JobClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,8 +96,7 @@ class TieringFailoverITCase extends FlinkTieringTestBase {
         TestingValuesLake.failWhen(t1.toString()).failWriteNext(2);
 
         // then start tiering job
-        JobClient jobClient = buildTieringJob(execEnv);
-        try {
+        try (TieringJobScope ignored = startTieringJob(execEnv)) {
             // check the status of replica after synced
             assertReplicaStatus(t1Bucket, 3);
 
@@ -117,10 +115,6 @@ class TieringFailoverITCase extends FlinkTieringTestBase {
             assertReplicaStatus(t1Bucket, expectedRows.size());
 
             checkDataInValuesTable(t1, expectedRows);
-        } finally {
-            if (!jobClient.getJobExecutionResult().isDone()) {
-                jobClient.cancel().get();
-            }
         }
     }
 

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -229,6 +229,7 @@ message FetchLogRequest {
   repeated PbFetchLogReqForTable tables_req = 3;
   optional int32 max_wait_ms = 4;
   optional int32 min_bytes = 5;
+  optional int32 read_preference = 6;
 }
 
 message FetchLogResponse {

--- a/fluss-rust/crates/fluss/src/client/table/scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/scanner.rs
@@ -2185,6 +2185,7 @@ impl LogFetcher {
                         tables_req: vec![req_for_table],
                         max_wait_ms: Some(self.fetch_wait_max_time_ms),
                         min_bytes: Some(self.fetch_min_bytes),
+                        read_preference: None,
                     };
                     (leader_id, fetch_log_request)
                 })

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/FetchParams.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/FetchParams.java
@@ -23,6 +23,7 @@ import org.apache.fluss.metadata.SchemaGetter;
 import org.apache.fluss.record.FileLogProjection;
 import org.apache.fluss.record.ProjectionPushdownCache;
 import org.apache.fluss.rpc.messages.FetchLogRequest;
+import org.apache.fluss.rpc.protocol.FetchLogReadPreference;
 
 import javax.annotation.Nullable;
 
@@ -69,14 +70,50 @@ public final class FetchParams {
     @Nullable private FileLogProjection fileLogProjection;
     private final int minFetchBytes;
     private final long maxWaitMs;
+    private final FetchLogReadPreference readPreference;
     // TODO: add more params like epoch etc.
 
     public FetchParams(int replicaId, int maxFetchBytes) {
-        this(replicaId, true, maxFetchBytes, DEFAULT_MIN_FETCH_BYTES, DEFAULT_MAX_WAIT_MS, null);
+        this(
+                replicaId,
+                true,
+                maxFetchBytes,
+                DEFAULT_MIN_FETCH_BYTES,
+                DEFAULT_MAX_WAIT_MS,
+                null,
+                FetchLogReadPreference.LOCAL_FIRST);
     }
 
     public FetchParams(int replicaId, int maxFetchBytes, int minFetchBytes, long maxWaitMs) {
-        this(replicaId, true, maxFetchBytes, minFetchBytes, maxWaitMs, null);
+        this(
+                replicaId,
+                true,
+                maxFetchBytes,
+                minFetchBytes,
+                maxWaitMs,
+                null,
+                FetchLogReadPreference.LOCAL_FIRST);
+    }
+
+    @VisibleForTesting
+    public FetchParams(
+            int replicaId,
+            boolean fetchOnlyLeader,
+            int maxFetchBytes,
+            int minFetchBytes,
+            long maxWaitMs,
+            @Nullable Map<Long, FilterInfo> tableFilterInfoMap,
+            FetchLogReadPreference readPreference) {
+        this.replicaId = replicaId;
+        this.fetchOnlyLeader = fetchOnlyLeader;
+        this.maxFetchBytes = maxFetchBytes;
+        this.fetchIsolation = FetchIsolation.of(replicaId >= 0);
+        this.minOneMessage = true;
+        this.fetchOffset = -1;
+        this.minFetchBytes = minFetchBytes;
+        this.maxWaitMs = maxWaitMs;
+        this.tableFilterInfoMap = tableFilterInfoMap;
+        this.readPreference = readPreference;
     }
 
     @VisibleForTesting
@@ -87,15 +124,14 @@ public final class FetchParams {
             int minFetchBytes,
             long maxWaitMs,
             @Nullable Map<Long, FilterInfo> tableFilterInfoMap) {
-        this.replicaId = replicaId;
-        this.fetchOnlyLeader = fetchOnlyLeader;
-        this.maxFetchBytes = maxFetchBytes;
-        this.fetchIsolation = FetchIsolation.of(replicaId >= 0);
-        this.minOneMessage = true;
-        this.fetchOffset = -1;
-        this.minFetchBytes = minFetchBytes;
-        this.maxWaitMs = maxWaitMs;
-        this.tableFilterInfoMap = tableFilterInfoMap;
+        this(
+                replicaId,
+                fetchOnlyLeader,
+                maxFetchBytes,
+                minFetchBytes,
+                maxWaitMs,
+                tableFilterInfoMap,
+                FetchLogReadPreference.LOCAL_FIRST);
     }
 
     public void setCurrentFetch(
@@ -183,6 +219,14 @@ public final class FetchParams {
         return replicaId >= 0;
     }
 
+    public FetchLogReadPreference readPreference() {
+        return readPreference;
+    }
+
+    public boolean isRemoteFirstClientFetch() {
+        return !isFromFollower() && readPreference == FetchLogReadPreference.REMOTE_FIRST;
+    }
+
     public boolean fetchOnlyLeader() {
         return isFromFollower() || fetchOnlyLeader;
     }
@@ -204,12 +248,19 @@ public final class FetchParams {
                 && maxFetchBytes == that.maxFetchBytes
                 && minFetchBytes == that.minFetchBytes
                 && maxWaitMs == that.maxWaitMs
+                && readPreference == that.readPreference
                 && Objects.equals(tableFilterInfoMap, that.tableFilterInfoMap);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(replicaId, maxFetchBytes, minFetchBytes, maxWaitMs, tableFilterInfoMap);
+        return Objects.hash(
+                replicaId,
+                maxFetchBytes,
+                minFetchBytes,
+                maxWaitMs,
+                tableFilterInfoMap,
+                readPreference);
     }
 
     @Override
@@ -225,6 +276,8 @@ public final class FetchParams {
                 + maxWaitMs
                 + ", tableFilterInfoMap="
                 + tableFilterInfoMap
+                + ", readPreference="
+                + readPreference
                 + ')';
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/FetchParamsBuilder.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/FetchParamsBuilder.java
@@ -18,6 +18,7 @@
 package org.apache.fluss.server.log;
 
 import org.apache.fluss.annotation.VisibleForTesting;
+import org.apache.fluss.rpc.protocol.FetchLogReadPreference;
 
 import javax.annotation.Nullable;
 
@@ -34,6 +35,7 @@ public final class FetchParamsBuilder {
     @Nullable private Map<Long, FilterInfo> tableFilterInfoMap;
     private int minFetchBytes;
     private long maxWaitMs;
+    private FetchLogReadPreference readPreference = FetchLogReadPreference.LOCAL_FIRST;
 
     public FetchParamsBuilder(int replicaId, int maxFetchBytes) {
         this.replicaId = replicaId;
@@ -63,6 +65,11 @@ public final class FetchParamsBuilder {
         return this;
     }
 
+    public FetchParamsBuilder withReadPreference(FetchLogReadPreference readPreference) {
+        this.readPreference = readPreference;
+        return this;
+    }
+
     public FetchParams build() {
         return new FetchParams(
                 replicaId,
@@ -70,6 +77,7 @@ public final class FetchParamsBuilder {
                 maxFetchBytes,
                 minFetchBytes,
                 maxWaitMs,
-                tableFilterInfoMap);
+                tableFilterInfoMap,
+                readPreference);
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1474,6 +1474,22 @@ public class ReplicaManager implements ServerReconfigurable {
                         replica.getArrowCompressionInfo(),
                         fetchReqInfo.getProjectFields(),
                         projectionsCache);
+
+                // If the client prefers remote reads and the offset is covered, return remote fetch
+                // info.
+                if (fetchParams.isRemoteFirstClientFetch()) {
+                    FetchLogResultForBucket remoteFirstFetchResult =
+                            tryFetchRemoteFirst(replica, fetchOffset);
+                    if (remoteFirstFetchResult != null) {
+                        logReadResult.put(
+                                tb,
+                                new LogReadResult(
+                                        remoteFirstFetchResult,
+                                        LogOffsetMetadata.UNKNOWN_OFFSET_METADATA));
+                        continue;
+                    }
+                }
+
                 LogReadInfo readInfo = replica.fetchRecords(fetchParams);
 
                 // Once we read from a non-empty bucket, we stop ignoring request and bucket
@@ -1530,6 +1546,37 @@ public class ReplicaManager implements ServerReconfigurable {
             }
         }
         return logReadResult;
+    }
+
+    private @Nullable FetchLogResultForBucket tryFetchRemoteFirst(
+            Replica replica, long fetchOffset) {
+        TableBucket tb = replica.getTableBucket();
+        long normalizedFetchOffset =
+                fetchOffset == FetchParams.FETCH_FROM_EARLIEST_OFFSET
+                        ? replica.getLogStartOffset()
+                        : fetchOffset;
+        if (!canFetchFromRemoteLog(replica, normalizedFetchOffset)) {
+            return null;
+        }
+
+        try {
+            RemoteLogFetchInfo remoteLogFetchInfo =
+                    fetchLogFromRemote(replica, normalizedFetchOffset);
+            if (remoteLogFetchInfo != null) {
+                return new FetchLogResultForBucket(
+                        tb, remoteLogFetchInfo, replica.getLogHighWatermark());
+            }
+            return new FetchLogResultForBucket(
+                    tb,
+                    ApiError.fromThrowable(
+                            new LogOffsetOutOfRangeException(
+                                    String.format(
+                                            "The fetch offset %s is covered by remote log range for table bucket %s, "
+                                                    + "but no remote log segment is available.",
+                                            normalizedFetchOffset, tb))));
+        } catch (Exception e) {
+            return new FetchLogResultForBucket(tb, ApiError.fromThrowable(e));
+        }
     }
 
     private FetchLogResultForBucket handleFetchOutOfRangeException(

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1566,16 +1566,12 @@ public class ReplicaManager implements ServerReconfigurable {
                 return new FetchLogResultForBucket(
                         tb, remoteLogFetchInfo, replica.getLogHighWatermark());
             }
-            return new FetchLogResultForBucket(
-                    tb,
-                    ApiError.fromThrowable(
-                            new LogOffsetOutOfRangeException(
-                                    String.format(
-                                            "The fetch offset %s is covered by remote log range for table bucket %s, "
-                                                    + "but no remote log segment is available.",
-                                            normalizedFetchOffset, tb))));
+            // Remote log is expected to cover the offset, but segments/manifest may not be ready yet.
+            // REMOTE_FIRST is a preference, so fall back to local reads.
+            return null;
         } catch (Exception e) {
-            return new FetchLogResultForBucket(tb, ApiError.fromThrowable(e));
+            // Fall back to local reads on remote fetch failures.
+            return null;
         }
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1566,7 +1566,8 @@ public class ReplicaManager implements ServerReconfigurable {
                 return new FetchLogResultForBucket(
                         tb, remoteLogFetchInfo, replica.getLogHighWatermark());
             }
-            // Remote log is expected to cover the offset, but segments/manifest may not be ready yet.
+            // Remote log is expected to cover the offset, but segments/manifest may not be ready
+            // yet.
             // REMOTE_FIRST is a preference, so fall back to local reads.
             return null;
         } catch (Exception e) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1550,6 +1550,13 @@ public class ReplicaManager implements ServerReconfigurable {
 
     private @Nullable FetchLogResultForBucket tryFetchRemoteFirst(
             Replica replica, long fetchOffset) {
+        if (!replica.isLeader()) {
+            throw new NotLeaderOrFollowerException(
+                    String.format(
+                            "Leader not local for bucket %s on tabletServer %d",
+                            replica.getTableBucket(), serverId));
+        }
+
         TableBucket tb = replica.getTableBucket();
         long normalizedFetchOffset =
                 fetchOffset == FetchParams.FETCH_FROM_EARLIEST_OFFSET
@@ -1571,6 +1578,11 @@ public class ReplicaManager implements ServerReconfigurable {
             // REMOTE_FIRST is a preference, so fall back to local reads.
             return null;
         } catch (Exception e) {
+            LOG.warn(
+                    "Failed to fetch remote log first for replica {} at offset {}; falling back to local reads",
+                    tb,
+                    normalizedFetchOffset,
+                    e);
             // Fall back to local reads on remote fetch failures.
             return null;
         }

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
@@ -76,6 +76,7 @@ import org.apache.fluss.rpc.messages.UpdateMetadataRequest;
 import org.apache.fluss.rpc.messages.UpdateMetadataResponse;
 import org.apache.fluss.rpc.protocol.ApiError;
 import org.apache.fluss.rpc.protocol.Errors;
+import org.apache.fluss.rpc.protocol.FetchLogReadPreference;
 import org.apache.fluss.rpc.protocol.MergeMode;
 import org.apache.fluss.security.acl.OperationType;
 import org.apache.fluss.security.acl.Resource;
@@ -248,6 +249,10 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     private static FetchParams getFetchParams(FetchLogRequest request) {
         FetchParams fetchParams;
         Map<Long, FilterInfo> tableFilterInfoMap = getTableFilterInfoMap(request);
+        FetchLogReadPreference readPreference =
+                request.hasReadPreference()
+                        ? FetchLogReadPreference.from(request.getReadPreference())
+                        : FetchLogReadPreference.LOCAL_FIRST;
         if (request.hasMinBytes()) {
             fetchParams =
                     new FetchParamsBuilder(request.getFollowerServerId(), request.getMaxBytes())
@@ -257,11 +262,13 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
                                             ? request.getMaxWaitMs()
                                             : DEFAULT_MAX_WAIT_MS_WHEN_MIN_BYTES_ENABLE)
                             .withTableFilterInfoMap(tableFilterInfoMap)
+                            .withReadPreference(readPreference)
                             .build();
         } else {
             fetchParams =
                     new FetchParamsBuilder(request.getFollowerServerId(), request.getMaxBytes())
                             .withTableFilterInfoMap(tableFilterInfoMap)
+                            .withReadPreference(readPreference)
                             .build();
         }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.fluss.remote.RemoteLogFetchInfo;
 import org.apache.fluss.remote.RemoteLogSegment;
 import org.apache.fluss.rpc.entity.FetchLogResultForBucket;
 import org.apache.fluss.rpc.protocol.ApiError;
+import org.apache.fluss.rpc.protocol.FetchLogReadPreference;
 import org.apache.fluss.server.coordinator.TestCoordinatorGateway;
 import org.apache.fluss.server.entity.FetchReqInfo;
 import org.apache.fluss.server.entity.StopReplicaData;
@@ -364,6 +365,53 @@ class RemoteLogManagerTest extends RemoteLogTestBase {
         assertThat(resultForBucket.getHighWatermark()).isEqualTo(50L);
         assertThat(resultForBucket.records()).isNotNull();
         assertThat(resultForBucket.fetchFromRemote()).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testRemoteFirstFetchPrefersRemoteWhenLocalStillHasRecords(boolean partitionTable)
+            throws Exception {
+        TableBucket tb = makeTableBucket(partitionTable);
+        makeLogTableAsLeader(tb, partitionTable);
+        LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
+        addMultiSegmentsToLogTablet(logTablet, 5);
+        remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
+        logTablet.updateRemoteLogEndOffset(40L);
+
+        Map<TableBucket, FetchReqInfo> fetchData =
+                Collections.singletonMap(tb, new FetchReqInfo(tb.getTableId(), 35L, 1024 * 1024));
+
+        CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> localFirstFuture =
+                new CompletableFuture<>();
+        replicaManager.fetchLogRecords(
+                new FetchParams(-1, Integer.MAX_VALUE),
+                fetchData,
+                null,
+                localFirstFuture::complete);
+        FetchLogResultForBucket localFirstResult = localFirstFuture.get().get(tb);
+        assertThat(localFirstResult.getError()).isEqualTo(ApiError.NONE);
+        assertThat(localFirstResult.fetchFromRemote()).isFalse();
+        assertThat(localFirstResult.records()).isNotNull();
+
+        CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> remoteFirstFuture =
+                new CompletableFuture<>();
+        replicaManager.fetchLogRecords(
+                new FetchParams(
+                        -1,
+                        true,
+                        Integer.MAX_VALUE,
+                        -1,
+                        -1,
+                        null,
+                        FetchLogReadPreference.REMOTE_FIRST),
+                fetchData,
+                null,
+                remoteFirstFuture::complete);
+        FetchLogResultForBucket remoteFirstResult = remoteFirstFuture.get().get(tb);
+        assertThat(remoteFirstResult.getError()).isEqualTo(ApiError.NONE);
+        assertThat(remoteFirstResult.fetchFromRemote()).isTrue();
+        assertThat(remoteFirstResult.records()).isNull();
+        assertThat(remoteFirstResult.remoteLogFetchInfo()).isNotNull();
     }
 
     @ParameterizedTest

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogManagerTest.java
@@ -28,6 +28,7 @@ import org.apache.fluss.rpc.protocol.ApiError;
 import org.apache.fluss.rpc.protocol.FetchLogReadPreference;
 import org.apache.fluss.server.coordinator.TestCoordinatorGateway;
 import org.apache.fluss.server.entity.FetchReqInfo;
+import org.apache.fluss.server.entity.NotifyLeaderAndIsrData;
 import org.apache.fluss.server.entity.StopReplicaData;
 import org.apache.fluss.server.entity.StopReplicaResultForBucket;
 import org.apache.fluss.server.log.FetchParams;
@@ -35,6 +36,7 @@ import org.apache.fluss.server.log.LogTablet;
 import org.apache.fluss.server.replica.Replica;
 import org.apache.fluss.server.replica.ReplicaManager;
 import org.apache.fluss.server.testutils.ServerTestTags;
+import org.apache.fluss.server.zk.data.LeaderAndIsr;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -60,6 +62,8 @@ import static org.apache.fluss.record.TestData.DATA1_SCHEMA;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_ID;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_PATH;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_PATH_PK;
+import static org.apache.fluss.server.coordinator.CoordinatorContext.INITIAL_COORDINATOR_EPOCH;
+import static org.apache.fluss.server.zk.data.LeaderAndIsr.INITIAL_BUCKET_EPOCH;
 import static org.apache.fluss.server.zk.data.LeaderAndIsr.INITIAL_LEADER_EPOCH;
 import static org.apache.fluss.utils.FlussPaths.remoteLogDir;
 import static org.apache.fluss.utils.FlussPaths.remoteLogTabletDir;
@@ -412,6 +416,53 @@ class RemoteLogManagerTest extends RemoteLogTestBase {
         assertThat(remoteFirstResult.fetchFromRemote()).isTrue();
         assertThat(remoteFirstResult.records()).isNull();
         assertThat(remoteFirstResult.remoteLogFetchInfo()).isNotNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testRemoteFirstFetchRejectsNonLeader(boolean partitionTable) throws Exception {
+        TableBucket tb = makeTableBucket(partitionTable);
+        makeLogTableAsLeader(tb, partitionTable);
+        Replica replica = replicaManager.getReplicaOrException(tb);
+        LogTablet logTablet = replica.getLogTablet();
+        addMultiSegmentsToLogTablet(logTablet, 5);
+        remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
+        logTablet.updateRemoteLogEndOffset(40L);
+
+        int newLeaderId = TABLET_SERVER_ID + 1;
+        replica.makeFollower(
+                new NotifyLeaderAndIsrData(
+                        partitionTable
+                                ? DATA1_PHYSICAL_TABLE_PATH_PA_2024
+                                : DATA1_PHYSICAL_TABLE_PATH,
+                        tb,
+                        Arrays.asList(TABLET_SERVER_ID, newLeaderId),
+                        new LeaderAndIsr(
+                                newLeaderId,
+                                INITIAL_LEADER_EPOCH + 1,
+                                Arrays.asList(TABLET_SERVER_ID, newLeaderId),
+                                Collections.emptyList(),
+                                INITIAL_COORDINATOR_EPOCH,
+                                INITIAL_BUCKET_EPOCH + 1)));
+
+        CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> fetchFuture =
+                new CompletableFuture<>();
+        replicaManager.fetchLogRecords(
+                new FetchParams(
+                        -1,
+                        true,
+                        Integer.MAX_VALUE,
+                        -1,
+                        -1,
+                        null,
+                        FetchLogReadPreference.REMOTE_FIRST),
+                Collections.singletonMap(tb, new FetchReqInfo(tb.getTableId(), 35L, 1024 * 1024)),
+                null,
+                fetchFuture::complete);
+
+        FetchLogResultForBucket result = fetchFuture.get().get(tb);
+        assertThat(result.getError().exception()).isInstanceOf(NotLeaderOrFollowerException.class);
+        assertThat(result.fetchFromRemote()).isFalse();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Purpose

The motivation of this PR is to reduce TabletServer RPC and local disk pressure when fetching high-throughput logs.

Based on observations from production workloads, when ingestion throughput reaches around 20 GB/s, log fetch traffic from the tiering service can reach about 30 GB/s. This puts significant additional pressure on TabletServers, especially on RPC handling and local disk reads.

link the issue of #3607 

### Brief change log

To address this, this PR makes it possible for tiering reads to fetch log data directly from remote storage when the requested offsets are already covered by remote logs.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
