### PR TITLE
[test] Wait for server tag cleanup

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -924,7 +924,7 @@ public class FlussAuthorizationITCase {
         guestAdmin.addServerTag(Collections.singletonList(0), ServerTag.PERMANENT_OFFLINE).get();
 
         // recover server tag
-        guestAdmin.removeServerTag(Collections.singletonList(0), ServerTag.PERMANENT_OFFLINE);
+        guestAdmin.removeServerTag(Collections.singletonList(0), ServerTag.PERMANENT_OFFLINE).get();
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Linked issue: close #3704

`FlussAuthorizationITCase.testAddServerTag` returned before its asynchronous server-tag cleanup completed. A subsequent test could therefore observe only two available tablet servers and fail while creating a replication-factor-3 table.

### Brief change log

- Wait for `removeServerTag(...)` to complete before `testAddServerTag` returns.
- Ensure `PERMANENT_OFFLINE` state cannot leak into subsequent test setup.

### Tests

- `./mvnw -pl fluss-client -am -Dtest=FlussAuthorizationITCase#testAddServerTag+testListDatabases -Dsurefire.failIfNoSpecifiedTests=false test`

### API and Format

No API or storage-format changes.

### Documentation

No documentation changes; this only fixes test cleanup synchronization.

### Generative AI disclosure

- [x] Yes

Generated-by: OpenAI Codex following the guidelines (https://github.com/apache/fluss/blob/main/AGENTS.md)
