### PR TITLE
[hotfix][dist] Disable Log4j shutdown hook in foreground mode

### DIFF
--- a/fluss-dist/src/main/resources/bin/fluss-console.sh
+++ b/fluss-dist/src/main/resources/bin/fluss-console.sh
@@ -81,7 +81,7 @@ log="${FLUSS_LOG_PREFIX}.log"
 out="${FLUSS_LOG_PREFIX}.out"
 err="${FLUSS_LOG_PREFIX}.err"
 
-log_setting=("-Dlog.file=${log}" "-Dlog4j.configuration=file:${FLUSS_CONF_DIR}/log4j-console.properties" "-Dlog4j.configurationFile=file:${FLUSS_CONF_DIR}/log4j-console.properties" "-Dlogback.configurationFile=file:${FLUSS_CONF_DIR}/logback-console.xml")
+log_setting=("-Dlog.file=${log}" "-Dlog4j.shutdownHookEnabled=false" "-Dlog4j.configuration=file:${FLUSS_CONF_DIR}/log4j-console.properties" "-Dlog4j.configurationFile=file:${FLUSS_CONF_DIR}/log4j-console.properties" "-Dlogback.configurationFile=file:${FLUSS_CONF_DIR}/logback-console.xml")
 
 echo "Starting $SERVICE as a console application on host $HOSTNAME."
 

--- a/fluss-dist/src/test/java/org/apache/fluss/dist/DistShellScriptTest.java
+++ b/fluss-dist/src/test/java/org/apache/fluss/dist/DistShellScriptTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.dist;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class DistShellScriptTest {
+
+    private static final String LOG4J_SHUTDOWN_HOOK_DISABLED = "-Dlog4j.shutdownHookEnabled=false";
+
+    @Test
+    void testForegroundAndDaemonDisableLog4jShutdownHook() throws Exception {
+        assertThat(readBinScript("fluss-console.sh"))
+                .contains(LOG4J_SHUTDOWN_HOOK_DISABLED)
+                .contains("log4j-console.properties");
+
+        assertThat(readBinScript("fluss-daemon.sh"))
+                .contains(LOG4J_SHUTDOWN_HOOK_DISABLED)
+                .contains("log4j.properties");
+    }
+
+    private static String readBinScript(String scriptName) throws IOException {
+        Path scriptPath =
+                Paths.get(
+                        System.getProperty("project.basedir"),
+                        "src",
+                        "main",
+                        "resources",
+                        "bin",
+                        scriptName);
+        return new String(Files.readAllBytes(scriptPath), StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

#2020 disabled Log4j's shutdown hook for daemon mode so Fluss shutdown-hook logs can still be emitted during process shutdown. However, Kubernetes and Docker deployments use start-foreground, which goes through `fluss-console.sh` instead of `fluss-daemon.sh`.

As a result, foreground TabletServer/Coordinator processes could still let Log4j close appenders before the Fluss shutdown hook runs, causing shutdown logs such as "Shutting down KvManager" to be lost.

Apply the same Log4j shutdown-hook setting to fluss-console.sh and add a dist script test to cover both foreground and daemon startup paths.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
