### PR TITLE
[client] Retry KV snapshot lease operations after metadata refresh.

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/admin/FlussAdmin.java
@@ -484,7 +484,12 @@ public class FlussAdmin implements Admin {
 
     @Override
     public KvSnapshotLease createKvSnapshotLease(String leaseId, long leaseDurationMs) {
-        return new KvSnapshotLeaseImpl(leaseId, leaseDurationMs, gateway);
+        return new KvSnapshotLeaseImpl(
+                leaseId,
+                leaseDurationMs,
+                gateway,
+                metadataUpdater::refreshClusterUntilAvailable,
+                refreshExecutor);
     }
 
     @Override

--- a/fluss-client/src/main/java/org/apache/fluss/client/admin/KvSnapshotLeaseImpl.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/admin/KvSnapshotLeaseImpl.java
@@ -20,6 +20,7 @@ package org.apache.fluss.client.admin;
 import org.apache.fluss.client.metadata.AcquireKvSnapshotLeaseResult;
 import org.apache.fluss.client.utils.ClientRpcMessageUtils;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.rpc.RetryableGatewayClientProxy;
 import org.apache.fluss.rpc.gateway.AdminGateway;
 import org.apache.fluss.rpc.messages.AcquireKvSnapshotLeaseRequest;
 import org.apache.fluss.rpc.messages.DropKvSnapshotLeaseRequest;
@@ -27,6 +28,7 @@ import org.apache.fluss.rpc.messages.DropKvSnapshotLeaseRequest;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 import static org.apache.fluss.client.utils.ClientRpcMessageUtils.makeAcquireKvSnapshotLeaseRequest;
 import static org.apache.fluss.client.utils.ClientRpcMessageUtils.makeReleaseKvSnapshotLeaseRequest;
@@ -37,10 +39,17 @@ public class KvSnapshotLeaseImpl implements KvSnapshotLease {
     private final long leaseDurationMs;
     private final AdminGateway gateway;
 
-    public KvSnapshotLeaseImpl(String leaseId, long leaseDurationMs, AdminGateway gateway) {
+    public KvSnapshotLeaseImpl(
+            String leaseId,
+            long leaseDurationMs,
+            AdminGateway gateway,
+            Runnable metadataRefreshAction,
+            Executor refreshExecutor) {
         this.leaseId = leaseId;
         this.leaseDurationMs = leaseDurationMs;
-        this.gateway = gateway;
+        this.gateway =
+                RetryableGatewayClientProxy.createRetryableGatewayProxy(
+                        gateway, metadataRefreshAction, refreshExecutor, AdminGateway.class);
     }
 
     @Override

--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
@@ -1150,6 +1150,46 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
     }
 
     @Test
+    void testKvSnapshotLeaseAfterCoordinatorServerRestart() throws Exception {
+        long tableId = admin.getTableInfo(DEFAULT_TABLE_PATH).get().getTableId();
+        TableBucket tableBucket = new TableBucket(tableId, 0);
+        Map<TableBucket, Long> snapshots = Collections.singletonMap(tableBucket, 0L);
+        KvSnapshotLease lease = admin.createKvSnapshotLease("test-retry-kv-snapshot-lease", 60000L);
+        ZooKeeperClient zkClient = FLUSS_CLUSTER_EXTENSION.getZooKeeperClient();
+
+        // Restart the coordinator server so that the lease uses a stale cached address.
+        restartCoordinatorServer(zkClient);
+
+        lease.acquireSnapshots(snapshots).get();
+        assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isPresent();
+
+        // Verify that release also refreshes metadata and retries against the new coordinator.
+        restartCoordinatorServer(zkClient);
+
+        lease.releaseSnapshots(Collections.singleton(tableBucket)).get();
+        assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isNotPresent();
+
+        // Recreate the lease before verifying drop with another stale coordinator address.
+        lease.acquireSnapshots(snapshots).get();
+        assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isPresent();
+
+        restartCoordinatorServer(zkClient);
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
+
+        lease.dropLease().get();
+        assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isNotPresent();
+    }
+
+    private void restartCoordinatorServer(ZooKeeperClient zkClient) throws Exception {
+        FLUSS_CLUSTER_EXTENSION.stopCoordinatorServer();
+        waitUntil(
+                () -> !zkClient.getCoordinatorLeaderAddress().isPresent(),
+                Duration.ofMinutes(1),
+                "Coordinator server node still exists in ZooKeeper");
+        FLUSS_CLUSTER_EXTENSION.startCoordinatorServer();
+    }
+
+    @Test
     void testListPartitionInfosByPartitionSpec() throws Exception {
         String dbName = DEFAULT_TABLE_PATH.getDatabaseName();
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseHandler.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseHandler.java
@@ -136,6 +136,9 @@ public class KvSnapshotLeaseHandler {
         Long partitionId = tableBucket.getPartitionId();
         int bucketId = tableBucket.getBucket();
         KvSnapshotTableLease tableLease = tableIdToTableLease.get(tableId);
+        if (tableLease == null) {
+            return -1L;
+        }
         if (partitionId == null) {
             // For none-partitioned table.
             bucketIndex = tableLease.getBucketSnapshots();

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseManagerTest.java
@@ -226,6 +226,21 @@ public class KvSnapshotLeaseManagerTest {
         release("lease1", Collections.singletonList(newTableBucket));
         assertThat(kvSnapshotLeaseManager.getLeasedBucketCount()).isEqualTo(7);
 
+        TableBucket onlyBucketForTable = new TableBucket(DATA1_TABLE_ID_PK + 100, 0);
+        tableIdToRegisterBucket = new HashMap<>();
+        tableIdToRegisterBucket.put(
+                onlyBucketForTable.getTableId(),
+                Collections.singletonList(new TableBucketSnapshot(onlyBucketForTable, 0L)));
+        acquire("lease1", tableIdToRegisterBucket);
+        assertThat(kvSnapshotLeaseManager.getLeasedBucketCount()).isEqualTo(8);
+
+        // Releasing the same table bucket again should be idempotent even after the first release
+        // removed the entire table from the lease while other tables remain.
+        release("lease1", Collections.singletonList(onlyBucketForTable));
+        assertThat(kvSnapshotLeaseManager.getLeasedBucketCount()).isEqualTo(7);
+        release("lease1", Collections.singletonList(onlyBucketForTable));
+        assertThat(kvSnapshotLeaseManager.getLeasedBucketCount()).isEqualTo(7);
+
         // release a non-exist bucket.
         release(
                 "lease1",

--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
@@ -295,6 +295,7 @@ public final class FlussClusterExtension
 
     public void stopCoordinatorServer() throws Exception {
         coordinatorServer.close();
+        coordinatorServer = null;
     }
 
     private void startTabletServers() throws Exception {


### PR DESCRIPTION
Use a retryable gateway for KV snapshot lease acquire, release, and drop operations so stale coordinator metadata can be refreshed transparently.

Make repeated snapshot release safe when the lease still exists but the target table has already been removed. This keeps retries transparent to the enumerator during job recovery or transient network failures.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/fluss/issues/3652

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
