### PR TITLE
[tiering] Reduce LakeSnapshot log verbosity in TieringSplitGenerator

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/split/TieringSplitGenerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/split/TieringSplitGenerator.java
@@ -65,7 +65,11 @@ public class TieringSplitGenerator {
         LakeSnapshot lakeSnapshotInfo;
         try {
             lakeSnapshotInfo = flussAdmin.getLatestLakeSnapshot(tableInfo.getTablePath()).get();
-            LOG.info("Last committed lake table snapshot info is:{}", lakeSnapshotInfo);
+            LOG.info(
+                    "Last committed lake table snapshot: snapshotId={}, numBucketOffsets={}",
+                    lakeSnapshotInfo.getSnapshotId(),
+                    lakeSnapshotInfo.getTableBucketsOffset().size());
+            LOG.debug("Last committed lake table snapshot detail: {}", lakeSnapshotInfo);
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
             if (t instanceof LakeTableSnapshotNotExistException) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
TieringSplitGenerator logs the full LakeSnapshot object at INFO level every time it generates splits (every tiering.poll.table.interval, default 30s). For partitioned tables with many buckets , a single log line becomes extremely long and floods out other logs needed for troubleshooting.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
- INFO level now logs only summary metadata: snapshotId + numBucketOffsets
- Full LakeSnapshot content moved to DEBUG level, available on demand during troubleshooting

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
No impact — logging-only change.

### Documentation

<!-- Does this change introduce a new feature -->
No documentation update needed.
