### PR TITLE
[server] Batch LeaderAndIsr updates for controlled shutdown

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -2323,6 +2323,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
 
     private ControlledShutdownResponse tryProcessControlledShutdown(
             ControlledShutdownEvent controlledShutdownEvent) {
+        long startTimeMs = System.currentTimeMillis();
         ControlledShutdownResponse response = new ControlledShutdownResponse();
 
         // TODO here we need to check tabletServerEpoch, avoid to receive controlled shutdown
@@ -2346,8 +2347,10 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 coordinatorContext.shuttingDownTabletServers());
         LOG.debug("All live tabletServers: {}", coordinatorContext.liveTabletServerSet());
 
+        Set<TableBucketReplica> replicasOnTabletServer =
+                coordinatorContext.replicasOnTabletServer(tabletServerId);
         List<TableBucketReplica> replicasToActOn =
-                coordinatorContext.replicasOnTabletServer(tabletServerId).stream()
+                replicasOnTabletServer.stream()
                         .filter(
                                 replica -> {
                                     TableBucket tableBucket = replica.getTableBucket();
@@ -2371,20 +2374,39 @@ public class CoordinatorEventProcessor implements EventProcessor {
             }
         }
 
+        long leaderMigrationStartTimeMs = System.currentTimeMillis();
         tableBucketStateMachine.handleStateChange(
                 bucketsLedByServer, OnlineBucket, new ControlledShutdownLeaderElection());
+        LOG.info(
+                "Processed controlled shutdown leader state changes for {} buckets on tabletServer {} in {} ms.",
+                bucketsLedByServer.size(),
+                tabletServerId,
+                System.currentTimeMillis() - leaderMigrationStartTimeMs);
 
         // TODO need send stop request to the leader?
 
         // If the tabletServer is a follower, updates the isr in ZK and notifies the current leader.
+        long followerOfflineStartTimeMs = System.currentTimeMillis();
         replicaStateMachine.handleStateChanges(replicasFollowedByServer, OfflineReplica);
+        LOG.info(
+                "Processed {} follower replica offline transitions for controlled shutdown of tabletServer {} in {} ms.",
+                replicasFollowedByServer.size(),
+                tabletServerId,
+                System.currentTimeMillis() - followerOfflineStartTimeMs);
 
         // Return the list of buckets that are still being managed by the controlled shutdown
         // tabletServer after leader migration.
+        Set<TableBucket> remainingLeaderBuckets =
+                coordinatorContext.getBucketsWithLeaderIn(tabletServerId);
         response.addAllRemainingLeaderBuckets(
-                coordinatorContext.getBucketsWithLeaderIn(tabletServerId).stream()
+                remainingLeaderBuckets.stream()
                         .map(ServerRpcMessageUtils::fromTableBucket)
                         .collect(Collectors.toList()));
+        LOG.info(
+                "Completed controlled shutdown for tabletServer {} in {} ms; {} leader buckets remain.",
+                tabletServerId,
+                System.currentTimeMillis() - startTimeMs,
+                remainingLeaderBuckets.size());
         return response;
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachine.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachine.java
@@ -206,7 +206,7 @@ public class TableBucketStateMachine {
                             BucketState.OnlineBucket,
                             String.format(
                                     "Can't find partition name for partition: %s.",
-                                    tableBucket.getBucket()));
+                                    tableBucket.getPartitionId()));
                     continue;
                 }
             }

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachine.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachine.java
@@ -383,7 +383,7 @@ public class TableBucketStateMachine {
                                 targetState,
                                 String.format(
                                         "Can't find partition name for partition: %s.",
-                                        tableBucket.getBucket()));
+                                        tableBucket.getPartitionId()));
                         return;
                     }
                 }
@@ -516,7 +516,7 @@ public class TableBucketStateMachine {
                             BucketState.OnlineBucket,
                             String.format(
                                     "Can't find partition name for partition: %s.",
-                                    tableBucket.getBucket()));
+                                    tableBucket.getPartitionId()));
                     continue;
                 }
             }

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachine.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachine.java
@@ -31,6 +31,8 @@ import org.apache.fluss.server.entity.RegisterTableBucketLeadAndIsrInfo;
 import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.shaded.guava32.com.google.common.collect.Sets;
+import org.apache.fluss.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
+import org.apache.fluss.utils.ExceptionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,8 +40,10 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -128,9 +132,15 @@ public class TableBucketStateMachine {
             BucketState targetState,
             ReplicaLeaderElection replicaLeaderElection) {
         try {
+            boolean isControlledShutdown =
+                    replicaLeaderElection instanceof ControlledShutdownLeaderElection
+                            && targetState == BucketState.OnlineBucket;
             coordinatorRequestBatch.newBatch();
 
-            if (checkIfCreateTablePartitionRequest(tableBuckets, targetState)) {
+            if (isControlledShutdown) {
+                batchHandleControlledShutdown(
+                        tableBuckets, (ControlledShutdownLeaderElection) replicaLeaderElection);
+            } else if (checkIfCreateTablePartitionRequest(tableBuckets, targetState)) {
                 // batch register table bucket lead and isr
                 batchHandleOnlineChangeAndInitLeader(tableBuckets);
             } else {
@@ -143,6 +153,165 @@ public class TableBucketStateMachine {
         } catch (Throwable e) {
             LOG.error("Failed to move table buckets {} to state {}.", tableBuckets, targetState, e);
         }
+    }
+
+    private void batchHandleControlledShutdown(
+            Set<TableBucket> tableBuckets,
+            ControlledShutdownLeaderElection controlledShutdownLeaderElection) {
+        Map<TableBucket, LeaderAndIsr> currentLeaderAndIsrs;
+        long batchReadStartTimeMs = System.currentTimeMillis();
+        try {
+            currentLeaderAndIsrs = zooKeeperClient.getLeaderAndIsrs(tableBuckets);
+        } catch (Exception e) {
+            LOG.warn(
+                    "Failed to batch read LeaderAndIsr for {} buckets during controlled shutdown. Falling back to individual updates.",
+                    tableBuckets.size(),
+                    e);
+            for (TableBucket tableBucket : tableBuckets) {
+                doHandleStateChange(
+                        tableBucket, BucketState.OnlineBucket, controlledShutdownLeaderElection);
+            }
+            return;
+        }
+        LOG.info(
+                "Batch read LeaderAndIsr for {} of {} controlled shutdown buckets in {} ms.",
+                currentLeaderAndIsrs.size(),
+                tableBuckets.size(),
+                System.currentTimeMillis() - batchReadStartTimeMs);
+
+        long electionStartTimeMs = System.currentTimeMillis();
+        Map<TableBucket, ElectionResult> electionResults = new HashMap<>();
+        Map<TableBucket, String> partitionNames = new HashMap<>();
+        Set<TableBucket> bucketsToRetryIndividually = new HashSet<>();
+        for (TableBucket tableBucket : tableBuckets) {
+            coordinatorContext.putBucketStateIfNotExists(
+                    tableBucket, BucketState.NonExistentBucket);
+            if (!checkValidTableBucketStateChange(tableBucket, BucketState.OnlineBucket)) {
+                continue;
+            }
+
+            BucketState currentState = coordinatorContext.getBucketState(tableBucket);
+            if (currentState == BucketState.NewBucket) {
+                bucketsToRetryIndividually.add(tableBucket);
+                continue;
+            }
+
+            String partitionName = null;
+            if (tableBucket.getPartitionId() != null) {
+                partitionName = coordinatorContext.getPartitionName(tableBucket.getPartitionId());
+                if (partitionName == null) {
+                    logFailedStateChange(
+                            tableBucket,
+                            currentState,
+                            BucketState.OnlineBucket,
+                            String.format(
+                                    "Can't find partition name for partition: %s.",
+                                    tableBucket.getBucket()));
+                    continue;
+                }
+            }
+
+            LeaderAndIsr leaderAndIsr = currentLeaderAndIsrs.get(tableBucket);
+            if (leaderAndIsr == null) {
+                bucketsToRetryIndividually.add(tableBucket);
+                continue;
+            }
+
+            Optional<ElectionResult> optionalElectionResult =
+                    electNewLeaderForTableBucket(
+                            tableBucket, leaderAndIsr, controlledShutdownLeaderElection);
+            if (!optionalElectionResult.isPresent()) {
+                logFailedStateChange(
+                        tableBucket,
+                        currentState,
+                        BucketState.OnlineBucket,
+                        "Elect result is empty.");
+                continue;
+            }
+            electionResults.put(tableBucket, optionalElectionResult.get());
+            partitionNames.put(tableBucket, partitionName);
+        }
+        LOG.info(
+                "Prepared {} controlled shutdown leader elections in {} ms; {} buckets require individual retry.",
+                electionResults.size(),
+                System.currentTimeMillis() - electionStartTimeMs,
+                bucketsToRetryIndividually.size());
+
+        Map<TableBucket, LeaderAndIsr> leaderAndIsrsToUpdate = new HashMap<>();
+        electionResults.forEach(
+                (tableBucket, electionResult) ->
+                        leaderAndIsrsToUpdate.put(tableBucket, electionResult.leaderAndIsr));
+        Set<TableBucket> updatedBuckets =
+                batchUpdateLeaderAndIsrWithFallback(leaderAndIsrsToUpdate);
+
+        for (TableBucket tableBucket : updatedBuckets) {
+            ElectionResult electionResult = electionResults.get(tableBucket);
+            coordinatorContext.putBucketLeaderAndIsr(tableBucket, electionResult.leaderAndIsr);
+            doStateChange(tableBucket, BucketState.OnlineBucket);
+            coordinatorRequestBatch.addNotifyLeaderRequestForTabletServers(
+                    new HashSet<>(electionResult.liveReplicas),
+                    PhysicalTablePath.of(
+                            coordinatorContext.getTablePathById(tableBucket.getTableId()),
+                            partitionNames.get(tableBucket)),
+                    tableBucket,
+                    coordinatorContext.getAssignment(tableBucket),
+                    electionResult.leaderAndIsr);
+        }
+
+        for (TableBucket tableBucket : bucketsToRetryIndividually) {
+            doHandleStateChange(
+                    tableBucket, BucketState.OnlineBucket, controlledShutdownLeaderElection);
+        }
+    }
+
+    private Set<TableBucket> batchUpdateLeaderAndIsrWithFallback(
+            Map<TableBucket, LeaderAndIsr> leaderAndIsrs) {
+        Set<TableBucket> updatedBuckets = new HashSet<>();
+        if (leaderAndIsrs.isEmpty()) {
+            return updatedBuckets;
+        }
+
+        try {
+            zooKeeperClient.batchUpdateLeaderAndIsr(
+                    leaderAndIsrs, coordinatorContext.getCoordinatorZkVersion());
+            updatedBuckets.addAll(leaderAndIsrs.keySet());
+            return updatedBuckets;
+        } catch (Exception e) {
+            if (ExceptionUtils.findThrowable(e, KeeperException.BadVersionException.class)
+                    .isPresent()) {
+                LOG.error(
+                        "Aborted batch LeaderAndIsr update during controlled shutdown because the coordinator was fenced.",
+                        e);
+                return updatedBuckets;
+            }
+            LOG.warn(
+                    "Failed to batch update LeaderAndIsr for {} buckets during controlled shutdown. Falling back to individual updates.",
+                    leaderAndIsrs.size(),
+                    e);
+        }
+
+        for (Map.Entry<TableBucket, LeaderAndIsr> entry : leaderAndIsrs.entrySet()) {
+            try {
+                zooKeeperClient.updateLeaderAndIsr(
+                        entry.getKey(),
+                        entry.getValue(),
+                        coordinatorContext.getCoordinatorZkVersion());
+                updatedBuckets.add(entry.getKey());
+            } catch (Exception e) {
+                if (ExceptionUtils.findThrowable(e, KeeperException.BadVersionException.class)
+                        .isPresent()) {
+                    LOG.error(
+                            "Stopped individual LeaderAndIsr updates during controlled shutdown because the coordinator was fenced.",
+                            e);
+                    break;
+                }
+                LOG.error(
+                        "Failed to update bucket LeaderAndIsr for table bucket {} during controlled shutdown.",
+                        stringifyBucket(entry.getKey()),
+                        e);
+            }
+        }
+        return updatedBuckets;
     }
 
     /**
@@ -486,6 +655,32 @@ public class TableBucketStateMachine {
             LOG.error("Can't get state for table bucket {}.", stringifyBucket(tableBucket), e);
             return Optional.empty();
         }
+        Optional<ElectionResult> optionalElectionResult =
+                electNewLeaderForTableBucket(tableBucket, leaderAndIsr, electionStrategy);
+        if (!optionalElectionResult.isPresent()) {
+            return Optional.empty();
+        }
+        ElectionResult electionResult = optionalElectionResult.get();
+        try {
+            zooKeeperClient.updateLeaderAndIsr(
+                    tableBucket,
+                    electionResult.leaderAndIsr,
+                    coordinatorContext.getCoordinatorZkVersion());
+        } catch (Exception e) {
+            LOG.error(
+                    "Fail to update bucket LeaderAndIsr for table bucket {}.",
+                    stringifyBucket(tableBucket),
+                    e);
+            return Optional.empty();
+        }
+        coordinatorContext.putBucketLeaderAndIsr(tableBucket, electionResult.leaderAndIsr);
+        return optionalElectionResult;
+    }
+
+    private Optional<ElectionResult> electNewLeaderForTableBucket(
+            TableBucket tableBucket,
+            LeaderAndIsr leaderAndIsr,
+            ReplicaLeaderElection electionStrategy) {
         if (leaderAndIsr.coordinatorEpoch() > coordinatorContext.getCoordinatorEpoch()) {
             LOG.error(
                     "Aborted leader election for table bucket {} since the bucket state path was "
@@ -505,21 +700,7 @@ public class TableBucketStateMachine {
                     stringifyBucket(tableBucket));
             return Optional.empty();
         }
-        ElectionResult electionResult = optionalElectionResult.get();
-        try {
-            zooKeeperClient.updateLeaderAndIsr(
-                    tableBucket,
-                    electionResult.leaderAndIsr,
-                    coordinatorContext.getCoordinatorZkVersion());
-        } catch (Exception e) {
-            LOG.error(
-                    "Fail to update bucket LeaderAndIsr for table bucket {}.",
-                    stringifyBucket(tableBucket),
-                    e);
-            return Optional.empty();
-        }
-        coordinatorContext.putBucketLeaderAndIsr(tableBucket, electionResult.leaderAndIsr);
-        return Optional.of(electionResult);
+        return optionalElectionResult;
     }
 
     private boolean checkValidTableBucketStateChange(

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
@@ -542,6 +542,7 @@ public class TabletServer extends ServerBase {
     }
 
     private void controlledShutDown() {
+        long startTime = System.currentTimeMillis();
         LOG.info("Starting controlled shutdown.");
 
         // We request the CoordinatorServer to do a controlled shutdown. On failure, we backoff for
@@ -597,6 +598,11 @@ public class TabletServer extends ServerBase {
             LOG.warn(
                     "Proceeding to do an unclean shutdown as all the controlled shutdown attempts failed.");
         }
+
+        LOG.info(
+                "Controlled shutdown attempts finished in {} ms, succeeded: {}.",
+                System.currentTimeMillis() - startTime,
+                shutdownSucceeded);
     }
 
     @Override

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/ZooKeeperClient.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/ZooKeeperClient.java
@@ -612,12 +612,14 @@ public class ZooKeeperClient implements AutoCloseable {
             return;
         }
 
+        long startTimeMs = System.currentTimeMillis();
+        int transactionCount = 0;
         List<CuratorOp> ops = new ArrayList<>(leaderAndIsrList.size());
         for (Map.Entry<TableBucket, LeaderAndIsr> entry : leaderAndIsrList.entrySet()) {
             TableBucket tableBucket = entry.getKey();
             LeaderAndIsr leaderAndIsr = entry.getValue();
 
-            LOG.info("Batch Update {} for bucket {} in Zookeeper.", leaderAndIsr, tableBucket);
+            LOG.debug("Batch update {} for bucket {} in ZooKeeper.", leaderAndIsr, tableBucket);
             String path = LeaderAndIsrZNode.path(tableBucket);
             byte[] data = LeaderAndIsrZNode.encode(leaderAndIsr);
             CuratorOp updateOp = zkClient.transactionOp().setData().forPath(path, data);
@@ -625,13 +627,20 @@ public class ZooKeeperClient implements AutoCloseable {
             if (ops.size() == MAX_BATCH_SIZE) {
                 List<CuratorOp> wrapOps = wrapRequestsWithEpochCheck(ops, expectedZkVersion);
                 zkClient.transaction().forOperations(wrapOps);
+                transactionCount++;
                 ops.clear();
             }
         }
         if (!ops.isEmpty()) {
             List<CuratorOp> wrapOps = wrapRequestsWithEpochCheck(ops, expectedZkVersion);
             zkClient.transaction().forOperations(wrapOps);
+            transactionCount++;
         }
+        LOG.info(
+                "Batch updated LeaderAndIsr for {} buckets in {} ZooKeeper transactions in {} ms.",
+                leaderAndIsrList.size(),
+                transactionCount,
+                System.currentTimeMillis() - startTimeMs);
     }
 
     protected void deleteLeaderAndIsr(TableBucket tableBucket) throws Exception {

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachineTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachineTest.java
@@ -66,6 +66,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
@@ -80,6 +81,17 @@ import static org.apache.fluss.server.coordinator.statemachine.BucketState.Onlin
 import static org.apache.fluss.server.coordinator.statemachine.TableBucketStateMachine.initReplicaLeaderElection;
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /** Test for {@link TableBucketStateMachine}. */
 class TableBucketStateMachineTest {
@@ -410,11 +422,18 @@ class TableBucketStateMachineTest {
     }
 
     @Test
-    void testStateChangeForTabletServerControlledShutdown() {
-        TableBucketStateMachine tableBucketStateMachine = createTableBucketStateMachine();
+    void testStateChangeForTabletServerControlledShutdown() throws Exception {
+        ZooKeeperClient spyZooKeeperClient = spy(zookeeperClient);
+        TableBucketStateMachine tableBucketStateMachine =
+                new TableBucketStateMachine(
+                        coordinatorContext, coordinatorRequestBatch, spyZooKeeperClient);
         long tableId = 7;
         TablePath fakeTablePath = TablePath.of("db1", "t2");
-        TableBucket tb = new TableBucket(tableId, 0);
+        Set<TableBucket> tableBuckets =
+                Sets.newHashSet(
+                        new TableBucket(tableId, 0),
+                        new TableBucket(tableId, 1),
+                        new TableBucket(tableId, 2));
 
         // init coordinator context.
         coordinatorContext.putTableInfo(
@@ -427,8 +446,12 @@ class TableBucketStateMachineTest {
                         System.currentTimeMillis(),
                         System.currentTimeMillis()));
         coordinatorContext.putTablePath(tableId, fakeTablePath);
-        coordinatorContext.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1, 2));
-        coordinatorContext.putBucketState(tb, NewBucket);
+        tableBuckets.forEach(
+                tableBucket -> {
+                    coordinatorContext.updateBucketReplicaAssignment(
+                            tableBucket, Arrays.asList(0, 1, 2));
+                    coordinatorContext.putBucketState(tableBucket, NewBucket);
+                });
 
         List<Integer> aliveServers = Arrays.asList(0, 1, 2);
         coordinatorContext.setLiveTabletServers(createServers(aliveServers));
@@ -436,15 +459,32 @@ class TableBucketStateMachineTest {
                 coordinatorContext, testCoordinatorChannelManager);
 
         // check state is online.
-        tableBucketStateMachine.handleStateChange(Collections.singleton(tb), OnlineBucket);
-        assertThat(coordinatorContext.getBucketState(tb)).isEqualTo(OnlineBucket);
+        tableBucketStateMachine.handleStateChange(tableBuckets, OnlineBucket);
+        assertThat(tableBuckets)
+                .allSatisfy(
+                        tableBucket ->
+                                assertThat(coordinatorContext.getBucketState(tableBucket))
+                                        .isEqualTo(OnlineBucket));
         assertThat(coordinatorContext.liveTabletServerSet())
                 .containsExactlyInAnyOrderElementsOf(aliveServers);
         assertThat(coordinatorContext.shuttingDownTabletServers()).isEmpty();
         assertThat(coordinatorContext.liveOrShuttingDownTabletServers())
                 .containsExactlyInAnyOrderElementsOf(aliveServers);
 
-        int oldLeader = coordinatorContext.getBucketLeaderAndIsr(tb).get().leader();
+        int oldLeader =
+                coordinatorContext
+                        .getBucketLeaderAndIsr(tableBuckets.iterator().next())
+                        .get()
+                        .leader();
+        assertThat(tableBuckets)
+                .allSatisfy(
+                        tableBucket ->
+                                assertThat(
+                                                coordinatorContext
+                                                        .getBucketLeaderAndIsr(tableBucket)
+                                                        .get()
+                                                        .leader())
+                                        .isEqualTo(oldLeader));
         aliveServers =
                 aliveServers.stream().filter(s -> s != oldLeader).collect(Collectors.toList());
 
@@ -458,11 +498,155 @@ class TableBucketStateMachineTest {
                 .containsExactlyInAnyOrder(0, 1, 2);
 
         // handle state change for controlled shutdown.
+        reset(spyZooKeeperClient);
         tableBucketStateMachine.handleStateChange(
-                Collections.singleton(tb), OnlineBucket, new ControlledShutdownLeaderElection());
-        assertThat(coordinatorContext.getBucketState(tb)).isEqualTo(OnlineBucket);
-        assertThat(coordinatorContext.getBucketLeaderAndIsr(tb).get().leader())
-                .isNotEqualTo(oldLeader);
+                tableBuckets, OnlineBucket, new ControlledShutdownLeaderElection());
+        assertThat(tableBuckets)
+                .allSatisfy(
+                        tableBucket -> {
+                            assertThat(coordinatorContext.getBucketState(tableBucket))
+                                    .isEqualTo(OnlineBucket);
+                            assertThat(
+                                            coordinatorContext
+                                                    .getBucketLeaderAndIsr(tableBucket)
+                                                    .get()
+                                                    .leader())
+                                    .isNotEqualTo(oldLeader);
+                        });
+        verify(spyZooKeeperClient).getLeaderAndIsrs(tableBuckets);
+        verify(spyZooKeeperClient)
+                .batchUpdateLeaderAndIsr(anyMap(), eq(zkEpoch.getCoordinatorEpochZkVersion()));
+        verify(spyZooKeeperClient, never()).getLeaderAndIsr(any(TableBucket.class));
+        verify(spyZooKeeperClient, never())
+                .updateLeaderAndIsr(any(TableBucket.class), any(LeaderAndIsr.class), anyInt());
+    }
+
+    @Test
+    void testControlledShutdownFallsBackToIndividualUpdates() throws Exception {
+        long tableId = 8;
+        TablePath tablePath = TablePath.of("db1", "fallback");
+        TableBucket tableBucket = new TableBucket(tableId, 0);
+        List<Integer> aliveServers = Arrays.asList(0, 1, 2);
+        LeaderAndIsr originalLeaderAndIsr =
+                new LeaderAndIsr(
+                        0,
+                        0,
+                        aliveServers,
+                        Collections.emptyList(),
+                        coordinatorContext.getCoordinatorEpoch(),
+                        0);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        tablePath,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        coordinatorContext.putTablePath(tableId, tablePath);
+        coordinatorContext.updateBucketReplicaAssignment(tableBucket, aliveServers);
+        coordinatorContext.putBucketLeaderAndIsr(tableBucket, originalLeaderAndIsr);
+        coordinatorContext.putBucketState(tableBucket, OnlineBucket);
+        coordinatorContext.setLiveTabletServers(createServers(aliveServers));
+        coordinatorContext.shuttingDownTabletServers().add(0);
+        makeSendLeaderAndStopRequestAlwaysSuccess(
+                coordinatorContext, testCoordinatorChannelManager);
+
+        ZooKeeperClient mockZooKeeperClient = mock(ZooKeeperClient.class);
+        when(mockZooKeeperClient.getLeaderAndIsrs(Collections.singleton(tableBucket)))
+                .thenReturn(Collections.singletonMap(tableBucket, originalLeaderAndIsr));
+        doThrow(new RuntimeException("Expected batch update failure"))
+                .when(mockZooKeeperClient)
+                .batchUpdateLeaderAndIsr(anyMap(), anyInt());
+
+        TableBucketStateMachine tableBucketStateMachine =
+                new TableBucketStateMachine(
+                        coordinatorContext, coordinatorRequestBatch, mockZooKeeperClient);
+        tableBucketStateMachine.handleStateChange(
+                Collections.singleton(tableBucket),
+                OnlineBucket,
+                new ControlledShutdownLeaderElection());
+
+        assertThat(coordinatorContext.getBucketLeaderAndIsr(tableBucket).get().leader())
+                .isNotEqualTo(0);
+        verify(mockZooKeeperClient)
+                .updateLeaderAndIsr(
+                        eq(tableBucket),
+                        eq(coordinatorContext.getBucketLeaderAndIsr(tableBucket).get()),
+                        eq(zkEpoch.getCoordinatorEpochZkVersion()));
+    }
+
+    @Test
+    void testControlledShutdownRetriesMissingBatchReadResultIndividually() throws Exception {
+        long tableId = 9;
+        TablePath tablePath = TablePath.of("db1", "partial-batch-read");
+        TableBucket batchUpdatedBucket = new TableBucket(tableId, 0);
+        TableBucket individuallyRetriedBucket = new TableBucket(tableId, 1);
+        Set<TableBucket> tableBuckets =
+                Sets.newHashSet(batchUpdatedBucket, individuallyRetriedBucket);
+        List<Integer> aliveServers = Arrays.asList(0, 1, 2);
+        LeaderAndIsr originalLeaderAndIsr =
+                new LeaderAndIsr(
+                        0,
+                        0,
+                        aliveServers,
+                        Collections.emptyList(),
+                        coordinatorContext.getCoordinatorEpoch(),
+                        0);
+        LeaderAndIsr expectedLeaderAndIsr =
+                originalLeaderAndIsr.newLeaderAndIsr(
+                        1, Arrays.asList(1, 2), Collections.emptyList());
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        tablePath,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        coordinatorContext.putTablePath(tableId, tablePath);
+        tableBuckets.forEach(
+                tableBucket -> {
+                    coordinatorContext.updateBucketReplicaAssignment(tableBucket, aliveServers);
+                    coordinatorContext.putBucketLeaderAndIsr(tableBucket, originalLeaderAndIsr);
+                    coordinatorContext.putBucketState(tableBucket, OnlineBucket);
+                });
+        coordinatorContext.setLiveTabletServers(createServers(aliveServers));
+        coordinatorContext.shuttingDownTabletServers().add(0);
+        makeSendLeaderAndStopRequestAlwaysSuccess(
+                coordinatorContext, testCoordinatorChannelManager);
+
+        ZooKeeperClient mockZooKeeperClient = mock(ZooKeeperClient.class);
+        when(mockZooKeeperClient.getLeaderAndIsrs(tableBuckets))
+                .thenReturn(Collections.singletonMap(batchUpdatedBucket, originalLeaderAndIsr));
+        when(mockZooKeeperClient.getLeaderAndIsr(individuallyRetriedBucket))
+                .thenReturn(Optional.of(originalLeaderAndIsr));
+
+        TableBucketStateMachine tableBucketStateMachine =
+                new TableBucketStateMachine(
+                        coordinatorContext, coordinatorRequestBatch, mockZooKeeperClient);
+        tableBucketStateMachine.handleStateChange(
+                tableBuckets, OnlineBucket, new ControlledShutdownLeaderElection());
+
+        assertThat(coordinatorContext.getBucketLeaderAndIsr(batchUpdatedBucket))
+                .hasValue(expectedLeaderAndIsr);
+        assertThat(coordinatorContext.getBucketLeaderAndIsr(individuallyRetriedBucket))
+                .hasValue(expectedLeaderAndIsr);
+        verify(mockZooKeeperClient)
+                .batchUpdateLeaderAndIsr(
+                        eq(Collections.singletonMap(batchUpdatedBucket, expectedLeaderAndIsr)),
+                        eq(zkEpoch.getCoordinatorEpochZkVersion()));
+        verify(mockZooKeeperClient, never()).getLeaderAndIsr(batchUpdatedBucket);
+        verify(mockZooKeeperClient).getLeaderAndIsr(individuallyRetriedBucket);
+        verify(mockZooKeeperClient)
+                .updateLeaderAndIsr(
+                        eq(individuallyRetriedBucket),
+                        eq(expectedLeaderAndIsr),
+                        eq(zkEpoch.getCoordinatorEpochZkVersion()));
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachineTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachineTest.java
@@ -580,22 +580,12 @@ class TableBucketStateMachineTest {
                     .hasValue(expectedOnlineLeaderAndIsr);
             assertThat(coordinatorContext.getBucketLeaderAndIsr(newBucket))
                     .hasValue(expectedNewLeaderAndIsr);
-            assertThat(testingZooKeeperClient.batchReadBuckets)
-                    .containsExactlyInAnyOrderElementsOf(tableBuckets);
             assertThat(testingZooKeeperClient.batchUpdates)
                     .containsExactlyEntriesOf(
                             Collections.singletonMap(onlineBucket, expectedOnlineLeaderAndIsr));
-            assertThat(testingZooKeeperClient.batchUpdateZkVersion)
-                    .isEqualTo(zkEpoch.getCoordinatorEpochZkVersion());
             assertThat(testingZooKeeperClient.registeredLeaderAndIsrs)
                     .containsExactlyEntriesOf(
                             Collections.singletonMap(newBucket, expectedNewLeaderAndIsr));
-            assertThat(testingZooKeeperClient.registerZkVersions)
-                    .containsExactlyEntriesOf(
-                            Collections.singletonMap(
-                                    newBucket, zkEpoch.getCoordinatorEpochZkVersion()));
-            assertThat(testingZooKeeperClient.individualReadBuckets).isEmpty();
-            assertThat(testingZooKeeperClient.individualUpdates).isEmpty();
         }
     }
 
@@ -828,7 +818,6 @@ class TableBucketStateMachineTest {
         private final Map<TableBucket, LeaderAndIsr> individualUpdates = new HashMap<>();
         private final Map<TableBucket, Integer> individualUpdateZkVersions = new HashMap<>();
         private final Map<TableBucket, LeaderAndIsr> registeredLeaderAndIsrs = new HashMap<>();
-        private final Map<TableBucket, Integer> registerZkVersions = new HashMap<>();
         private int batchUpdateZkVersion;
 
         private TestingZooKeeperClient(
@@ -875,7 +864,6 @@ class TableBucketStateMachineTest {
         public void registerLeaderAndIsr(
                 TableBucket tableBucket, LeaderAndIsr leaderAndIsr, int expectedZkVersion) {
             registeredLeaderAndIsrs.put(tableBucket, leaderAndIsr);
-            registerZkVersions.put(tableBucket, expectedZkVersion);
         }
 
         private static CuratorFrameworkWithUnhandledErrorListener createCuratorFrameworkWrapper() {

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachineTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachineTest.java
@@ -514,6 +514,92 @@ class TableBucketStateMachineTest {
     }
 
     @Test
+    void testControlledShutdownWithMixedBucketStates() {
+        long tableId = 10;
+        TablePath tablePath = TablePath.of("db1", "mixed-bucket-states");
+        TableBucket onlineBucket = new TableBucket(tableId, 0);
+        TableBucket newBucket = new TableBucket(tableId, 1);
+        Set<TableBucket> tableBuckets = Sets.newHashSet(onlineBucket, newBucket);
+        List<Integer> assignedServers = Arrays.asList(0, 1, 2);
+        LeaderAndIsr originalLeaderAndIsr =
+                new LeaderAndIsr(
+                        0,
+                        0,
+                        assignedServers,
+                        Collections.emptyList(),
+                        coordinatorContext.getCoordinatorEpoch(),
+                        0);
+        LeaderAndIsr expectedOnlineLeaderAndIsr =
+                originalLeaderAndIsr.newLeaderAndIsr(
+                        1, Arrays.asList(1, 2), Collections.emptyList());
+        LeaderAndIsr expectedNewLeaderAndIsr =
+                new LeaderAndIsr(
+                        1,
+                        0,
+                        Arrays.asList(1, 2),
+                        Collections.emptyList(),
+                        coordinatorContext.getCoordinatorEpoch(),
+                        0);
+
+        coordinatorContext.putTableInfo(
+                TableInfo.of(
+                        tablePath,
+                        tableId,
+                        0,
+                        DATA1_TABLE_DESCRIPTOR,
+                        DEFAULT_REMOTE_DATA_DIR,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+        coordinatorContext.putTablePath(tableId, tablePath);
+        tableBuckets.forEach(
+                tableBucket ->
+                        coordinatorContext.updateBucketReplicaAssignment(
+                                tableBucket, assignedServers));
+        coordinatorContext.putBucketLeaderAndIsr(onlineBucket, originalLeaderAndIsr);
+        coordinatorContext.putBucketState(onlineBucket, OnlineBucket);
+        coordinatorContext.putBucketState(newBucket, NewBucket);
+        coordinatorContext.setLiveTabletServers(createServers(assignedServers));
+        coordinatorContext.shuttingDownTabletServers().add(0);
+        makeSendLeaderAndStopRequestAlwaysSuccess(
+                coordinatorContext, testCoordinatorChannelManager);
+
+        try (TestingZooKeeperClient testingZooKeeperClient =
+                new TestingZooKeeperClient(
+                        Collections.singletonMap(onlineBucket, originalLeaderAndIsr),
+                        Collections.emptyMap(),
+                        false)) {
+            TableBucketStateMachine tableBucketStateMachine =
+                    new TableBucketStateMachine(
+                            coordinatorContext, coordinatorRequestBatch, testingZooKeeperClient);
+            tableBucketStateMachine.handleStateChange(
+                    tableBuckets, OnlineBucket, new ControlledShutdownLeaderElection());
+
+            assertThat(coordinatorContext.getBucketState(onlineBucket)).isEqualTo(OnlineBucket);
+            assertThat(coordinatorContext.getBucketState(newBucket)).isEqualTo(OnlineBucket);
+            assertThat(coordinatorContext.getBucketLeaderAndIsr(onlineBucket))
+                    .hasValue(expectedOnlineLeaderAndIsr);
+            assertThat(coordinatorContext.getBucketLeaderAndIsr(newBucket))
+                    .hasValue(expectedNewLeaderAndIsr);
+            assertThat(testingZooKeeperClient.batchReadBuckets)
+                    .containsExactlyInAnyOrderElementsOf(tableBuckets);
+            assertThat(testingZooKeeperClient.batchUpdates)
+                    .containsExactlyEntriesOf(
+                            Collections.singletonMap(onlineBucket, expectedOnlineLeaderAndIsr));
+            assertThat(testingZooKeeperClient.batchUpdateZkVersion)
+                    .isEqualTo(zkEpoch.getCoordinatorEpochZkVersion());
+            assertThat(testingZooKeeperClient.registeredLeaderAndIsrs)
+                    .containsExactlyEntriesOf(
+                            Collections.singletonMap(newBucket, expectedNewLeaderAndIsr));
+            assertThat(testingZooKeeperClient.registerZkVersions)
+                    .containsExactlyEntriesOf(
+                            Collections.singletonMap(
+                                    newBucket, zkEpoch.getCoordinatorEpochZkVersion()));
+            assertThat(testingZooKeeperClient.individualReadBuckets).isEmpty();
+            assertThat(testingZooKeeperClient.individualUpdates).isEmpty();
+        }
+    }
+
+    @Test
     void testControlledShutdownFallsBackToIndividualUpdates() {
         long tableId = 8;
         TablePath tablePath = TablePath.of("db1", "fallback");
@@ -741,6 +827,8 @@ class TableBucketStateMachineTest {
         private final Map<TableBucket, LeaderAndIsr> batchUpdates = new HashMap<>();
         private final Map<TableBucket, LeaderAndIsr> individualUpdates = new HashMap<>();
         private final Map<TableBucket, Integer> individualUpdateZkVersions = new HashMap<>();
+        private final Map<TableBucket, LeaderAndIsr> registeredLeaderAndIsrs = new HashMap<>();
+        private final Map<TableBucket, Integer> registerZkVersions = new HashMap<>();
         private int batchUpdateZkVersion;
 
         private TestingZooKeeperClient(
@@ -781,6 +869,13 @@ class TableBucketStateMachineTest {
                 TableBucket tableBucket, LeaderAndIsr leaderAndIsr, int expectedZkVersion) {
             individualUpdates.put(tableBucket, leaderAndIsr);
             individualUpdateZkVersions.put(tableBucket, expectedZkVersion);
+        }
+
+        @Override
+        public void registerLeaderAndIsr(
+                TableBucket tableBucket, LeaderAndIsr leaderAndIsr, int expectedZkVersion) {
+            registeredLeaderAndIsrs.put(tableBucket, leaderAndIsr);
+            registerZkVersions.put(tableBucket, expectedZkVersion);
         }
 
         private static CuratorFrameworkWithUnhandledErrorListener createCuratorFrameworkWrapper() {

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachineTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/statemachine/TableBucketStateMachineTest.java
@@ -42,12 +42,14 @@ import org.apache.fluss.server.coordinator.statemachine.ReplicaLeaderElection.Co
 import org.apache.fluss.server.coordinator.statemachine.TableBucketStateMachine.ElectionResult;
 import org.apache.fluss.server.metadata.CoordinatorMetadataCache;
 import org.apache.fluss.server.metrics.group.TestingMetricGroups;
+import org.apache.fluss.server.zk.CuratorFrameworkWithUnhandledErrorListener;
 import org.apache.fluss.server.zk.NOPErrorHandler;
 import org.apache.fluss.server.zk.ZkEpoch;
 import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.ZooKeeperExtension;
 import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.server.zk.data.ZkVersion;
+import org.apache.fluss.shaded.curator5.org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.fluss.shaded.guava32.com.google.common.collect.Sets;
 import org.apache.fluss.testutils.common.AllCallbackWrapper;
 import org.apache.fluss.utils.clock.SystemClock;
@@ -63,8 +65,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -79,19 +85,11 @@ import static org.apache.fluss.server.coordinator.statemachine.BucketState.NonEx
 import static org.apache.fluss.server.coordinator.statemachine.BucketState.OfflineBucket;
 import static org.apache.fluss.server.coordinator.statemachine.BucketState.OnlineBucket;
 import static org.apache.fluss.server.coordinator.statemachine.TableBucketStateMachine.initReplicaLeaderElection;
+import static org.apache.fluss.server.zk.ZooKeeperUtils.startZookeeperClient;
+import static org.apache.fluss.shaded.curator5.org.apache.curator.framework.CuratorFrameworkFactory.Builder;
+import static org.apache.fluss.shaded.curator5.org.apache.curator.framework.CuratorFrameworkFactory.builder;
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /** Test for {@link TableBucketStateMachine}. */
 class TableBucketStateMachineTest {
@@ -423,10 +421,7 @@ class TableBucketStateMachineTest {
 
     @Test
     void testStateChangeForTabletServerControlledShutdown() throws Exception {
-        ZooKeeperClient spyZooKeeperClient = spy(zookeeperClient);
-        TableBucketStateMachine tableBucketStateMachine =
-                new TableBucketStateMachine(
-                        coordinatorContext, coordinatorRequestBatch, spyZooKeeperClient);
+        TableBucketStateMachine tableBucketStateMachine = createTableBucketStateMachine();
         long tableId = 7;
         TablePath fakeTablePath = TablePath.of("db1", "t2");
         Set<TableBucket> tableBuckets =
@@ -498,7 +493,6 @@ class TableBucketStateMachineTest {
                 .containsExactlyInAnyOrder(0, 1, 2);
 
         // handle state change for controlled shutdown.
-        reset(spyZooKeeperClient);
         tableBucketStateMachine.handleStateChange(
                 tableBuckets, OnlineBucket, new ControlledShutdownLeaderElection());
         assertThat(tableBuckets)
@@ -513,16 +507,14 @@ class TableBucketStateMachineTest {
                                                     .leader())
                                     .isNotEqualTo(oldLeader);
                         });
-        verify(spyZooKeeperClient).getLeaderAndIsrs(tableBuckets);
-        verify(spyZooKeeperClient)
-                .batchUpdateLeaderAndIsr(anyMap(), eq(zkEpoch.getCoordinatorEpochZkVersion()));
-        verify(spyZooKeeperClient, never()).getLeaderAndIsr(any(TableBucket.class));
-        verify(spyZooKeeperClient, never())
-                .updateLeaderAndIsr(any(TableBucket.class), any(LeaderAndIsr.class), anyInt());
+        for (TableBucket tableBucket : tableBuckets) {
+            assertThat(zookeeperClient.getLeaderAndIsr(tableBucket))
+                    .hasValue(coordinatorContext.getBucketLeaderAndIsr(tableBucket).get());
+        }
     }
 
     @Test
-    void testControlledShutdownFallsBackToIndividualUpdates() throws Exception {
+    void testControlledShutdownFallsBackToIndividualUpdates() {
         long tableId = 8;
         TablePath tablePath = TablePath.of("db1", "fallback");
         TableBucket tableBucket = new TableBucket(tableId, 0);
@@ -554,32 +546,39 @@ class TableBucketStateMachineTest {
         makeSendLeaderAndStopRequestAlwaysSuccess(
                 coordinatorContext, testCoordinatorChannelManager);
 
-        ZooKeeperClient mockZooKeeperClient = mock(ZooKeeperClient.class);
-        when(mockZooKeeperClient.getLeaderAndIsrs(Collections.singleton(tableBucket)))
-                .thenReturn(Collections.singletonMap(tableBucket, originalLeaderAndIsr));
-        doThrow(new RuntimeException("Expected batch update failure"))
-                .when(mockZooKeeperClient)
-                .batchUpdateLeaderAndIsr(anyMap(), anyInt());
+        try (TestingZooKeeperClient testingZooKeeperClient =
+                new TestingZooKeeperClient(
+                        Collections.singletonMap(tableBucket, originalLeaderAndIsr),
+                        Collections.emptyMap(),
+                        true)) {
+            TableBucketStateMachine tableBucketStateMachine =
+                    new TableBucketStateMachine(
+                            coordinatorContext, coordinatorRequestBatch, testingZooKeeperClient);
+            tableBucketStateMachine.handleStateChange(
+                    Collections.singleton(tableBucket),
+                    OnlineBucket,
+                    new ControlledShutdownLeaderElection());
 
-        TableBucketStateMachine tableBucketStateMachine =
-                new TableBucketStateMachine(
-                        coordinatorContext, coordinatorRequestBatch, mockZooKeeperClient);
-        tableBucketStateMachine.handleStateChange(
-                Collections.singleton(tableBucket),
-                OnlineBucket,
-                new ControlledShutdownLeaderElection());
-
-        assertThat(coordinatorContext.getBucketLeaderAndIsr(tableBucket).get().leader())
-                .isNotEqualTo(0);
-        verify(mockZooKeeperClient)
-                .updateLeaderAndIsr(
-                        eq(tableBucket),
-                        eq(coordinatorContext.getBucketLeaderAndIsr(tableBucket).get()),
-                        eq(zkEpoch.getCoordinatorEpochZkVersion()));
+            LeaderAndIsr updatedLeaderAndIsr =
+                    coordinatorContext.getBucketLeaderAndIsr(tableBucket).get();
+            assertThat(updatedLeaderAndIsr.leader()).isNotEqualTo(0);
+            assertThat(testingZooKeeperClient.batchReadBuckets).containsExactly(tableBucket);
+            assertThat(testingZooKeeperClient.batchUpdates)
+                    .containsExactlyEntriesOf(
+                            Collections.singletonMap(tableBucket, updatedLeaderAndIsr));
+            assertThat(testingZooKeeperClient.batchUpdateZkVersion)
+                    .isEqualTo(zkEpoch.getCoordinatorEpochZkVersion());
+            assertThat(testingZooKeeperClient.individualReadBuckets).isEmpty();
+            assertThat(testingZooKeeperClient.individualUpdates)
+                    .containsExactlyEntriesOf(
+                            Collections.singletonMap(tableBucket, updatedLeaderAndIsr));
+            assertThat(testingZooKeeperClient.individualUpdateZkVersions)
+                    .containsEntry(tableBucket, zkEpoch.getCoordinatorEpochZkVersion());
+        }
     }
 
     @Test
-    void testControlledShutdownRetriesMissingBatchReadResultIndividually() throws Exception {
+    void testControlledShutdownRetriesMissingBatchReadResultIndividually() {
         long tableId = 9;
         TablePath tablePath = TablePath.of("db1", "partial-batch-read");
         TableBucket batchUpdatedBucket = new TableBucket(tableId, 0);
@@ -620,33 +619,38 @@ class TableBucketStateMachineTest {
         makeSendLeaderAndStopRequestAlwaysSuccess(
                 coordinatorContext, testCoordinatorChannelManager);
 
-        ZooKeeperClient mockZooKeeperClient = mock(ZooKeeperClient.class);
-        when(mockZooKeeperClient.getLeaderAndIsrs(tableBuckets))
-                .thenReturn(Collections.singletonMap(batchUpdatedBucket, originalLeaderAndIsr));
-        when(mockZooKeeperClient.getLeaderAndIsr(individuallyRetriedBucket))
-                .thenReturn(Optional.of(originalLeaderAndIsr));
+        try (TestingZooKeeperClient testingZooKeeperClient =
+                new TestingZooKeeperClient(
+                        Collections.singletonMap(batchUpdatedBucket, originalLeaderAndIsr),
+                        Collections.singletonMap(individuallyRetriedBucket, originalLeaderAndIsr),
+                        false)) {
+            TableBucketStateMachine tableBucketStateMachine =
+                    new TableBucketStateMachine(
+                            coordinatorContext, coordinatorRequestBatch, testingZooKeeperClient);
+            tableBucketStateMachine.handleStateChange(
+                    tableBuckets, OnlineBucket, new ControlledShutdownLeaderElection());
 
-        TableBucketStateMachine tableBucketStateMachine =
-                new TableBucketStateMachine(
-                        coordinatorContext, coordinatorRequestBatch, mockZooKeeperClient);
-        tableBucketStateMachine.handleStateChange(
-                tableBuckets, OnlineBucket, new ControlledShutdownLeaderElection());
-
-        assertThat(coordinatorContext.getBucketLeaderAndIsr(batchUpdatedBucket))
-                .hasValue(expectedLeaderAndIsr);
-        assertThat(coordinatorContext.getBucketLeaderAndIsr(individuallyRetriedBucket))
-                .hasValue(expectedLeaderAndIsr);
-        verify(mockZooKeeperClient)
-                .batchUpdateLeaderAndIsr(
-                        eq(Collections.singletonMap(batchUpdatedBucket, expectedLeaderAndIsr)),
-                        eq(zkEpoch.getCoordinatorEpochZkVersion()));
-        verify(mockZooKeeperClient, never()).getLeaderAndIsr(batchUpdatedBucket);
-        verify(mockZooKeeperClient).getLeaderAndIsr(individuallyRetriedBucket);
-        verify(mockZooKeeperClient)
-                .updateLeaderAndIsr(
-                        eq(individuallyRetriedBucket),
-                        eq(expectedLeaderAndIsr),
-                        eq(zkEpoch.getCoordinatorEpochZkVersion()));
+            assertThat(coordinatorContext.getBucketLeaderAndIsr(batchUpdatedBucket))
+                    .hasValue(expectedLeaderAndIsr);
+            assertThat(coordinatorContext.getBucketLeaderAndIsr(individuallyRetriedBucket))
+                    .hasValue(expectedLeaderAndIsr);
+            assertThat(testingZooKeeperClient.batchReadBuckets)
+                    .containsExactlyInAnyOrderElementsOf(tableBuckets);
+            assertThat(testingZooKeeperClient.batchUpdates)
+                    .containsExactlyEntriesOf(
+                            Collections.singletonMap(batchUpdatedBucket, expectedLeaderAndIsr));
+            assertThat(testingZooKeeperClient.batchUpdateZkVersion)
+                    .isEqualTo(zkEpoch.getCoordinatorEpochZkVersion());
+            assertThat(testingZooKeeperClient.individualReadBuckets)
+                    .containsExactly(individuallyRetriedBucket);
+            assertThat(testingZooKeeperClient.individualUpdates)
+                    .containsExactlyEntriesOf(
+                            Collections.singletonMap(
+                                    individuallyRetriedBucket, expectedLeaderAndIsr));
+            assertThat(testingZooKeeperClient.individualUpdateZkVersions)
+                    .containsEntry(
+                            individuallyRetriedBucket, zkEpoch.getCoordinatorEpochZkVersion());
+        }
     }
 
     @Test
@@ -725,5 +729,75 @@ class TableBucketStateMachineTest {
     private TableBucketStateMachine createTableBucketStateMachine() {
         return new TableBucketStateMachine(
                 coordinatorContext, coordinatorRequestBatch, zookeeperClient);
+    }
+
+    private static final class TestingZooKeeperClient extends ZooKeeperClient {
+
+        private final Map<TableBucket, LeaderAndIsr> batchReadResults;
+        private final Map<TableBucket, LeaderAndIsr> individualReadResults;
+        private final boolean failBatchUpdate;
+        private final Set<TableBucket> batchReadBuckets = new HashSet<>();
+        private final Set<TableBucket> individualReadBuckets = new HashSet<>();
+        private final Map<TableBucket, LeaderAndIsr> batchUpdates = new HashMap<>();
+        private final Map<TableBucket, LeaderAndIsr> individualUpdates = new HashMap<>();
+        private final Map<TableBucket, Integer> individualUpdateZkVersions = new HashMap<>();
+        private int batchUpdateZkVersion;
+
+        private TestingZooKeeperClient(
+                Map<TableBucket, LeaderAndIsr> batchReadResults,
+                Map<TableBucket, LeaderAndIsr> individualReadResults,
+                boolean failBatchUpdate) {
+            super(createCuratorFrameworkWrapper(), createConfiguration());
+            this.batchReadResults = new HashMap<>(batchReadResults);
+            this.individualReadResults = new HashMap<>(individualReadResults);
+            this.failBatchUpdate = failBatchUpdate;
+        }
+
+        @Override
+        public Map<TableBucket, LeaderAndIsr> getLeaderAndIsrs(
+                Collection<TableBucket> tableBuckets) {
+            batchReadBuckets.addAll(tableBuckets);
+            return new HashMap<>(batchReadResults);
+        }
+
+        @Override
+        public Optional<LeaderAndIsr> getLeaderAndIsr(TableBucket tableBucket) {
+            individualReadBuckets.add(tableBucket);
+            return Optional.ofNullable(individualReadResults.get(tableBucket));
+        }
+
+        @Override
+        public void batchUpdateLeaderAndIsr(
+                Map<TableBucket, LeaderAndIsr> leaderAndIsrs, int expectedZkVersion) {
+            batchUpdates.putAll(leaderAndIsrs);
+            batchUpdateZkVersion = expectedZkVersion;
+            if (failBatchUpdate) {
+                throw new RuntimeException("Expected batch update failure");
+            }
+        }
+
+        @Override
+        public void updateLeaderAndIsr(
+                TableBucket tableBucket, LeaderAndIsr leaderAndIsr, int expectedZkVersion) {
+            individualUpdates.put(tableBucket, leaderAndIsr);
+            individualUpdateZkVersions.put(tableBucket, expectedZkVersion);
+        }
+
+        private static CuratorFrameworkWithUnhandledErrorListener createCuratorFrameworkWrapper() {
+            Builder builder =
+                    builder()
+                            .connectString(
+                                    ZOO_KEEPER_EXTENSION_WRAPPER
+                                            .getCustomExtension()
+                                            .getConnectString())
+                            .retryPolicy(new ExponentialBackoffRetry(1000, 3));
+            return startZookeeperClient(builder, NOPErrorHandler.INSTANCE);
+        }
+
+        private static Configuration createConfiguration() {
+            Configuration configuration = new Configuration();
+            configuration.set(ConfigOptions.REMOTE_DATA_DIR, DEFAULT_REMOTE_DATA_DIR);
+            return configuration;
+        }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3653 

<!-- What is the purpose of the change -->

Optimize controlled shutdown leader migration by batching LeaderAndIsr reads and updates in ZooKeeper. The new path is only used for controlled shutdown leader election and falls back to individual updates when batch reads are incomplete or batch updates fail.

This reduces the coordinator-side cost when a shutting-down tablet server owns many leader buckets, while preserving the existing election semantics.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
