### PR TITLE
[CI] Split Spark lake tests to reduce pipeline time

### DIFF
--- a/.github/workflows/ci-template.yaml
+++ b/.github/workflows/ci-template.yaml
@@ -36,12 +36,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        module: [ core, flink1, flink2, spark3, spark3-scala213, lake ]
+        module: [ core, flink1, flink2, spark3, spark3-lake, spark3-scala213, lake ]
         include:
           - module: flink1
             test-profile: "test-flink1"
           - module: flink2
             test-profile: "test-flink2"
+          - module: spark3-lake
+            test-profile: "test-spark3"
           - module: spark3-scala213
             scala-profile: "-Pscala-2.13"
             test-profile: "test-spark3"

--- a/.github/workflows/stage.sh
+++ b/.github/workflows/stage.sh
@@ -21,8 +21,11 @@ STAGE_CORE="core"
 STAGE_FLINK1="flink1"
 STAGE_FLINK2="flink2"
 STAGE_SPARK="spark3"
+STAGE_SPARK_LAKE="spark3-lake"
 STAGE_SPARK_SCALA213="spark3-scala213"
 STAGE_LAKE="lake"
+
+SPARK_LAKE_TEST_TAG="org.apache.fluss.spark.lake.SparkLakeTest"
 
 MODULES_FLINK1="\
 fluss-flink/fluss-flink-1.20,\
@@ -85,10 +88,13 @@ function get_test_modules_for_stage() {
             echo "-pl fluss-test-coverage,$modules_flink2"
         ;;
         (${STAGE_SPARK})
-            echo "-pl fluss-test-coverage,$modules_spark3"
+            echo "-DtagsToExclude=$SPARK_LAKE_TEST_TAG -pl fluss-test-coverage,$modules_spark3"
+        ;;
+        (${STAGE_SPARK_LAKE})
+            echo "-DtagsToInclude=$SPARK_LAKE_TEST_TAG -pl fluss-test-coverage,$modules_spark3"
         ;;
         (${STAGE_SPARK_SCALA213})
-            echo "-Pscala-2.13 -pl fluss-test-coverage,$modules_spark3"
+            echo "-Pscala-2.13 -DtagsToExclude=$SPARK_LAKE_TEST_TAG -pl fluss-test-coverage,$modules_spark3"
         ;;
         (${STAGE_LAKE})
             echo "-pl fluss-test-coverage,$modules_lake"

--- a/fluss-spark/fluss-spark-ut/src/test/java/org/apache/fluss/spark/lake/SparkLakeTest.java
+++ b/fluss-spark/fluss-spark-ut/src/test/java/org/apache/fluss/spark/lake/SparkLakeTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.spark.lake;
+
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Identifies Spark test suites that exercise lake storage integrations. */
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface SparkLakeTest {}

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/lake/SparkLakeLogTableReadTest.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/lake/SparkLakeLogTableReadTest.scala
@@ -685,6 +685,7 @@ abstract class SparkLakeLogTableReadTest extends SparkLakeTableReadTestBase {
 
 }
 
+@SparkLakeTest
 class SparkLakePaimonLogTableReadTest extends SparkLakeLogTableReadTest {
   override protected def dataLakeFormat: DataLakeFormat = DataLakeFormat.PAIMON
 
@@ -707,6 +708,7 @@ class SparkLakePaimonLogTableReadTest extends SparkLakeLogTableReadTest {
   }
 }
 
+@SparkLakeTest
 class SparkLakeIcebergLogTableReadTest extends SparkLakeLogTableReadTest {
   override protected def dataLakeFormat: DataLakeFormat = DataLakeFormat.ICEBERG
 

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/lake/SparkLakePrimaryKeyTableReadTestBase.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/lake/SparkLakePrimaryKeyTableReadTestBase.scala
@@ -551,6 +551,7 @@ abstract class SparkLakePrimaryKeyTableReadTestBase extends SparkLakeTableReadTe
 
 }
 
+@SparkLakeTest
 class SparkLakePaimonPrimaryKeyTableReadTest extends SparkLakePrimaryKeyTableReadTestBase {
 
   override protected def dataLakeFormat: DataLakeFormat = DataLakeFormat.PAIMON

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/lake/paimon/SparkLakePaimonCatalogTest.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/lake/paimon/SparkLakePaimonCatalogTest.scala
@@ -25,6 +25,7 @@ import org.apache.fluss.metadata.TableDescriptor.{BUCKET_COLUMN_NAME, OFFSET_COL
 import org.apache.fluss.server.utils.LakeStorageUtils
 import org.apache.fluss.spark.SparkCatalogTest
 import org.apache.fluss.spark.SparkConnectorOptions.{BUCKET_KEY, BUCKET_NUMBER, PRIMARY_KEY}
+import org.apache.fluss.spark.lake.SparkLakeTest
 
 import org.scalatest.matchers.must.Matchers.contain
 import org.scalatest.matchers.should.Matchers.{a, convertToAnyShouldWrapper}
@@ -33,6 +34,7 @@ import java.nio.file.Files
 
 import scala.collection.JavaConverters._
 
+@SparkLakeTest
 class SparkLakePaimonCatalogTest extends SparkCatalogTest {
 
   private var paimonCatalog: org.apache.paimon.catalog.Catalog = _


### PR DESCRIPTION
<!--

-->

### Purpose

Related issue: #3273

The Spark 3 CI lanes currently run the same 264-test suite for both Scala 2.12 and Scala 2.13. Most of the runtime is spent in lake integration tests, while the Spark 3.4 and 3.5 wrapper modules finish quickly.

Following the CI-stage splitting approach in #3692 and the representative-version coverage strategy described in #3273, this change keeps complete Spark coverage on Scala 2.12 while using Scala 2.13 as a non-lake compatibility lane. This reduces duplicated work and lowers the risk of Spark jobs approaching the CI timeout as more tests are added.

### Brief change log

- Add a suite-level `SparkLakeTest` ScalaTest tag and apply it to the four Paimon and Iceberg lake suites.
- Split Scala 2.12 Spark tests into `spark3` (214 non-lake tests) and `spark3-lake` (50 lake tests), which run as independent matrix jobs.
- Keep `spark3-scala213` as a 214-test non-lake compatibility lane.
- Map `spark3-lake` to the existing `test-spark3` coverage profile.
- Keep unfiltered local Maven runs unchanged so they continue to discover all 264 tests.

### Tests

- `bash -n .github/workflows/stage.sh`
- Verified the generated Maven modules, Scala profiles, coverage profiles, and ScalaTest tag filters for all three Spark stages.
- Verified ScalaTest discovery counts:
  - `spark3`: 214 tests
  - `spark3-lake`: 50 tests
  - `spark3-scala213`: 214 tests
- Verified the Scala 2.12 groups sum to the complete 264-test suite.
- Passed Maven Checkstyle/RAT validation and Spotless checks.
- Compiled the affected Spark common and test modules for Scala 2.12 and Scala 2.13.

### API and Format

No public API or storage format changes.

### Documentation

No documentation changes. This change only updates CI configuration and Spark test grouping.

Generative AI disclosure:
- [ ] No generative AI tools used
- [x] Yes: Codex (OpenAI)

Generated-by: Codex (OpenAI) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
