### PR TITLE
[docs] Add docs for env.* JVM and process options

### DIFF
--- a/website/docs/maintenance/configuration.md
+++ b/website/docs/maintenance/configuration.md
@@ -54,6 +54,22 @@ during the Fluss cluster working.
 | server.io-pool.size                                 | Integer            | 10                                                                                                                                                                       | The size of the IO thread pool to run blocking operations for both coordinator and tablet servers. This includes discard unnecessary snapshot files, transfer kv snapshot files, and transfer remote log files. Increase this value if you experience slow IO operations. The default value is 10.                                                                                                                                                                                                                                                                                                                                                                                                                 |
 
 
+## Environment
+
+The following options control the launch environment of the Fluss server processes, such as the JVM options and the directory for process id files. They are set in `conf/server.yaml` and are applied by the startup scripts under `bin/` when starting the CoordinatorServer and TabletServer.
+
+| Option                           | Type   | Default | Description                                                                                                                                                                             |
+|----------------------------------|--------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| env.java.home                    | String | (None)  | Path to the JDK/JRE used to run the Fluss processes. If not set, the system `JAVA_HOME` or the `java` binary found on the `PATH` is used.                                               |
+| env.java.opts.all                | String | (None)  | JVM options applied to all Fluss server processes, i.e. both the CoordinatorServer and the TabletServer, for example `-Xmx4g -XX:+UseG1GC`. When `FLUSS_ENV_JAVA_OPTS` is not already set, the startup scripts prepend `-XX:+IgnoreUnrecognizedVMOptions` to the configured options and, on JDK 18+, append `-Djava.security.manager=allow`. |
+| env.java.opts.coordinator-server | String | (None)  | Additional JVM options applied only to the CoordinatorServer process. They are appended after `env.java.opts.all`.                                                                     |
+| env.java.opts.tablet-server      | String | (None)  | Additional JVM options applied only to the TabletServer process. They are appended after `env.java.opts.all`.                                                                          |
+| env.pid.dir                      | String | /tmp    | The directory where the `*.pid` files of the running Fluss processes are stored.                                                                                                       |
+
+:::note
+The logging-related environment options (`env.log.dir`, `env.log.level`, `env.log.max` and `env.stdout-err.redirect-to-file`) are described in the [Logging](observability/logging.md) documentation.
+:::
+
 ## CoordinatorServer
 
 | Option                                                 | Type       | Default   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |


### PR DESCRIPTION
### Purpose

Linked issue: close #2513

The `env.*` options that the `bin/` startup scripts read from `conf/server.yaml` were undocumented. This adds an **Environment** section to the Server Configuration page covering the JVM and process-launch options.

### Brief change log

- Add an `## Environment` section to `maintenance/configuration.md` documenting the options that `bin/config.sh` reads and applies at process launch:
  - `env.java.home`
  - `env.java.opts.all`
  - `env.java.opts.coordinator-server`
  - `env.java.opts.tablet-server`
  - `env.pid.dir`
- Cross-reference the [Logging](https://github.com/apache/fluss/blob/main/website/docs/maintenance/observability/logging.md) docs, which already document the `env.log.*` options, to avoid duplication.

Not included (from the issue's key list):
- `env.log.dir` / `env.log.level` / `env.log.max` / `env.stdout-err.redirect-to-file` — already documented under Logging.
- `remote.data.dir` — already documented in the same page's Common section.
- `env.ssh.opts` and `zookeeper.heap.mb` — currently read into shell variables (`FLUSS_SSH_OPTS`, `ZK_HEAP`) but not wired to any behavior in the shipped scripts, so documenting them as functional options would be misleading. Happy to include them if they are intended to work.

### Tests

Docs-only change. Built the site locally (`build_versioned_docs.sh` + `docusaurus build`); the new cross-reference link resolves and the change adds no broken links.

### API and Format

No API or storage format changes.

### Documentation

This PR is the documentation.

<!--
Generative AI disclosure: generative AI tools were used in authoring this PR.
Tool: Claude Code (Opus 4.8), following https://github.com/apache/fluss/blob/main/AGENTS.md
-->
