### PR TITLE
[flink] Fix TableNotExistException when listing partitions on  changelog / binlog virtual tables

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -705,7 +705,7 @@ public class FlinkCatalog extends AbstractCatalog {
                     CatalogException {
         // $changelog / $binlog are read-only virtual tables; reject partition mutations.
         if (isVirtualTable(objectPath)) {
-            throw new CatalogException(
+            throw new UnsupportedOperationException(
                     String.format(
                             "Cannot create partition on read-only virtual table %s in %s. "
                                     + "Please create the partition on the base table instead.",
@@ -759,7 +759,7 @@ public class FlinkCatalog extends AbstractCatalog {
             throws PartitionNotExistException, CatalogException {
         // $changelog / $binlog are read-only virtual tables; reject partition mutations.
         if (isVirtualTable(objectPath)) {
-            throw new CatalogException(
+            throw new UnsupportedOperationException(
                     String.format(
                             "Cannot drop partition on read-only virtual table %s in %s. "
                                     + "Please drop the partition on the base table instead.",

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -490,7 +490,8 @@ public class FlinkCatalog extends AbstractCatalog {
 
     @Override
     public boolean tableExists(ObjectPath objectPath) throws CatalogException {
-        TablePath tablePath = toTablePath(objectPath);
+        // For virtual tables ($changelog, $binlog), check if the base physical table exists
+        TablePath tablePath = toPhysicalTablePath(objectPath);
         try {
             return admin.tableExists(tablePath).get();
         } catch (Exception e) {
@@ -638,7 +639,8 @@ public class FlinkCatalog extends AbstractCatalog {
         }
 
         try {
-            TablePath tablePath = toTablePath(objectPath);
+            // For virtual tables ($changelog, $binlog), list partitions of the base physical table
+            TablePath tablePath = toPhysicalTablePath(objectPath);
             List<PartitionInfo> partitionInfos;
             if (catalogPartitionSpec != null) {
                 Map<String, String> partitionSpec = catalogPartitionSpec.getPartitionSpec();
@@ -701,7 +703,8 @@ public class FlinkCatalog extends AbstractCatalog {
             throws TableNotExistException, TableNotPartitionedException,
                     PartitionSpecInvalidException, PartitionAlreadyExistsException,
                     CatalogException {
-        TablePath tablePath = toTablePath(objectPath);
+        // For virtual tables ($changelog, $binlog), operate on the base physical table
+        TablePath tablePath = toPhysicalTablePath(objectPath);
         PartitionSpec partitionSpec = new PartitionSpec(catalogPartitionSpec.getPartitionSpec());
         try {
             admin.createPartition(tablePath, partitionSpec, b).get();
@@ -749,7 +752,8 @@ public class FlinkCatalog extends AbstractCatalog {
             throws PartitionNotExistException, CatalogException {
         PartitionSpec partitionSpec = new PartitionSpec(catalogPartitionSpec.getPartitionSpec());
         try {
-            admin.dropPartition(toTablePath(objectPath), partitionSpec, b).get();
+            // For virtual tables ($changelog, $binlog), operate on the base physical table
+            admin.dropPartition(toPhysicalTablePath(objectPath), partitionSpec, b).get();
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
             if (isPartitionNotExist(t)) {
@@ -878,6 +882,28 @@ public class FlinkCatalog extends AbstractCatalog {
 
     protected TablePath toTablePath(ObjectPath objectPath) {
         return TablePath.of(objectPath.getDatabaseName(), objectPath.getObjectName());
+    }
+
+    /**
+     * Converts an {@link ObjectPath} to a physical {@link TablePath}, stripping any virtual table
+     * suffix ($changelog, $binlog) if present. This is needed because virtual tables share the same
+     * partitioning and physical storage as their base table, so partition-related operations must
+     * be performed against the base table name.
+     *
+     * <p>For $lake tables, the suffix is also stripped to get the base Fluss table name.
+     */
+    private TablePath toPhysicalTablePath(ObjectPath objectPath) {
+        String tableName = objectPath.getObjectName();
+        // Strip virtual table suffixes to get the base physical table name
+        if (tableName.endsWith(CHANGELOG_TABLE_SUFFIX)) {
+            tableName =
+                    tableName.substring(0, tableName.length() - CHANGELOG_TABLE_SUFFIX.length());
+        } else if (tableName.endsWith(BINLOG_TABLE_SUFFIX)) {
+            tableName = tableName.substring(0, tableName.length() - BINLOG_TABLE_SUFFIX.length());
+        } else if (tableName.contains(LAKE_TABLE_SPLITTER)) {
+            tableName = tableName.split("\\" + LAKE_TABLE_SPLITTER)[0];
+        }
+        return TablePath.of(objectPath.getDatabaseName(), tableName);
     }
 
     @Override

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -703,8 +703,15 @@ public class FlinkCatalog extends AbstractCatalog {
             throws TableNotExistException, TableNotPartitionedException,
                     PartitionSpecInvalidException, PartitionAlreadyExistsException,
                     CatalogException {
-        // For virtual tables ($changelog, $binlog), operate on the base physical table
-        TablePath tablePath = toPhysicalTablePath(objectPath);
+        // $changelog / $binlog are read-only virtual tables; reject partition mutations.
+        if (isVirtualTable(objectPath)) {
+            throw new CatalogException(
+                    String.format(
+                            "Cannot create partition on read-only virtual table %s in %s. "
+                                    + "Please create the partition on the base table instead.",
+                            objectPath, getName()));
+        }
+        TablePath tablePath = toTablePath(objectPath);
         PartitionSpec partitionSpec = new PartitionSpec(catalogPartitionSpec.getPartitionSpec());
         try {
             admin.createPartition(tablePath, partitionSpec, b).get();
@@ -750,10 +757,17 @@ public class FlinkCatalog extends AbstractCatalog {
     public void dropPartition(
             ObjectPath objectPath, CatalogPartitionSpec catalogPartitionSpec, boolean b)
             throws PartitionNotExistException, CatalogException {
+        // $changelog / $binlog are read-only virtual tables; reject partition mutations.
+        if (isVirtualTable(objectPath)) {
+            throw new CatalogException(
+                    String.format(
+                            "Cannot drop partition on read-only virtual table %s in %s. "
+                                    + "Please drop the partition on the base table instead.",
+                            objectPath, getName()));
+        }
         PartitionSpec partitionSpec = new PartitionSpec(catalogPartitionSpec.getPartitionSpec());
         try {
-            // For virtual tables ($changelog, $binlog), operate on the base physical table
-            admin.dropPartition(toPhysicalTablePath(objectPath), partitionSpec, b).get();
+            admin.dropPartition(toTablePath(objectPath), partitionSpec, b).get();
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
             if (isPartitionNotExist(t)) {
@@ -889,8 +903,6 @@ public class FlinkCatalog extends AbstractCatalog {
      * suffix ($changelog, $binlog) if present. This is needed because virtual tables share the same
      * partitioning and physical storage as their base table, so partition-related operations must
      * be performed against the base table name.
-     *
-     * <p>For $lake tables, the suffix is also stripped to get the base Fluss table name.
      */
     private TablePath toPhysicalTablePath(ObjectPath objectPath) {
         String tableName = objectPath.getObjectName();
@@ -900,10 +912,15 @@ public class FlinkCatalog extends AbstractCatalog {
                     tableName.substring(0, tableName.length() - CHANGELOG_TABLE_SUFFIX.length());
         } else if (tableName.endsWith(BINLOG_TABLE_SUFFIX)) {
             tableName = tableName.substring(0, tableName.length() - BINLOG_TABLE_SUFFIX.length());
-        } else if (tableName.contains(LAKE_TABLE_SPLITTER)) {
-            tableName = tableName.split("\\" + LAKE_TABLE_SPLITTER)[0];
         }
         return TablePath.of(objectPath.getDatabaseName(), tableName);
+    }
+
+    /** Returns whether the given path refers to a read-only $changelog / $binlog virtual table. */
+    private static boolean isVirtualTable(ObjectPath objectPath) {
+        String tableName = objectPath.getObjectName();
+        return tableName.endsWith(CHANGELOG_TABLE_SUFFIX)
+                || tableName.endsWith(BINLOG_TABLE_SUFFIX);
     }
 
     @Override

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
@@ -1083,6 +1084,31 @@ abstract class FlinkCatalogITCase {
                         .build();
 
         assertThat(logChangelogTable.getUnresolvedSchema()).isEqualTo(expectedLogSchema);
+    }
+
+    @Test
+    void testListPartitionsOnChangelogVirtualTableForPlannerStats() throws Exception {
+        // Flink's planner asks Catalog#listPartitions(ObjectPath) when recomputing statistics for
+        // partitioned tables. For a $changelog virtual table, the catalog should transparently list
+        // the base table's partitions instead of looking up a physical table named
+        // '<base>$changelog'.
+        tEnv.executeSql(
+                "CREATE TABLE partitioned_changelog_for_stats ("
+                        + "  id INT NOT NULL,"
+                        + "  name STRING,"
+                        + "  region STRING NOT NULL,"
+                        + "  PRIMARY KEY (id, region) NOT ENFORCED"
+                        + ") PARTITIONED BY (region) "
+                        + "WITH ('bucket.num' = '1')");
+
+        ObjectPath basePath = new ObjectPath(DEFAULT_DB, "partitioned_changelog_for_stats");
+        CatalogPartitionSpec partitionSpec =
+                new CatalogPartitionSpec(Collections.singletonMap("region", "us"));
+        catalog.createPartition(basePath, partitionSpec, null, false);
+
+        ObjectPath changelogPath =
+                new ObjectPath(DEFAULT_DB, "partitioned_changelog_for_stats$changelog");
+        assertThat(catalog.listPartitions(changelogPath)).containsExactly(partitionSpec);
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
@@ -878,14 +878,18 @@ class FlinkCatalogTest {
         assertThat(binlogPartitions).hasSize(1);
         assertThat(binlogPartitions.get(0).getPartitionSpec()).containsEntry("first", "1");
 
-        // Test createPartition on $changelog virtual table — should work on base table
+        // Test createPartition on $changelog virtual table — should be rejected (read-only)
         CatalogPartitionSpec partSpec2 =
                 new CatalogPartitionSpec(Collections.singletonMap("first", "2"));
-        catalog.createPartition(changelogPath, partSpec2, null, false);
-        assertThat(catalog.listPartitions(basePath)).hasSize(2);
+        assertThatThrownBy(() -> catalog.createPartition(changelogPath, partSpec2, null, false))
+                .isInstanceOf(CatalogException.class)
+                .hasMessageContaining("read-only virtual table");
+        assertThat(catalog.listPartitions(basePath)).hasSize(1);
 
-        // Test dropPartition on $binlog virtual table — should work on base table
-        catalog.dropPartition(binlogPath, partSpec2, false);
+        // Test dropPartition on $binlog virtual table — should be rejected (read-only)
+        assertThatThrownBy(() -> catalog.dropPartition(binlogPath, partSpec, false))
+                .isInstanceOf(CatalogException.class)
+                .hasMessageContaining("read-only virtual table");
         assertThat(catalog.listPartitions(basePath)).hasSize(1);
 
         // Clean up

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
@@ -825,6 +825,75 @@ class FlinkCatalogTest {
     }
 
     @Test
+    void testVirtualTablePartitionsAndExistence() throws Exception {
+        // Create a partitioned PK table
+        ObjectPath basePath = new ObjectPath(DEFAULT_DB, "partitioned_virtual_t");
+        ResolvedSchema resolvedSchema = this.createSchema();
+        CatalogTable partitionedTable =
+                new ResolvedCatalogTable(
+                        toCatalogTable(
+                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
+                                "test comment",
+                                Collections.singletonList("first"),
+                                Collections.emptyMap()),
+                        resolvedSchema);
+        catalog.createTable(basePath, partitionedTable, false);
+
+        // Create a partition on the base table
+        CatalogPartitionSpec partSpec =
+                new CatalogPartitionSpec(Collections.singletonMap("first", "1"));
+        catalog.createPartition(basePath, partSpec, null, false);
+
+        // Verify base table partitions
+        List<CatalogPartitionSpec> basePartitions = catalog.listPartitions(basePath);
+        assertThat(basePartitions).hasSize(1);
+        assertThat(basePartitions.get(0).getPartitionSpec()).containsEntry("first", "1");
+
+        // Test tableExists on $changelog virtual table — should return true (base table exists)
+        ObjectPath changelogPath =
+                new ObjectPath(
+                        DEFAULT_DB, "partitioned_virtual_t" + FlinkCatalog.CHANGELOG_TABLE_SUFFIX);
+        assertThat(catalog.tableExists(changelogPath)).isTrue();
+
+        // Test listPartitions on $changelog virtual table — should return same partitions as base
+        List<CatalogPartitionSpec> changelogPartitions = catalog.listPartitions(changelogPath);
+        assertThat(changelogPartitions).hasSize(1);
+        assertThat(changelogPartitions.get(0).getPartitionSpec()).containsEntry("first", "1");
+
+        // Test listPartitions with spec on $changelog virtual table
+        List<CatalogPartitionSpec> changelogPartitionsWithSpec =
+                catalog.listPartitions(changelogPath, partSpec);
+        assertThat(changelogPartitionsWithSpec).hasSize(1);
+        assertThat(changelogPartitionsWithSpec.get(0).getPartitionSpec())
+                .containsEntry("first", "1");
+
+        // Test tableExists on $binlog virtual table — should return true (base table exists)
+        ObjectPath binlogPath =
+                new ObjectPath(
+                        DEFAULT_DB, "partitioned_virtual_t" + FlinkCatalog.BINLOG_TABLE_SUFFIX);
+        assertThat(catalog.tableExists(binlogPath)).isTrue();
+
+        // Test listPartitions on $binlog virtual table — should return same partitions as base
+        List<CatalogPartitionSpec> binlogPartitions = catalog.listPartitions(binlogPath);
+        assertThat(binlogPartitions).hasSize(1);
+        assertThat(binlogPartitions.get(0).getPartitionSpec()).containsEntry("first", "1");
+
+        // Test createPartition on $changelog virtual table — should work on base table
+        CatalogPartitionSpec partSpec2 =
+                new CatalogPartitionSpec(Collections.singletonMap("first", "2"));
+        catalog.createPartition(changelogPath, partSpec2, null, false);
+        assertThat(catalog.listPartitions(basePath)).hasSize(2);
+
+        // Test dropPartition on $binlog virtual table — should work on base table
+        catalog.dropPartition(binlogPath, partSpec2, false);
+        assertThat(catalog.listPartitions(basePath)).hasSize(1);
+
+        // Clean up
+        catalog.dropPartition(basePath, partSpec, false);
+        catalog.dropTable(basePath, false);
+    }
+
+    @Test
     void testCreatePartitions() throws Exception {
         ObjectPath nonPartitionedPath = new ObjectPath(DEFAULT_DB, "non_partitioned_table1");
         ResolvedSchema resolvedSchema = this.createSchema();

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
@@ -882,13 +882,13 @@ class FlinkCatalogTest {
         CatalogPartitionSpec partSpec2 =
                 new CatalogPartitionSpec(Collections.singletonMap("first", "2"));
         assertThatThrownBy(() -> catalog.createPartition(changelogPath, partSpec2, null, false))
-                .isInstanceOf(CatalogException.class)
+                .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("read-only virtual table");
         assertThat(catalog.listPartitions(basePath)).hasSize(1);
 
         // Test dropPartition on $binlog virtual table — should be rejected (read-only)
         assertThatThrownBy(() -> catalog.dropPartition(binlogPath, partSpec, false))
-                .isInstanceOf(CatalogException.class)
+                .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("read-only virtual table");
         assertThat(catalog.listPartitions(basePath)).hasSize(1);
 

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
@@ -559,6 +559,47 @@ abstract class ChangelogVirtualTableITCase {
         rowIter.close();
     }
 
+    @Test
+    public void testShowPartitionsOnChangelogVirtualTable() throws Exception {
+        // Create a partitioned primary key table
+        tEnv.executeSql(
+                "CREATE TABLE partitioned_show_test ("
+                        + "  id INT NOT NULL,"
+                        + "  name STRING,"
+                        + "  region STRING NOT NULL,"
+                        + "  PRIMARY KEY (id, region) NOT ENFORCED"
+                        + ") PARTITIONED BY (region) WITH ('bucket.num' = '1')");
+
+        // Insert data to create partitions
+        CLOCK.advanceTime(Duration.ofMillis(100));
+        tEnv.executeSql(
+                        "INSERT INTO partitioned_show_test VALUES "
+                                + "(1, 'Item-1', 'us'), "
+                                + "(2, 'Item-2', 'eu')")
+                .await();
+
+        // SHOW PARTITIONS on base table — should work
+        List<String> basePartitions = new ArrayList<>();
+        try (CloseableIterator<Row> iter =
+                tEnv.executeSql("SHOW PARTITIONS partitioned_show_test").collect()) {
+            while (iter.hasNext()) {
+                basePartitions.add(iter.next().toString());
+            }
+        }
+        assertThat(basePartitions).containsExactlyInAnyOrder("+I[region=us]", "+I[region=eu]");
+
+        // SHOW PARTITIONS on $changelog virtual table — should return same partitions
+        // Without the fix, this throws TableNotExistException
+        List<String> changelogPartitions = new ArrayList<>();
+        try (CloseableIterator<Row> iter =
+                tEnv.executeSql("SHOW PARTITIONS partitioned_show_test$changelog").collect()) {
+            while (iter.hasNext()) {
+                changelogPartitions.add(iter.next().toString());
+            }
+        }
+        assertThat(changelogPartitions).containsExactlyInAnyOrder("+I[region=us]", "+I[region=eu]");
+    }
+
     private static org.apache.flink.configuration.Configuration getFileBasedCheckpointsConfig(
             File savepointDir) {
         return getFileBasedCheckpointsConfig(savepointDir.toURI().toString());


### PR DESCRIPTION
### Purpose

Linked issue: close #3640 

When the Flink optimizer calls `listPartitions()` on a `$changelog` or `$binlog` virtual table, it throws `TableNotExistException` because the virtual table suffix is not stripped before querying the Fluss server.

`getTable()` correctly dispatches virtual table names to `getVirtualChangelogTable()`/`getVirtualBinlogTable()`, but `tableExists()`, `listPartitions()`, `createPartition()`, and `dropPartition()` all pass the unstripped virtual table name directly to the admin API, which fails because no physical table named `xxx$changelog` exists.

### Brief change log

- Added `toPhysicalTablePath()` private helper method to `FlinkCatalog` that strips `$changelog`, `$binlog`, and `$lake` suffixes from the table name, returning the base physical table path
- Updated `tableExists()` to use `toPhysicalTablePath()` — virtual tables now correctly report existence based on the base table
- Updated `listPartitions(ObjectPath, CatalogPartitionSpec)` to use `toPhysicalTablePath()` — virtual tables now list partitions of the base table
- Updated `createPartition()` and `dropPartition()` to use `toPhysicalTablePath()` — partition management through virtual table names delegates to the base table

### Tests

- Added `FlinkCatalogTest#testVirtualTablePartitionsAndExistence` which verifies:
  - `tableExists()` returns `true` for `$changelog` and `$binlog` virtual table names
  - `listPartitions()` returns the same partitions as the base table for both virtual table suffixes
  - `listPartitions()` with a `CatalogPartitionSpec` works correctly on virtual table names
  - `createPartition()` and `dropPartition()` work through virtual table names
- Existing `FlinkCatalogTest#testOperatePartitions` continues to pass (no regression)

### API and Format

No API or storage format changes. The fix only affects internal catalog method behavior for virtual table names.

### Documentation

No documentation changes needed — this is a bug fix that makes virtual table behavior consistent with `getTable()`.