### PR TITLE
[lake/tiering] Fix lake writer resource leak in TieringSplitReader close chain

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/utils/IOUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/utils/IOUtils.java
@@ -107,6 +107,31 @@ public class IOUtils {
         return copyBytes(in, out, BLOCKSIZE, close);
     }
 
+    /**
+     * Closes all non-null {@link AutoCloseable} objects in the parameter, suppressing exceptions.
+     * Exception will be emitted after calling close() on every object.
+     *
+     * @param closeables iterable with closeables to close.
+     * @throws Exception collected exceptions that occurred during closing
+     */
+    public static void closeAll(Iterable<? extends AutoCloseable> closeables) throws Exception {
+        if (null != closeables) {
+            Exception collectedExceptions = null;
+            for (AutoCloseable closeable : closeables) {
+                try {
+                    if (null != closeable) {
+                        closeable.close();
+                    }
+                } catch (Exception e) {
+                    collectedExceptions = ExceptionUtils.firstOrSuppressed(e, collectedExceptions);
+                }
+            }
+            if (null != collectedExceptions) {
+                throw collectedExceptions;
+            }
+        }
+    }
+
     /** Closes all elements in the iterable with closeQuietly(). */
     public static void closeAllQuietly(Iterable<? extends AutoCloseable> closeables) {
         if (null != closeables) {

--- a/fluss-common/src/test/java/org/apache/fluss/utils/IOUtilsTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/utils/IOUtilsTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link org.apache.fluss.utils.IOUtils}. */
 class IOUtilsTest {
@@ -38,6 +39,23 @@ class IOUtilsTest {
         IOUtils.closeQuietly(withoutException);
         // test close with multi-instances
         IOUtils.closeAllQuietly(Arrays.asList(withException, withoutException));
+    }
+
+    @Test
+    void testCloseAll() throws Exception {
+        // null iterable and null elements should be tolerated
+        IOUtils.closeAll(null);
+        IOUtils.closeAll(Arrays.asList(null, new CloserWithoutException()));
+
+        // every closeable should be closed even if one fails, and the first
+        // exception should be thrown with the others suppressed
+        CloserWithException failing1 = new CloserWithException();
+        CloserWithException failing2 = new CloserWithException();
+        CloserWithoutException succeeding = new CloserWithoutException();
+        assertThatThrownBy(() -> IOUtils.closeAll(Arrays.asList(failing1, succeeding, failing2)))
+                .hasMessage("Fail to close")
+                .satisfies(t -> assertThat(t.getSuppressed()).hasSize(1));
+        assertThat(succeeding.closed).isTrue();
     }
 
     @Test
@@ -81,9 +99,13 @@ class IOUtilsTest {
     }
 
     private static class CloserWithoutException implements AutoCloseable {
+
+        private boolean closed;
+
         @Override
         public void close() throws Exception {
             // don't throw exception
+            closed = true;
         }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSplitReader.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSplitReader.java
@@ -42,6 +42,7 @@ import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.record.ArrowBatchData;
 import org.apache.fluss.utils.CloseableIterator;
+import org.apache.fluss.utils.IOUtils;
 import org.apache.fluss.utils.function.SupplierWithException;
 
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
@@ -56,6 +57,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -622,7 +624,14 @@ public class TieringSplitReader<WriteResult>
         LakeWriter<WriteResult> lakeWriter = lakeWriters.remove(bucket);
         WriteResult writeResult = null;
         if (lakeWriter != null) {
-            writeResult = lakeWriter.complete();
+            try {
+                writeResult = lakeWriter.complete();
+            } catch (Exception e) {
+                // make sure the lake writer is always closed to release resources
+                // when complete fails, otherwise resources like arrow buffers leak
+                IOUtils.closeQuietly(lakeWriter, "lake writer for bucket " + bucket);
+                throw e;
+            }
             lakeWriter.close();
         }
         return toTableBucketWriteResult(
@@ -721,6 +730,10 @@ public class TieringSplitReader<WriteResult>
     }
 
     private void finishCurrentTable() throws IOException {
+        // defensive cleanup: lake writers should have been completed and closed when
+        // their splits finished, close any residual writers before closing the log
+        // scanner since their resources may be allocated from the scanner
+        closeAllLakeWriters();
         try {
             if (currentLogScanner != null) {
                 currentLogScanner.close();
@@ -776,14 +789,35 @@ public class TieringSplitReader<WriteResult>
 
     @Override
     public void close() throws Exception {
-        if (currentLogScanner != null) {
-            currentLogScanner.close();
-        }
-        if (currentTable != null) {
-            currentTable.close();
-        }
+        // lake writers must be closed before the log scanner since their resources
+        // (e.g. arrow buffers) may be allocated from the scanner;
+        // the connection is owned and closed by TieringSourceReader
+        List<AutoCloseable> closeables = new ArrayList<>(lakeWriters.values());
+        closeables.add(currentSnapshotSplitReader);
+        closeables.add(currentLogScanner);
+        closeables.add(currentTable);
 
-        // don't need to close connection, will be closed by TieringSourceReader
+        // clear the fields to make close() idempotent
+        lakeWriters.clear();
+        currentSnapshotSplitReader = null;
+        currentLogScanner = null;
+        currentTable = null;
+
+        IOUtils.closeAll(closeables);
+    }
+
+    private void closeAllLakeWriters() {
+        if (lakeWriters.isEmpty()) {
+            return;
+        }
+        LOG.warn(
+                "{} lake writer(s) of table {} are still in-flight, closing them.",
+                lakeWriters.size(),
+                currentTablePath);
+        for (Map.Entry<TableBucket, LakeWriter<WriteResult>> entry : lakeWriters.entrySet()) {
+            IOUtils.closeQuietly(entry.getValue(), "lake writer for bucket " + entry.getKey());
+        }
+        lakeWriters.clear();
     }
 
     private void subscribeLog(TieringLogSplit logSplit) {

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSplitReader.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSplitReader.java
@@ -818,6 +818,8 @@ public class TieringSplitReader<WriteResult>
             IOUtils.closeQuietly(entry.getValue(), "lake writer for bucket " + entry.getKey());
         }
         lakeWriters.clear();
+
+        // don't need to close connection, will be closed by TieringSourceReader
     }
 
     private void subscribeLog(TieringLogSplit logSplit) {

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TestingLakeTieringFactory.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TestingLakeTieringFactory.java
@@ -45,8 +45,20 @@ public class TestingLakeTieringFactory
 
     @Nullable private TestingLakeCommitter testingLakeCommitter;
 
+    // the exception to be thrown when complete() is called on created lake writers
+    @Nullable private final IOException writerCompleteException;
+
+    private final List<TestingLakeWriter> createdLakeWriters = new ArrayList<>();
+
     public TestingLakeTieringFactory(@Nullable TestingLakeCommitter testingLakeCommitter) {
+        this(testingLakeCommitter, null);
+    }
+
+    public TestingLakeTieringFactory(
+            @Nullable TestingLakeCommitter testingLakeCommitter,
+            @Nullable IOException writerCompleteException) {
         this.testingLakeCommitter = testingLakeCommitter;
+        this.writerCompleteException = writerCompleteException;
     }
 
     public TestingLakeTieringFactory() {
@@ -59,7 +71,13 @@ public class TestingLakeTieringFactory
     @Override
     public LakeWriter<TestingWriteResult> createLakeWriter(WriterInitContext writerInitContext)
             throws IOException {
-        return new TestingLakeWriter();
+        TestingLakeWriter lakeWriter = new TestingLakeWriter(writerCompleteException);
+        createdLakeWriters.add(lakeWriter);
+        return lakeWriter;
+    }
+
+    public List<TestingLakeWriter> getCreatedLakeWriters() {
+        return createdLakeWriters;
     }
 
     @Override
@@ -82,9 +100,22 @@ public class TestingLakeTieringFactory
                 "method getCommittableSerializer is not supported.");
     }
 
-    private static final class TestingLakeWriter implements LakeWriter<TestingWriteResult> {
+    /** A lake writer for testing purpose which tracks the closed state. */
+    public static final class TestingLakeWriter implements LakeWriter<TestingWriteResult> {
 
         private int writtenRecords;
+
+        @Nullable private final IOException completeException;
+
+        private boolean closed;
+
+        public TestingLakeWriter() {
+            this(null);
+        }
+
+        public TestingLakeWriter(@Nullable IOException completeException) {
+            this.completeException = completeException;
+        }
 
         @Override
         public void write(LogRecord record) throws IOException {
@@ -93,11 +124,20 @@ public class TestingLakeTieringFactory
 
         @Override
         public TestingWriteResult complete() throws IOException {
+            if (completeException != null) {
+                throw completeException;
+            }
             return new TestingWriteResult(writtenRecords);
         }
 
         @Override
-        public void close() throws IOException {}
+        public void close() throws IOException {
+            closed = true;
+        }
+
+        public boolean isClosed() {
+            return closed;
+        }
     }
 
     /** A lake committer for testing purpose. */

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringSplitReaderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringSplitReaderTest.java
@@ -65,6 +65,7 @@ import java.util.stream.Collectors;
 import static org.apache.fluss.client.table.scanner.log.LogScanner.EARLIEST_OFFSET;
 import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** UT for {@link TieringSplitReader}. */
 class TieringSplitReaderTest extends FlinkTestBase {
@@ -73,11 +74,12 @@ class TieringSplitReaderTest extends FlinkTestBase {
     void testTieringTable() throws Exception {
         TablePath tablePath = TablePath.of("fluss", "fluss_test_tiering_one_table");
         long tableId = createTable(tablePath, DEFAULT_PK_TABLE_DESCRIPTOR);
+        TestingLakeTieringFactory lakeTieringFactory = new TestingLakeTieringFactory();
         try (Connection connection =
                         ConnectionFactory.createConnection(
                                 FLUSS_CLUSTER_EXTENSION.getClientConfig());
                 TieringSplitReader<TestingWriteResult> tieringSplitReader =
-                        createTieringReader(connection)) {
+                        createTieringReader(connection, lakeTieringFactory)) {
             // test empty splits
             SplitsAddition<TieringSplit> splitsAddition =
                     new SplitsAddition<>(
@@ -161,6 +163,11 @@ class TieringSplitReaderTest extends FlinkTestBase {
             tieringSplitReader.handleSplitsChanges(new SplitsAddition<>(logSplits));
             verifyTieringRows(
                     tieringSplitReader, tableId, expectedRowCount, expectFinishTieringSplits);
+
+            // all created lake writers must be completed and closed with the splits
+            assertThat(lakeTieringFactory.getCreatedLakeWriters()).isNotEmpty();
+            assertThat(lakeTieringFactory.getCreatedLakeWriters())
+                    .allSatisfy(writer -> assertThat(writer.isClosed()).isTrue());
         }
     }
 
@@ -335,6 +342,105 @@ class TieringSplitReaderTest extends FlinkTestBase {
             assertThat(writeResult).isNotNull();
             // expect null write result since no any records written
             assertThat(writeResult.writeResult()).isNull();
+        }
+    }
+
+    /**
+     * Verifies the lake writer is always closed even if {@link LakeWriter#complete()} fails,
+     * otherwise the writer is leaked since it has been removed from the tracking map and can never
+     * be reached again.
+     */
+    @Test
+    void testLakeWriterClosedWhenCompleteFails() throws Exception {
+        TablePath tablePath = TablePath.of("fluss", "tiering_close_writer_on_complete_failure");
+        TableDescriptor singleBucketPkTableDescriptor =
+                TableDescriptor.builder()
+                        .schema(DEFAULT_PK_TABLE_SCHEMA)
+                        .distributedBy(1, "id")
+                        .build();
+        long tableId = createTable(tablePath, singleBucketPkTableDescriptor);
+        // the factory creates lake writers whose complete() always throws the given exception
+        TestingLakeTieringFactory lakeTieringFactory =
+                new TestingLakeTieringFactory(null, new IOException("Injected complete failure"));
+        try (Connection connection =
+                        ConnectionFactory.createConnection(
+                                FLUSS_CLUSTER_EXTENSION.getClientConfig());
+                Table table = connection.getTable(tablePath);
+                TieringSplitReader<TestingWriteResult> tieringSplitReader =
+                        createTieringReader(connection, lakeTieringFactory)) {
+            // write 2 records which occupy log offset 0 and 1
+            UpsertWriter upsertWriter = table.newUpsert().createWriter();
+            upsertWriter.upsert(row(1, "v1"));
+            upsertWriter.upsert(row(2, "v2"));
+            upsertWriter.flush();
+
+            // add a log split covering all the written records, so that once the split reaches
+            // the stopping offset (2), the reader completes the lake writer
+            TableBucket tableBucket = new TableBucket(tableId, 0);
+            tieringSplitReader.handleSplitsChanges(
+                    new SplitsAddition<>(
+                            Collections.singletonList(
+                                    new TieringLogSplit(
+                                            tablePath, tableBucket, null, EARLIEST_OFFSET, 2, 1))));
+
+            // the injected complete() failure should propagate out of fetch()
+            assertThatThrownBy(
+                            () -> {
+                                for (int i = 0; i < 10; i++) {
+                                    tieringSplitReader.fetch();
+                                }
+                            })
+                    .hasMessageContaining("Injected complete failure");
+
+            // the writer must be closed although complete() failed
+            assertThat(lakeTieringFactory.getCreatedLakeWriters()).hasSize(1);
+            assertThat(lakeTieringFactory.getCreatedLakeWriters().get(0).isClosed()).isTrue();
+        }
+    }
+
+    /**
+     * Verifies {@link TieringSplitReader#close()} closes all in-flight lake writers, which is the
+     * case when the split reader is closed on task failure before the splits finish.
+     */
+    @Test
+    void testCloseClosesAllInFlightLakeWriters() throws Exception {
+        TablePath tablePath = TablePath.of("fluss", "tiering_close_in_flight_writers");
+        long tableId = createTable(tablePath, DEFAULT_PK_TABLE_DESCRIPTOR);
+        TestingLakeTieringFactory lakeTieringFactory = new TestingLakeTieringFactory();
+        try (Connection connection =
+                        ConnectionFactory.createConnection(
+                                FLUSS_CLUSTER_EXTENSION.getClientConfig());
+                TieringSplitReader<TestingWriteResult> tieringSplitReader =
+                        createTieringReader(connection, lakeTieringFactory)) {
+            Map<TableBucket, List<InternalRow>> rows = putRows(tableId, tablePath, 10);
+
+            // add log splits with a stopping offset beyond the log end offset, so the splits
+            // never finish and the lake writers stay in-flight
+            List<TieringSplit> logSplits = new ArrayList<>();
+            for (Map.Entry<TableBucket, List<InternalRow>> entry : rows.entrySet()) {
+                logSplits.add(
+                        createLogSplit(
+                                tablePath,
+                                tableId,
+                                entry.getKey().getBucket(),
+                                EARLIEST_OFFSET,
+                                entry.getValue().size() + 100));
+            }
+            tieringSplitReader.handleSplitsChanges(new SplitsAddition<>(logSplits));
+
+            // fetch until a lake writer has been created for every bucket with records
+            for (int i = 0;
+                    i < 10 && lakeTieringFactory.getCreatedLakeWriters().size() < rows.size();
+                    i++) {
+                tieringSplitReader.fetch();
+            }
+            assertThat(lakeTieringFactory.getCreatedLakeWriters()).hasSize(rows.size());
+
+            // close the reader while all the writers are still in-flight,
+            // all of them must be closed to avoid resource leaks
+            tieringSplitReader.close();
+            assertThat(lakeTieringFactory.getCreatedLakeWriters())
+                    .allSatisfy(writer -> assertThat(writer.isClosed()).isTrue());
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3719

<!-- What is the purpose of the change -->
`TieringSplitReader` never closes in-flight lake writers on failure. The leaked Arrow buffers make the log scanner close fail with "Memory was leaked by query", masking the real exception during failover.
### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- `completeLakeWriter()`: always close the writer even when `complete()` throws.
- `close()`: close all in-flight lake writers (before the log scanner, since their Arrow buffers are allocated from it) and the snapshot split reader.
- `finishCurrentTable()`: close residual writers before switching tables.
- Introduce `IOUtils.closeAll()` (aligned with Flink) to close a group of resources and throw the first failure with the rest suppressed.

https://github.com/apache/flink/blob/c643a2953ba44b3b316ba52983932329dc0162e4/flink-core/src/main/java/org/apache/flink/util/IOUtils.java#L245-L271

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
