### PR TITLE
[common] Add config providers to resolve secrets in configuration

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/ConnectionFactory.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/ConnectionFactory.java
@@ -19,7 +19,9 @@ package org.apache.fluss.client;
 
 import org.apache.fluss.annotation.PublicEvolving;
 import org.apache.fluss.client.admin.Admin;
+import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.provider.ConfigProviders;
 import org.apache.fluss.metrics.registry.MetricRegistry;
 
 /**
@@ -52,7 +54,7 @@ public class ConnectionFactory {
      * }</pre>
      */
     public static Connection createConnection(Configuration conf) {
-        return new FlussConnection(conf);
+        return new FlussConnection(resolveConfigProviders(conf));
     }
 
     /**
@@ -63,6 +65,16 @@ public class ConnectionFactory {
      * <p>See more comments in method {@link #createConnection(Configuration)}
      */
     public static Connection createConnection(Configuration conf, MetricRegistry metricRegistry) {
-        return new FlussConnection(conf, metricRegistry);
+        return new FlussConnection(resolveConfigProviders(conf), metricRegistry);
+    }
+
+    /** Resolves {@code ${provider:...}} markers without mutating the caller's configuration. */
+    private static Configuration resolveConfigProviders(Configuration conf) {
+        if (conf.get(ConfigOptions.CONFIG_PROVIDERS).isEmpty()) {
+            return conf;
+        }
+        Configuration resolved = new Configuration(conf);
+        ConfigProviders.resolve(resolved);
+        return resolved;
     }
 }

--- a/fluss-client/src/test/java/org/apache/fluss/client/ConfigProviderConnectionITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/ConfigProviderConnectionITCase.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.client;
+
+import org.apache.fluss.client.admin.Admin;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.server.testutils.FlussClusterExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT case for {@link ConnectionFactory} resolving config provider markers. */
+class ConfigProviderConnectionITCase {
+
+    @RegisterExtension
+    public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
+            FlussClusterExtension.builder().setNumOfTabletServers(1).build();
+
+    @Test
+    void testConnectWithConfigProviderResolvedBootstrapServers(@TempDir Path secretsDir)
+            throws Exception {
+        Configuration clientConf = FLUSS_CLUSTER_EXTENSION.getClientConfig();
+        String bootstrapServers = clientConf.get(ConfigOptions.BOOTSTRAP_SERVERS).get(0);
+        Files.write(
+                secretsDir.resolve("bootstrap-servers"),
+                bootstrapServers.getBytes(StandardCharsets.UTF_8));
+
+        Configuration conf = new Configuration(clientConf);
+        conf.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "directory");
+        conf.setString("config.providers.directory.param.allowed.paths", secretsDir.toString());
+        conf.setString(
+                ConfigOptions.BOOTSTRAP_SERVERS.key(),
+                "${directory:" + secretsDir + ":bootstrap-servers}");
+
+        try (Connection connection = ConnectionFactory.createConnection(conf);
+                Admin admin = connection.getAdmin()) {
+            assertThat(admin.listDatabases().get()).contains("fluss");
+        }
+
+        // caller's configuration is not mutated
+        assertThat(conf.toMap().get(ConfigOptions.BOOTSTRAP_SERVERS.key()))
+                .startsWith("${directory:");
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -71,6 +71,24 @@ public class ConfigOptions {
     // ------------------------------------------------------------------------
     //  ConfigOptions for Fluss Cluster
     // ------------------------------------------------------------------------
+    public static final ConfigOption<List<String>> CONFIG_PROVIDERS =
+            key("config.providers")
+                    .stringType()
+                    .asList()
+                    .defaultValues()
+                    .withDescription(
+                            "A comma-separated list of config provider identifiers to enable, e.g. "
+                                    + "'directory,env'. Config providers resolve indirection markers of the "
+                                    + "form ${provider:[path:]key} in configuration values at load time, so "
+                                    + "secrets can be kept out of the configuration file (e.g. in a mounted "
+                                    + "Kubernetes Secret or an environment variable). Built-in providers: "
+                                    + "'directory' (${directory:/dir:file}, reads the file content), 'env' "
+                                    + "(${env:VAR}, reads an environment variable) and 'file' "
+                                    + "(${file:/path/to/file.properties:key}, reads a single property). "
+                                    + "Providers are configured via config.providers.<identifier>.param.<param> "
+                                    + "keys; the filesystem-reading providers require the 'allowed.paths' "
+                                    + "parameter restricting which paths they may read.");
+
     public static final ConfigOption<Integer> DEFAULT_BUCKET_NUMBER =
             key("default.bucket.number")
                     .intType()

--- a/fluss-common/src/main/java/org/apache/fluss/config/Configuration.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/Configuration.java
@@ -17,6 +17,7 @@
 
 package org.apache.fluss.config;
 
+import org.apache.fluss.annotation.Internal;
 import org.apache.fluss.annotation.PublicStable;
 import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.utils.CollectionUtils;
@@ -55,6 +56,9 @@ public class Configuration implements Serializable, ReadableConfig {
     /** Stores the concrete key/value pairs of this configuration object. */
     protected final HashMap<String, Object> confData;
 
+    /** Keys resolved from a secret source, hidden in {@link #toString()}. */
+    private Set<String> sensitiveKeys = new HashSet<>();
+
     // --------------------------------------------------------------------------------------------
 
     /** Creates a new empty configuration. */
@@ -69,6 +73,7 @@ public class Configuration implements Serializable, ReadableConfig {
      */
     public Configuration(Configuration other) {
         this.confData = new HashMap<>(other.confData);
+        this.sensitiveKeys = new HashSet<>(other.sensitiveKeys());
     }
 
     // --------------------------------------------------------------------------------------------
@@ -457,8 +462,17 @@ public class Configuration implements Serializable, ReadableConfig {
                             "Value for config option %s must be one of %s (was %s)",
                             configOption.key(),
                             Arrays.toString(enumClass.getEnumConstants()),
-                            rawValue);
+                            hasSensitiveValue(configOption) ? Password.HIDDEN_CONTENT : rawValue);
             throw new IllegalArgumentException(errorMessage);
+        }
+    }
+
+    /** Whether the option's value must be hidden in error messages and logs. */
+    private boolean hasSensitiveValue(ConfigOption<?> option) {
+        synchronized (this.confData) {
+            return option.isSensitive()
+                    || sensitiveKeys().contains(option.key())
+                    || ConfigurationUtils.isSensitiveKey(option.key());
         }
     }
 
@@ -495,8 +509,33 @@ public class Configuration implements Serializable, ReadableConfig {
         synchronized (this.confData) {
             synchronized (other.confData) {
                 this.confData.putAll(other.confData);
+                this.sensitiveKeys().addAll(other.sensitiveKeys());
             }
         }
+    }
+
+    /** Marks the key as holding secret material, hiding it in {@link #toString()}. */
+    @Internal
+    public void markSensitive(String key) {
+        synchronized (this.confData) {
+            sensitiveKeys().add(key);
+        }
+    }
+
+    /** Returns the keys marked via {@link #markSensitive(String)}. */
+    @Internal
+    public Set<String> getSensitiveKeys() {
+        synchronized (this.confData) {
+            return new HashSet<>(sensitiveKeys());
+        }
+    }
+
+    /** Lazily recreated, as the set is {@code null} when deserialized from older streams. */
+    private Set<String> sensitiveKeys() {
+        if (sensitiveKeys == null) {
+            sensitiveKeys = new HashSet<>();
+        }
+        return sensitiveKeys;
     }
 
     /**
@@ -566,7 +605,7 @@ public class Configuration implements Serializable, ReadableConfig {
             }
         } catch (Exception e) {
             throw new IllegalArgumentException(
-                    option.isSensitive()
+                    hasSensitiveValue(option)
                             ? String.format("Could not parse value for key '%s'.", option.key())
                             : String.format(
                                     "Could not parse value '%s' for key '%s'.",
@@ -745,6 +784,18 @@ public class Configuration implements Serializable, ReadableConfig {
 
     @Override
     public String toString() {
-        return this.confData.toString();
+        // hides secret material; use toMap()/get() to read real values
+        synchronized (this.confData) {
+            Map<String, Object> safe = new HashMap<>(this.confData.size());
+            for (Map.Entry<String, Object> entry : confData.entrySet()) {
+                safe.put(
+                        entry.getKey(),
+                        sensitiveKeys().contains(entry.getKey())
+                                ? Password.HIDDEN_CONTENT
+                                : ConfigurationUtils.hideSensitiveValue(
+                                        entry.getKey(), entry.getValue()));
+            }
+            return safe.toString();
+        }
     }
 }

--- a/fluss-common/src/main/java/org/apache/fluss/config/GlobalConfiguration.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/GlobalConfiguration.java
@@ -18,6 +18,7 @@
 package org.apache.fluss.config;
 
 import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.config.provider.ConfigProviders;
 import org.apache.fluss.exception.IllegalConfigurationException;
 
 import org.slf4j.Logger;
@@ -115,6 +116,9 @@ public class GlobalConfiguration {
             logConfiguration("Loading dynamic", dynamicProperties);
             configuration.addAll(dynamicProperties);
         }
+
+        // resolve ${provider:...} markers after merging, so the logs above show only markers
+        ConfigProviders.resolve(configuration);
 
         return configuration;
     }

--- a/fluss-common/src/main/java/org/apache/fluss/config/provider/AllowedPaths.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/provider/AllowedPaths.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.config.provider;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The mandatory {@code allowed.paths} parameter of file-reading {@link ConfigProvider}s: a
+ * comma-separated list of roots the provider may read from.
+ */
+final class AllowedPaths {
+
+    static final String PARAM = "allowed.paths";
+
+    private final String identifier;
+    private final List<Path> roots;
+
+    private AllowedPaths(String identifier, List<Path> roots) {
+        this.identifier = identifier;
+        this.roots = roots;
+    }
+
+    static AllowedPaths parse(String identifier, @Nullable String value) {
+        List<Path> roots = new ArrayList<>();
+        if (value != null) {
+            for (String root : value.split(",")) {
+                String trimmed = root.trim();
+                if (!trimmed.isEmpty()) {
+                    roots.add(canonicalize(Paths.get(trimmed)));
+                }
+            }
+        }
+        if (roots.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "The '"
+                            + identifier
+                            + "' config provider requires the '"
+                            + PARAM
+                            + "' parameter (comma-separated roots it may read from); set "
+                            + "config.providers."
+                            + identifier
+                            + ".param."
+                            + PARAM
+                            + ".");
+        }
+        return new AllowedPaths(identifier, roots);
+    }
+
+    /** Canonicalizes {@code file} and checks it lies under one of the allowed roots. */
+    Path check(Path file) {
+        Path canonical = canonicalize(file);
+        for (Path root : roots) {
+            if (canonical.startsWith(root)) {
+                return canonical;
+            }
+        }
+        throw new IllegalArgumentException(
+                "File '"
+                        + canonical
+                        + "' is outside the "
+                        + PARAM
+                        + " "
+                        + roots
+                        + " of the '"
+                        + identifier
+                        + "' config provider.");
+    }
+
+    private static Path canonicalize(Path path) {
+        try {
+            return Paths.get(path.toFile().getCanonicalPath());
+        } catch (IOException e) {
+            return path.toAbsolutePath().normalize();
+        }
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/config/provider/ConfigProvider.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/provider/ConfigProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.config.provider;
+
+import org.apache.fluss.annotation.PublicEvolving;
+
+import java.util.Map;
+
+/**
+ * Resolves indirect configuration values, referenced as <code>${identifier:[path:]key}</code>
+ * markers, from an external source such as environment variables or files.
+ *
+ * <p>Providers are discovered via {@link java.util.ServiceLoader} and are only active when listed
+ * in {@code config.providers}. Implementations must be thread-safe.
+ *
+ * @since 1.0
+ */
+@PublicEvolving
+public interface ConfigProvider extends AutoCloseable {
+
+    /** The name referencing this provider in markers, e.g. {@code "env"}. Must be unique. */
+    String identifier();
+
+    /** Applies {@code config.providers.<identifier>.param.*} parameters, prefix stripped. */
+    default void configure(Map<String, String> params) {}
+
+    /**
+     * Resolves the value for a single marker.
+     *
+     * @param path the middle segment of the marker, or an empty string when absent
+     * @param key the final segment of the marker
+     * @return the resolved value, never {@code null}
+     * @throws IllegalArgumentException if the value cannot be resolved
+     */
+    String resolve(String path, String key);
+
+    @Override
+    default void close() {}
+}

--- a/fluss-common/src/main/java/org/apache/fluss/config/provider/ConfigProviders.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/provider/ConfigProviders.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.config.provider;
+
+import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.IllegalConfigurationException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+/**
+ * Resolves <code>${identifier:[path:]key}</code> markers in a {@link Configuration} through the
+ * {@link ConfigProvider}s declared in {@link ConfigOptions#CONFIG_PROVIDERS}. A marker must be the
+ * whole value; a literal leading <code>${</code> can be escaped as <code>$${</code>.
+ */
+@Internal
+public final class ConfigProviders {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigProviders.class);
+
+    private static final String PROVIDER_PREFIX = ConfigOptions.CONFIG_PROVIDERS.key() + ".";
+    private static final String PARAM_INFIX = ".param.";
+
+    private ConfigProviders() {}
+
+    /**
+     * Resolves all markers in {@code config} in place. A no-op when {@link
+     * ConfigOptions#CONFIG_PROVIDERS} is absent.
+     *
+     * @throws IllegalConfigurationException if a marker is malformed, references an undeclared
+     *     provider, or fails to resolve
+     */
+    public static void resolve(Configuration config) {
+        List<String> declared = config.get(ConfigOptions.CONFIG_PROVIDERS);
+        if (declared == null || declared.isEmpty()) {
+            warnAboutUnresolvableMarkers(config);
+            return;
+        }
+
+        Map<String, ConfigProvider> providers = loadProviders(config, declared);
+        try {
+            for (String key : config.keySet()) {
+                Optional<Object> raw = config.getRawValue(key);
+                if (!raw.isPresent() || !(raw.get() instanceof String)) {
+                    continue;
+                }
+                String value = (String) raw.get();
+                if (value.startsWith("$${")) {
+                    // escaped: drop one '$', leave the rest literal
+                    config.setString(key, value.substring(1));
+                } else if (isMarker(value)) {
+                    config.setString(key, resolveMarker(value, providers));
+                    // hide the resolved secret even under a key name that doesn't look sensitive
+                    config.markSensitive(key);
+                }
+            }
+        } finally {
+            closeAll(providers);
+        }
+    }
+
+    private static String resolveMarker(String value, Map<String, ConfigProvider> providers) {
+        String inner = value.substring(2, value.length() - 1);
+        int firstColon = inner.indexOf(':');
+        if (firstColon <= 0 || firstColon == inner.length() - 1) {
+            throw new IllegalConfigurationException(
+                    "Malformed config provider marker '"
+                            + value
+                            + "'. Expected ${identifier:[path:]key}.");
+        }
+        String identifier = inner.substring(0, firstColon);
+        String rest = inner.substring(firstColon + 1);
+        int lastColon = rest.lastIndexOf(':');
+        String path = lastColon < 0 ? "" : rest.substring(0, lastColon);
+        String key = lastColon < 0 ? rest : rest.substring(lastColon + 1);
+
+        ConfigProvider provider = providers.get(identifier);
+        if (provider == null) {
+            throw new IllegalConfigurationException(
+                    "Config provider '"
+                            + identifier
+                            + "' referenced by marker '"
+                            + value
+                            + "' is not declared in '"
+                            + ConfigOptions.CONFIG_PROVIDERS.key()
+                            + "'.");
+        }
+        try {
+            return provider.resolve(path, key);
+        } catch (Exception e) {
+            throw new IllegalConfigurationException(
+                    "Failed to resolve config provider marker '" + value + "': " + e.getMessage(),
+                    e);
+        }
+    }
+
+    /** Whether the value has the <code>${...}</code> marker shape. */
+    public static boolean isMarker(String value) {
+        return value.length() > 3 && value.startsWith("${") && value.endsWith("}");
+    }
+
+    private static void warnAboutUnresolvableMarkers(Configuration config) {
+        for (String key : config.keySet()) {
+            Optional<Object> raw = config.getRawValue(key);
+            if (raw.isPresent() && raw.get() instanceof String && isMarker((String) raw.get())) {
+                LOG.warn(
+                        "Value of '{}' looks like a config provider marker, but '{}' is not set; "
+                                + "it is kept as a literal.",
+                        key,
+                        ConfigOptions.CONFIG_PROVIDERS.key());
+            }
+        }
+    }
+
+    private static Map<String, ConfigProvider> loadProviders(
+            Configuration config, List<String> declared) {
+        Set<String> requested = new HashSet<>();
+        for (String name : declared) {
+            String trimmed = name.trim();
+            if (!trimmed.isEmpty()) {
+                requested.add(trimmed);
+            }
+        }
+
+        Map<String, ConfigProvider> providers = new HashMap<>();
+        try {
+            ServiceLoader<ConfigProvider> loader =
+                    ServiceLoader.load(ConfigProvider.class, ConfigProvider.class.getClassLoader());
+            for (Iterator<ConfigProvider> it = loader.iterator(); it.hasNext(); ) {
+                ConfigProvider provider = it.next();
+                if (requested.contains(provider.identifier())
+                        && !providers.containsKey(provider.identifier())) {
+                    try {
+                        provider.configure(paramsFor(config, provider.identifier()));
+                    } catch (Exception e) {
+                        throw new IllegalConfigurationException(
+                                "Invalid configuration for config provider '"
+                                        + provider.identifier()
+                                        + "': "
+                                        + e.getMessage(),
+                                e);
+                    }
+                    providers.put(provider.identifier(), provider);
+                }
+            }
+
+            for (String name : requested) {
+                if (!providers.containsKey(name)) {
+                    throw new IllegalConfigurationException(
+                            "No config provider with identifier '"
+                                    + name
+                                    + "' found on the classpath, but it is declared in '"
+                                    + ConfigOptions.CONFIG_PROVIDERS.key()
+                                    + "'.");
+                }
+            }
+            return providers;
+        } catch (Exception e) {
+            closeAll(providers);
+            throw e;
+        }
+    }
+
+    private static void closeAll(Map<String, ConfigProvider> providers) {
+        for (ConfigProvider provider : providers.values()) {
+            try {
+                provider.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close config provider '{}'.", provider.identifier(), e);
+            }
+        }
+    }
+
+    private static Map<String, String> paramsFor(Configuration config, String identifier) {
+        String prefix = PROVIDER_PREFIX + identifier + PARAM_INFIX;
+        Map<String, String> params = new HashMap<>();
+        for (String key : config.keySet()) {
+            if (key.startsWith(prefix)) {
+                config.getRawValue(key)
+                        .ifPresent(v -> params.put(key.substring(prefix.length()), v.toString()));
+            }
+        }
+        return params;
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/config/provider/DirectoryConfigProvider.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/provider/DirectoryConfigProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.config.provider;
+
+import org.apache.fluss.annotation.Internal;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.apache.fluss.utils.Preconditions.checkState;
+
+/**
+ * A {@link ConfigProvider} resolving <code>${directory:/dir:file}</code> markers to the verbatim
+ * UTF-8 content of {@code /dir/file}, matching a Kubernetes {@code Secret} mounted as a volume. The
+ * mandatory {@code allowed.paths} parameter restricts which directories may be read.
+ */
+@Internal
+public class DirectoryConfigProvider implements ConfigProvider {
+
+    public static final String IDENTIFIER = "directory";
+
+    private AllowedPaths allowedPaths;
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public void configure(Map<String, String> params) {
+        ProviderParams.validateKeys(IDENTIFIER, params, AllowedPaths.PARAM);
+        allowedPaths = AllowedPaths.parse(IDENTIFIER, params.get(AllowedPaths.PARAM));
+    }
+
+    @Override
+    public String resolve(String path, String key) {
+        checkState(allowedPaths != null, "Provider '%s' has not been configured.", IDENTIFIER);
+        if (path.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "The 'directory' config provider requires a directory path; use "
+                            + "${directory:/dir:file}.");
+        }
+        Path file = allowedPaths.check(Paths.get(path, key));
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                    "Failed to read secret file '"
+                            + file
+                            + "' referenced by ${directory:"
+                            + path
+                            + ":"
+                            + key
+                            + "}.",
+                    e);
+        }
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/config/provider/EnvVarConfigProvider.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/provider/EnvVarConfigProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.config.provider;
+
+import org.apache.fluss.annotation.Internal;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * A {@link ConfigProvider} resolving <code>${env:VAR_NAME}</code> markers from environment
+ * variables. The optional {@code allowlist.pattern} parameter (a regex the variable name must fully
+ * match) restricts which variables may be read.
+ */
+@Internal
+public class EnvVarConfigProvider implements ConfigProvider {
+
+    public static final String IDENTIFIER = "env";
+    private static final String ALLOWLIST_PATTERN = "allowlist.pattern";
+
+    private Pattern allowlist;
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public void configure(Map<String, String> params) {
+        ProviderParams.validateKeys(IDENTIFIER, params, ALLOWLIST_PATTERN);
+        String pattern = params.get(ALLOWLIST_PATTERN);
+        if (pattern != null) {
+            allowlist = Pattern.compile(pattern);
+        }
+    }
+
+    @Override
+    public String resolve(String path, String key) {
+        if (!path.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "The 'env' config provider takes no path segment; use ${env:VAR_NAME}, got path '"
+                            + path
+                            + "'.");
+        }
+        if (allowlist != null && !allowlist.matcher(key).matches()) {
+            throw new IllegalArgumentException(
+                    "Environment variable '"
+                            + key
+                            + "' is not permitted by allowlist.pattern of the 'env' config provider.");
+        }
+        String value = System.getenv(key);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "Environment variable '"
+                            + key
+                            + "' referenced by ${env:"
+                            + key
+                            + "} is not set.");
+        }
+        return value;
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/config/provider/FileConfigProvider.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/provider/FileConfigProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.config.provider;
+
+import org.apache.fluss.annotation.Internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.fluss.utils.Preconditions.checkState;
+
+/**
+ * A {@link ConfigProvider} resolving <code>${file:/path/creds.properties:key}</code> markers to a
+ * single property of a Java properties file. The mandatory {@code allowed.paths} parameter
+ * restricts which files may be read.
+ */
+@Internal
+public class FileConfigProvider implements ConfigProvider {
+
+    public static final String IDENTIFIER = "file";
+
+    private AllowedPaths allowedPaths;
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public void configure(Map<String, String> params) {
+        ProviderParams.validateKeys(IDENTIFIER, params, AllowedPaths.PARAM);
+        allowedPaths = AllowedPaths.parse(IDENTIFIER, params.get(AllowedPaths.PARAM));
+    }
+
+    @Override
+    public String resolve(String path, String key) {
+        checkState(allowedPaths != null, "Provider '%s' has not been configured.", IDENTIFIER);
+        if (path.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "The 'file' config provider requires a file path; use "
+                            + "${file:/path/to/file.properties:property}.");
+        }
+        Path file = allowedPaths.check(Paths.get(path));
+        Properties properties = new Properties();
+        try (InputStream in = Files.newInputStream(file)) {
+            properties.load(in);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                    "Failed to read properties file '" + path + "' for the 'file' config provider.",
+                    e);
+        }
+        String value = properties.getProperty(key);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "Property '" + key + "' not found in file '" + path + "'.");
+        }
+        return value;
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/config/provider/ProviderParams.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/provider/ProviderParams.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.config.provider;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/** Parameter validation shared by the built-in {@link ConfigProvider}s. */
+final class ProviderParams {
+
+    private ProviderParams() {}
+
+    /** Rejects unknown parameter keys so a typo'd parameter fails instead of being ignored. */
+    static void validateKeys(String identifier, Map<String, String> params, String... knownKeys) {
+        Set<String> known = new HashSet<>(Arrays.asList(knownKeys));
+        for (String key : params.keySet()) {
+            if (!known.contains(key)) {
+                throw new IllegalArgumentException(
+                        "Unknown parameter '"
+                                + key
+                                + "' for the '"
+                                + identifier
+                                + "' config provider. Supported parameters: "
+                                + known
+                                + ".");
+            }
+        }
+    }
+}

--- a/fluss-common/src/main/resources/META-INF/services/org.apache.fluss.config.provider.ConfigProvider
+++ b/fluss-common/src/main/resources/META-INF/services/org.apache.fluss.config.provider.ConfigProvider
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.apache.fluss.config.provider.EnvVarConfigProvider
+org.apache.fluss.config.provider.DirectoryConfigProvider
+org.apache.fluss.config.provider.FileConfigProvider

--- a/fluss-common/src/test/java/org/apache/fluss/config/provider/ConfigProvidersTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/config/provider/ConfigProvidersTest.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.config.provider;
+
+import org.apache.fluss.config.ConfigBuilder;
+import org.apache.fluss.config.ConfigOption;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.GlobalConfiguration;
+import org.apache.fluss.exception.IllegalConfigurationException;
+import org.apache.fluss.utils.InstantiationUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** Tests for {@link ConfigProviders} and the built-in {@link ConfigProvider}s. */
+class ConfigProvidersTest {
+
+    @Test
+    void testProviderDefaultMethods() {
+        ConfigProvider provider =
+                new ConfigProvider() {
+                    @Override
+                    public String identifier() {
+                        return "noop";
+                    }
+
+                    @Override
+                    public String resolve(String path, String key) {
+                        return path + key;
+                    }
+                };
+        provider.configure(Collections.emptyMap());
+        assertThat(provider.resolve("a", "b")).isEqualTo("ab");
+        provider.close();
+    }
+
+    @Test
+    void testNoProvidersDeclaredLeavesMarkersUntouched() {
+        Configuration config = new Configuration();
+        config.setString("datalake.paimon.oauth.token", "${env:WHATEVER}");
+        ConfigProviders.resolve(config);
+        assertThat(config.toMap().get("datalake.paimon.oauth.token")).isEqualTo("${env:WHATEVER}");
+    }
+
+    @Test
+    void testDirectoryProviderReadsFileVerbatim(@TempDir Path secretsDir) throws Exception {
+        // K8s Secret volumes expose exact bytes with no trailing newline.
+        Files.write(secretsDir.resolve("oauth-token"), "s3cr3t".getBytes(StandardCharsets.UTF_8));
+
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "directory");
+        config.setString("config.providers.directory.param.allowed.paths", secretsDir.toString());
+        config.setString(
+                "datalake.paimon.oauth.token", "${directory:" + secretsDir + ":oauth-token}");
+        ConfigProviders.resolve(config);
+
+        assertThat(config.toMap().get("datalake.paimon.oauth.token")).isEqualTo("s3cr3t");
+    }
+
+    @Test
+    void testDirectoryProviderRequiresAllowedPaths() {
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "directory");
+        assertThatThrownBy(() -> ConfigProviders.resolve(config))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("requires the 'allowed.paths' parameter");
+    }
+
+    @Test
+    void testUnknownProviderParamFailsFast(@TempDir Path secretsDir) {
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "directory");
+        config.setString("config.providers.directory.param.allowd.paths", secretsDir.toString());
+        assertThatThrownBy(() -> ConfigProviders.resolve(config))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("Unknown parameter 'allowd.paths'");
+    }
+
+    @Test
+    void testDirectoryProviderAllowedPathsRejectsOutsideRoot(@TempDir Path base) throws Exception {
+        Path allowed = base.resolve("allowed");
+        Path other = base.resolve("other");
+        Files.createDirectories(allowed);
+        Files.createDirectories(other);
+        Files.write(other.resolve("token"), "leak".getBytes(StandardCharsets.UTF_8));
+
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "directory");
+        config.setString("config.providers.directory.param.allowed.paths", allowed.toString());
+        config.setString("secret", "${directory:" + other + ":token}");
+
+        assertThatThrownBy(() -> ConfigProviders.resolve(config))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("allowed.paths");
+    }
+
+    @Test
+    void testFileProviderReadsProperty(@TempDir Path dir) throws Exception {
+        Path props = dir.resolve("creds.properties");
+        Files.write(props, Arrays.asList("db.user=alice", "db.password=hunter2"));
+
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "file");
+        config.setString("config.providers.file.param.allowed.paths", dir.toString());
+        config.setString("kv.password", "${file:" + props + ":db.password}");
+        ConfigProviders.resolve(config);
+
+        assertThat(config.toMap().get("kv.password")).isEqualTo("hunter2");
+    }
+
+    @Test
+    void testEnvProviderResolvesAndRejectsMissing() {
+        assumeTrue(System.getenv("PATH") != null, "requires PATH to be set");
+
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "env");
+        config.setString("some.path", "${env:PATH}");
+        ConfigProviders.resolve(config);
+        assertThat(config.toMap().get("some.path")).isEqualTo(System.getenv("PATH"));
+
+        Configuration missing = new Configuration();
+        missing.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "env");
+        missing.setString("x", "${env:FLUSS_DEFINITELY_UNSET_VAR_XYZ}");
+        assertThatThrownBy(() -> ConfigProviders.resolve(missing))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("FLUSS_DEFINITELY_UNSET_VAR_XYZ");
+    }
+
+    @Test
+    void testDoubleDollarEscapesLiteralMarker() {
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "env");
+        config.setString("literal", "$${env:PATH}");
+        config.setString("dollars", "$$100");
+        ConfigProviders.resolve(config);
+        assertThat(config.toMap().get("literal")).isEqualTo("${env:PATH}");
+        assertThat(config.toMap().get("dollars")).isEqualTo("$$100");
+    }
+
+    @Test
+    void testResolvedValuesAreHiddenInToString(@TempDir Path secretsDir) throws Exception {
+        Files.write(secretsDir.resolve("cred"), "raw-secret".getBytes(StandardCharsets.UTF_8));
+
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "directory");
+        config.setString("config.providers.directory.param.allowed.paths", secretsDir.toString());
+        // key name intentionally does not match the sensitive-key heuristics
+        config.setString("some.resolved.value", "${directory:" + secretsDir + ":cred}");
+        ConfigProviders.resolve(config);
+
+        assertThat(config.toMap().get("some.resolved.value")).isEqualTo("raw-secret");
+        assertThat(config.toString()).doesNotContain("raw-secret").contains("******");
+        assertThat(new Configuration(config).toString()).doesNotContain("raw-secret");
+        Configuration merged = new Configuration();
+        merged.addAll(config);
+        assertThat(merged.toString()).doesNotContain("raw-secret");
+        // hiding survives java serialization
+        Configuration deserialized = InstantiationUtils.clone(config);
+        assertThat(deserialized.toMap().get("some.resolved.value")).isEqualTo("raw-secret");
+        assertThat(deserialized.toString()).doesNotContain("raw-secret");
+    }
+
+    @Test
+    void testResolvedValuesAreHiddenInParseErrors(@TempDir Path secretsDir) throws Exception {
+        Files.write(secretsDir.resolve("cred"), "raw-secret".getBytes(StandardCharsets.UTF_8));
+
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "directory");
+        config.setString("config.providers.directory.param.allowed.paths", secretsDir.toString());
+        config.setString("some.resolved.value", "${directory:" + secretsDir + ":cred}");
+        ConfigProviders.resolve(config);
+
+        ConfigOption<Integer> intOption =
+                ConfigBuilder.key("some.resolved.value").intType().noDefaultValue();
+        assertThatThrownBy(() -> config.get(intOption))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageNotContaining("raw-secret");
+    }
+
+    @Test
+    void testUndeclaredProviderFailsFast() {
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "env");
+        config.setString("x", "${directory:/etc/secrets:token}");
+        assertThatThrownBy(() -> ConfigProviders.resolve(config))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("not declared");
+    }
+
+    @Test
+    void testUnknownDeclaredProviderFailsFast() {
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "vault");
+        assertThatThrownBy(() -> ConfigProviders.resolve(config))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("vault");
+    }
+
+    @Test
+    void testMalformedMarkerFailsFast() {
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "env");
+        config.setString("x", "${nocolon}");
+        assertThatThrownBy(() -> ConfigProviders.resolve(config))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("Malformed");
+    }
+
+    @Test
+    void testInlineMarkerIsNotResolved() {
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "env");
+        config.setString("url", "https://host/${env:PATH}/x");
+        ConfigProviders.resolve(config);
+        assertThat(config.toMap().get("url")).isEqualTo("https://host/${env:PATH}/x");
+    }
+
+    @Test
+    void testLoadConfigurationResolvesMarkers(@TempDir Path confDir, @TempDir Path secretsDir)
+            throws Exception {
+        Files.write(secretsDir.resolve("oauth-token"), "tok-42".getBytes(StandardCharsets.UTF_8));
+        Files.write(
+                confDir.resolve(GlobalConfiguration.FLUSS_CONF_FILENAME),
+                Arrays.asList(
+                        "config.providers: directory",
+                        "config.providers.directory.param.allowed.paths: " + secretsDir,
+                        "datalake.paimon.oauth.token: ${directory:" + secretsDir + ":oauth-token}",
+                        "bind.listeners: FLUSS://localhost:9123"),
+                StandardCharsets.UTF_8);
+
+        Configuration config = GlobalConfiguration.loadConfiguration(confDir.toString(), null);
+
+        assertThat(config.toMap().get("datalake.paimon.oauth.token")).isEqualTo("tok-42");
+        assertThat(config.toMap().get("bind.listeners")).isEqualTo("FLUSS://localhost:9123");
+    }
+}

--- a/fluss-flink/fluss-flink-tiering/src/main/java/org/apache/fluss/flink/tiering/FlussLakeTiering.java
+++ b/fluss-flink/fluss-flink-tiering/src/main/java/org/apache/fluss/flink/tiering/FlussLakeTiering.java
@@ -20,12 +20,14 @@ package org.apache.fluss.flink.tiering;
 
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.provider.ConfigProviders;
 import org.apache.fluss.flink.adapter.MultipleParameterToolAdapter;
 
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
@@ -58,7 +60,7 @@ public class FlussLakeTiering {
     public FlussLakeTiering(String[] args) {
         // parse params
         final MultipleParameterToolAdapter params = MultipleParameterToolAdapter.fromArgs(args);
-        Map<String, String> paramsMap = params.toMap();
+        Map<String, String> paramsMap = resolveConfigProviders(params.toMap());
 
         // extract fluss config
         Map<String, String> flussConfigMap = extractAndRemovePrefix(paramsMap, FLUSS_CONF_PREFIX);
@@ -98,6 +100,13 @@ public class FlussLakeTiering {
         flinkConfig.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, FULL_RESTART_STRATEGY_NAME);
 
         execEnv = StreamExecutionEnvironment.getExecutionEnvironment(flinkConfig);
+    }
+
+    /** Resolves {@code ${provider:...}} markers in all parameters before prefix extraction. */
+    private static Map<String, String> resolveConfigProviders(Map<String, String> paramsMap) {
+        Configuration params = Configuration.fromMap(paramsMap);
+        ConfigProviders.resolve(params);
+        return new HashMap<>(params.toMap());
     }
 
     protected void run() throws Exception {

--- a/fluss-server/src/main/java/org/apache/fluss/server/DynamicConfigManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/DynamicConfigManager.java
@@ -25,6 +25,7 @@ import org.apache.fluss.config.cluster.AlterConfig;
 import org.apache.fluss.config.cluster.ConfigEntry;
 import org.apache.fluss.config.cluster.ConfigValidator;
 import org.apache.fluss.config.cluster.ServerReconfigurable;
+import org.apache.fluss.config.provider.ConfigProviders;
 import org.apache.fluss.exception.ConfigException;
 import org.apache.fluss.server.authorizer.ZkNodeChangeNotificationWatcher;
 import org.apache.fluss.server.zk.ZooKeeperClient;
@@ -145,6 +146,13 @@ public class DynamicConfigManager {
                     }
 
                     String configValue = alterConfigOp.value();
+                    if (configValue != null && ConfigProviders.isMarker(configValue)) {
+                        throw new ConfigException(
+                                String.format(
+                                        "Config provider markers are resolved at startup only and "
+                                                + "are not supported in dynamic configuration: key '%s'.",
+                                        configKey));
+                    }
                     switch (alterConfigOp.opType()) {
                         case SET:
                             configsProps.put(configKey, configValue);

--- a/fluss-server/src/main/java/org/apache/fluss/server/DynamicServerConfig.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/DynamicServerConfig.java
@@ -118,6 +118,11 @@ class DynamicServerConfig {
         this.initialConfigMap = flussConfig.toMap();
         this.currentConfigMap = flussConfig.toMap();
         registerDefaultRedactors();
+        // never expose provider-resolved values through the describe config APIs
+        Set<String> resolvedSecretKeys = flussConfig.getSensitiveKeys();
+        if (!resolvedSecretKeys.isEmpty()) {
+            configRedactors.add(ConfigRedactors.value(resolvedSecretKeys::contains));
+        }
     }
 
     void register(ServerReconfigurable serverReconfigurable) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/DynamicConfigChangeTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/DynamicConfigChangeTest.java
@@ -983,4 +983,42 @@ public class DynamicConfigChangeTest {
         assertThat(zkConfig.get(ConfigOptions.SERVER_SASL_CREDENTIALS.key()))
                 .isEqualTo("bob:bob-secret");
     }
+
+    @Test
+    void testRejectProviderMarkerInDynamicConfig() throws Exception {
+        Configuration configuration = new Configuration();
+        DynamicConfigManager dynamicConfigManager =
+                new DynamicConfigManager(zookeeperClient, configuration, true);
+        dynamicConfigManager.startup();
+
+        assertThatThrownBy(
+                        () ->
+                                dynamicConfigManager.alterConfigs(
+                                        Collections.singletonList(
+                                                new AlterConfig(
+                                                        "datalake.paimon.s3.secret-key",
+                                                        "${directory:/etc/fluss/secrets:s3-secret-key}",
+                                                        AlterConfigOpType.SET))))
+                .isInstanceOf(ConfigException.class)
+                .hasMessageContaining("resolved at startup only");
+    }
+
+    @Test
+    void testDescribeConfigsRedactsProviderResolvedValues() throws Exception {
+        Configuration configuration = new Configuration();
+        // key name intentionally does not match the sensitive-key heuristics
+        configuration.setString("datalake.paimon.custom.value", "raw-secret");
+        configuration.markSensitive("datalake.paimon.custom.value");
+
+        DynamicConfigManager dynamicConfigManager =
+                new DynamicConfigManager(zookeeperClient, configuration, true);
+        dynamicConfigManager.startup();
+
+        ConfigEntry entry =
+                dynamicConfigManager.describeConfigs().stream()
+                        .filter(e -> e.key().equals("datalake.paimon.custom.value"))
+                        .findFirst()
+                        .get();
+        assertThat(entry.value()).isEqualTo("******");
+    }
 }

--- a/website/docs/security/secrets.md
+++ b/website/docs/security/secrets.md
@@ -1,0 +1,104 @@
+---
+sidebar_label: Secrets in Configuration
+title: Secrets in Configuration
+sidebar_position: 4
+---
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# Secrets in Configuration
+
+Configuration values such as credentials for lake catalogs or object storage do not need to be
+written into `server.yaml` (or client configuration) as literals. Instead, a value can be an
+**indirection marker** that points at an external source, and Fluss resolves it at load time:
+
+```yaml title="conf/server.yaml"
+config.providers: directory,env
+config.providers.directory.param.allowed.paths: /etc/fluss/secrets
+
+# read from the file /etc/fluss/secrets/s3-secret-key
+datalake.paimon.s3.secret-key: ${directory:/etc/fluss/secrets:s3-secret-key}
+# read from an environment variable
+datalake.paimon.s3.access-key: ${env:PAIMON_S3_ACCESS_KEY}
+```
+
+This keeps the configuration file free of secret material, so it can be checked into version
+control or shipped as a plain Kubernetes ConfigMap while the secrets live in a mounted
+`Secret` volume or injected environment variables.
+
+## Markers
+
+A marker has the form `${provider:[path:]key}` and must be the **entire** configuration value;
+markers embedded inside larger values are not resolved. To use a literal value that starts with
+`${`, escape it by doubling the dollar sign: `$${literal}` becomes `${literal}`.
+
+Resolution happens once, when the configuration is loaded: on server startup, when a client
+connection is created via `ConnectionFactory`, and when the lake tiering service parses its
+arguments. Rotating a secret requires a restart of the affected process. Markers are rejected in
+dynamically altered cluster configuration. If a value looks like a marker but `config.providers`
+is not set, it is kept as a literal and a warning is logged.
+
+## Providers
+
+Providers are enabled explicitly with `config.providers`; a marker referencing a provider that is
+not declared fails the startup. Provider parameters are passed as
+`config.providers.<identifier>.param.<parameter>`.
+
+| Provider | Marker | Description |
+| --- | --- | --- |
+| `directory` | `${directory:/dir:file}` | Reads the content of `/dir/file` verbatim (UTF-8). Matches a Kubernetes `Secret` mounted as a volume, where each secret key becomes a file. |
+| `env` | `${env:VAR}` | Reads an environment variable, e.g. one injected via `secretKeyRef`. |
+| `file` | `${file:/path/creds.properties:key}` | Reads a single property from a Java properties file. |
+
+The filesystem-reading providers (`directory`, `file`) require the `allowed.paths` parameter — a
+comma-separated list of roots they may read from. A marker resolving to a file outside every root
+is rejected, so a stray marker cannot read arbitrary files. The `env` provider optionally accepts
+`allowlist.pattern`, a regular expression the variable name must match.
+
+Custom providers can be added by implementing
+`org.apache.fluss.config.provider.ConfigProvider` and registering the implementation for
+Java `ServiceLoader` discovery. The provider must be visible to the classloader that loads Fluss
+itself: place the jar on the server classpath (`lib/`), or bundle it with the Fluss connector for
+Flink jobs. Plugin directories are not scanned.
+
+## Kubernetes example
+
+```yaml
+# server.yaml shipped as a plain ConfigMap — contains no secrets
+config.providers: directory
+config.providers.directory.param.allowed.paths: /etc/fluss/secrets
+datalake.paimon.s3.secret-key: ${directory:/etc/fluss/secrets:s3-secret-key}
+```
+
+```yaml
+# pod spec: the secret is a normal Secret volume, never part of the ConfigMap
+volumes:
+  - name: fluss-secrets
+    secret:
+      secretName: fluss-paimon-creds
+containers:
+  - name: tablet-server
+    volumeMounts:
+      - name: fluss-secrets
+        mountPath: /etc/fluss/secrets
+        readOnly: true
+```
+
+Values resolved through a provider are treated as sensitive and are hidden when the configuration
+is logged, regardless of the key name.


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/3659
Today a secret in server.yaml (catalog OAuth creds, SASL passwords) can only be a literal and so the whole file becomes sensitive, and on K8s you end up rendering it through an init container just to inject one value.

This adds a Kafka-style ConfigProvider SPI: a value can be a marker that Fluss dereferences at load time, so the config file only ever holds pointers.
```
config.providers: directory
config.providers.directory.param.allowed.paths: /etc/fluss/secrets
datalake.paimon.s3.secret-key: ${directory:/etc/fluss/secrets:s3-secret-key}
```