### PR TITLE
[tiering][iceberg] Validate partition spec before lake tiering

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/lake/writer/TieringTableValidator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/lake/writer/TieringTableValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.writer;
+
+import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.metadata.TableInfo;
+
+import java.io.IOException;
+
+/**
+ * An optional capability that a {@link LakeTieringFactory} may implement to validate whether a
+ * Fluss table can be tiered to the configured lake storage.
+ *
+ * <p>The validation runs before tiering splits are generated, so an incompatible table only fails
+ * that table instead of the whole tiering job. Lake formats that do not implement this interface
+ * are tiered without extra validation.
+ */
+@Internal
+public interface TieringTableValidator {
+
+    /**
+     * Validates whether the given Fluss table can be tiered to the configured lake storage.
+     *
+     * @param tableInfo the Fluss table metadata
+     * @throws IOException if the validation fails or cannot be completed
+     */
+    void validateTable(TableInfo tableInfo) throws IOException;
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSource.java
@@ -84,7 +84,7 @@ public class TieringSource<WriteResult>
     public SplitEnumerator<TieringSplit, TieringSourceEnumeratorState> createEnumerator(
             SplitEnumeratorContext<TieringSplit> splitEnumeratorContext) {
         return new TieringSourceEnumerator(
-                flussConf, splitEnumeratorContext, pollTieringTableIntervalMs);
+                flussConf, splitEnumeratorContext, lakeTieringFactory, pollTieringTableIntervalMs);
     }
 
     @Override
@@ -93,7 +93,7 @@ public class TieringSource<WriteResult>
             TieringSourceEnumeratorState tieringSourceEnumeratorState) {
         // stateless operator
         return new TieringSourceEnumerator(
-                flussConf, splitEnumeratorContext, pollTieringTableIntervalMs);
+                flussConf, splitEnumeratorContext, lakeTieringFactory, pollTieringTableIntervalMs);
     }
 
     @Override

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumerator.java
@@ -31,6 +31,8 @@ import org.apache.fluss.flink.tiering.source.split.TieringSplit;
 import org.apache.fluss.flink.tiering.source.split.TieringSplitGenerator;
 import org.apache.fluss.flink.tiering.source.state.TieringSourceEnumeratorState;
 import org.apache.fluss.lake.committer.TieringStats;
+import org.apache.fluss.lake.writer.LakeTieringFactory;
+import org.apache.fluss.lake.writer.TieringTableValidator;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.rpc.GatewayClientProxy;
@@ -99,6 +101,7 @@ public class TieringSourceEnumerator
 
     private final Configuration flussConf;
     private final SplitEnumeratorContext<TieringSplit> context;
+    private final LakeTieringFactory<?, ?> lakeTieringFactory;
     private final ScheduledExecutorService timerService;
     private final SplitEnumeratorMetricGroup enumeratorMetricGroup;
     private final long pollTieringTableIntervalMs;
@@ -125,9 +128,11 @@ public class TieringSourceEnumerator
     public TieringSourceEnumerator(
             Configuration flussConf,
             SplitEnumeratorContext<TieringSplit> context,
+            LakeTieringFactory<?, ?> lakeTieringFactory,
             long pollTieringTableIntervalMs) {
         this.flussConf = flussConf;
         this.context = context;
+        this.lakeTieringFactory = lakeTieringFactory;
         this.timerService =
                 Executors.newSingleThreadScheduledExecutor(
                         r -> new Thread(r, "Tiering-Timer-Thread"));
@@ -449,6 +454,9 @@ public class TieringSourceEnumerator
         try {
             TablePath tablePath = tieringTable.f2;
             final TableInfo tableInfo = flussAdmin.getTableInfo(tablePath).get();
+            if (lakeTieringFactory instanceof TieringTableValidator) {
+                ((TieringTableValidator) lakeTieringFactory).validateTable(tableInfo);
+            }
             List<TieringSplit> tieringSplits = splitGenerator.generateTableSplits(tableInfo);
             // shuffle tiering split to avoid splits tiering skew
             // after introduce tiering max duration

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TestingLakeTieringFactory.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TestingLakeTieringFactory.java
@@ -26,7 +26,9 @@ import org.apache.fluss.lake.committer.LakeCommitter;
 import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
 import org.apache.fluss.lake.writer.LakeWriter;
+import org.apache.fluss.lake.writer.TieringTableValidator;
 import org.apache.fluss.lake.writer.WriterInitContext;
+import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.record.LogRecord;
 
 import javax.annotation.Nullable;
@@ -38,7 +40,8 @@ import java.util.Map;
 
 /** An implementation of {@link LakeTieringFactory} for testing purpose. */
 public class TestingLakeTieringFactory
-        implements LakeTieringFactory<TestingWriteResult, TestingCommittable> {
+        implements LakeTieringFactory<TestingWriteResult, TestingCommittable>,
+                TieringTableValidator {
 
     @Nullable private TestingLakeCommitter testingLakeCommitter;
 
@@ -49,6 +52,9 @@ public class TestingLakeTieringFactory
     public TestingLakeTieringFactory() {
         this(null);
     }
+
+    @Override
+    public void validateTable(TableInfo tableInfo) throws IOException {}
 
     @Override
     public LakeWriter<TestingWriteResult> createLakeWriter(WriterInitContext writerInitContext)

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumeratorTest.java
@@ -20,6 +20,7 @@ package org.apache.fluss.flink.tiering.source.enumerator;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.NetworkException;
+import org.apache.fluss.flink.tiering.TestingLakeTieringFactory;
 import org.apache.fluss.flink.tiering.event.FailedTieringEvent;
 import org.apache.fluss.flink.tiering.event.FinishedTieringEvent;
 import org.apache.fluss.flink.tiering.event.TieringReachMaxDurationEvent;
@@ -28,8 +29,10 @@ import org.apache.fluss.flink.tiering.source.split.TieringLogSplit;
 import org.apache.fluss.flink.tiering.source.split.TieringSnapshotSplit;
 import org.apache.fluss.flink.tiering.source.split.TieringSplit;
 import org.apache.fluss.flink.tiering.source.split.TieringSplitGenerator;
+import org.apache.fluss.lake.writer.LakeTieringFactory;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableChange;
+import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.rpc.messages.CommitLakeTableSnapshotRequest;
 import org.apache.fluss.rpc.messages.PbLakeTableOffsetForBucket;
@@ -45,12 +48,14 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -773,7 +778,41 @@ class TieringSourceEnumeratorTest extends TieringTestBase {
 
     private TieringSourceEnumerator createTieringSourceEnumerator(
             Configuration flussConf, MockSplitEnumeratorContext<TieringSplit> context) {
-        return new TieringSourceEnumerator(flussConf, context, 500);
+        return createTieringSourceEnumerator(flussConf, context, new TestingLakeTieringFactory());
+    }
+
+    private TieringSourceEnumerator createTieringSourceEnumerator(
+            Configuration flussConf,
+            MockSplitEnumeratorContext<TieringSplit> context,
+            LakeTieringFactory<?, ?> lakeTieringFactory) {
+        return new TieringSourceEnumerator(flussConf, context, lakeTieringFactory, 500);
+    }
+
+    @Test
+    void testTableValidationFailureDoesNotAssignSplits() throws Exception {
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "tiering-validation-failure");
+        createTable(tablePath, DEFAULT_LOG_TABLE_DESCRIPTOR);
+        AtomicReference<TableInfo> validatedTable = new AtomicReference<>();
+        TestingLakeTieringFactory lakeTieringFactory =
+                new TestingLakeTieringFactory() {
+                    @Override
+                    public void validateTable(TableInfo tableInfo) throws IOException {
+                        validatedTable.set(tableInfo);
+                        throw new IOException("expected validation failure");
+                    }
+                };
+
+        try (FlussMockSplitEnumeratorContext<TieringSplit> context =
+                        new FlussMockSplitEnumeratorContext<>(1);
+                TieringSourceEnumerator enumerator =
+                        createTieringSourceEnumerator(flussConf, context, lakeTieringFactory)) {
+            enumerator.start();
+            registerSingleReaderAndHandleSplitRequests(context, enumerator, 0, 0);
+
+            assertThat(validatedTable.get()).isNotNull();
+            assertThat(validatedTable.get().getTablePath()).isEqualTo(tablePath);
+            assertThat(context.getSplitsAssignmentSequence()).isEmpty();
+        }
     }
 
     @Test

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalog.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalog.java
@@ -20,10 +20,10 @@ package org.apache.fluss.lake.iceberg;
 import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.InvalidAlterTableException;
-import org.apache.fluss.exception.InvalidTableException;
 import org.apache.fluss.exception.TableAlreadyExistException;
 import org.apache.fluss.exception.TableNotExistException;
 import org.apache.fluss.lake.iceberg.utils.IcebergCatalogUtils;
+import org.apache.fluss.lake.iceberg.utils.IcebergPartitionSpecUtils;
 import org.apache.fluss.lake.lakestorage.LakeCatalog;
 import org.apache.fluss.metadata.TableChange;
 import org.apache.fluss.metadata.TableDescriptor;
@@ -46,24 +46,18 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types;
 
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.fluss.metadata.TableDescriptor.BUCKET_COLUMN_NAME;
+import static org.apache.fluss.lake.iceberg.IcebergSchemaUtils.SYSTEM_COLUMNS;
 import static org.apache.fluss.metadata.TableDescriptor.OFFSET_COLUMN_NAME;
-import static org.apache.fluss.metadata.TableDescriptor.TIMESTAMP_COLUMN_NAME;
 import static org.apache.fluss.utils.Preconditions.checkArgument;
-import static org.apache.iceberg.types.Type.TypeID.STRING;
 
 /** An Iceberg implementation of {@link LakeCatalog}. */
 public class IcebergLakeCatalog implements LakeCatalog {
@@ -73,16 +67,6 @@ public class IcebergLakeCatalog implements LakeCatalog {
                     TableProperties.MERGE_MODE,
                     TableProperties.UPDATE_MODE,
                     TableProperties.DELETE_MODE);
-
-    public static final LinkedHashMap<String, Type> SYSTEM_COLUMNS = new LinkedHashMap<>();
-
-    static {
-        // We need __bucket system column to filter out the given bucket
-        // for iceberg bucket append only table & primary key table.
-        SYSTEM_COLUMNS.put(BUCKET_COLUMN_NAME, Types.IntegerType.get());
-        SYSTEM_COLUMNS.put(OFFSET_COLUMN_NAME, Types.LongType.get());
-        SYSTEM_COLUMNS.put(TIMESTAMP_COLUMN_NAME, Types.TimestampType.withZone());
-    }
 
     private final Catalog icebergCatalog;
 
@@ -106,11 +90,11 @@ public class IcebergLakeCatalog implements LakeCatalog {
         // convert Fluss table path to iceberg table
         boolean isPkTable = tableDescriptor.hasPrimaryKey();
         TableIdentifier icebergId = toIcebergTableIdentifier(tablePath);
-        Schema icebergSchema = convertToIcebergSchema(tableDescriptor, isPkTable);
+        Schema icebergSchema = IcebergSchemaUtils.createIcebergSchema(tableDescriptor, isPkTable);
         Catalog.TableBuilder tableBuilder = icebergCatalog.buildTable(icebergId, icebergSchema);
 
         PartitionSpec partitionSpec =
-                createPartitionSpec(tableDescriptor, icebergSchema, isPkTable);
+                IcebergPartitionSpecUtils.createPartitionSpec(tableDescriptor, icebergSchema);
         SortOrder sortOrder = createSortOrder(icebergSchema);
         tableBuilder.withProperties(buildTableProperties(tableDescriptor, isPkTable));
         tableBuilder.withPartitionSpec(partitionSpec);
@@ -253,10 +237,8 @@ public class IcebergLakeCatalog implements LakeCatalog {
      * descriptor. Compatibility means the user columns and system columns match in name, type, and
      * nullability (ignoring Iceberg-assigned field IDs).
      *
-     * <p>Iceberg reassigns field IDs during table creation, so the IDs in the stored schema differ
-     * from those we generate via {@link #convertToIcebergSchema}. We normalize both schemas to the
-     * same fresh ID space using {@link TypeUtil#assignIncreasingFreshIds} before comparing, so that
-     * {@link Type#equals} works correctly for all types including complex ones (Map, List, Struct).
+     * <p>Iceberg reassigns field IDs during table creation, so field IDs are ignored by this
+     * comparison.
      */
     @VisibleForTesting
     boolean isIcebergSchemaCompatible(
@@ -264,29 +246,9 @@ public class IcebergLakeCatalog implements LakeCatalog {
         if (flussTableDescriptor == null) {
             return false;
         }
-        // isPkTable=false: identifier fields don't affect the comparison
-        Schema expectedSchema = convertToIcebergSchema(flussTableDescriptor, false);
-
-        Schema normalizedIceberg = TypeUtil.assignIncreasingFreshIds(icebergSchema);
-        Schema normalizedExpected = TypeUtil.assignIncreasingFreshIds(expectedSchema);
-
-        List<Types.NestedField> currentFields = normalizedIceberg.columns();
-        List<Types.NestedField> expectedFields = normalizedExpected.columns();
-
-        if (currentFields.size() != expectedFields.size()) {
-            return false;
-        }
-
-        for (int i = 0; i < currentFields.size(); i++) {
-            Types.NestedField current = currentFields.get(i);
-            Types.NestedField expected = expectedFields.get(i);
-            if (!current.name().equals(expected.name())
-                    || !current.type().equals(expected.type())
-                    || current.isOptional() != expected.isOptional()) {
-                return false;
-            }
-        }
-        return true;
+        // Identifier fields don't affect the comparison.
+        Schema expectedSchema = IcebergSchemaUtils.createIcebergSchema(flussTableDescriptor, false);
+        return IcebergSchemaUtils.compatibleWith(icebergSchema, expectedSchema);
     }
 
     private TableIdentifier toIcebergTableIdentifier(TablePath tablePath) {
@@ -299,114 +261,6 @@ public class IcebergLakeCatalog implements LakeCatalog {
         } catch (AlreadyExistsException e) {
             throw new TableAlreadyExistException("Table " + tablePath + " already exists.");
         }
-    }
-
-    public Schema convertToIcebergSchema(TableDescriptor tableDescriptor, boolean isPkTable) {
-        List<Types.NestedField> fields = new ArrayList<>();
-        int fieldId = 0;
-
-        int totalTopLevelFields =
-                tableDescriptor.getSchema().getColumns().size() + SYSTEM_COLUMNS.size();
-        FlussDataTypeToIcebergDataType converter =
-                new FlussDataTypeToIcebergDataType(totalTopLevelFields);
-
-        // general columns
-        for (org.apache.fluss.metadata.Schema.Column column :
-                tableDescriptor.getSchema().getColumns()) {
-            String colName = column.getName();
-            if (SYSTEM_COLUMNS.containsKey(colName)) {
-                throw new IllegalArgumentException(
-                        "Column '" + colName + "' conflicts with a reserved system column name.");
-            }
-            Types.NestedField field;
-            if (column.getDataType().isNullable()) {
-                field =
-                        Types.NestedField.optional(
-                                fieldId++,
-                                colName,
-                                column.getDataType().accept(converter),
-                                column.getComment().orElse(null));
-            } else {
-                field =
-                        Types.NestedField.required(
-                                fieldId++,
-                                colName,
-                                column.getDataType().accept(converter),
-                                column.getComment().orElse(null));
-            }
-            fields.add(field);
-        }
-
-        // system columns
-        for (Map.Entry<String, Type> systemColumn : SYSTEM_COLUMNS.entrySet()) {
-            fields.add(
-                    Types.NestedField.required(
-                            fieldId++, systemColumn.getKey(), systemColumn.getValue()));
-        }
-
-        if (isPkTable) {
-            // set identifier fields
-            int[] primaryKeyIndexes = tableDescriptor.getSchema().getPrimaryKeyIndexes();
-            Set<Integer> identifierFieldIds = new HashSet<>();
-            for (int pkIdx : primaryKeyIndexes) {
-                identifierFieldIds.add(fields.get(pkIdx).fieldId());
-            }
-            return new Schema(fields, identifierFieldIds);
-        } else {
-            return new Schema(fields);
-        }
-    }
-
-    private PartitionSpec createPartitionSpec(
-            TableDescriptor tableDescriptor, Schema icebergSchema, boolean isPkTable) {
-        List<String> bucketKeys = tableDescriptor.getBucketKeys();
-        int bucketCount =
-                tableDescriptor
-                        .getTableDistribution()
-                        .flatMap(TableDescriptor.TableDistribution::getBucketCount)
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                "Bucket count (bucket.num) must be set"));
-
-        // Only support one bucket key for now
-        if (bucketKeys.size() > 1) {
-            throw new UnsupportedOperationException(
-                    "Only one bucket key is supported for Iceberg at the moment");
-        }
-
-        // pk table must have bucket key
-        if (bucketKeys.isEmpty() && isPkTable) {
-            throw new IllegalArgumentException(
-                    "Bucket key must be set for primary key Iceberg tables");
-        }
-
-        PartitionSpec.Builder builder = PartitionSpec.builderFor(icebergSchema);
-        List<String> partitionKeys = tableDescriptor.getPartitionKeys();
-        // always set identity partition with partition key
-        for (String partitionKey : partitionKeys) {
-            if (!icebergSchema.findType(partitionKey).typeId().equals(STRING)) {
-                // TODO: Support other types of partition keys
-                throw new InvalidTableException(
-                        String.format(
-                                "Partition key only support string type for iceberg currently. Column `%s` is not string type.",
-                                partitionKey));
-            }
-            builder.identity(partitionKey);
-        }
-
-        if (isPkTable) {
-            builder.bucket(bucketKeys.get(0), bucketCount);
-        } else {
-            // if there is no bucket keys, use identity(__bucket)
-            if (bucketKeys.isEmpty()) {
-                builder.identity(BUCKET_COLUMN_NAME);
-            } else {
-                builder.bucket(bucketKeys.get(0), bucketCount);
-            }
-        }
-
-        return builder.build();
     }
 
     private void setFlussPropertyToIceberg(

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/IcebergSchemaUtils.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/IcebergSchemaUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.iceberg;
+
+import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.metadata.TableDescriptor;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.fluss.metadata.TableDescriptor.BUCKET_COLUMN_NAME;
+import static org.apache.fluss.metadata.TableDescriptor.OFFSET_COLUMN_NAME;
+import static org.apache.fluss.metadata.TableDescriptor.TIMESTAMP_COLUMN_NAME;
+
+/** Utilities for constructing and comparing the Iceberg schema managed by Fluss. */
+@Internal
+public final class IcebergSchemaUtils {
+
+    /** The Iceberg-only system columns appended to every Fluss-managed Iceberg table. */
+    public static final Map<String, Type> SYSTEM_COLUMNS;
+
+    static {
+        LinkedHashMap<String, Type> systemColumns = new LinkedHashMap<>();
+        systemColumns.put(BUCKET_COLUMN_NAME, Types.IntegerType.get());
+        systemColumns.put(OFFSET_COLUMN_NAME, Types.LongType.get());
+        systemColumns.put(TIMESTAMP_COLUMN_NAME, Types.TimestampType.withZone());
+        SYSTEM_COLUMNS = Collections.unmodifiableMap(systemColumns);
+    }
+
+    private IcebergSchemaUtils() {}
+
+    /** Creates the Iceberg schema managed by Fluss from a Fluss table descriptor. */
+    public static Schema createIcebergSchema(
+            TableDescriptor tableDescriptor, boolean isPrimaryKeyTable) {
+        List<Types.NestedField> fields = new ArrayList<>();
+        int fieldId = 0;
+
+        int totalTopLevelFields =
+                tableDescriptor.getSchema().getColumns().size() + SYSTEM_COLUMNS.size();
+        FlussDataTypeToIcebergDataType converter =
+                new FlussDataTypeToIcebergDataType(totalTopLevelFields);
+
+        for (org.apache.fluss.metadata.Schema.Column column :
+                tableDescriptor.getSchema().getColumns()) {
+            String columnName = column.getName();
+            if (SYSTEM_COLUMNS.containsKey(columnName)) {
+                throw new IllegalArgumentException(
+                        "Column '"
+                                + columnName
+                                + "' conflicts with a reserved system column name.");
+            }
+            Types.NestedField field;
+            if (column.getDataType().isNullable()) {
+                field =
+                        Types.NestedField.optional(
+                                fieldId++,
+                                columnName,
+                                column.getDataType().accept(converter),
+                                column.getComment().orElse(null));
+            } else {
+                field =
+                        Types.NestedField.required(
+                                fieldId++,
+                                columnName,
+                                column.getDataType().accept(converter),
+                                column.getComment().orElse(null));
+            }
+            fields.add(field);
+        }
+
+        for (Map.Entry<String, Type> systemColumn : SYSTEM_COLUMNS.entrySet()) {
+            fields.add(
+                    Types.NestedField.required(
+                            fieldId++, systemColumn.getKey(), systemColumn.getValue()));
+        }
+
+        if (isPrimaryKeyTable) {
+            int[] primaryKeyIndexes = tableDescriptor.getSchema().getPrimaryKeyIndexes();
+            Set<Integer> identifierFieldIds = new HashSet<>();
+            for (int primaryKeyIndex : primaryKeyIndexes) {
+                identifierFieldIds.add(fields.get(primaryKeyIndex).fieldId());
+            }
+            return new Schema(fields, identifierFieldIds);
+        }
+        return new Schema(fields);
+    }
+
+    /** Returns whether two Iceberg schemas have the same Fluss-managed structure. */
+    public static boolean compatibleWith(Schema currentSchema, Schema expectedSchema) {
+        List<Types.NestedField> currentFields =
+                TypeUtil.assignIncreasingFreshIds(currentSchema).columns();
+        List<Types.NestedField> expectedFields =
+                TypeUtil.assignIncreasingFreshIds(expectedSchema).columns();
+        if (currentFields.size() != expectedFields.size()) {
+            return false;
+        }
+        for (int i = 0; i < currentFields.size(); i++) {
+            Types.NestedField current = currentFields.get(i);
+            Types.NestedField expected = expectedFields.get(i);
+            if (!current.name().equals(expected.name())
+                    || !current.type().equals(expected.type())
+                    || current.isOptional() != expected.isOptional()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergRecordAsFlussRow.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergRecordAsFlussRow.java
@@ -38,7 +38,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.fluss.lake.iceberg.IcebergLakeCatalog.SYSTEM_COLUMNS;
+import static org.apache.fluss.lake.iceberg.IcebergSchemaUtils.SYSTEM_COLUMNS;
 
 /** Adapter for Iceberg Record as fluss row. */
 public class IcebergRecordAsFlussRow implements InternalRow {

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/FlussRecordAsIcebergRecord.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/FlussRecordAsIcebergRecord.java
@@ -28,7 +28,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
-import static org.apache.fluss.lake.iceberg.IcebergLakeCatalog.SYSTEM_COLUMNS;
+import static org.apache.fluss.lake.iceberg.IcebergSchemaUtils.SYSTEM_COLUMNS;
 import static org.apache.fluss.metadata.TableDescriptor.BUCKET_COLUMN_NAME;
 import static org.apache.fluss.metadata.TableDescriptor.OFFSET_COLUMN_NAME;
 import static org.apache.fluss.metadata.TableDescriptor.TIMESTAMP_COLUMN_NAME;

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeTieringFactory.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeTieringFactory.java
@@ -23,13 +23,22 @@ import org.apache.fluss.lake.committer.LakeCommitter;
 import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
 import org.apache.fluss.lake.writer.LakeWriter;
+import org.apache.fluss.lake.writer.TieringTableValidator;
 import org.apache.fluss.lake.writer.WriterInitContext;
+import org.apache.fluss.metadata.TableInfo;
+import org.apache.fluss.utils.IOUtils;
+
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
 
 import java.io.IOException;
 
+import static org.apache.fluss.lake.iceberg.utils.IcebergConversions.toIceberg;
+
 /** Implementation of {@link LakeTieringFactory} for Iceberg. */
 public class IcebergLakeTieringFactory
-        implements LakeTieringFactory<IcebergWriteResult, IcebergCommittable> {
+        implements LakeTieringFactory<IcebergWriteResult, IcebergCommittable>,
+                TieringTableValidator {
 
     private static final long serialVersionUID = 1L;
 
@@ -43,6 +52,20 @@ public class IcebergLakeTieringFactory
     public LakeWriter<IcebergWriteResult> createLakeWriter(WriterInitContext writerInitContext)
             throws IOException {
         return new IcebergLakeWriter(icebergCatalogProvider, writerInitContext);
+    }
+
+    @Override
+    public void validateTable(TableInfo tableInfo) throws IOException {
+        Catalog icebergCatalog = icebergCatalogProvider.get();
+        try {
+            Table icebergTable = icebergCatalog.loadTable(toIceberg(tableInfo.getTablePath()));
+            IcebergPartitionSpecValidator.validate(icebergTable, tableInfo);
+        } finally {
+            if (icebergCatalog instanceof AutoCloseable) {
+                IOUtils.closeQuietly(
+                        (AutoCloseable) icebergCatalog, "iceberg-catalog-table-validator");
+            }
+        }
     }
 
     @Override

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeWriter.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeWriter.java
@@ -68,6 +68,7 @@ public class IcebergLakeWriter implements LakeWriter<IcebergWriteResult> {
             throws IOException {
         this.icebergCatalog = icebergCatalogProvider.get();
         this.icebergTable = getTable(writerInitContext.tablePath());
+        IcebergPartitionSpecValidator.validate(icebergTable, writerInitContext.tableInfo());
 
         // Create a record writer
         this.recordWriter = createRecordWriter(writerInitContext);

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergPartitionSpecValidator.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergPartitionSpecValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.iceberg.tiering;
+
+import org.apache.fluss.exception.InvalidTableException;
+import org.apache.fluss.lake.iceberg.IcebergSchemaUtils;
+import org.apache.fluss.lake.iceberg.utils.IcebergPartitionSpecUtils;
+import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.metadata.TableInfo;
+
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+
+import java.util.List;
+
+/** Validates that an Iceberg partition spec is compatible with Fluss lake tiering. */
+final class IcebergPartitionSpecValidator {
+
+    private IcebergPartitionSpecValidator() {}
+
+    static void validate(Table icebergTable, TableInfo tableInfo) {
+        TableDescriptor tableDescriptor = tableInfo.toTableDescriptor();
+        Schema icebergSchema = icebergTable.schema();
+        Schema expectedSchema =
+                IcebergSchemaUtils.createIcebergSchema(tableDescriptor, tableInfo.hasPrimaryKey());
+        if (!IcebergSchemaUtils.compatibleWith(icebergSchema, expectedSchema)) {
+            throw new InvalidTableException(
+                    String.format(
+                            "Iceberg schema is incompatible with Fluss table %s. "
+                                    + "Expected Iceberg schema: %s, but the current Iceberg schema is: %s.",
+                            tableInfo.getTablePath(), expectedSchema, icebergSchema));
+        }
+
+        PartitionSpec icebergSpec = icebergTable.spec();
+        PartitionSpec expectedSpec =
+                IcebergPartitionSpecUtils.createPartitionSpec(tableDescriptor, icebergSchema);
+
+        if (!compatibleWith(icebergSpec, expectedSpec)) {
+            throw new InvalidTableException(
+                    String.format(
+                            "Iceberg partition spec is incompatible with Fluss table %s. "
+                                    + "Expected Iceberg partition spec: %s, but the current Iceberg partition spec is: %s.",
+                            tableInfo.getTablePath(), expectedSpec, icebergSpec));
+        }
+    }
+
+    private static boolean compatibleWith(PartitionSpec currentSpec, PartitionSpec expectedSpec) {
+        List<PartitionField> currentFields = currentSpec.fields();
+        List<PartitionField> expectedFields = expectedSpec.fields();
+        if (currentFields.size() != expectedFields.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < currentFields.size(); i++) {
+            PartitionField currentField = currentFields.get(i);
+            PartitionField expectedField = expectedFields.get(i);
+            if (currentField.sourceId() != expectedField.sourceId()
+                    || !currentField.transform().equals(expectedField.transform())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/utils/IcebergPartitionSpecUtils.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/utils/IcebergPartitionSpecUtils.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.iceberg.utils;
+
+import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.exception.InvalidTableException;
+import org.apache.fluss.metadata.TableDescriptor;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+
+import java.util.List;
+
+import static org.apache.fluss.metadata.TableDescriptor.BUCKET_COLUMN_NAME;
+import static org.apache.iceberg.types.Type.TypeID.STRING;
+
+/** Utilities for constructing the Iceberg partition spec used by Fluss lake tiering. */
+@Internal
+public final class IcebergPartitionSpecUtils {
+
+    private IcebergPartitionSpecUtils() {}
+
+    /** Creates an Iceberg partition spec from a Fluss table descriptor. */
+    public static PartitionSpec createPartitionSpec(
+            TableDescriptor tableDescriptor, Schema icebergSchema) {
+        int bucketCount =
+                tableDescriptor
+                        .getTableDistribution()
+                        .flatMap(TableDescriptor.TableDistribution::getBucketCount)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Bucket count (bucket.num) must be set"));
+        return createPartitionSpec(
+                icebergSchema,
+                tableDescriptor.hasPrimaryKey(),
+                tableDescriptor.getBucketKeys(),
+                tableDescriptor.getPartitionKeys(),
+                bucketCount);
+    }
+
+    private static PartitionSpec createPartitionSpec(
+            Schema icebergSchema,
+            boolean isPrimaryKeyTable,
+            List<String> bucketKeys,
+            List<String> partitionKeys,
+            int bucketCount) {
+        if (bucketKeys.size() > 1) {
+            throw new UnsupportedOperationException(
+                    "Only one bucket key is supported for Iceberg at the moment");
+        }
+
+        if (bucketKeys.isEmpty() && isPrimaryKeyTable) {
+            throw new IllegalArgumentException(
+                    "Bucket key must be set for primary key Iceberg tables");
+        }
+
+        PartitionSpec.Builder builder = PartitionSpec.builderFor(icebergSchema);
+        for (String partitionKey : partitionKeys) {
+            if (!icebergSchema.findType(partitionKey).typeId().equals(STRING)) {
+                throw new InvalidTableException(
+                        String.format(
+                                "Partition key only support string type for iceberg currently. Column `%s` is not string type.",
+                                partitionKey));
+            }
+            builder.identity(partitionKey);
+        }
+
+        if (bucketKeys.isEmpty()) {
+            // __offset and __timestamp are system data columns, but only __bucket is a
+            // partition field when the Fluss table has no bucket key.
+            builder.identity(BUCKET_COLUMN_NAME);
+        } else {
+            builder.bucket(bucketKeys.get(0), bucketCount);
+        }
+        return builder.build();
+    }
+}

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/flink/FlinkCatalogLakeTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/flink/FlinkCatalogLakeTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.fluss.config.ConfigOptions.TABLE_DATALAKE_ENABLED;
-import static org.apache.fluss.lake.iceberg.IcebergLakeCatalog.SYSTEM_COLUMNS;
+import static org.apache.fluss.lake.iceberg.IcebergSchemaUtils.SYSTEM_COLUMNS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test class for {@link FlinkCatalog}. */

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergPartitionSpecValidatorTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergPartitionSpecValidatorTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.iceberg.tiering;
+
+import org.apache.fluss.exception.InvalidTableException;
+import org.apache.fluss.metadata.Schema;
+import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.metadata.TableInfo;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.types.DataTypes;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.fluss.record.TestData.DEFAULT_REMOTE_DATA_DIR;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link IcebergPartitionSpecValidator}. */
+class IcebergPartitionSpecValidatorTest {
+
+    private static final int BUCKET_NUM = 3;
+    private static final TablePath TABLE_PATH = TablePath.of("iceberg", "partition_spec_test");
+
+    private static final org.apache.iceberg.Schema ICEBERG_SCHEMA =
+            new org.apache.iceberg.Schema(
+                    Types.NestedField.required(1, "c1", Types.IntegerType.get()),
+                    Types.NestedField.optional(2, "c2", Types.StringType.get()),
+                    Types.NestedField.required(3, "c3", Types.StringType.get()),
+                    Types.NestedField.required(4, "__bucket", Types.IntegerType.get()),
+                    Types.NestedField.required(5, "__offset", Types.LongType.get()),
+                    Types.NestedField.required(6, "__timestamp", Types.TimestampType.withZone()));
+
+    @Test
+    void testMatchingPartitionSpec() {
+        PartitionSpec icebergSpec =
+                PartitionSpec.builderFor(ICEBERG_SCHEMA)
+                        .identity("c3")
+                        .bucket("c1", BUCKET_NUM)
+                        .build();
+
+        assertThatCode(
+                        () ->
+                                IcebergPartitionSpecValidator.validate(
+                                        mockTable(icebergSpec), createTableInfo()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testAllowDifferentPartitionFieldNames() {
+        PartitionSpec icebergSpec =
+                PartitionSpec.builderFor(ICEBERG_SCHEMA)
+                        .identity("c3", "renamed_partition")
+                        .bucket("c1", BUCKET_NUM, "renamed_bucket")
+                        .build();
+
+        assertThatCode(
+                        () ->
+                                IcebergPartitionSpecValidator.validate(
+                                        mockTable(icebergSpec), createTableInfo()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRejectRenamedIcebergColumn() {
+        org.apache.iceberg.Schema renamedSchema =
+                new org.apache.iceberg.Schema(
+                        Types.NestedField.required(1, "c1", Types.IntegerType.get()),
+                        Types.NestedField.optional(2, "renamed_c2", Types.StringType.get()),
+                        Types.NestedField.required(3, "c3", Types.StringType.get()),
+                        Types.NestedField.required(4, "__bucket", Types.IntegerType.get()),
+                        Types.NestedField.required(5, "__offset", Types.LongType.get()),
+                        Types.NestedField.required(
+                                6, "__timestamp", Types.TimestampType.withZone()));
+
+        assertThatThrownBy(
+                        () ->
+                                IcebergPartitionSpecValidator.validate(
+                                        mockTable(renamedSchema, PartitionSpec.unpartitioned()),
+                                        createTableInfo()))
+                .isInstanceOf(InvalidTableException.class)
+                .hasMessageContaining("Iceberg schema is incompatible")
+                .hasMessageContaining("renamed_c2");
+    }
+
+    @Test
+    void testRejectDifferentIcebergColumnType() {
+        org.apache.iceberg.Schema changedSchema =
+                new org.apache.iceberg.Schema(
+                        Types.NestedField.required(1, "c1", Types.IntegerType.get()),
+                        Types.NestedField.optional(2, "c2", Types.IntegerType.get()),
+                        Types.NestedField.required(3, "c3", Types.StringType.get()),
+                        Types.NestedField.required(4, "__bucket", Types.IntegerType.get()),
+                        Types.NestedField.required(5, "__offset", Types.LongType.get()),
+                        Types.NestedField.required(
+                                6, "__timestamp", Types.TimestampType.withZone()));
+
+        assertThatThrownBy(
+                        () ->
+                                IcebergPartitionSpecValidator.validate(
+                                        mockTable(changedSchema, PartitionSpec.unpartitioned()),
+                                        createTableInfo()))
+                .isInstanceOf(InvalidTableException.class)
+                .hasMessageContaining("Iceberg schema is incompatible");
+    }
+
+    @Test
+    void testRejectDifferentIcebergColumnNullability() {
+        org.apache.iceberg.Schema changedSchema =
+                new org.apache.iceberg.Schema(
+                        Types.NestedField.required(1, "c1", Types.IntegerType.get()),
+                        Types.NestedField.required(2, "c2", Types.StringType.get()),
+                        Types.NestedField.required(3, "c3", Types.StringType.get()),
+                        Types.NestedField.required(4, "__bucket", Types.IntegerType.get()),
+                        Types.NestedField.required(5, "__offset", Types.LongType.get()),
+                        Types.NestedField.required(
+                                6, "__timestamp", Types.TimestampType.withZone()));
+
+        assertThatThrownBy(
+                        () ->
+                                IcebergPartitionSpecValidator.validate(
+                                        mockTable(changedSchema, PartitionSpec.unpartitioned()),
+                                        createTableInfo()))
+                .isInstanceOf(InvalidTableException.class)
+                .hasMessageContaining("Iceberg schema is incompatible");
+    }
+
+    @Test
+    void testRejectDifferentPartitionFieldCount() {
+        PartitionSpec icebergSpec =
+                PartitionSpec.builderFor(ICEBERG_SCHEMA).bucket("c1", BUCKET_NUM).build();
+
+        assertIncompatible(icebergSpec);
+    }
+
+    @Test
+    void testRejectReorderedPartitionFields() {
+        PartitionSpec icebergSpec =
+                PartitionSpec.builderFor(ICEBERG_SCHEMA)
+                        .bucket("c1", BUCKET_NUM)
+                        .identity("c3")
+                        .build();
+
+        assertIncompatible(icebergSpec);
+    }
+
+    @Test
+    void testRejectDifferentPartitionSourceColumn() {
+        PartitionSpec icebergSpec =
+                PartitionSpec.builderFor(ICEBERG_SCHEMA)
+                        .identity("c2")
+                        .bucket("c1", BUCKET_NUM)
+                        .build();
+
+        assertIncompatible(icebergSpec);
+    }
+
+    @Test
+    void testRejectDifferentPartitionTransform() {
+        PartitionSpec icebergSpec =
+                PartitionSpec.builderFor(ICEBERG_SCHEMA)
+                        .identity("c3")
+                        .bucket("c1", BUCKET_NUM * 2)
+                        .build();
+
+        assertIncompatible(icebergSpec);
+    }
+
+    private static void assertIncompatible(PartitionSpec icebergSpec) {
+        assertThatThrownBy(
+                        () ->
+                                IcebergPartitionSpecValidator.validate(
+                                        mockTable(icebergSpec), createTableInfo()))
+                .isInstanceOf(InvalidTableException.class)
+                .hasMessageContaining("Iceberg partition spec is incompatible");
+    }
+
+    private static Table mockTable(PartitionSpec icebergSpec) {
+        return mockTable(ICEBERG_SCHEMA, icebergSpec);
+    }
+
+    private static Table mockTable(
+            org.apache.iceberg.Schema icebergSchema, PartitionSpec icebergSpec) {
+        Table icebergTable = mock(Table.class);
+        when(icebergTable.schema()).thenReturn(icebergSchema);
+        when(icebergTable.spec()).thenReturn(icebergSpec);
+        return icebergTable;
+    }
+
+    private static TableInfo createTableInfo() {
+        Schema flussSchema =
+                Schema.newBuilder()
+                        .column("c1", DataTypes.INT())
+                        .column("c2", DataTypes.STRING())
+                        .column("c3", DataTypes.STRING())
+                        .primaryKey("c1", "c3")
+                        .build();
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder()
+                        .schema(flussSchema)
+                        .distributedBy(BUCKET_NUM)
+                        .partitionedBy("c3")
+                        .build();
+        return TableInfo.of(TABLE_PATH, 0, 1, tableDescriptor, DEFAULT_REMOTE_DATA_DIR, 1L, 1L);
+    }
+}

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
@@ -19,11 +19,13 @@ package org.apache.fluss.lake.iceberg.tiering;
 
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.InvalidTableException;
 import org.apache.fluss.lake.committer.CommitterInitContext;
 import org.apache.fluss.lake.committer.LakeCommitter;
 import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
 import org.apache.fluss.lake.writer.LakeWriter;
 import org.apache.fluss.lake.writer.WriterInitContext;
+import org.apache.fluss.metadata.Schema;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableDescriptor;
 import org.apache.fluss.metadata.TableInfo;
@@ -48,6 +50,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -78,8 +81,10 @@ import static org.apache.fluss.record.ChangeType.INSERT;
 import static org.apache.fluss.record.ChangeType.UPDATE_AFTER;
 import static org.apache.fluss.record.ChangeType.UPDATE_BEFORE;
 import static org.apache.fluss.record.TestData.DEFAULT_REMOTE_DATA_DIR;
+import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Unit test for tiering to Iceberg via {@link IcebergLakeTieringFactory}. */
 class IcebergTieringTest {
@@ -127,7 +132,7 @@ class IcebergTieringTest {
         TableDescriptor descriptor =
                 TableDescriptor.builder()
                         .schema(
-                                org.apache.fluss.metadata.Schema.newBuilder()
+                                Schema.newBuilder()
                                         .column("c1", DataTypes.INT())
                                         .column("c2", DataTypes.STRING())
                                         .column("c3", DataTypes.STRING())
@@ -216,6 +221,40 @@ class IcebergTieringTest {
                 verifyTableRecords(actualRecords, expectRecords, bucket, partition);
             }
         }
+    }
+
+    @Test
+    void testRejectIncompatiblePartitionSpec() {
+        TablePath tablePath = TablePath.of("iceberg", "test_incompatible_partition_spec");
+        createTable(tablePath, true, false);
+        TableDescriptor descriptor =
+                TableDescriptor.builder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("c1", DataTypes.INT())
+                                        .column("c2", DataTypes.STRING())
+                                        .column("c3", DataTypes.STRING())
+                                        .primaryKey("c1", "c3")
+                                        .build())
+                        .distributedBy(BUCKET_NUM, "c1")
+                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
+                        .build();
+        TableInfo tableInfo =
+                TableInfo.of(tablePath, 0, 1, descriptor, DEFAULT_REMOTE_DATA_DIR, 1L, 1L);
+
+        Table icebergTable = icebergCatalog.loadTable(toIceberg(tablePath));
+        String bucketFieldName = icebergTable.spec().fields().get(0).name();
+        icebergTable
+                .updateSpec()
+                .removeField(bucketFieldName)
+                .addField(bucket("c1", BUCKET_NUM * 2))
+                .commit();
+
+        assertThatThrownBy(() -> icebergLakeTieringFactory.validateTable(tableInfo))
+                .isInstanceOf(InvalidTableException.class)
+                .hasMessageContaining("Iceberg partition spec is incompatible")
+                .hasMessageContaining("bucket[3]")
+                .hasMessageContaining("bucket[6]");
     }
 
     private LakeWriter<IcebergWriteResult> createLakeWriter(

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringTest.java
@@ -129,19 +129,7 @@ class IcebergTieringTest {
                                 isPartitionedTable ? "partitioned" : "unpartitioned"));
         createTable(tablePath, isPrimaryKeyTable, isPartitionedTable);
 
-        TableDescriptor descriptor =
-                TableDescriptor.builder()
-                        .schema(
-                                Schema.newBuilder()
-                                        .column("c1", DataTypes.INT())
-                                        .column("c2", DataTypes.STRING())
-                                        .column("c3", DataTypes.STRING())
-                                        .build())
-                        .distributedBy(BUCKET_NUM)
-                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
-                        .build();
-        TableInfo tableInfo =
-                TableInfo.of(tablePath, 0, 1, descriptor, DEFAULT_REMOTE_DATA_DIR, 1L, 1L);
+        TableInfo tableInfo = createTableInfo(tablePath, isPrimaryKeyTable, isPartitionedTable);
 
         Table icebergTable = icebergCatalog.loadTable(toIceberg(tablePath));
 
@@ -227,20 +215,7 @@ class IcebergTieringTest {
     void testRejectIncompatiblePartitionSpec() {
         TablePath tablePath = TablePath.of("iceberg", "test_incompatible_partition_spec");
         createTable(tablePath, true, false);
-        TableDescriptor descriptor =
-                TableDescriptor.builder()
-                        .schema(
-                                Schema.newBuilder()
-                                        .column("c1", DataTypes.INT())
-                                        .column("c2", DataTypes.STRING())
-                                        .column("c3", DataTypes.STRING())
-                                        .primaryKey("c1", "c3")
-                                        .build())
-                        .distributedBy(BUCKET_NUM, "c1")
-                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
-                        .build();
-        TableInfo tableInfo =
-                TableInfo.of(tablePath, 0, 1, descriptor, DEFAULT_REMOTE_DATA_DIR, 1L, 1L);
+        TableInfo tableInfo = createTableInfo(tablePath, true, false);
 
         Table icebergTable = icebergCatalog.loadTable(toIceberg(tablePath));
         String bucketFieldName = icebergTable.spec().fields().get(0).name();
@@ -255,6 +230,37 @@ class IcebergTieringTest {
                 .hasMessageContaining("Iceberg partition spec is incompatible")
                 .hasMessageContaining("bucket[3]")
                 .hasMessageContaining("bucket[6]");
+
+        assertThatThrownBy(() -> createLakeWriter(tablePath, 0, null, null, tableInfo))
+                .isInstanceOf(InvalidTableException.class)
+                .hasMessageContaining("Iceberg partition spec is incompatible");
+    }
+
+    private TableInfo createTableInfo(
+            TablePath tablePath, boolean isPrimaryKeyTable, boolean isPartitionedTable) {
+        Schema.Builder schemaBuilder =
+                Schema.newBuilder()
+                        .column("c1", DataTypes.INT())
+                        .column("c2", DataTypes.STRING())
+                        .column("c3", DataTypes.STRING());
+        if (isPrimaryKeyTable) {
+            if (isPartitionedTable) {
+                schemaBuilder.primaryKey("c1", "c3");
+            } else {
+                schemaBuilder.primaryKey("c1");
+            }
+        }
+
+        TableDescriptor.Builder descriptorBuilder =
+                TableDescriptor.builder()
+                        .schema(schemaBuilder.build())
+                        .distributedBy(BUCKET_NUM)
+                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true);
+        if (isPartitionedTable) {
+            descriptorBuilder.partitionedBy("c3");
+        }
+        return TableInfo.of(
+                tablePath, 0, 1, descriptorBuilder.build(), DEFAULT_REMOTE_DATA_DIR, 1L, 1L);
     }
 
     private LakeWriter<IcebergWriteResult> createLakeWriter(
@@ -420,9 +426,17 @@ class IcebergTieringTest {
         org.apache.iceberg.Schema schema =
                 new org.apache.iceberg.Schema(
                         Arrays.asList(
-                                Types.NestedField.required(1, "c1", Types.IntegerType.get()),
+                                isPrimaryTable
+                                        ? Types.NestedField.required(
+                                                1, "c1", Types.IntegerType.get())
+                                        : Types.NestedField.optional(
+                                                1, "c1", Types.IntegerType.get()),
                                 Types.NestedField.optional(2, "c2", Types.StringType.get()),
-                                Types.NestedField.required(3, "c3", Types.StringType.get()),
+                                isPrimaryTable && isPartitionedTable
+                                        ? Types.NestedField.required(
+                                                3, "c3", Types.StringType.get())
+                                        : Types.NestedField.optional(
+                                                3, "c3", Types.StringType.get()),
                                 Types.NestedField.required(
                                         4, BUCKET_COLUMN_NAME, Types.IntegerType.get()),
                                 Types.NestedField.required(


### PR DESCRIPTION
<!--
Generated-by: OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: close #3638

Iceberg lake tiering constructs partition keys from the current Iceberg partition spec, but fills them with partition and bucket values produced according to the Fluss table metadata. If an external client evolves the Iceberg partition spec, a newly created writer can silently attach incorrect partition metadata to data files.

This change validates the current Iceberg partition spec before the tiering writer is created and fails fast when the source columns, field order, transforms, or transform parameters are incompatible with the Fluss table.

### Brief change log

- Extract the Fluss-to-Iceberg partition-spec construction into a shared internal utility used by both automatic Iceberg table creation and writer validation.
- Add a partition-spec validator that compares the expected and current Iceberg specs by field order, source field ID, and transform, including parameters such as bucket count.
- Run the validation before creating the Iceberg task writer and throw a descriptive, non-retriable `InvalidTableException` on mismatch.
- Add regression coverage for an externally evolved bucket transform and align the existing tiering test metadata with the tested table definitions.

### Tests

- `mvn -pl fluss-lake/fluss-lake-iceberg verify`
  - 108 unit tests passed.
  - 28 integration tests passed.

### API and Format

No public API or storage-format changes. The shared partition-spec utility is marked `@Internal`, and the existing Iceberg table mapping remains unchanged.

### Documentation

No documentation changes. This is a correctness fix with no new user-facing configuration.

### Generative AI disclosure

Yes. Generated with OpenAI Codex and reviewed by the human developer.
