### PR TITLE
[helm] Support statefulset and service annotations

### DIFF
--- a/helm/templates/sts-coordinator.yaml
+++ b/helm/templates/sts-coordinator.yaml
@@ -22,6 +22,10 @@ metadata:
   name: coordinator-server
   labels:
   {{- include "fluss.labels" . | nindent 4 }}
+  {{- with .Values.coordinator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: coordinator-server-hs
   replicas: {{ .Values.coordinator.numberOfReplicas }}

--- a/helm/templates/sts-tablet.yaml
+++ b/helm/templates/sts-tablet.yaml
@@ -22,6 +22,10 @@ metadata:
   name: tablet-server
   labels:
   {{- include "fluss.labels" . | nindent 4 }}
+  {{- with .Values.tablet.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: tablet-server-hs
   replicas: {{ .Values.tablet.numberOfReplicas }}

--- a/helm/templates/svc-coordinator.yaml
+++ b/helm/templates/svc-coordinator.yaml
@@ -23,6 +23,10 @@ metadata:
   labels:
     {{- include "fluss.labels" . | nindent 4 }}
     app.kubernetes.io/component: coordinator
+  {{- with .Values.coordinator.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   type: ClusterIP

--- a/helm/templates/svc-tablet.yaml
+++ b/helm/templates/svc-tablet.yaml
@@ -23,6 +23,10 @@ metadata:
   labels:
     {{- include "fluss.labels" . | nindent 4 }}
     app.kubernetes.io/component: tablet
+  {{- with .Values.tablet.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   type: ClusterIP

--- a/helm/tests/annotations_test.yaml
+++ b/helm/tests/annotations_test.yaml
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: workload-and-service-annotations
+templates:
+  - templates/sts-coordinator.yaml
+  - templates/sts-tablet.yaml
+  - templates/svc-coordinator.yaml
+  - templates/svc-tablet.yaml
+tests:
+  - it: renders no annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: renders statefulset metadata annotations
+    set:
+      coordinator.annotations:
+        secret.reloader.stakater.com/reload: fluss-paimon-creds
+      tablet.annotations:
+        secret.reloader.stakater.com/reload: fluss-paimon-creds
+    asserts:
+      - equal:
+          path: metadata.annotations["secret.reloader.stakater.com/reload"]
+          value: fluss-paimon-creds
+        template: templates/sts-coordinator.yaml
+      - equal:
+          path: metadata.annotations["secret.reloader.stakater.com/reload"]
+          value: fluss-paimon-creds
+        template: templates/sts-tablet.yaml
+
+  - it: renders service annotations
+    set:
+      coordinator.service.annotations:
+        example.com/key: coordinator-value
+      tablet.service.annotations:
+        example.com/key: tablet-value
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/key"]
+          value: coordinator-value
+        template: templates/svc-coordinator.yaml
+      - equal:
+          path: metadata.annotations["example.com/key"]
+          value: tablet-value
+        template: templates/svc-tablet.yaml

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,6 +85,9 @@ tablet:
   initContainers: []
   extraEnv: []
   envFrom: []
+  annotations: {}
+  service:
+    annotations: {}
   podAnnotations: {}
   podLabels: {}
   podDisruptionBudget:
@@ -128,6 +131,9 @@ coordinator:
   initContainers: []
   extraEnv: []
   envFrom: []
+  annotations: {}
+  service:
+    annotations: {}
   podAnnotations: {}
   podLabels: {}
   podDisruptionBudget:


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/3688

The metrics services already accept annotations, but the statefulsets and the main headless services don't. This adds coordinator.annotations / tablet.annotations for the statefulset metadata, and coordinator.service.annotations / tablet.service.annotations for the services, following the existing podAnnotations style.

Workload-level annotations are where tooling like Reloader (secret.reloader.stakater.com/reload) or Argo CD sync-waves hook in, without them you're stuck patching the chart output out-of-band.

Pure passthrough, no change to rendered output unless the values are set.