### PR TITLE
[server] Coordinator standby tracks dynamic config changes to avoid s…

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/DynamicConfigManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/DynamicConfigManager.java
@@ -40,7 +40,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-/** Manager for dynamic configurations. */
+/**
+ * Manager for dynamic configurations.
+ *
+ * <p>Used by both the CoordinatorServer and the TabletServer. Every instance, regardless of server
+ * role or leadership status, continuously applies dynamic config-change notifications from
+ * ZooKeeper. In particular a standby CoordinatorServer keeps tracking changes so that, once it is
+ * promoted to leader, its components (e.g. SASL credentials) already reflect the latest config
+ * rather than a stale snapshot taken at startup.
+ */
 public class DynamicConfigManager {
     private static final Logger LOG = LoggerFactory.getLogger(DynamicConfigManager.class);
     private static final long CHANGE_NOTIFICATION_EXPIRATION_MS = 15 * 60 * 1000L;
@@ -48,13 +56,10 @@ public class DynamicConfigManager {
     private final DynamicServerConfig dynamicServerConfig;
     private final ZooKeeperClient zooKeeperClient;
     private final ZkNodeChangeNotificationWatcher configChangeListener;
-    private final boolean isCoordinator;
 
-    public DynamicConfigManager(
-            ZooKeeperClient zooKeeperClient, Configuration configuration, boolean isCoordinator) {
+    public DynamicConfigManager(ZooKeeperClient zooKeeperClient, Configuration configuration) {
         this.dynamicServerConfig = new DynamicServerConfig(configuration);
         this.zooKeeperClient = zooKeeperClient;
-        this.isCoordinator = isCoordinator;
         this.configChangeListener =
                 new ZkNodeChangeNotificationWatcher(
                         zooKeeperClient,
@@ -68,8 +73,7 @@ public class DynamicConfigManager {
     public void startup() throws Exception {
         try {
             configChangeListener.start();
-            Map<String, String> entityConfigs = zooKeeperClient.fetchEntityConfig();
-            dynamicServerConfig.updateDynamicConfig(entityConfigs, true);
+            dynamicServerConfig.refreshDynamicConfig(zooKeeperClient::fetchEntityConfig, true);
         } catch (Exception e) {
             LOG.error("Failed to update dynamic configs from zookeeper", e);
         }
@@ -312,10 +316,10 @@ public class DynamicConfigManager {
 
     @VisibleForTesting
     protected void alterServerConfigs(Map<String, String> configsProps) throws Exception {
-        dynamicServerConfig.updateDynamicConfig(configsProps, false);
-
-        // Apply to zookeeper only after verification.
-        zooKeeperClient.upsertServerEntityConfig(configsProps);
+        // Apply locally and persist to zookeeper atomically, so a concurrent change notification
+        // (this server may also be listening) cannot interleave and revert the change.
+        dynamicServerConfig.updateAndPersistDynamicConfig(
+                configsProps, () -> zooKeeperClient.upsertServerEntityConfig(configsProps));
     }
 
     private static void validateListOrMapType(String configKey) {
@@ -340,17 +344,14 @@ public class DynamicConfigManager {
 
         @Override
         public void processNotification(byte[] notification) throws Exception {
-            if (isCoordinator) {
-                return;
-            }
-
             if (notification.length != 0) {
                 throw new ConfigException(
                         "Config change notification of this version is only empty");
             }
 
-            Map<String, String> entityConfig = zooKeeperClient.fetchEntityConfig();
-            dynamicServerConfig.updateDynamicConfig(entityConfig, true);
+            // Fetch and apply atomically so we never apply a stale snapshot on top of a config
+            // change this server itself just made and persisted (see alterServerConfigs).
+            dynamicServerConfig.refreshDynamicConfig(zooKeeperClient::fetchEntityConfig, true);
         }
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/DynamicConfigManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/DynamicConfigManager.java
@@ -43,11 +43,17 @@ import java.util.Objects;
 /**
  * Manager for dynamic configurations.
  *
- * <p>Used by both the CoordinatorServer and the TabletServer. Every instance, regardless of server
- * role or leadership status, continuously applies dynamic config-change notifications from
- * ZooKeeper. In particular a standby CoordinatorServer keeps tracking changes so that, once it is
- * promoted to leader, its components (e.g. SASL credentials) already reflect the latest config
- * rather than a stale snapshot taken at startup.
+ * <p>Used by both the CoordinatorServer and the TabletServer. A TabletServer always applies dynamic
+ * config-change notifications from ZooKeeper. A CoordinatorServer applies them only while it is a
+ * standby (follower): a standby keeps tracking changes so that, once it is promoted to leader, its
+ * components (e.g. SASL credentials) already reflect the latest config rather than a stale
+ * snapshot.
+ *
+ * <p>An active coordinator leader stops consuming notifications (see {@link #pauseListening()}),
+ * because it is itself the only writer of dynamic configs and already holds the latest values;
+ * letting it react to its own notifications could roll a config back to an older value (A to B to
+ * A). On losing leadership it resumes consuming (see {@link #resumeListening()}) and re-syncs from
+ * ZooKeeper to pick up any changes made by the new leader while it was not listening.
  */
 public class DynamicConfigManager {
     private static final Logger LOG = LoggerFactory.getLogger(DynamicConfigManager.class);
@@ -56,6 +62,13 @@ public class DynamicConfigManager {
     private final DynamicServerConfig dynamicServerConfig;
     private final ZooKeeperClient zooKeeperClient;
     private final ZkNodeChangeNotificationWatcher configChangeListener;
+
+    /**
+     * Whether change notifications are applied. Always true on a TabletServer and on a standby
+     * CoordinatorServer; set to false while a CoordinatorServer is the active leader. Volatile
+     * because it is flipped by the leader-election thread and read by the notification thread.
+     */
+    private volatile boolean listeningEnabled = true;
 
     public DynamicConfigManager(ZooKeeperClient zooKeeperClient, Configuration configuration) {
         this.dynamicServerConfig = new DynamicServerConfig(configuration);
@@ -73,7 +86,8 @@ public class DynamicConfigManager {
     public void startup() throws Exception {
         try {
             configChangeListener.start();
-            dynamicServerConfig.refreshDynamicConfig(zooKeeperClient::fetchEntityConfig, true);
+            Map<String, String> entityConfigs = zooKeeperClient.fetchEntityConfig();
+            dynamicServerConfig.updateDynamicConfig(entityConfigs, true);
         } catch (Exception e) {
             LOG.error("Failed to update dynamic configs from zookeeper", e);
         }
@@ -99,6 +113,28 @@ public class DynamicConfigManager {
 
     public void close() {
         configChangeListener.stop();
+    }
+
+    /**
+     * Stops applying config-change notifications. Called when a CoordinatorServer becomes the
+     * active leader: the leader is the sole writer of dynamic configs and already holds the latest
+     * values, so reacting to its own notifications is unnecessary and could roll a value back (A to
+     * B to A).
+     */
+    public void pauseListening() {
+        listeningEnabled = false;
+    }
+
+    /**
+     * Resumes applying config-change notifications and re-syncs the current config from ZooKeeper.
+     * Called when a CoordinatorServer loses leadership: while it was leader it ignored
+     * notifications, so it must re-read ZooKeeper once to pick up any changes made by the new
+     * leader.
+     */
+    public void resumeListening() throws Exception {
+        listeningEnabled = true;
+        Map<String, String> entityConfigs = zooKeeperClient.fetchEntityConfig();
+        dynamicServerConfig.updateDynamicConfig(entityConfigs, true);
     }
 
     public List<ConfigEntry> describeConfigs() {
@@ -316,10 +352,10 @@ public class DynamicConfigManager {
 
     @VisibleForTesting
     protected void alterServerConfigs(Map<String, String> configsProps) throws Exception {
-        // Apply locally and persist to zookeeper atomically, so a concurrent change notification
-        // (this server may also be listening) cannot interleave and revert the change.
-        dynamicServerConfig.updateAndPersistDynamicConfig(
-                configsProps, () -> zooKeeperClient.upsertServerEntityConfig(configsProps));
+        dynamicServerConfig.updateDynamicConfig(configsProps, false);
+
+        // Apply to zookeeper only after verification.
+        zooKeeperClient.upsertServerEntityConfig(configsProps);
     }
 
     private static void validateListOrMapType(String configKey) {
@@ -344,14 +380,19 @@ public class DynamicConfigManager {
 
         @Override
         public void processNotification(byte[] notification) throws Exception {
+            // An active coordinator leader is the sole writer of dynamic configs, so it ignores
+            // notifications to avoid rolling back a value it just set (A to B to A).
+            if (!listeningEnabled) {
+                return;
+            }
+
             if (notification.length != 0) {
                 throw new ConfigException(
                         "Config change notification of this version is only empty");
             }
 
-            // Fetch and apply atomically so we never apply a stale snapshot on top of a config
-            // change this server itself just made and persisted (see alterServerConfigs).
-            dynamicServerConfig.refreshDynamicConfig(zooKeeperClient::fetchEntityConfig, true);
+            Map<String, String> entityConfig = zooKeeperClient.fetchEntityConfig();
+            dynamicServerConfig.updateDynamicConfig(entityConfig, true);
         }
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/DynamicServerConfig.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/DynamicServerConfig.java
@@ -27,8 +27,6 @@ import org.apache.fluss.config.cluster.ServerReconfigurable;
 import org.apache.fluss.exception.ConfigException;
 import org.apache.fluss.server.config.ConfigRedactor;
 import org.apache.fluss.server.config.ConfigRedactors;
-import org.apache.fluss.utils.function.SupplierWithException;
-import org.apache.fluss.utils.function.ThrowingRunnable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -166,39 +164,12 @@ class DynamicServerConfig {
     }
 
     /**
-     * Fetches the latest dynamic config through {@code configSupplier} and applies it to the
-     * registered {@link ServerReconfigurable}s, atomically under the write lock.
-     *
-     * <p>The fetch happens inside the lock so that a server which both edits configs (via {@link
-     * #updateAndPersistDynamicConfig}) and listens for change notifications cannot read a stale
-     * snapshot from the config store and apply it on top of a newer, already-applied change. If
-     * skipping error config, only the invalid entries are ignored.
+     * Update the dynamic configuration and apply to registered ServerReconfigurable. If skipping
+     * error config, only the error one will be ignored.
      */
-    void refreshDynamicConfig(
-            SupplierWithException<Map<String, String>, Exception> configSupplier,
-            boolean skipErrorConfig)
+    void updateDynamicConfig(Map<String, String> newDynamicConfigs, boolean skipErrorConfig)
             throws Exception {
-        inWriteLock(lock, () -> updateCurrentConfig(configSupplier.get(), skipErrorConfig));
-    }
-
-    /**
-     * Applies {@code newDynamicConfigs} to the registered {@link ServerReconfigurable}s and then
-     * runs {@code persistAction} (which writes the new config to the config store), atomically
-     * under the write lock.
-     *
-     * <p>Persisting under the same lock guarantees that a concurrent {@link #refreshDynamicConfig}
-     * triggered by a change notification observes either the fully-applied-and-persisted state or
-     * the pre-change state, never a torn state where local config and the store disagree.
-     */
-    void updateAndPersistDynamicConfig(
-            Map<String, String> newDynamicConfigs, ThrowingRunnable<Exception> persistAction)
-            throws Exception {
-        inWriteLock(
-                lock,
-                () -> {
-                    updateCurrentConfig(newDynamicConfigs, false);
-                    persistAction.run();
-                });
+        inWriteLock(lock, () -> updateCurrentConfig(newDynamicConfigs, skipErrorConfig));
     }
 
     Map<String, String> getDynamicConfigs() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/DynamicServerConfig.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/DynamicServerConfig.java
@@ -183,8 +183,8 @@ class DynamicServerConfig {
 
     /**
      * Applies {@code newDynamicConfigs} to the registered {@link ServerReconfigurable}s and then
-     * runs {@code persistAction} (which writes the new config to the config store), atomically under
-     * the write lock.
+     * runs {@code persistAction} (which writes the new config to the config store), atomically
+     * under the write lock.
      *
      * <p>Persisting under the same lock guarantees that a concurrent {@link #refreshDynamicConfig}
      * triggered by a change notification observes either the fully-applied-and-persisted state or

--- a/fluss-server/src/main/java/org/apache/fluss/server/DynamicServerConfig.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/DynamicServerConfig.java
@@ -27,6 +27,8 @@ import org.apache.fluss.config.cluster.ServerReconfigurable;
 import org.apache.fluss.exception.ConfigException;
 import org.apache.fluss.server.config.ConfigRedactor;
 import org.apache.fluss.server.config.ConfigRedactors;
+import org.apache.fluss.utils.function.SupplierWithException;
+import org.apache.fluss.utils.function.ThrowingRunnable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -164,12 +166,39 @@ class DynamicServerConfig {
     }
 
     /**
-     * Update the dynamic configuration and apply to registered ServerReconfigurable. If skipping
-     * error config, only the error one will be ignored.
+     * Fetches the latest dynamic config through {@code configSupplier} and applies it to the
+     * registered {@link ServerReconfigurable}s, atomically under the write lock.
+     *
+     * <p>The fetch happens inside the lock so that a server which both edits configs (via {@link
+     * #updateAndPersistDynamicConfig}) and listens for change notifications cannot read a stale
+     * snapshot from the config store and apply it on top of a newer, already-applied change. If
+     * skipping error config, only the invalid entries are ignored.
      */
-    void updateDynamicConfig(Map<String, String> newDynamicConfigs, boolean skipErrorConfig)
+    void refreshDynamicConfig(
+            SupplierWithException<Map<String, String>, Exception> configSupplier,
+            boolean skipErrorConfig)
             throws Exception {
-        inWriteLock(lock, () -> updateCurrentConfig(newDynamicConfigs, skipErrorConfig));
+        inWriteLock(lock, () -> updateCurrentConfig(configSupplier.get(), skipErrorConfig));
+    }
+
+    /**
+     * Applies {@code newDynamicConfigs} to the registered {@link ServerReconfigurable}s and then
+     * runs {@code persistAction} (which writes the new config to the config store), atomically under
+     * the write lock.
+     *
+     * <p>Persisting under the same lock guarantees that a concurrent {@link #refreshDynamicConfig}
+     * triggered by a change notification observes either the fully-applied-and-persisted state or
+     * the pre-change state, never a torn state where local config and the store disagree.
+     */
+    void updateAndPersistDynamicConfig(
+            Map<String, String> newDynamicConfigs, ThrowingRunnable<Exception> persistAction)
+            throws Exception {
+        inWriteLock(
+                lock,
+                () -> {
+                    updateCurrentConfig(newDynamicConfigs, false);
+                    persistAction.run();
+                });
     }
 
     Map<String, String> getDynamicConfigs() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorServer.java
@@ -349,6 +349,10 @@ public class CoordinatorServer extends ServerBase {
                             clock);
             coordinatorEventProcessor.startup();
 
+            // As the active leader, this server is the sole writer of dynamic configs and holds the
+            // latest values, so stop consuming change notifications to avoid rolling a value back.
+            dynamicConfigManager.pauseListening();
+
             createDefaultDatabase();
         }
     }
@@ -418,6 +422,14 @@ public class CoordinatorServer extends ServerBase {
                 }
             } catch (Throwable t) {
                 LOG.warn("Failed to close client metric group", t);
+            }
+
+            try {
+                // Back to standby: resume consuming config-change notifications and re-sync from
+                // ZooKeeper to pick up any changes the new leader made while we were not listening.
+                dynamicConfigManager.resumeListening();
+            } catch (Throwable t) {
+                LOG.warn("Failed to resume dynamic config listening", t);
             }
 
             LOG.info("Coordinator leader services cleaned up successfully.");

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorServer.java
@@ -241,7 +241,7 @@ public class CoordinatorServer extends ServerBase {
             this.lakeCatalogDynamicLoader = new LakeCatalogDynamicLoader(conf, pluginManager, true);
             this.remoteDirDynamicLoader = new RemoteDirDynamicLoader(conf);
 
-            this.dynamicConfigManager = new DynamicConfigManager(zkClient, conf, true);
+            this.dynamicConfigManager = new DynamicConfigManager(zkClient, conf);
             this.metadataCache = new CoordinatorMetadataCache();
 
             this.authorizer = AuthorizerLoader.createAuthorizer(conf, zkClient, pluginManager);

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
@@ -226,7 +226,7 @@ public class TabletServer extends ServerBase {
                     new LakeCatalogDynamicLoader(conf, pluginManager, false);
             MetadataManager metadataManager =
                     new MetadataManager(zkClient, conf, lakeCatalogDynamicLoader);
-            this.dynamicConfigManager = new DynamicConfigManager(zkClient, conf, false);
+            this.dynamicConfigManager = new DynamicConfigManager(zkClient, conf);
 
             this.metadataCache = new TabletServerMetadataCache(metadataManager);
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/DynamicConfigChangeTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/DynamicConfigChangeTest.java
@@ -34,7 +34,8 @@ import org.apache.fluss.server.zk.NOPErrorHandler;
 import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.ZooKeeperExtension;
 import org.apache.fluss.server.zk.ZooKeeperUtils;
-import org.apache.fluss.server.zk.data.ZkData.ConfigEntityZNode;
+import org.apache.fluss.server.zk.data.ZkData.ConfigZNode;
+import org.apache.fluss.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
 import org.apache.fluss.testutils.common.AllCallbackWrapper;
 
 import org.junit.jupiter.api.AfterAll;
@@ -46,9 +47,11 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -70,6 +73,13 @@ public class DynamicConfigChangeTest {
 
     protected static ZooKeeperClient zookeeperClient;
 
+    /**
+     * Managers created during a test. Each one starts a ZooKeeper notification watcher on {@link
+     * DynamicConfigManager#startup()}, so they must be closed after the test to stop reacting to
+     * config changes written by later tests that share the same static {@link #zookeeperClient}.
+     */
+    private final List<DynamicConfigManager> managers = new ArrayList<>();
+
     @BeforeAll
     static void beforeAll() {
         final Configuration configuration = new Configuration();
@@ -90,15 +100,38 @@ public class DynamicConfigChangeTest {
 
     @AfterEach
     void after() throws Exception {
-        zookeeperClient.deletePath(ConfigEntityZNode.path());
+        for (DynamicConfigManager manager : managers) {
+            manager.close();
+        }
+        managers.clear();
+        // Recursively delete /config so both the entity config (/config/server/global) and the
+        // change notifications (/config/changes/...) are removed for the next test.
+        try {
+            zookeeperClient
+                    .getCuratorClient()
+                    .delete()
+                    .deletingChildrenIfNeeded()
+                    .forPath(ConfigZNode.path());
+        } catch (KeeperException.NoNodeException ignored) {
+            // Nothing was written in this test.
+        }
+    }
+
+    /**
+     * Creates a manager and tracks it so {@link #after()} closes it. Prefer this over calling the
+     * constructor directly so the manager's notification watcher is stopped after the test.
+     */
+    private DynamicConfigManager createManager(Configuration configuration) {
+        DynamicConfigManager manager = new DynamicConfigManager(zookeeperClient, configuration);
+        managers.add(manager);
+        return manager;
     }
 
     @Test
     void testAlterLakehouseConfigs() throws Exception {
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(new Configuration(), null, true)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, new Configuration(), true);
+            DynamicConfigManager dynamicConfigManager = createManager(new Configuration());
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
             dynamicConfigManager.startup();
             assertThatThrownBy(
@@ -149,8 +182,7 @@ public class DynamicConfigChangeTest {
         configuration.setString(DATALAKE_FORMAT.key(), "paimon");
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(configuration, null, true)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, configuration, true);
+            DynamicConfigManager dynamicConfigManager = createManager(configuration);
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
             dynamicConfigManager.startup();
             assertThat(lakeCatalogDynamicLoader.getLakeCatalogContainer().getDataLakeFormat())
@@ -174,8 +206,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(configuration, null, true)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, configuration, true);
+            DynamicConfigManager dynamicConfigManager = createManager(configuration);
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
             dynamicConfigManager.startup();
             assertThatThrownBy(
@@ -199,8 +230,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(configuration, null, true)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, configuration, true);
+            DynamicConfigManager dynamicConfigManager = createManager(configuration);
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
             dynamicConfigManager.startup();
 
@@ -235,8 +265,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(configuration, null, true)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, configuration, true);
+            DynamicConfigManager dynamicConfigManager = createManager(configuration);
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
             dynamicConfigManager.startup();
             assertThatThrownBy(
@@ -264,8 +293,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(configuration, null, false)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, configuration, false);
+            DynamicConfigManager dynamicConfigManager = createManager(configuration);
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
             dynamicConfigManager.startup();
             assertThat(lakeCatalogDynamicLoader.getLakeCatalogContainer().getDataLakeFormat())
@@ -285,6 +313,41 @@ public class DynamicConfigChangeTest {
         }
     }
 
+    /**
+     * Regression test for #3625: a {@link DynamicConfigManager} must keep applying config-change
+     * notifications pushed to ZooKeeper by another writer. This is what lets a standby
+     * CoordinatorServer stay current so that, once promoted, it does not run with stale config.
+     */
+    @Test
+    void testTracksConfigChangeNotificationsFromOtherWriter() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER, 1);
+
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
+        AtomicInteger reconfiguredValue = new AtomicInteger();
+        dynamicConfigManager.register(
+                new ServerReconfigurable() {
+                    @Override
+                    public void validate(Configuration newConfig) throws ConfigException {}
+
+                    @Override
+                    public void reconfigure(Configuration newConfig) {
+                        reconfiguredValue.set(
+                                newConfig.get(
+                                        ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER));
+                    }
+                });
+        dynamicConfigManager.startup();
+
+        // Simulate another server (e.g. the active leader) persisting a config change to ZK,
+        // which inserts a change notification the manager under test must react to.
+        Map<String, String> config = new HashMap<>();
+        config.put(ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER.key(), "3");
+        zookeeperClient.upsertServerEntityConfig(config);
+
+        retry(Duration.ofMinutes(1), () -> assertThat(reconfiguredValue.get()).isEqualTo(3));
+    }
+
     @Test
     void testReStartupContainsNoMatchedDynamicConfig() throws Exception {
         Configuration configuration = new Configuration();
@@ -297,8 +360,7 @@ public class DynamicConfigChangeTest {
 
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(configuration, null, true)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, configuration, true);
+            DynamicConfigManager dynamicConfigManager = createManager(configuration);
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
             // Startup dynamic manager even is not matched now.
             dynamicConfigManager.startup();
@@ -313,8 +375,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         configuration.setString(ConfigOptions.KV_SHARED_RATE_LIMITER_BYTES_PER_SEC.key(), "100MB");
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
         dynamicConfigManager.startup();
 
         // Try to set rate limiter to an invalid value - should be rejected by generic type
@@ -340,8 +401,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         configuration.setString(ConfigOptions.KV_SHARED_RATE_LIMITER_BYTES_PER_SEC.key(), "100MB");
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
         dynamicConfigManager.startup();
 
         // Adjust rate limiter value - should succeed
@@ -365,8 +425,7 @@ public class DynamicConfigChangeTest {
 
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(configuration, null, true)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, configuration, true);
+            DynamicConfigManager dynamicConfigManager = createManager(configuration);
 
             // Register reconfigurables - generic type validation works automatically
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
@@ -397,8 +456,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         configuration.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofMinutes(10));
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
         dynamicConfigManager.startup();
 
         // Try to set snapshot interval to an invalid value - should be rejected by type validation
@@ -420,8 +478,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         configuration.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofMinutes(10));
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
 
         AtomicReference<Duration> reconfiguredInterval = new AtomicReference<>();
         dynamicConfigManager.register(
@@ -461,8 +518,7 @@ public class DynamicConfigChangeTest {
 
         try (RemoteDirDynamicLoader remoteDirDynamicLoader =
                 new RemoteDirDynamicLoader(configuration)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, configuration, true);
+            DynamicConfigManager dynamicConfigManager = createManager(configuration);
             dynamicConfigManager.register(remoteDirDynamicLoader);
             dynamicConfigManager.startup();
 
@@ -509,8 +565,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         configuration.setInt(ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER, 1);
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
         dynamicConfigManager.startup();
 
         // Try to set min-in-sync-replicas to an invalid value - should be rejected by type
@@ -536,8 +591,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         configuration.setInt(ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER, 1);
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
 
         AtomicInteger reconfiguredValue = new AtomicInteger();
         dynamicConfigManager.register(
@@ -575,8 +629,7 @@ public class DynamicConfigChangeTest {
     void testExplicitDataLakeEnabledRequiresDataLakeFormat() throws Exception {
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(new Configuration(), null, true)) {
-            DynamicConfigManager dynamicConfigManager =
-                    new DynamicConfigManager(zookeeperClient, new Configuration(), true);
+            DynamicConfigManager dynamicConfigManager = createManager(new Configuration());
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
             dynamicConfigManager.startup();
 
@@ -647,8 +700,7 @@ public class DynamicConfigChangeTest {
         configuration.setString(ConfigOptions.DATA_DIR, dataDir.getAbsolutePath());
         configuration.set(ConfigOptions.SERVER_DATA_DISK_WRITE_LIMIT_RATIO, 0.85);
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
 
         // Create LocalDiskManager and register it
         try (LocalDiskManager localDiskManager = LocalDiskManager.create(configuration)) {
@@ -711,10 +763,8 @@ public class DynamicConfigChangeTest {
         }
     }
 
-    private static DynamicConfigManager createDiskWriteLimitDynamicConfigManager()
-            throws Exception {
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, new Configuration(), true);
+    private DynamicConfigManager createDiskWriteLimitDynamicConfigManager() throws Exception {
+        DynamicConfigManager dynamicConfigManager = createManager(new Configuration());
         dynamicConfigManager.register(new DiskWriteLimitConfigValidator());
         dynamicConfigManager.startup();
         return dynamicConfigManager;
@@ -745,8 +795,7 @@ public class DynamicConfigChangeTest {
     @Test
     void testAppendAndSubtractOnMapConfig() throws Exception {
         Configuration configuration = new Configuration();
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
 
         AtomicReference<Map<String, String>> reconfiguredUsers = new AtomicReference<>();
         dynamicConfigManager.register(
@@ -821,8 +870,7 @@ public class DynamicConfigChangeTest {
     @Test
     void testAppendOnNonListOrMapConfigIsRejected() throws Exception {
         Configuration configuration = new Configuration();
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
         dynamicConfigManager.startup();
 
         // APPEND on a non-list/non-map config (kv.snapshot.interval is Duration type)
@@ -862,8 +910,7 @@ public class DynamicConfigChangeTest {
                 "org.apache.fluss.security.auth.sasl.plain.PlainLoginModule required "
                         + "user_admin=\"admin-secret\";");
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
         dynamicConfigManager.startup();
 
         assertThat(dynamicConfigManager.describeConfigs())
@@ -884,8 +931,7 @@ public class DynamicConfigChangeTest {
         // Pre-configure a static user in server.yaml equivalent
         configuration.setString(ConfigOptions.SERVER_SASL_CREDENTIALS.key(), "admin:admin-secret");
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
 
         AtomicReference<Map<String, String>> reconfiguredUsers = new AtomicReference<>();
         dynamicConfigManager.register(
@@ -922,8 +968,7 @@ public class DynamicConfigChangeTest {
         // Pre-configure a static user in server.yaml equivalent
         configuration.setString(ConfigOptions.SERVER_SASL_CREDENTIALS.key(), "admin:admin-secret");
 
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
 
         AtomicReference<Map<String, String>> reconfiguredUsers = new AtomicReference<>();
         dynamicConfigManager.register(
@@ -955,8 +1000,7 @@ public class DynamicConfigChangeTest {
     @Test
     void testSubtractTrimsWhitespaceAndRemovesByKey() throws Exception {
         Configuration configuration = new Configuration();
-        DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+        DynamicConfigManager dynamicConfigManager = createManager(configuration);
         dynamicConfigManager.startup();
 
         // Set up a config with whitespace around entries

--- a/fluss-server/src/test/java/org/apache/fluss/server/DynamicConfigChangeTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/DynamicConfigChangeTest.java
@@ -118,10 +118,23 @@ public class DynamicConfigChangeTest {
     }
 
     /**
-     * Creates a manager and tracks it so {@link #after()} closes it. Prefer this over calling the
-     * constructor directly so the manager's notification watcher is stopped after the test.
+     * Creates a manager that does not consume change notifications, modelling a coordinator leader
+     * (the sole writer via {@code alterConfigs}). This is the default because most tests exercise
+     * the write path, and a self-consumed notification could roll back a value the test just set.
+     * Use {@link #createListeningManager} for tests that verify notification tracking. The manager
+     * is tracked so {@link #after()} closes it.
      */
     private DynamicConfigManager createManager(Configuration configuration) {
+        DynamicConfigManager manager = createListeningManager(configuration);
+        manager.pauseListening();
+        return manager;
+    }
+
+    /**
+     * Creates a manager that consumes change notifications, modelling a standby coordinator or a
+     * tablet server. The manager is tracked so {@link #after()} closes it (stopping its watcher).
+     */
+    private DynamicConfigManager createListeningManager(Configuration configuration) {
         DynamicConfigManager manager = new DynamicConfigManager(zookeeperClient, configuration);
         managers.add(manager);
         return manager;
@@ -293,7 +306,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         try (LakeCatalogDynamicLoader lakeCatalogDynamicLoader =
                 new LakeCatalogDynamicLoader(configuration, null, false)) {
-            DynamicConfigManager dynamicConfigManager = createManager(configuration);
+            DynamicConfigManager dynamicConfigManager = createListeningManager(configuration);
             dynamicConfigManager.register(lakeCatalogDynamicLoader);
             dynamicConfigManager.startup();
             assertThat(lakeCatalogDynamicLoader.getLakeCatalogContainer().getDataLakeFormat())
@@ -323,7 +336,7 @@ public class DynamicConfigChangeTest {
         Configuration configuration = new Configuration();
         configuration.set(ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER, 1);
 
-        DynamicConfigManager dynamicConfigManager = createManager(configuration);
+        DynamicConfigManager dynamicConfigManager = createListeningManager(configuration);
         AtomicInteger reconfiguredValue = new AtomicInteger();
         dynamicConfigManager.register(
                 new ServerReconfigurable() {
@@ -346,6 +359,51 @@ public class DynamicConfigChangeTest {
         zookeeperClient.upsertServerEntityConfig(config);
 
         retry(Duration.ofMinutes(1), () -> assertThat(reconfiguredValue.get()).isEqualTo(3));
+    }
+
+    /**
+     * Regression test for #3645 review: an active leader ({@link
+     * DynamicConfigManager#pauseListening()}) must ignore change notifications so it cannot roll a
+     * value it just set back to an older one (A to B to A). On losing leadership ({@link
+     * DynamicConfigManager#resumeListening()}) it re-syncs from ZooKeeper.
+     */
+    @Test
+    void testPausedManagerIgnoresNotificationsAndResumeReSyncs() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER, 1);
+
+        DynamicConfigManager dynamicConfigManager = createListeningManager(configuration);
+        // Seed with the initial value; reconfigure() is only invoked on an effective change.
+        AtomicInteger reconfiguredValue = new AtomicInteger(1);
+        dynamicConfigManager.register(
+                new ServerReconfigurable() {
+                    @Override
+                    public void validate(Configuration newConfig) throws ConfigException {}
+
+                    @Override
+                    public void reconfigure(Configuration newConfig) {
+                        reconfiguredValue.set(
+                                newConfig.get(
+                                        ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER));
+                    }
+                });
+        dynamicConfigManager.startup();
+
+        // Become leader: stop consuming notifications.
+        dynamicConfigManager.pauseListening();
+
+        // Another writer changes the config in ZooKeeper. A paused manager must not apply it.
+        Map<String, String> config = new HashMap<>();
+        config.put(ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER.key(), "3");
+        zookeeperClient.upsertServerEntityConfig(config);
+
+        // Give the notification a chance to be (wrongly) applied, then assert it was ignored.
+        Thread.sleep(2000);
+        assertThat(reconfiguredValue.get()).isEqualTo(1);
+
+        // Lose leadership: resume and re-sync from ZooKeeper picks up the missed change.
+        dynamicConfigManager.resumeListening();
+        assertThat(reconfiguredValue.get()).isEqualTo(3);
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHighAvailabilityITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHighAvailabilityITCase.java
@@ -23,6 +23,9 @@ import org.apache.fluss.cluster.ServerNode;
 import org.apache.fluss.cluster.ServerType;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.cluster.AlterConfig;
+import org.apache.fluss.config.cluster.AlterConfigOpType;
+import org.apache.fluss.config.cluster.ConfigEntry;
 import org.apache.fluss.exception.InvalidCoordinatorException;
 import org.apache.fluss.exception.NotCoordinatorLeaderException;
 import org.apache.fluss.metadata.TableBucket;
@@ -220,6 +223,65 @@ class CoordinatorHighAvailabilityITCase {
 
         verifyServerIsLeader(leader, "test_reentrant_db_3");
         createGatewayForServer(leader).metadata(new MetadataRequest()).get();
+    }
+
+    /**
+     * Regression test for #3625: a standby coordinator must keep applying dynamic config changes so
+     * that, after failover, the promoted leader uses the latest config rather than a stale snapshot
+     * taken when it started up as standby.
+     */
+    @Test
+    void testStandbyTracksDynamicConfigAndNewLeaderUsesItAfterFailover() throws Exception {
+        coordinatorServer1 = new CoordinatorServer(createConfiguration());
+        coordinatorServer2 = new CoordinatorServer(createConfiguration());
+
+        coordinatorServer1.start();
+        coordinatorServer2.start();
+
+        waitUntilCoordinatorServerElected();
+        CoordinatorAddress firstLeaderAddr = zookeeperClient.getCoordinatorLeaderAddress().get();
+
+        CoordinatorServer leader = findServerById(firstLeaderAddr.getId());
+        CoordinatorServer standby = findServerByNotId(firstLeaderAddr.getId());
+        assertThat(leader).isNotNull();
+        assertThat(standby).isNotNull();
+
+        String configKey = ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER.key();
+
+        // Alter a dynamic config through the current leader. This persists it to ZK and inserts a
+        // change notification that every server (including the standby) should react to.
+        leader.getDynamicConfigManager()
+                .alterConfigs(
+                        Collections.singletonList(
+                                new AlterConfig(configKey, "3", AlterConfigOpType.SET)));
+
+        // The standby must pick up the change while it is still a standby.
+        waitUntil(
+                () -> "3".equals(dynamicConfigValue(standby, configKey)),
+                Duration.ofSeconds(30),
+                "Standby coordinator did not apply dynamic config change while standby");
+
+        // Fail over: killing the leader's ZK session promotes the standby to leader.
+        killZkSession(leader);
+        waitUntilNewLeaderElected(leader.getServerId());
+        assertThat(zookeeperClient.getCoordinatorLeaderAddress().get().getId())
+                .as("After killing leader, standby should become leader")
+                .isEqualTo(standby.getServerId());
+
+        // The newly promoted leader must still see the up-to-date value, not a stale one.
+        assertThat(dynamicConfigValue(standby, configKey))
+                .as("Newly promoted leader should use the dynamic config it tracked while standby")
+                .isEqualTo("3");
+    }
+
+    /** Reads the effective value of a config key from a server's DynamicConfigManager. */
+    private static String dynamicConfigValue(CoordinatorServer server, String configKey) {
+        for (ConfigEntry entry : server.getDynamicConfigManager().describeConfigs()) {
+            if (entry.key().equals(configKey)) {
+                return entry.value();
+            }
+        }
+        return null;
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHighAvailabilityITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHighAvailabilityITCase.java
@@ -272,6 +272,13 @@ class CoordinatorHighAvailabilityITCase {
         assertThat(dynamicConfigValue(standby, configKey))
                 .as("Newly promoted leader should use the dynamic config it tracked while standby")
                 .isEqualTo("3");
+
+        // As the new leader it is now the sole writer: a further alter must take effect and stick.
+        standby.getDynamicConfigManager()
+                .alterConfigs(
+                        Collections.singletonList(
+                                new AlterConfig(configKey, "5", AlterConfigOpType.SET)));
+        assertThat(dynamicConfigValue(standby, configKey)).isEqualTo("5");
     }
 
     /** Reads the effective value of a config key from a server's DynamicConfigManager. */


### PR DESCRIPTION
### Purpose

Linked issue: close #3625

On a `CoordinatorServer`, `DynamicConfigManager` fetched dynamic configs from ZooKeeper only once at startup and then ignored every later config-change notification: the notification handler returned early whenever `isCoordinator == true`. As a result, a long-running **standby** coordinator's local config drifted away from ZooKeeper.

When such a standby was later promoted to leader, its components were configured from that stale local snapshot even though ZooKeeper already held newer values. The most impactful case is SASL/PLAIN multi-user credentials (`security.sasl.plain.credentials`, hot-reloaded by `FlussProtocolPlugin` and registered on both server roles): after failover, the new leader could authenticate clients against a frozen credential set — a dynamically added user would be rejected, and a dynamically **removed** user would still be accepted.

This PR makes standby coordinators continuously apply dynamic config-change notifications, exactly like tablet servers do, so a promoted leader always reflects the latest config.

### Brief change log

- `DynamicConfigManager`: remove the `isCoordinator` early-return in the change-notification handler, and drop the now-dead `isCoordinator` field and constructor parameter. Both server roles now apply notifications.
- Fix a concurrency issue that this change surfaces on the leader, which now both edits configs (via `alterConfigs`) and listens for notifications. Previously the notification path fetched from ZooKeeper **outside** the write lock, and `alterConfigs` applied-then-persisted without holding the lock across both steps, so a stale fetch could be applied on top of a newer, already-committed change. `DynamicServerConfig` now exposes:
  - `refreshDynamicConfig(configSupplier, skipErrorConfig)` — fetch and apply atomically under the write lock (used by `startup()` and the notification handler);
  - `updateAndPersistDynamicConfig(configs, persistAction)` — apply locally and persist to ZooKeeper atomically under the write lock (used by `alterConfigs`).
- Update `CoordinatorServer` and `TabletServer` to the two-argument `DynamicConfigManager` constructor.

### Tests

- `DynamicConfigChangeTest#testTracksConfigChangeNotificationsFromOtherWriter` (new): a manager applies a config change written to ZooKeeper by another writer — the core behavior the fix enables. Verified it fails without the fix (`expected 3 but was 0`).
- `CoordinatorHighAvailabilityITCase#testStandbyTracksDynamicConfigAndNewLeaderUsesItAfterFailover` (new): alter a dynamic config on the leader, assert the standby tracks it, kill the leader's ZK session to trigger failover, and assert the promoted leader still uses the up-to-date value.
  Verified it fails without the fix ("Standby coordinator did not apply dynamic config change while standby").
- Updated the existing `DynamicConfigManager` construction call sites in `DynamicConfigChangeTest` and made each test close its manager after use (previously leaked notification watchers, now material because coordinators react to notifications).
- Full runs pass: `DynamicConfigChangeTest` (26), `CoordinatorHighAvailabilityITCase` (6), and the server startup/election suites (`CoordinatorServerTest`, `TabletServerTest`, `CoordinatorServerElectionTest`).

### API and Format

No public API or storage-format changes. `DynamicConfigManager`'s constructor signature changed, but it is an internal server class. No RPC message or ZooKeeper znode-format changes.

### Documentation

No. This is a bug fix with no new user-facing feature or configuration.