### PR TITLE
[hotfix][test] Fix DynamicConfigManager constructor invocation

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/DynamicConfigChangeTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/DynamicConfigChangeTest.java
@@ -1148,7 +1148,7 @@ public class DynamicConfigChangeTest {
     void testRejectProviderMarkerInDynamicConfig() throws Exception {
         Configuration configuration = new Configuration();
         DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+                new DynamicConfigManager(zookeeperClient, configuration);
         dynamicConfigManager.startup();
 
         assertThatThrownBy(
@@ -1171,7 +1171,7 @@ public class DynamicConfigChangeTest {
         configuration.markSensitive("datalake.paimon.custom.value");
 
         DynamicConfigManager dynamicConfigManager =
-                new DynamicConfigManager(zookeeperClient, configuration, true);
+                new DynamicConfigManager(zookeeperClient, configuration);
         dynamicConfigManager.startup();
 
         ConfigEntry entry =


### PR DESCRIPTION
#3658 crossed with #3645, which removed the isCoordinator arg from DynamicConfigManager — two tests added in #3658 still call the old 3-arg constructor, breaking test compile on main.