### PR TITLE
[tiering] Use exponential delay restart strategy for Flink tiering job

### DIFF
--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/FlinkTieringTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/FlinkTieringTestBase.java
@@ -103,7 +103,6 @@ class FlinkTieringTestBase {
         execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         execEnv.setRuntimeMode(RuntimeExecutionMode.STREAMING);
         execEnv.setParallelism(2);
-        execEnv.enableCheckpointing(500);
     }
 
     protected long createTable(TablePath tablePath, Schema schema) throws Exception {

--- a/fluss-flink/fluss-flink-tiering/pom.xml
+++ b/fluss-flink/fluss-flink-tiering/pom.xml
@@ -117,6 +117,11 @@
             <scope>test</scope>
         </dependency>
 
+        <!--
+         Required at test runtime because TieringSource loads FlinkConnectorOptionsUtils, which
+         references ValidationException from flink-table-common. fluss-flink-common declares this
+         dependency as provided, so it is not transitively available to this module's tests.
+        -->
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-common</artifactId>

--- a/fluss-flink/fluss-flink-tiering/pom.xml
+++ b/fluss-flink/fluss-flink-tiering/pom.xml
@@ -57,6 +57,72 @@
             <version>${flink.minor.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-flink-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-test-utils</artifactId>
+        </dependency>
+
+        <!-- for curator TestingServer -->
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${curator.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-base</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/fluss-flink/fluss-flink-tiering/src/main/java/org/apache/fluss/flink/tiering/FlussLakeTiering.java
+++ b/fluss-flink/fluss-flink-tiering/src/main/java/org/apache/fluss/flink/tiering/FlussLakeTiering.java
@@ -23,12 +23,14 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.flink.adapter.MultipleParameterToolAdapter;
 
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 import java.util.Map;
 import java.util.ServiceLoader;
 
+import static org.apache.flink.configuration.RestartStrategyOptions.RestartStrategyType.EXPONENTIAL_DELAY;
 import static org.apache.flink.runtime.executiongraph.failover.FailoverStrategyFactoryLoader.FULL_RESTART_STRATEGY_NAME;
 import static org.apache.fluss.flink.tiering.source.TieringSourceOptions.DATA_LAKE_CONFIG_PREFIX;
 import static org.apache.fluss.utils.PropertiesUtils.extractAndRemovePrefix;
@@ -96,6 +98,11 @@ public class FlussLakeTiering {
         org.apache.flink.configuration.Configuration flinkConfig =
                 new org.apache.flink.configuration.Configuration();
         flinkConfig.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, FULL_RESTART_STRATEGY_NAME);
+        // Configure restart strategy: the tiering job is completely stateless (offsets are
+        // persisted in Fluss Server's LakeSnapshot, not in Flink checkpoint state), so it is
+        // safe to restart indefinitely on failure. Without this, Flink defaults to "no-restart"
+        // when checkpoint is not enabled, causing the job to fail permanently on any exception.
+        flinkConfig.set(RestartStrategyOptions.RESTART_STRATEGY, EXPONENTIAL_DELAY.getMainValue());
 
         execEnv = StreamExecutionEnvironment.getExecutionEnvironment(flinkConfig);
     }

--- a/fluss-flink/fluss-flink-tiering/src/test/java/org/apache/fluss/flink/tiering/TieringFailoverITCase.java
+++ b/fluss-flink/fluss-flink-tiering/src/test/java/org/apache/fluss/flink/tiering/TieringFailoverITCase.java
@@ -18,16 +18,20 @@
 
 package org.apache.fluss.flink.tiering;
 
+import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.lake.values.TestingValuesLake;
+import org.apache.fluss.metadata.DataLakeFormat;
 import org.apache.fluss.metadata.Schema;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.types.DataTypes;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.core.execution.JobClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -59,6 +63,24 @@ class TieringFailoverITCase extends FlinkTieringTestBase {
         FlinkTieringTestBase.afterAll();
     }
 
+    @BeforeEach
+    @Override
+    void beforeEach() {
+        String bootstrapServers = String.join(",", clientConf.get(ConfigOptions.BOOTSTRAP_SERVERS));
+        String[] args = {
+            "--fluss.bootstrap.servers",
+            bootstrapServers,
+            "--datalake.format",
+            DataLakeFormat.PAIMON.toString()
+        };
+        FlussLakeTiering tiering = new FlussLakeTiering(args);
+        execEnv = tiering.execEnv;
+        execEnv.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        execEnv.setParallelism(2);
+
+        assertThat(execEnv.getCheckpointConfig().isCheckpointingEnabled()).isFalse();
+    }
+
     @Test
     void testTiering() throws Exception {
         // create a pk table, write some records and wait until snapshot finished
@@ -71,8 +93,8 @@ class TieringFailoverITCase extends FlinkTieringTestBase {
         writeRows(t1, rows, false);
         FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(t1);
 
-        // fail the first write to the pk table
-        TestingValuesLake.failWhen(t1.toString()).failWriteOnce();
+        // fail the first two writes to the pk table
+        TestingValuesLake.failWhen(t1.toString()).failWriteNext(2);
 
         // then start tiering job
         JobClient jobClient = buildTieringJob(execEnv);
@@ -96,7 +118,9 @@ class TieringFailoverITCase extends FlinkTieringTestBase {
 
             checkDataInValuesTable(t1, expectedRows);
         } finally {
-            jobClient.cancel().get();
+            if (!jobClient.getJobExecutionResult().isDone()) {
+                jobClient.cancel().get();
+            }
         }
     }
 


### PR DESCRIPTION
Configure the stateless tiering job to retry indefinitely when checkpointing is disabled, preventing transient failures from terminating the job permanently.

Move the failover integration test to fluss-flink-tiering so that it covers the production job configuration.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3681 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

`TieringFailoverITCase`
  - Verifies that checkpointing is disabled.
  - Injects two consecutive lake write failures.
  - Verifies that the job recovers and continues tiering data correctly.

### API and Format

<!-- Does this change affect API or storage format -->
No public API or storage format changes.

### Documentation

<!-- Does this change introduce a new feature -->
No documentation changes are required.
