### PR TITLE
[common][helm] helm support for config providers

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/provider/AllowedPaths.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/provider/AllowedPaths.java
@@ -91,7 +91,8 @@ final class AllowedPaths {
         try {
             return Paths.get(path.toFile().getCanonicalPath());
         } catch (IOException e) {
-            return path.toAbsolutePath().normalize();
+            throw new IllegalArgumentException(
+                    "Cannot canonicalize path '" + path + "' for the allowed-paths check.", e);
         }
     }
 }

--- a/fluss-common/src/main/java/org/apache/fluss/config/provider/ConfigProviders.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/provider/ConfigProviders.java
@@ -154,20 +154,31 @@ public final class ConfigProviders {
                     ServiceLoader.load(ConfigProvider.class, ConfigProvider.class.getClassLoader());
             for (Iterator<ConfigProvider> it = loader.iterator(); it.hasNext(); ) {
                 ConfigProvider provider = it.next();
-                if (requested.contains(provider.identifier())
-                        && !providers.containsKey(provider.identifier())) {
-                    try {
-                        provider.configure(paramsFor(config, provider.identifier()));
-                    } catch (Exception e) {
-                        throw new IllegalConfigurationException(
-                                "Invalid configuration for config provider '"
-                                        + provider.identifier()
-                                        + "': "
-                                        + e.getMessage(),
-                                e);
-                    }
-                    providers.put(provider.identifier(), provider);
+                if (!requested.contains(provider.identifier())) {
+                    continue;
                 }
+                ConfigProvider existing = providers.get(provider.identifier());
+                if (existing != null) {
+                    throw new IllegalConfigurationException(
+                            "Multiple config providers with identifier '"
+                                    + provider.identifier()
+                                    + "' found on the classpath: "
+                                    + existing.getClass().getName()
+                                    + ", "
+                                    + provider.getClass().getName()
+                                    + ".");
+                }
+                try {
+                    provider.configure(paramsFor(config, provider.identifier()));
+                } catch (Exception e) {
+                    throw new IllegalConfigurationException(
+                            "Invalid configuration for config provider '"
+                                    + provider.identifier()
+                                    + "': "
+                                    + e.getMessage(),
+                            e);
+                }
+                providers.put(provider.identifier(), provider);
             }
 
             for (String name : requested) {

--- a/fluss-common/src/test/java/org/apache/fluss/config/provider/ConfigProvidersTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/config/provider/ConfigProvidersTest.java
@@ -164,6 +164,49 @@ class ConfigProvidersTest {
     }
 
     @Test
+    void testEscapeNotAppliedWithoutProviders() {
+        Configuration config = new Configuration();
+        config.setString("literal", "$${env:PATH}");
+        ConfigProviders.resolve(config);
+        assertThat(config.toMap().get("literal")).isEqualTo("$${env:PATH}");
+    }
+
+    @Test
+    void testDuplicateProviderIdentifierFailsFast() {
+        Configuration config = new Configuration();
+        config.setString(ConfigOptions.CONFIG_PROVIDERS.key(), "dup");
+        assertThatThrownBy(() -> ConfigProviders.resolve(config))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("Multiple config providers with identifier 'dup'");
+    }
+
+    /** Registered in the test services file, clashing with {@link DuplicateProviderB}. */
+    public static class DuplicateProviderA implements ConfigProvider {
+        @Override
+        public String identifier() {
+            return "dup";
+        }
+
+        @Override
+        public String resolve(String path, String key) {
+            return key;
+        }
+    }
+
+    /** Registered in the test services file, clashing with {@link DuplicateProviderA}. */
+    public static class DuplicateProviderB implements ConfigProvider {
+        @Override
+        public String identifier() {
+            return "dup";
+        }
+
+        @Override
+        public String resolve(String path, String key) {
+            return key;
+        }
+    }
+
+    @Test
     void testResolvedValuesAreHiddenInToString(@TempDir Path secretsDir) throws Exception {
         Files.write(secretsDir.resolve("cred"), "raw-secret".getBytes(StandardCharsets.UTF_8));
 

--- a/fluss-common/src/test/resources/META-INF/services/org.apache.fluss.config.provider.ConfigProvider
+++ b/fluss-common/src/test/resources/META-INF/services/org.apache.fluss.config.provider.ConfigProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.apache.fluss.config.provider.ConfigProvidersTest$DuplicateProviderA
+org.apache.fluss.config.provider.ConfigProvidersTest$DuplicateProviderB

--- a/helm/templates/_secrets.tpl
+++ b/helm/templates/_secrets.tpl
@@ -1,0 +1,133 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Whether any secret mounts or env entries are configured.
+Usage:
+  include "fluss.secrets.enabled" .
+*/}}
+{{- define "fluss.secrets.enabled" -}}
+{{- if or .Values.secrets.mounts .Values.secrets.env -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Base directory under which each secret mount gets its own subdirectory.
+*/}}
+{{- define "fluss.secrets.basePath" -}}
+/etc/fluss/secrets
+{{- end -}}
+
+{{/*
+Pod volumes for the configured secret mounts.
+Usage:
+  include "fluss.secrets.volumes" .
+*/}}
+{{- define "fluss.secrets.volumes" -}}
+{{- range .Values.secrets.mounts }}
+- name: secret-{{ .name }}
+  secret:
+    secretName: {{ .secretName }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Read-only container volumeMounts, one subdirectory per secret mount.
+Usage:
+  include "fluss.secrets.volumeMounts" .
+*/}}
+{{- define "fluss.secrets.volumeMounts" -}}
+{{- range .Values.secrets.mounts }}
+- name: secret-{{ .name }}
+  mountPath: {{ include "fluss.secrets.basePath" $ }}/{{ .name }}
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{/*
+secretKeyRef env entries for the configured secret env vars.
+Usage:
+  include "fluss.secrets.env" .
+*/}}
+{{- define "fluss.secrets.env" -}}
+{{- range .Values.secrets.env }}
+- name: {{ .name }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .secretName }}
+      key: {{ .key }}
+{{- end }}
+{{- end -}}
+
+{{/*
+server.yaml lines enabling the config providers for the configured secrets,
+restricted to the mounted subdirectories and declared env names.
+Usage:
+  include "fluss.secrets.configLines" .
+*/}}
+{{- define "fluss.secrets.configLines" -}}
+{{- $providers := list -}}
+{{- if .Values.secrets.mounts -}}
+{{- $providers = append $providers "directory" -}}
+{{- end -}}
+{{- if .Values.secrets.env -}}
+{{- $providers = append $providers "env" -}}
+{{- end -}}
+config.providers: {{ join "," $providers }}
+{{- if .Values.secrets.mounts }}
+{{- $paths := list }}
+{{- range .Values.secrets.mounts }}
+{{- $paths = append $paths (printf "%s/%s" (include "fluss.secrets.basePath" $) .name) }}
+{{- end }}
+config.providers.directory.param.allowed.paths: {{ join "," $paths }}
+{{- end }}
+{{- if .Values.secrets.env }}
+{{- $names := list }}
+{{- range .Values.secrets.env }}
+{{- $names = append $names .name }}
+{{- end }}
+config.providers.env.param.allowlist.pattern: {{ join "|" $names }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Collects secrets error messages.
+Usage:
+  include "fluss.secrets.validateError" .
+*/}}
+{{- define "fluss.secrets.validateError" -}}
+{{- $errMessages := list -}}
+{{- $names := list -}}
+{{- range .Values.secrets.mounts -}}
+{{- if or (not .name) (not .secretName) -}}
+{{- $errMessages = append $errMessages "secrets.mounts entries require both 'name' and 'secretName'." -}}
+{{- else if has .name $names -}}
+{{- $errMessages = append $errMessages (printf "secrets.mounts contains duplicate name '%s'." .name) -}}
+{{- else -}}
+{{- $names = append $names .name -}}
+{{- end -}}
+{{- end -}}
+{{- range .Values.secrets.env -}}
+{{- if or (not .name) (not .secretName) (not .key) -}}
+{{- $errMessages = append $errMessages "secrets.env entries require 'name', 'secretName' and 'key'." -}}
+{{- end -}}
+{{- end -}}
+{{- $errMessages = without $errMessages "" -}}
+{{- join "\n" $errMessages -}}
+{{- end -}}

--- a/helm/templates/_secrets.tpl
+++ b/helm/templates/_secrets.tpl
@@ -31,7 +31,7 @@ true
 Base directory under which each secret mount gets its own subdirectory.
 */}}
 {{- define "fluss.secrets.basePath" -}}
-/etc/fluss/secrets
+{{- .Values.secrets.basePath | default "/etc/fluss/secrets" | trimSuffix "/" -}}
 {{- end -}}
 
 {{/*
@@ -113,6 +113,9 @@ Usage:
 */}}
 {{- define "fluss.secrets.validateError" -}}
 {{- $errMessages := list -}}
+{{- if and .Values.secrets.mounts (not (hasPrefix "/" (include "fluss.secrets.basePath" .))) -}}
+{{- $errMessages = append $errMessages "secrets.basePath must be an absolute path." -}}
+{{- end -}}
 {{- $names := list -}}
 {{- range .Values.secrets.mounts -}}
 {{- if or (not .name) (not .secretName) -}}

--- a/helm/templates/_validate.tpl
+++ b/helm/templates/_validate.tpl
@@ -40,6 +40,7 @@ Usage:
 
 {{- $messages = append $messages (include "fluss.security.validateError" .) -}}
 {{- $messages = append $messages (include "fluss.metrics.validateError" .) -}}
+{{- $messages = append $messages (include "fluss.secrets.validateError" .) -}}
 
 {{- $messages = without $messages "" -}}
 {{- join "\n" $messages -}}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -59,3 +59,9 @@ data:
     {{- if (include "fluss.security.zookeeper.sasl.enabled" .) }}
     zookeeper.client.config-path: /etc/fluss/conf/zookeeper-client.properties
     {{- end }}
+
+    {{- if include "fluss.secrets.enabled" . }}
+    ### Secrets
+
+    {{- include "fluss.secrets.configLines" . | nindent 4 }}
+    {{- end }}

--- a/helm/templates/sts-coordinator.yaml
+++ b/helm/templates/sts-coordinator.yaml
@@ -98,6 +98,9 @@ spec:
             - name: FLUSS_ENV_JAVA_OPTS
               value: "-Djava.security.auth.login.config=/etc/fluss/conf/jaas.conf"
             {{- end }}
+            {{- if (include "fluss.secrets.enabled" .) }}
+            {{- include "fluss.secrets.env" . | trim | nindent 12 }}
+            {{- end }}
             {{- with .Values.coordinator.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -151,6 +154,9 @@ spec:
               mountPath: /etc/fluss/conf
               readOnly: true
             {{- end }}
+            {{- if (include "fluss.secrets.enabled" .) }}
+            {{- include "fluss.secrets.volumeMounts" . | trim | nindent 12 }}
+            {{- end }}
             {{- with .Values.coordinator.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -164,6 +170,9 @@ spec:
         {{- end }}
         {{- if (include "fluss.security.jaas.required" .) }}
         {{- include "fluss.security.jaas.volumes" . | nindent 8 }}
+        {{- end }}
+        {{- if (include "fluss.secrets.enabled" .) }}
+        {{- include "fluss.secrets.volumes" . | trim | nindent 8 }}
         {{- end }}
         {{- with .Values.coordinator.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/sts-tablet.yaml
+++ b/helm/templates/sts-tablet.yaml
@@ -94,6 +94,9 @@ spec:
             - name: FLUSS_ENV_JAVA_OPTS
               value: "-Djava.security.auth.login.config=/etc/fluss/conf/jaas.conf"
             {{- end }}
+            {{- if (include "fluss.secrets.enabled" .) }}
+            {{- include "fluss.secrets.env" . | trim | nindent 12 }}
+            {{- end }}
             {{- with .Values.tablet.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -164,6 +167,9 @@ spec:
               mountPath: /etc/fluss/conf
               readOnly: true
             {{- end }}
+            {{- if (include "fluss.secrets.enabled" .) }}
+            {{- include "fluss.secrets.volumeMounts" . | trim | nindent 12 }}
+            {{- end }}
             {{- with .Values.tablet.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -177,6 +183,9 @@ spec:
         {{- end }}
         {{- if (include "fluss.security.jaas.required" .) }}
         {{- include "fluss.security.jaas.volumes" . | nindent 8 }}
+        {{- end }}
+        {{- if (include "fluss.secrets.enabled" .) }}
+        {{- include "fluss.secrets.volumes" . | trim | nindent 8 }}
         {{- end }}
         {{- with .Values.tablet.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/helm/tests/secrets_test.yaml
+++ b/helm/tests/secrets_test.yaml
@@ -112,6 +112,25 @@ tests:
                 key: access-key
         template: templates/sts-tablet.yaml
 
+  - it: honors a custom basePath for mounts and allowed.paths
+    set:
+      secrets.basePath: /mnt/creds/
+      secrets.mounts:
+        - name: paimon-creds
+          secretName: fluss-paimon-creds
+    asserts:
+      - matchRegex:
+          path: data["server.yaml"]
+          pattern: 'config\.providers\.directory\.param\.allowed\.paths: /mnt/creds/paimon-creds'
+        template: templates/configmap.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secret-paimon-creds
+            mountPath: /mnt/creds/paimon-creds
+            readOnly: true
+        template: templates/sts-coordinator.yaml
+
   - it: enables both providers when mounts and env are combined
     set:
       secrets.mounts:

--- a/helm/tests/secrets_test.yaml
+++ b/helm/tests/secrets_test.yaml
@@ -1,0 +1,128 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: secrets
+templates:
+  - templates/configmap.yaml
+  - templates/sts-coordinator.yaml
+  - templates/sts-tablet.yaml
+tests:
+  - it: renders nothing secrets-related by default
+    asserts:
+      - notMatchRegex:
+          path: data["server.yaml"]
+          pattern: 'config\.providers'
+        template: templates/configmap.yaml
+
+  - it: mounts secrets and enables the directory provider with matching allowed.paths
+    set:
+      secrets.mounts:
+        - name: paimon-creds
+          secretName: fluss-paimon-creds
+      configurationOverrides:
+        datalake.paimon.s3.secret-key: ${directory:/etc/fluss/secrets/paimon-creds:secret-key}
+    asserts:
+      - matchRegex:
+          path: data["server.yaml"]
+          pattern: 'config\.providers: directory'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: data["server.yaml"]
+          pattern: 'config\.providers\.directory\.param\.allowed\.paths: /etc/fluss/secrets/paimon-creds'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: data["server.yaml"]
+          pattern: 'datalake\.paimon\.s3\.secret-key: \$\{directory:/etc/fluss/secrets/paimon-creds:secret-key\}'
+        template: templates/configmap.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secret-paimon-creds
+            secret:
+              secretName: fluss-paimon-creds
+        template: templates/sts-coordinator.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secret-paimon-creds
+            mountPath: /etc/fluss/secrets/paimon-creds
+            readOnly: true
+        template: templates/sts-coordinator.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secret-paimon-creds
+            secret:
+              secretName: fluss-paimon-creds
+        template: templates/sts-tablet.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secret-paimon-creds
+            mountPath: /etc/fluss/secrets/paimon-creds
+            readOnly: true
+        template: templates/sts-tablet.yaml
+
+  - it: injects secretKeyRef env vars and enables the env provider with an allowlist
+    set:
+      secrets.env:
+        - name: PAIMON_S3_ACCESS_KEY
+          secretName: fluss-paimon-creds
+          key: access-key
+    asserts:
+      - matchRegex:
+          path: data["server.yaml"]
+          pattern: 'config\.providers: env'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: data["server.yaml"]
+          pattern: 'config\.providers\.env\.param\.allowlist\.pattern: PAIMON_S3_ACCESS_KEY'
+        template: templates/configmap.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PAIMON_S3_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fluss-paimon-creds
+                key: access-key
+        template: templates/sts-coordinator.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PAIMON_S3_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fluss-paimon-creds
+                key: access-key
+        template: templates/sts-tablet.yaml
+
+  - it: enables both providers when mounts and env are combined
+    set:
+      secrets.mounts:
+        - name: creds
+          secretName: my-secret
+      secrets.env:
+        - name: MY_TOKEN
+          secretName: my-secret
+          key: token
+    asserts:
+      - matchRegex:
+          path: data["server.yaml"]
+          pattern: 'config\.providers: directory,env'
+        template: templates/configmap.yaml

--- a/helm/tests/secrets_validate_test.yaml
+++ b/helm/tests/secrets_validate_test.yaml
@@ -39,6 +39,16 @@ tests:
       - failedTemplate:
           errorMessage: "VALUES VALIDATION:\nsecrets.mounts contains duplicate name 'creds'."
 
+  - it: fails on a relative basePath
+    set:
+      secrets.basePath: relative/path
+      secrets.mounts:
+        - name: creds
+          secretName: my-secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "VALUES VALIDATION:\nsecrets.basePath must be an absolute path."
+
   - it: fails when an env entry is missing key
     set:
       secrets.env:

--- a/helm/tests/secrets_validate_test.yaml
+++ b/helm/tests/secrets_validate_test.yaml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: secrets-validation
+templates:
+  - templates/NOTES.txt
+tests:
+  - it: fails when a mount entry is missing secretName
+    set:
+      secrets.mounts:
+        - name: creds
+    asserts:
+      - failedTemplate:
+          errorMessage: "VALUES VALIDATION:\nsecrets.mounts entries require both 'name' and 'secretName'."
+
+  - it: fails on duplicate mount names
+    set:
+      secrets.mounts:
+        - name: creds
+          secretName: a
+        - name: creds
+          secretName: b
+    asserts:
+      - failedTemplate:
+          errorMessage: "VALUES VALIDATION:\nsecrets.mounts contains duplicate name 'creds'."
+
+  - it: fails when an env entry is missing key
+    set:
+      secrets.env:
+        - name: MY_TOKEN
+          secretName: my-secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "VALUES VALIDATION:\nsecrets.env entries require 'name', 'secretName' and 'key'."

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -147,9 +147,10 @@ listeners:
     port: 9124
 
 # Secrets referenced from configurationOverrides via config provider markers:
-# mounts are read with ${directory:/etc/fluss/secrets/<name>:<key>}, env entries
-# with ${env:<NAME>}. The chart generates the matching config.providers lines.
+# mounts are read with ${directory:<basePath>/<name>:<key>}, env entries with
+# ${env:<NAME>}. The chart generates the matching config.providers lines.
 secrets:
+  basePath: /etc/fluss/secrets
   # - name: paimon-creds
   #   secretName: fluss-paimon-creds
   mounts: []

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -146,6 +146,18 @@ listeners:
   client:
     port: 9124
 
+# Secrets referenced from configurationOverrides via config provider markers:
+# mounts are read with ${directory:/etc/fluss/secrets/<name>:<key>}, env entries
+# with ${env:<NAME>}. The chart generates the matching config.providers lines.
+secrets:
+  # - name: paimon-creds
+  #   secretName: fluss-paimon-creds
+  mounts: []
+  # - name: PAIMON_S3_ACCESS_KEY
+  #   secretName: fluss-paimon-creds
+  #   key: access-key
+  env: []
+
 # Fluss security configurations
 security:
   client:

--- a/website/docs/install-deploy/deploying-with-helm.md
+++ b/website/docs/install-deploy/deploying-with-helm.md
@@ -383,6 +383,45 @@ The same pattern works with Sealed Secrets, HashiCorp Vault Agent Injector (prod
 | `configurationOverrides.data.dir` | Local data directory | `/tmp/fluss/data` |
 | `configurationOverrides.internal.listener.name` | Internal listener name | `INTERNAL` |
 
+### Secrets in Configuration Overrides
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `secrets.mounts` | Secrets mounted as files under `/etc/fluss/secrets/<name>`, entries of `{name, secretName}` | `[]` |
+| `secrets.env` | Secret values injected as env vars via `secretKeyRef`, entries of `{name, secretName, key}` | `[]` |
+
+Any `configurationOverrides` value can reference a secret through a
+[config provider marker](../security/secrets.md) instead of a literal, so the rendered
+`server.yaml` ConfigMap never contains secret material. The chart generates the matching
+`config.providers` settings, restricted to the declared mounts and env names.
+
+```bash
+kubectl create secret generic fluss-paimon-creds \
+  --from-literal=access-key=... --from-literal=secret-key=...
+```
+
+```yaml
+secrets:
+  mounts:
+    - name: paimon-creds
+      secretName: fluss-paimon-creds
+
+configurationOverrides:
+  datalake.paimon.s3.access-key: ${directory:/etc/fluss/secrets/paimon-creds:access-key}
+  datalake.paimon.s3.secret-key: ${directory:/etc/fluss/secrets/paimon-creds:secret-key}
+```
+
+To rotate a secret, update the Kubernetes Secret and restart the pods
+(`kubectl rollout restart statefulset -l app.kubernetes.io/name=fluss`); markers are resolved at
+server startup.
+
+This works with any Secret producer — for example, an
+[External Secrets Operator](https://external-secrets.io/) `ExternalSecret` syncing from AWS
+Secrets Manager or Vault into the referenced Secret. To restart pods automatically when the
+Secret changes, a controller such as [Reloader](https://github.com/stakater/Reloader) can watch
+it (annotate the StatefulSets with `secret.reloader.stakater.com/reload: "<secret-name>"`),
+making rotation fully hands-off.
+
 ### Tablet Server Parameters
 
 | Parameter | Description | Default |

--- a/website/docs/install-deploy/deploying-with-helm.md
+++ b/website/docs/install-deploy/deploying-with-helm.md
@@ -387,7 +387,8 @@ The same pattern works with Sealed Secrets, HashiCorp Vault Agent Injector (prod
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `secrets.mounts` | Secrets mounted as files under `/etc/fluss/secrets/<name>`, entries of `{name, secretName}` | `[]` |
+| `secrets.basePath` | Base directory for secret mounts | `/etc/fluss/secrets` |
+| `secrets.mounts` | Secrets mounted as files under `<basePath>/<name>`, entries of `{name, secretName}` | `[]` |
 | `secrets.env` | Secret values injected as env vars via `secretKeyRef`, entries of `{name, secretName, key}` | `[]` |
 
 Any `configurationOverrides` value can reference a secret through a
@@ -409,6 +410,19 @@ secrets:
 configurationOverrides:
   datalake.paimon.s3.access-key: ${directory:/etc/fluss/secrets/paimon-creds:access-key}
   datalake.paimon.s3.secret-key: ${directory:/etc/fluss/secrets/paimon-creds:secret-key}
+```
+
+Alternatively, a value can be injected as an environment variable:
+
+```yaml
+secrets:
+  env:
+    - name: PAIMON_S3_ACCESS_KEY
+      secretName: fluss-paimon-creds
+      key: access-key
+
+configurationOverrides:
+  datalake.paimon.s3.access-key: ${env:PAIMON_S3_ACCESS_KEY}
 ```
 
 To rotate a secret, update the Kubernetes Secret and restart the pods

--- a/website/docs/security/secrets.md
+++ b/website/docs/security/secrets.md
@@ -46,7 +46,8 @@ control or shipped as a plain Kubernetes ConfigMap while the secrets live in a m
 
 A marker has the form `${provider:[path:]key}` and must be the **entire** configuration value;
 markers embedded inside larger values are not resolved. To use a literal value that starts with
-`${`, escape it by doubling the dollar sign: `$${literal}` becomes `${literal}`.
+`${`, escape it by doubling the dollar sign: `$${literal}` becomes `${literal}`. The escape, like
+marker resolution, only applies when `config.providers` is set.
 
 Resolution happens once, when the configuration is loaded: on server startup, when a client
 connection is created via `ConnectionFactory`, and when the lake tiering service parses its
@@ -78,6 +79,10 @@ itself: place the jar on the server classpath (`lib/`), or bundle it with the Fl
 Flink jobs. Plugin directories are not scanned.
 
 ## Kubernetes example
+
+When deploying with the Helm chart, the `secrets.mounts` / `secrets.env` values generate all of
+the below — see
+[Deploying with Helm](../install-deploy/deploying-with-helm.md#secrets-in-configuration-overrides).
 
 ```yaml
 # server.yaml shipped as a plain ConfigMap — contains no secrets


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/3686

On the helm side, secrets become declarative:
```
 secrets:
   mounts:
     - name: paimon-creds
       secretName: fluss-paimon-creds

 configurationOverrides:
   datalake.paimon.s3.secret-key: ${directory:/etc/fluss/secrets/paimon-creds:secret-key}
```

The chart generates the config.providers config with allowed.paths/env allowlist derived from the declared entries, so the rendered server.yaml stays a plain ConfigMap with no secret material. 

Plus some follow-ups from the #3658 review threads:
- allowed.paths canonicalization now fails closed
- duplicate provider identifiers on the classpath fail fast
- test + docs pinning the gated $${ escape semantics