### PR TITLE
[test] Tolerate removed tablet servers FlussClusterExtension helpers

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
@@ -638,7 +638,9 @@ public final class FlussClusterExtension
             assertThat(leaderAndIsrOpt).isPresent();
             List<Integer> isr = leaderAndIsrOpt.get().isr();
             for (int replicaId : isr) {
-                ReplicaManager replicaManager = getTabletServerById(replicaId).getReplicaManager();
+                TabletServer tabletServer = getTabletServerById(replicaId);
+                assertThat(tabletServer).isNotNull();
+                ReplicaManager replicaManager = tabletServer.getReplicaManager();
                 assertThat(replicaManager.getReplica(tb))
                         .isInstanceOf(ReplicaManager.OnlineReplica.class);
             }
@@ -683,6 +685,7 @@ public final class FlussClusterExtension
                     List<Integer> isr = leaderAndIsr.isr();
                     for (int replicaId : isr) {
                         TabletServer tabletServer = getTabletServerById(replicaId);
+                        assertThat(tabletServer).isNotNull();
                         ReplicaManager replicaManager = tabletServer.getReplicaManager();
                         assertThat(replicaManager.getReplica(tableBucket))
                                 .isInstanceOf(ReplicaManager.OnlineReplica.class);
@@ -695,7 +698,9 @@ public final class FlussClusterExtension
                     }
 
                     int leader = leaderAndIsr.leader();
-                    ReplicaManager replicaManager = getTabletServerById(leader).getReplicaManager();
+                    TabletServer leaderServer = getTabletServerById(leader);
+                    assertThat(leaderServer).isNotNull();
+                    ReplicaManager replicaManager = leaderServer.getReplicaManager();
                     assertThat(replicaManager.getReplicaOrException(tableBucket).isLeader())
                             .isTrue();
                 });


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/3716

Follow-up to #3667, which fixed a NullPointerException in FlussClusterExtension#getReplica when a tablet server is removed while a failover is in progress. The same race exists at three more call sites.