### PR TITLE
[rust][client] Support comma-separated bootstrap servers

### DIFF
--- a/fluss-rust/crates/fluss/src/client/metadata.rs
+++ b/fluss-rust/crates/fluss/src/client/metadata.rs
@@ -22,7 +22,7 @@ use crate::metadata::{PhysicalTablePath, TableBucket, TablePath};
 use crate::proto::MetadataResponse;
 use crate::rpc::message::UpdateMetadataRequest;
 use crate::rpc::{RpcClient, ServerConnection};
-use log::info;
+use log::{info, warn};
 use parking_lot::RwLock;
 use std::collections::HashSet;
 use std::net::{SocketAddr, ToSocketAddrs};
@@ -94,11 +94,7 @@ impl Metadata {
         for bootstrap in bootstrap_servers.split(',') {
             let bootstrap = bootstrap.trim();
             if bootstrap.is_empty() {
-                return Err(Error::IllegalArgument {
-                    message: format!(
-                        "Invalid bootstrap servers '{bootstrap_servers}': empty bootstrap server"
-                    ),
-                });
+                continue;
             }
             bootstraps.push(BootstrapServer {
                 raw: bootstrap.to_string(),
@@ -117,13 +113,20 @@ impl Metadata {
 
     async fn init_cluster(bootstrap_servers: &str, connections: Arc<RpcClient>) -> Result<Cluster> {
         let bootstraps = Self::parse_bootstrap_servers(bootstrap_servers)?;
+        let bootstrap_count = bootstraps.len();
         let mut errors = Vec::new();
         let mut last_connection_error = None;
 
-        for bootstrap in bootstraps {
+        for (index, bootstrap) in bootstraps.into_iter().enumerate() {
             let socket_address = match bootstrap.address {
                 Ok(socket_address) => socket_address,
                 Err(err) => {
+                    if index + 1 < bootstrap_count {
+                        warn!(
+                            "Failed to resolve bootstrap server '{}', trying the next server: {err}",
+                            bootstrap.raw
+                        );
+                    }
                     errors.push(format!("{}: {err}", bootstrap.raw));
                     continue;
                 }
@@ -138,7 +141,13 @@ impl Metadata {
             match Self::fetch_cluster_from_bootstrap(&server_node, connections.clone()).await {
                 Ok(cluster) => return Ok(cluster),
                 Err(err) => {
-                    errors.push(format!("{socket_address}: {err}"));
+                    if index + 1 < bootstrap_count {
+                        warn!(
+                            "Failed to initialize cluster from bootstrap server '{}', trying the next server: {err}",
+                            bootstrap.raw
+                        );
+                    }
+                    errors.push(format!("{}: {err}", bootstrap.raw));
                     last_connection_error = Some(err);
                 }
             }
@@ -157,6 +166,10 @@ impl Metadata {
         last_connection_error: Option<Error>,
     ) -> Error {
         if let Some(error) = last_connection_error {
+            warn!(
+                "Unable to initialize cluster from bootstrap servers '{bootstrap_servers}': {}",
+                errors.join("; ")
+            );
             return error;
         }
 
@@ -508,13 +521,17 @@ mod tests {
     }
 
     #[test]
-    fn parse_bootstrap_rejects_empty_comma_separated_entries() {
-        let err = Metadata::parse_bootstrap_servers("127.0.0.1:8080, , localhost:9090")
-            .expect_err("empty bootstrap entries should be rejected");
+    fn parse_bootstrap_ignores_empty_comma_separated_entries() {
+        let bootstraps =
+            Metadata::parse_bootstrap_servers("127.0.0.1:8080, , localhost:9090,").unwrap();
 
-        assert!(
-            err.to_string().contains("empty bootstrap server"),
-            "unexpected error: {err}"
-        );
+        assert_eq!(bootstraps.len(), 2);
+        assert_eq!(bootstraps[0].raw, "127.0.0.1:8080");
+        assert_eq!(bootstraps[1].raw, "localhost:9090");
+    }
+
+    #[test]
+    fn parse_bootstrap_rejects_config_without_servers() {
+        assert!(Metadata::parse_bootstrap_servers(" , ").is_err());
     }
 }

--- a/fluss-rust/crates/fluss/src/client/metadata.rs
+++ b/fluss-rust/crates/fluss/src/client/metadata.rs
@@ -36,6 +36,12 @@ pub struct Metadata {
     cluster_version_tx: watch::Sender<u64>,
 }
 
+#[derive(Debug)]
+struct BootstrapServer {
+    raw: String,
+    address: Result<SocketAddr>,
+}
+
 impl Metadata {
     pub async fn new(bootstrap: &str, connections: Arc<RpcClient>) -> Result<Self> {
         let cluster = Self::init_cluster(bootstrap, connections.clone()).await?;
@@ -57,12 +63,12 @@ impl Metadata {
             .send_modify(|v| *v = v.wrapping_add(1));
     }
 
-    fn parse_bootstrap(boot_strap: &str) -> Result<SocketAddr> {
+    fn parse_bootstrap(bootstrap: &str) -> Result<SocketAddr> {
         // Resolve all socket addresses and deterministically choose one.
-        let addrs = boot_strap
+        let addrs = bootstrap
             .to_socket_addrs()
             .map_err(|e| Error::IllegalArgument {
-                message: format!("Invalid bootstrap address '{boot_strap}': {e}"),
+                message: format!("Invalid bootstrap address '{bootstrap}': {e}"),
             })?;
 
         // Prefer IPv4 addresses; if none are available, fall back to the first IPv6.
@@ -77,20 +83,95 @@ impl Metadata {
         }
 
         let addr = ipv6_candidate.ok_or_else(|| Error::IllegalArgument {
-            message: format!("Unable to resolve bootstrap address '{boot_strap}'"),
+            message: format!("Unable to resolve bootstrap address '{bootstrap}'"),
         })?;
         Ok(addr)
     }
 
-    async fn init_cluster(boot_strap: &str, connections: Arc<RpcClient>) -> Result<Cluster> {
-        let socket_address = Self::parse_bootstrap(boot_strap)?;
-        let server_node = ServerNode::new(
-            -1,
-            socket_address.ip().to_string(),
-            socket_address.port() as u32,
-            ServerType::Unknown,
+    fn parse_bootstrap_servers(bootstrap_servers: &str) -> Result<Vec<BootstrapServer>> {
+        let mut bootstraps = Vec::new();
+
+        for bootstrap in bootstrap_servers.split(',') {
+            let bootstrap = bootstrap.trim();
+            if bootstrap.is_empty() {
+                return Err(Error::IllegalArgument {
+                    message: format!(
+                        "Invalid bootstrap servers '{bootstrap_servers}': empty bootstrap server"
+                    ),
+                });
+            }
+            bootstraps.push(BootstrapServer {
+                raw: bootstrap.to_string(),
+                address: Self::parse_bootstrap(bootstrap),
+            });
+        }
+
+        if bootstraps.is_empty() {
+            return Err(Error::IllegalArgument {
+                message: "No bootstrap servers configured".to_string(),
+            });
+        }
+
+        Ok(bootstraps)
+    }
+
+    async fn init_cluster(bootstrap_servers: &str, connections: Arc<RpcClient>) -> Result<Cluster> {
+        let bootstraps = Self::parse_bootstrap_servers(bootstrap_servers)?;
+        let mut errors = Vec::new();
+        let mut last_connection_error = None;
+
+        for bootstrap in bootstraps {
+            let socket_address = match bootstrap.address {
+                Ok(socket_address) => socket_address,
+                Err(err) => {
+                    errors.push(format!("{}: {err}", bootstrap.raw));
+                    continue;
+                }
+            };
+            let server_node = ServerNode::new(
+                -1,
+                socket_address.ip().to_string(),
+                socket_address.port() as u32,
+                ServerType::Unknown,
+            );
+
+            match Self::fetch_cluster_from_bootstrap(&server_node, connections.clone()).await {
+                Ok(cluster) => return Ok(cluster),
+                Err(err) => {
+                    errors.push(format!("{socket_address}: {err}"));
+                    last_connection_error = Some(err);
+                }
+            }
+        }
+
+        Err(Self::bootstrap_initialization_error(
+            bootstrap_servers,
+            errors,
+            last_connection_error,
+        ))
+    }
+
+    fn bootstrap_initialization_error(
+        bootstrap_servers: &str,
+        errors: Vec<String>,
+        last_connection_error: Option<Error>,
+    ) -> Error {
+        if let Some(error) = last_connection_error {
+            return error;
+        }
+
+        let message = format!(
+            "Unable to initialize cluster from bootstrap servers '{bootstrap_servers}': {}",
+            errors.join("; ")
         );
-        let con = connections.get_connection(&server_node).await?;
+        Error::IllegalArgument { message }
+    }
+
+    async fn fetch_cluster_from_bootstrap(
+        server_node: &ServerNode,
+        connections: Arc<RpcClient>,
+    ) -> Result<Cluster> {
+        let con = connections.get_connection(server_node).await?;
 
         let response = con
             .request(UpdateMetadataRequest::new(
@@ -315,6 +396,7 @@ impl Metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ApiError;
     use crate::metadata::{TableBucket, TablePath};
     use crate::test_utils::build_cluster_arc;
 
@@ -342,29 +424,97 @@ mod tests {
     }
 
     #[test]
+    fn bootstrap_failure_preserves_last_connection_error() {
+        let authentication_error = Error::FlussAPIError {
+            api_error: ApiError {
+                code: FlussError::AuthenticateException.code(),
+                message: "Authentication failed".to_string(),
+            },
+        };
+
+        let error = Metadata::bootstrap_initialization_error(
+            "127.0.0.1:9123",
+            vec!["127.0.0.1:9123: Authentication failed".to_string()],
+            Some(authentication_error),
+        );
+
+        assert_eq!(error.api_error(), Some(FlussError::AuthenticateException));
+    }
+
+    #[test]
     fn parse_bootstrap_variants() {
         // valid IP
-        let addr = Metadata::parse_bootstrap("127.0.0.1:8080").unwrap();
+        let bootstraps = Metadata::parse_bootstrap_servers("127.0.0.1:8080").unwrap();
+        let addr = bootstraps[0].address.as_ref().unwrap();
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
         assert_eq!(addr.port(), 8080);
 
         // valid hostname
-        let addr = Metadata::parse_bootstrap("localhost:9090").unwrap();
+        let bootstraps = Metadata::parse_bootstrap_servers("localhost:9090").unwrap();
+        let addr = bootstraps[0].address.as_ref().unwrap();
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
         assert_eq!(addr.port(), 9090);
 
         // valid IPv6 address
-        let addr = Metadata::parse_bootstrap("[::1]:8080").unwrap();
+        let bootstraps = Metadata::parse_bootstrap_servers("[::1]:8080").unwrap();
+        let addr = bootstraps[0].address.as_ref().unwrap();
+        assert_eq!(addr.ip().to_string(), "::1");
         assert_eq!(addr.port(), 8080);
 
-        // invalid input: missing port
-        assert!(Metadata::parse_bootstrap("localhost").is_err());
+        // invalid input: missing port is preserved as an entry-level parse error
+        let bootstraps = Metadata::parse_bootstrap_servers("localhost").unwrap();
+        assert!(bootstraps[0].address.is_err());
 
-        // invalid input: out-of-range port
-        assert!(Metadata::parse_bootstrap("localhost:99999").is_err());
+        // invalid input: out-of-range port is preserved as an entry-level parse error
+        let bootstraps = Metadata::parse_bootstrap_servers("localhost:99999").unwrap();
+        assert!(bootstraps[0].address.is_err());
 
         // invalid input: empty string
-        assert!(Metadata::parse_bootstrap("").is_err());
+        assert!(Metadata::parse_bootstrap_servers("").is_err());
 
-        // invalid input: nonsensical address
-        assert!(Metadata::parse_bootstrap("invalid_address").is_err());
+        // invalid input: nonsensical address is preserved as an entry-level parse error
+        let bootstraps = Metadata::parse_bootstrap_servers("invalid_address").unwrap();
+        assert!(bootstraps[0].address.is_err());
+    }
+
+    #[test]
+    fn parse_bootstrap_accepts_comma_separated_servers() {
+        let bootstraps =
+            Metadata::parse_bootstrap_servers("127.0.0.1:8080, localhost:9090, [::1]:7070")
+                .unwrap();
+
+        assert_eq!(bootstraps.len(), 3);
+        let first = bootstraps[0].address.as_ref().unwrap();
+        assert_eq!(first.ip().to_string(), "127.0.0.1");
+        assert_eq!(first.port(), 8080);
+        let second = bootstraps[1].address.as_ref().unwrap();
+        assert_eq!(second.ip().to_string(), "127.0.0.1");
+        assert_eq!(second.port(), 9090);
+        let third = bootstraps[2].address.as_ref().unwrap();
+        assert_eq!(third.ip().to_string(), "::1");
+        assert_eq!(third.port(), 7070);
+    }
+
+    #[test]
+    fn parse_bootstrap_preserves_later_entries_when_one_entry_is_unresolvable() {
+        let bootstraps =
+            Metadata::parse_bootstrap_servers("invalid_address:8080, 127.0.0.1:9090").unwrap();
+
+        assert_eq!(bootstraps.len(), 2);
+        assert!(bootstraps[0].address.is_err());
+        let addr = bootstraps[1].address.as_ref().unwrap();
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
+        assert_eq!(addr.port(), 9090);
+    }
+
+    #[test]
+    fn parse_bootstrap_rejects_empty_comma_separated_entries() {
+        let err = Metadata::parse_bootstrap_servers("127.0.0.1:8080, , localhost:9090")
+            .expect_err("empty bootstrap entries should be rejected");
+
+        assert!(
+            err.to_string().contains("empty bootstrap server"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/fluss-rust/crates/fluss/tests/integration/admin.rs
+++ b/fluss-rust/crates/fluss/tests/integration/admin.rs
@@ -557,6 +557,19 @@ mod admin_test {
     }
 
     #[tokio::test]
+    async fn test_bootstrap_server_failover() {
+        let cluster = get_shared_cluster();
+        let bootstrap_servers = format!("127.0.0.1:1,{}", cluster.plaintext_bootstrap_servers());
+
+        FlussConnection::new(Config {
+            bootstrap_servers,
+            ..Default::default()
+        })
+        .await
+        .expect("should fall back to the second bootstrap server");
+    }
+
+    #[tokio::test]
     async fn test_error_table_not_partitioned() {
         let cluster = get_shared_cluster();
         let connection = cluster.get_fluss_connection().await;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3710

<!-- What is the purpose of the change -->

### Brief change log

Support comma-separated bootstrap_servers in the Rust client so users can configure multiple bootstrap endpoints for high availability.

#### Brief change log
- Parse bootstrap_servers as a comma-separated list of bootstrap endpoints.
- Trim whitespace around each endpoint and reject empty entries.
- Try bootstrap servers in order during metadata initialization until one succeeds.
- Preserve existing single-bootstrap-server behavior.

### Tests

Added unit tests.

### API and Format

No public API or storage format changes.

### Documentation

No documentation changes.