### PR TITLE
[common] Fix equals/hashCode contract violation in Schema.PrimaryKey

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
@@ -102,10 +102,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -350,6 +352,45 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
                 admin.getTableInfo(tablePath).get().getProperties().toMap();
         assertThat(properties.containsKey("table.datalake.paimon.jdbc.user")).isTrue();
         assertThat(properties.containsKey("table.datalake.paimon.jdbc.password")).isFalse();
+    }
+
+    @Test
+    void testPrimaryKeySchemaReadBackIsUsableAsHashKey() throws Exception {
+        // End-to-end: create a primary-key table through the Admin API (the coordinator
+        // persists its schema to ZooKeeper), then read the schema back from the cluster.
+        // The schema returned by the server is deserialized from its persisted form, so it is
+        // a different instance than the one submitted. Per the Object.hashCode() contract,
+        // equal schemas must have equal hash codes and must be interchangeable as keys in
+        // hash-based collections. Before the Schema.PrimaryKey.hashCode() fix, the read-back
+        // schema was equal() to the submitted one but hashed differently (its PrimaryKey
+        // folded in the Object identity hash), so it could not be found in a HashSet/HashMap.
+        TablePath tablePath = TablePath.of("test_db", "pk_schema_hashkey");
+        Schema submittedSchema =
+                Schema.newBuilder()
+                        .primaryKey("id")
+                        .column("id", DataTypes.INT())
+                        .column("name", DataTypes.STRING())
+                        .build();
+        admin.createTable(
+                        tablePath,
+                        TableDescriptor.builder()
+                                .schema(submittedSchema)
+                                .distributedBy(3, "id")
+                                .build(),
+                        false)
+                .get();
+
+        Schema readBackSchema = admin.getTableSchema(tablePath).get().getSchema();
+
+        // The schema read back from the cluster is equal to the submitted one ...
+        assertThat(readBackSchema).isEqualTo(submittedSchema);
+        // ... so per the equals/hashCode contract it must hash the same ...
+        assertThat(readBackSchema.hashCode()).isEqualTo(submittedSchema.hashCode());
+        // ... and be found via a hash-based lookup when the submitted schema is used as a key
+        // (HashSet.contains relies on hashCode, unlike AssertJ's equals-only contains).
+        Set<Schema> knownSchemas = new HashSet<>();
+        knownSchemas.add(submittedSchema);
+        assertThat(knownSchemas.contains(readBackSchema)).isTrue();
     }
 
     @Test

--- a/fluss-common/src/main/java/org/apache/fluss/metadata/Schema.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metadata/Schema.java
@@ -732,7 +732,7 @@ public final class Schema implements Serializable {
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), columnNames);
+            return Objects.hash(columnNames);
         }
     }
 

--- a/fluss-common/src/test/java/org/apache/fluss/metadata/TableSchemaTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/metadata/TableSchemaTest.java
@@ -24,7 +24,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -338,6 +340,54 @@ class TableSchemaTest {
 
         assertThat(schema1).isEqualTo(schema2);
         assertThat(schema1).isNotEqualTo(schema3);
+    }
+
+    @Test
+    void testPrimaryKeySchemaSurvivesJsonRoundTripAsHashKey() {
+        // A primary-key schema is serialized to JSON when it is persisted (e.g. to
+        // ZooKeeper via SchemaZNode) and deserialized when it is read back. The reloaded
+        // schema is equal() to the in-memory one, so per the Object.hashCode() contract
+        // ("If two objects are equal according to the equals(Object) method, then calling
+        // the hashCode method on each of the two objects must produce the same integer
+        // result.") it must also hash equally and remain usable as a key in hash-based
+        // collections. Before this fix, Schema.PrimaryKey.hashCode() folded in
+        // super.hashCode() (the Object identity hash) while equals() compares only the
+        // column names, so a reloaded schema could not be found in a HashSet/HashMap.
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column("value", DataTypes.BIGINT())
+                        .primaryKey("id")
+                        .build();
+
+        Schema reloaded = Schema.fromJsonBytes(schema.toJsonBytes());
+
+        // Root cause: the two equal primary keys must hash equally.
+        Schema.PrimaryKey primaryKey = schema.getPrimaryKey().get();
+        Schema.PrimaryKey reloadedPrimaryKey = reloaded.getPrimaryKey().get();
+        assertThat(reloadedPrimaryKey).isEqualTo(primaryKey);
+        assertThat(reloadedPrimaryKey.hashCode()).isEqualTo(primaryKey.hashCode());
+
+        // The violation propagates to the enclosing Schema, which includes the primary key.
+        assertThat(reloaded).isEqualTo(schema);
+        assertThat(reloaded.hashCode()).isEqualTo(schema.hashCode());
+
+        // A reloaded schema must be found in a hash-based collection of schemas.
+        Set<Schema> schemas = new HashSet<>();
+        schemas.add(schema);
+        assertThat(schemas.contains(reloaded)).isTrue();
+
+        // equals() intentionally ignores constraintName, so two primary keys with the same
+        // columns but different constraint names are equal and therefore must hash equally.
+        // This pins the fix to hashing columnNames only: a hashCode over constraintName would
+        // pass the round-trip assertions above (the serde regenerates an identical name) but
+        // would break this contract.
+        Schema.PrimaryKey generatedName =
+                new Schema.PrimaryKey("PK_id", Collections.singletonList("id"));
+        Schema.PrimaryKey customName =
+                new Schema.PrimaryKey("custom_pk", Collections.singletonList("id"));
+        assertThat(customName).isEqualTo(generatedName);
+        assertThat(customName.hashCode()).isEqualTo(generatedName.hashCode());
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Linked issue: close #3628

`Schema.PrimaryKey.hashCode()` folds in `super.hashCode()` (the `Object` per-instance hash) while `equals()` compares only `columnNames`, so two value-equal primary keys return different hash codes. This violates the `Object.equals`/`hashCode` contract and propagates through `Schema.hashCode()` and the public `TableDescriptor`, so an equal schema/table descriptor can be missing from a `HashSet`/`HashMap` (e.g. after a `toJsonBytes`/`fromJsonBytes` round-trip). Standalone reproduction against the released 0.9.1-incubating artifact: https://github.com/NestDream/fluss-pk-hashcode-demo

### Brief change log

- `Schema.PrimaryKey.hashCode()`: `Objects.hash(super.hashCode(), columnNames)` → `Objects.hash(columnNames)`, matching the field `equals()` compares and the value-based hashing already used by `Schema` and `Column`.

### Tests

- `TableSchemaTest#testPrimaryKeySchemaSurvivesJsonRoundTripAsHashKey` (unit): round-trips a primary-key schema via `toJsonBytes`/`fromJsonBytes` and asserts the reloaded schema hashes equally and is found in a `HashSet<Schema>`; also asserts two primary keys with equal columns but different constraint names are equal and hash-equal. Fails before the fix, passes after.
- `FlussAdminITCase#testPrimaryKeySchemaReadBackIsUsableAsHashKey` (end-to-end): creates a primary-key table via `Admin.createTable`, reads the schema back via `Admin.getTableSchema`, and asserts it is usable as a hash key. Fails before the fix, passes after.
- Existing `TableSchemaTest`, `TableDescriptorTest`, `SchemaJsonSerdeTest` continue to pass (`mvn verify -pl fluss-common`: 1684 tests, 0 failures).

### API and Format

No public API or storage format change. `hashCode()` is never persisted or transmitted (`SchemaJsonSerde` writes explicit fields; on-the-wire schema identity is the separate `schemaId`).

### Documentation

No documentation change; behavior-only fix.

- [ ] No generative AI tools used
- [x] Yes (please specify the tool below)

Assisted by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)