### PR TITLE
[server] Offload NotifyLeaderAndIsr to dedicated single-thread executor

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
@@ -178,6 +178,14 @@ public class TabletServer extends ServerBase {
     @GuardedBy("lock")
     private ExecutorService ioExecutor;
 
+    /**
+     * Runs replica state changes outside RPC worker threads to prevent potentially slow state
+     * transitions from blocking other RPCs. A single thread is sufficient because replica state
+     * changes are serialized by the replica state change lock.
+     */
+    @GuardedBy("lock")
+    private ExecutorService replicaStateChangeExecutor;
+
     public TabletServer(Configuration conf) {
         this(conf, SystemClock.getInstance());
     }
@@ -266,6 +274,9 @@ public class TabletServer extends ServerBase {
                     Executors.newFixedThreadPool(
                             conf.get(ConfigOptions.SERVER_IO_POOL_SIZE),
                             new ExecutorThreadFactory("tablet-server-io"));
+            this.replicaStateChangeExecutor =
+                    Executors.newSingleThreadExecutor(
+                            new ExecutorThreadFactory("tablet-server-replica-state-change"));
 
             this.scannerManager = new ScannerManager(conf, scheduler);
 
@@ -302,6 +313,7 @@ public class TabletServer extends ServerBase {
                             authorizer,
                             dynamicConfigManager,
                             ioExecutor,
+                            replicaStateChangeExecutor,
                             scannerManager,
                             coordinatorGateway,
                             interListenerName);
@@ -434,6 +446,14 @@ public class TabletServer extends ServerBase {
             try {
                 if (tabletService != null) {
                     tabletService.shutdown();
+                }
+            } catch (Throwable t) {
+                exception = ExceptionUtils.firstOrSuppressed(t, exception);
+            }
+
+            try {
+                if (replicaStateChangeExecutor != null) {
+                    ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaStateChangeExecutor);
                 }
             } catch (Throwable t) {
                 exception = ExceptionUtils.firstOrSuppressed(t, exception);

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
@@ -154,6 +154,7 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     private final ScannerManager scannerManager;
     private final CoordinatorGateway coordinatorGateway;
     private final String interListenerName;
+    private final ExecutorService replicaStateChangeExecutor;
 
     public TabletService(
             int serverId,
@@ -165,6 +166,7 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
             @Nullable Authorizer authorizer,
             DynamicConfigManager dynamicConfigManager,
             ExecutorService ioExecutor,
+            ExecutorService replicaStateChangeExecutor,
             ScannerManager scannerManager,
             CoordinatorGateway coordinatorGateway,
             String interListenerName) {
@@ -184,6 +186,7 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
         this.scannerManager = scannerManager;
         this.coordinatorGateway = coordinatorGateway;
         this.interListenerName = interListenerName;
+        this.replicaStateChangeExecutor = replicaStateChangeExecutor;
     }
 
     @Override
@@ -359,12 +362,26 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     public CompletableFuture<NotifyLeaderAndIsrResponse> notifyLeaderAndIsr(
             NotifyLeaderAndIsrRequest notifyLeaderAndIsrRequest) {
         CompletableFuture<NotifyLeaderAndIsrResponse> response = new CompletableFuture<>();
+        int coordinatorEpoch = notifyLeaderAndIsrRequest.getCoordinatorEpoch();
         List<NotifyLeaderAndIsrData> notifyLeaderAndIsrRequestData =
                 getNotifyLeaderAndIsrRequestData(notifyLeaderAndIsrRequest);
-        replicaManager.becomeLeaderOrFollower(
-                notifyLeaderAndIsrRequest.getCoordinatorEpoch(),
-                notifyLeaderAndIsrRequestData,
-                result -> response.complete(makeNotifyLeaderAndIsrResponse(result)));
+        try {
+            replicaStateChangeExecutor.execute(
+                    () -> {
+                        try {
+                            replicaManager.becomeLeaderOrFollower(
+                                    coordinatorEpoch,
+                                    notifyLeaderAndIsrRequestData,
+                                    result ->
+                                            response.complete(
+                                                    makeNotifyLeaderAndIsrResponse(result)));
+                        } catch (Throwable t) {
+                            response.completeExceptionally(t);
+                        }
+                    });
+        } catch (Throwable t) {
+            response.completeExceptionally(t);
+        }
         return response;
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
@@ -84,7 +84,11 @@ import org.apache.fluss.server.RpcServiceBase;
 import org.apache.fluss.server.authorizer.Authorizer;
 import org.apache.fluss.server.coordinator.MetadataManager;
 import org.apache.fluss.server.entity.FetchReqInfo;
+import org.apache.fluss.server.entity.NotifyKvSnapshotOffsetData;
+import org.apache.fluss.server.entity.NotifyLakeTableOffsetData;
 import org.apache.fluss.server.entity.NotifyLeaderAndIsrData;
+import org.apache.fluss.server.entity.NotifyRemoteLogOffsetsData;
+import org.apache.fluss.server.entity.StopReplicaData;
 import org.apache.fluss.server.entity.UserContext;
 import org.apache.fluss.server.kv.scan.OpenScanResult;
 import org.apache.fluss.server.kv.scan.ScannerContext;
@@ -93,6 +97,7 @@ import org.apache.fluss.server.log.FetchParams;
 import org.apache.fluss.server.log.FetchParamsBuilder;
 import org.apache.fluss.server.log.FilterInfo;
 import org.apache.fluss.server.log.ListOffsetsParam;
+import org.apache.fluss.server.metadata.ClusterMetadata;
 import org.apache.fluss.server.metadata.TabletServerMetadataCache;
 import org.apache.fluss.server.metadata.TabletServerMetadataProvider;
 import org.apache.fluss.server.replica.Replica;
@@ -111,6 +116,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.apache.fluss.security.acl.OperationType.READ;
@@ -365,24 +371,13 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
         int coordinatorEpoch = notifyLeaderAndIsrRequest.getCoordinatorEpoch();
         List<NotifyLeaderAndIsrData> notifyLeaderAndIsrRequestData =
                 getNotifyLeaderAndIsrRequestData(notifyLeaderAndIsrRequest);
-        try {
-            replicaStateChangeExecutor.execute(
-                    () -> {
-                        try {
-                            replicaManager.becomeLeaderOrFollower(
-                                    coordinatorEpoch,
-                                    notifyLeaderAndIsrRequestData,
-                                    result ->
-                                            response.complete(
-                                                    makeNotifyLeaderAndIsrResponse(result)));
-                        } catch (Throwable t) {
-                            response.completeExceptionally(t);
-                        }
-                    });
-        } catch (Throwable t) {
-            response.completeExceptionally(t);
-        }
-        return response;
+        return submitReplicaStateChange(
+                response,
+                result ->
+                        replicaManager.becomeLeaderOrFollower(
+                                coordinatorEpoch,
+                                notifyLeaderAndIsrRequestData,
+                                value -> result.complete(makeNotifyLeaderAndIsrResponse(value))));
     }
 
     @Override
@@ -404,20 +399,29 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
                 request.hasCoordinatorEpoch()
                         ? request.getCoordinatorEpoch()
                         : INITIAL_COORDINATOR_EPOCH;
-        replicaManager.maybeUpdateMetadataCache(
-                coordinatorEpoch, getUpdateMetadataRequestData(request));
-        return CompletableFuture.completedFuture(new UpdateMetadataResponse());
+        ClusterMetadata clusterMetadata = getUpdateMetadataRequestData(request);
+        CompletableFuture<UpdateMetadataResponse> response = new CompletableFuture<>();
+        return submitReplicaStateChange(
+                response,
+                result -> {
+                    replicaManager.maybeUpdateMetadataCache(coordinatorEpoch, clusterMetadata);
+                    result.complete(new UpdateMetadataResponse());
+                });
     }
 
     @Override
     public CompletableFuture<StopReplicaResponse> stopReplica(
             StopReplicaRequest stopReplicaRequest) {
         CompletableFuture<StopReplicaResponse> response = new CompletableFuture<>();
-        replicaManager.stopReplicas(
-                stopReplicaRequest.getCoordinatorEpoch(),
-                getStopReplicaData(stopReplicaRequest),
-                result -> response.complete(makeStopReplicaResponse(result)));
-        return response;
+        int coordinatorEpoch = stopReplicaRequest.getCoordinatorEpoch();
+        List<StopReplicaData> stopReplicaData = getStopReplicaData(stopReplicaRequest);
+        return submitReplicaStateChange(
+                response,
+                result ->
+                        replicaManager.stopReplicas(
+                                coordinatorEpoch,
+                                stopReplicaData,
+                                value -> result.complete(makeStopReplicaResponse(value))));
     }
 
     @Override
@@ -451,26 +455,38 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
     public CompletableFuture<NotifyRemoteLogOffsetsResponse> notifyRemoteLogOffsets(
             NotifyRemoteLogOffsetsRequest request) {
         CompletableFuture<NotifyRemoteLogOffsetsResponse> response = new CompletableFuture<>();
-        replicaManager.notifyRemoteLogOffsets(
-                getNotifyRemoteLogOffsetsData(request), response::complete);
-        return response;
+        NotifyRemoteLogOffsetsData notifyRemoteLogOffsetsData =
+                getNotifyRemoteLogOffsetsData(request);
+        return submitReplicaStateChange(
+                response,
+                result ->
+                        replicaManager.notifyRemoteLogOffsets(
+                                notifyRemoteLogOffsetsData, result::complete));
     }
 
     @Override
     public CompletableFuture<NotifyKvSnapshotOffsetResponse> notifyKvSnapshotOffset(
             NotifyKvSnapshotOffsetRequest request) {
         CompletableFuture<NotifyKvSnapshotOffsetResponse> response = new CompletableFuture<>();
-        replicaManager.notifyKvSnapshotOffset(
-                getNotifySnapshotOffsetData(request), response::complete);
-        return response;
+        NotifyKvSnapshotOffsetData notifyKvSnapshotOffsetData =
+                getNotifySnapshotOffsetData(request);
+        return submitReplicaStateChange(
+                response,
+                result ->
+                        replicaManager.notifyKvSnapshotOffset(
+                                notifyKvSnapshotOffsetData, result::complete));
     }
 
     @Override
     public CompletableFuture<NotifyLakeTableOffsetResponse> notifyLakeTableOffset(
             NotifyLakeTableOffsetRequest request) {
         CompletableFuture<NotifyLakeTableOffsetResponse> response = new CompletableFuture<>();
-        replicaManager.notifyLakeTableOffset(getNotifyLakeTableOffset(request), response::complete);
-        return response;
+        NotifyLakeTableOffsetData notifyLakeTableOffsetData = getNotifyLakeTableOffset(request);
+        return submitReplicaStateChange(
+                response,
+                result ->
+                        replicaManager.notifyLakeTableOffset(
+                                notifyLakeTableOffsetData, result::complete));
     }
 
     @Override
@@ -699,6 +715,23 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
         }
 
         return CompletableFuture.completedFuture(response);
+    }
+
+    private <T> CompletableFuture<T> submitReplicaStateChange(
+            CompletableFuture<T> response, Consumer<CompletableFuture<T>> action) {
+        try {
+            replicaStateChangeExecutor.execute(
+                    () -> {
+                        try {
+                            action.accept(response);
+                        } catch (Throwable t) {
+                            response.completeExceptionally(t);
+                        }
+                    });
+        } catch (Throwable t) {
+            response.completeExceptionally(t);
+        }
+        return response;
     }
 
     @Override


### PR DESCRIPTION
### Purpose

Linked issue: close #3646

`NotifyLeaderAndIsr` is currently processed on the RPC worker thread. The underlying `becomeLeaderOrFollower` operation may perform relatively expensive replica state transitions, such as initializing local replicas and updating replica fetchers. A slow transition can therefore occupy an RPC worker thread and delay unrelated RPC requests.

### Brief change log

Introduce a dedicated single-thread executor for `NotifyLeaderAndIsr` operations.
The executor is created and managed by `TabletServer` , injected into `TabletService` , and gracefully shut down before replica-related resources are closed. `TabletService` parses the request on the RPC worker thread and submits the replica state transition to the dedicated executor.

A single thread is sufficient because replica state changes are already serialized by the replica state change lock. It also preserves the execution order of `NotifyLeaderAndIsr` requests while preventing slow transitions from blocking other RPCs.
The RPC semantics remain unchanged: the response future is completed only after `becomeLeaderOrFollower` finishes.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
