### PR TITLE
[rust] Add SnapshotId type alias and use it in snapshot metadata paths

### DIFF
--- a/fluss-rust/crates/fluss/src/client/admin.rs
+++ b/fluss-rust/crates/fluss/src/client/admin.rs
@@ -45,7 +45,7 @@ use crate::rpc::{RpcClient, ServerConnection};
 
 use crate::error::{Error, Result};
 use crate::proto::GetTableInfoResponse;
-use crate::{BucketId, PartitionId, TableId};
+use crate::{BucketId, PartitionId, SnapshotId, TableId};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::task::JoinHandle;
@@ -595,7 +595,7 @@ impl FlussAdmin {
         table_id: TableId,
         partition_id: Option<PartitionId>,
         bucket_id: BucketId,
-        snapshot_id: i64,
+        snapshot_id: SnapshotId,
     ) -> Result<KvSnapshotMetadata> {
         let response = self
             .admin_gateway()
@@ -633,7 +633,7 @@ impl FlussAdmin {
     pub async fn get_lake_snapshot(
         &self,
         table_path: &TablePath,
-        snapshot_id: Option<i64>,
+        snapshot_id: Option<SnapshotId>,
         readable: Option<bool>,
     ) -> Result<LakeSnapshotInfo> {
         let response = self

--- a/fluss-rust/crates/fluss/src/lib.rs
+++ b/fluss-rust/crates/fluss/src/lib.rs
@@ -145,6 +145,7 @@ mod test_utils;
 pub type TableId = i64;
 pub type PartitionId = i64;
 pub type BucketId = i32;
+pub type SnapshotId = i64;
 
 pub(crate) mod proto {
     // Generated from the canonical proto; not every 1.x message is wired up to a

--- a/fluss-rust/crates/fluss/src/metadata/kv_snapshot.rs
+++ b/fluss-rust/crates/fluss/src/metadata/kv_snapshot.rs
@@ -19,7 +19,7 @@ use crate::proto::{
     AcquireKvSnapshotLeaseResponse, GetKvSnapshotMetadataResponse, GetLatestKvSnapshotsResponse,
     ListKvSnapshotsResponse, PbKvSnapshot, PbRemotePathAndLocalFile,
 };
-use crate::{BucketId, PartitionId, TableId};
+use crate::{BucketId, PartitionId, SnapshotId, TableId};
 
 use crate::metadata::KvSnapshotLeaseForTable;
 
@@ -27,7 +27,7 @@ use crate::metadata::KvSnapshotLeaseForTable;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KvSnapshot {
     pub bucket_id: BucketId,
-    pub snapshot_id: Option<i64>,
+    pub snapshot_id: Option<SnapshotId>,
     pub log_offset: Option<i64>,
 }
 

--- a/fluss-rust/crates/fluss/src/metadata/kv_snapshot_lease.rs
+++ b/fluss-rust/crates/fluss/src/metadata/kv_snapshot_lease.rs
@@ -16,14 +16,14 @@
 // under the License.
 
 use crate::proto::{PbKvSnapshotLeaseForBucket, PbKvSnapshotLeaseForTable};
-use crate::{BucketId, PartitionId, TableId};
+use crate::{BucketId, PartitionId, SnapshotId, TableId};
 
 /// One bucket's slot in a KV-snapshot lease request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KvSnapshotLeaseForBucket {
     pub partition_id: Option<PartitionId>,
     pub bucket_id: BucketId,
-    pub snapshot_id: i64,
+    pub snapshot_id: SnapshotId,
 }
 
 impl KvSnapshotLeaseForBucket {

--- a/fluss-rust/crates/fluss/src/metadata/lake_snapshot.rs
+++ b/fluss-rust/crates/fluss/src/metadata/lake_snapshot.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::proto::{GetLakeSnapshotResponse, PbLakeSnapshotForBucket};
-use crate::{BucketId, PartitionId, TableId};
+use crate::{BucketId, PartitionId, SnapshotId, TableId};
 
 /// One bucket's slice of a lake snapshot.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,7 +44,7 @@ impl LakeBucketSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LakeSnapshotInfo {
     pub table_id: TableId,
-    pub snapshot_id: i64,
+    pub snapshot_id: SnapshotId,
     pub bucket_snapshots: Vec<LakeBucketSnapshot>,
 }
 

--- a/fluss-rust/crates/fluss/src/metadata/table.rs
+++ b/fluss-rust/crates/fluss/src/metadata/table.rs
@@ -22,7 +22,7 @@ use crate::metadata::DataLakeFormat;
 use crate::metadata::datatype::{
     DataField, DataType, RowType, UNASSIGNED_FIELD_ID, reassign_field_ids,
 };
-use crate::{BucketId, PartitionId, TableId};
+use crate::{BucketId, PartitionId, SnapshotId, TableId};
 use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -1501,19 +1501,19 @@ impl Display for TableBucket {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LakeSnapshot {
-    pub snapshot_id: i64,
+    pub snapshot_id: SnapshotId,
     pub table_buckets_offset: HashMap<TableBucket, i64>,
 }
 
 impl LakeSnapshot {
-    pub fn new(snapshot_id: i64, table_buckets_offset: HashMap<TableBucket, i64>) -> Self {
+    pub fn new(snapshot_id: SnapshotId, table_buckets_offset: HashMap<TableBucket, i64>) -> Self {
         Self {
             snapshot_id,
             table_buckets_offset,
         }
     }
 
-    pub fn snapshot_id(&self) -> i64 {
+    pub fn snapshot_id(&self) -> SnapshotId {
         self.snapshot_id
     }
 

--- a/fluss-rust/crates/fluss/src/rpc/message/get_kv_snapshot_metadata.rs
+++ b/fluss-rust/crates/fluss/src/rpc/message/get_kv_snapshot_metadata.rs
@@ -18,7 +18,7 @@
 use crate::rpc::api_key::ApiKey;
 use crate::rpc::frame::{ReadError, WriteError};
 use crate::rpc::message::{ReadType, RequestBody, WriteType};
-use crate::{BucketId, PartitionId, TableId, impl_read_type, impl_write_type, proto};
+use crate::{BucketId, PartitionId, SnapshotId, TableId, impl_read_type, impl_write_type, proto};
 use bytes::{Buf, BufMut};
 use prost::Message;
 
@@ -32,7 +32,7 @@ impl GetKvSnapshotMetadataRequest {
         table_id: TableId,
         partition_id: Option<PartitionId>,
         bucket_id: BucketId,
-        snapshot_id: i64,
+        snapshot_id: SnapshotId,
     ) -> Self {
         GetKvSnapshotMetadataRequest {
             inner_request: proto::GetKvSnapshotMetadataRequest {

--- a/fluss-rust/crates/fluss/src/rpc/message/get_lake_snapshot.rs
+++ b/fluss-rust/crates/fluss/src/rpc/message/get_lake_snapshot.rs
@@ -20,7 +20,7 @@ use crate::rpc::api_key::ApiKey;
 use crate::rpc::convert::to_table_path;
 use crate::rpc::frame::{ReadError, WriteError};
 use crate::rpc::message::{ReadType, RequestBody, WriteType};
-use crate::{impl_read_type, impl_write_type, proto};
+use crate::{SnapshotId, impl_read_type, impl_write_type, proto};
 use bytes::{Buf, BufMut};
 use prost::Message;
 
@@ -30,7 +30,11 @@ pub struct GetLakeSnapshotRequest {
 }
 
 impl GetLakeSnapshotRequest {
-    pub fn new(table_path: &TablePath, snapshot_id: Option<i64>, readable: Option<bool>) -> Self {
+    pub fn new(
+        table_path: &TablePath,
+        snapshot_id: Option<SnapshotId>,
+        readable: Option<bool>,
+    ) -> Self {
         GetLakeSnapshotRequest {
             inner_request: proto::GetLakeSnapshotRequest {
                 table_path: to_table_path(table_path),


### PR DESCRIPTION
### Purpose

Moved from apache/fluss-rust#657 at @fresh-borzoni's request, now that the `fluss-rust` repo has been merged into this monorepo. Original issue: apache/fluss-rust#636.

`TableId`, `PartitionId`, and `BucketId` already have type aliases in `lib.rs`, but `snapshot_id` was still spelled `i64` everywhere. This adds a matching `SnapshotId` alias so snapshot-related signatures read consistently with the other ID types.

### Brief change log

- Add `pub type SnapshotId = i64;` next to the existing aliases in `fluss-rust/crates/fluss/src/lib.rs`.
- Apply it to the hand-written sites: `LakeSnapshot` (`metadata/table.rs`), `LakeSnapshotInfo`, `KvSnapshot`, `KvSnapshotLeaseForBucket`, the admin client methods (`get_kv_snapshot_metadata`, `get_lake_snapshot`), and the `GetKvSnapshotMetadataRequest` / `GetLakeSnapshotRequest` constructors.
- Generated proto code is untouched; `HashMap<TableBucket, i64>` offset values stay `i64` since they are offsets, not snapshot IDs.

### Tests

No behavior change (the alias resolves to the same type). `cargo build -p fluss-rs`, `cargo test -p fluss-rs --lib` (571 passed, 0 failed), and `cargo fmt -p fluss-rs --check` are all clean.

### API and Format

Public signatures now name `SnapshotId` instead of `i64`; since it is a plain type alias, this is source- and ABI-compatible. No storage format impact.

### Documentation

No new feature; no documentation changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
