### PR TITLE
[docs] Fix misaligned rowspans in Table/Bucket metrics table

### DIFF
--- a/website/docs/maintenance/observability/monitor-metrics.md
+++ b/website/docs/maintenance/observability/monitor-metrics.md
@@ -762,7 +762,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </thead>
   <tbody>
     <tr>
-      <th rowspan="30"><strong>tabletserver</strong></th>
+      <th rowspan="31"><strong>tabletserver</strong></th>
       <td rowspan="20">table</td>
       <td>messagesInPerSecond</td>
       <td>The number of messages written per second to this table.</td>
@@ -864,7 +864,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>Meter</td>
     </tr>
      <tr>
-      <td rowspan="2">table_bucket_log</td>
+      <td rowspan="3">table_bucket_log</td>
       <td>numSegments</td>
       <td>The number of segments in local storage for this table bucket.</td>
       <td>Gauge</td>
@@ -896,7 +896,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>Gauge</td>
     </tr>
     <tr>
-      <td rowspan="3">table_bucket_remoteLog</td>
+      <td rowspan="4">table_bucket_remoteLog</td>
       <td>numSegments</td>
       <td>The number of segments in remote storage for this table bucket.</td>
       <td>Gauge</td>


### PR DESCRIPTION
### Purpose

Linked issue: #2812

The **Table/Bucket** table on the [Monitor Metrics](https://fluss.apache.org/docs/next/maintenance/observability/monitor-metrics/) page renders misaligned in the current (`next`) docs.

The table is written as raw HTML and uses `rowspan` to group rows by scope/infix. Three `rowspan` values were left smaller than the number of rows actually in each group:

| Element | `rowspan` | Actual rows |
|---|---|---|
| `tabletserver` (scope) | `30` → `31` | 20 + 3 + 2 + 4 + 2 |
| `table_bucket_log` (infix) | `2` → `3` | numSegments, startOffset, endOffset |
| `table_bucket_remoteLog` (infix) | `3` → `4` | numSegments, startOffset, endOffset, size |

Because each group spans one row too few, the trailing rows (`endOffset`, `size`, `kvSize`) shift left into the wrong columns — the metric name lands under **Metrics**, the type under **Description**, and **Type** is left blank; `kvSize` even bleeds into the **Scope** column.

**Note — this is not a duplicate of the already-merged #2813.** #2813 fixed the misaligned tables *as they were at that time* (including the Coordinator Server table shown in the #2812 screenshot, which now renders correctly). Afterwards, the `startOffset` rows were added to the `table_bucket_log` and `table_bucket_remoteLog` groups without bumping their `rowspan`, so the **Table/Bucket** table broke again. #2812 is still open, and this PR fixes the remaining/regressed table that #2813 did not cover. The released docs are unaffected — the breakage is only visible in the `next` (development) version.

### Brief change log

- Correct the `rowspan` counts for `tabletserver`, `table_bucket_log`, and `table_bucket_remoteLog` in `website/docs/maintenance/observability/monitor-metrics.md`.

### Screenshots

**Before:**


<img width="1433" height="675" alt="Screenshot 2026-07-08 at 4 06 34 PM" src="https://github.com/user-attachments/assets/f2e00da8-b8c3-42a5-9ac5-5d2550ba30f0" />

**After:**

<img width="1491" height="582" alt="Screenshot 2026-07-08 at 4 06 49 PM" src="https://github.com/user-attachments/assets/594b9719-47db-434b-ab80-ac6f1892c32a" />

### Tests

Docs-only change. Built the site locally (`docusaurus build`) with no new broken links, and verified every HTML table on the page now aligns (each `rowspan` matches its group's row count).

### API and Format

No API or storage format changes.

### Documentation

This PR is a documentation fix.

<!--
Generative AI disclosure: generative AI tools were used in authoring this PR.
Tool: Claude Code (Opus 4.8), following https://github.com/apache/fluss/blob/main/AGENTS.md
-->
