### PR TITLE
[docs] Fix Flink docs anchors and Java 8 build note

### DIFF
--- a/website/community/dev/building.md
+++ b/website/community/dev/building.md
@@ -50,6 +50,13 @@ The build script will be:
 mvn clean install -DskipTests -T 1C
 ```
 
+If you need to compile artifacts that target Java 8 bytecode, enable the
+`java8` Maven profile:
+
+```bash
+mvn clean install -DskipTests -Pjava8
+```
+
 **NOTE**:
 - For local testing, it's recommend to use directory `${project}/build-target` in project.
 - For deploying distributed cluster, it's recommend to use binary file named `fluss-xxx-bin.tgz`, the file is in directory `${project}/fluss-dist/target`.

--- a/website/docs/engine-flink/getting-started.md
+++ b/website/docs/engine-flink/getting-started.md
@@ -59,7 +59,7 @@ For Flink's Table API, Fluss supports the following features:
 | [SQL Show Partitions](ddl.md#show-partitions)                   | ✔️    |                                          |
 | [SQL Add Partition](ddl.md#add-partition)                       | ✔️    |                                          |
 | [SQL Drop Partition](ddl.md#drop-partition)                     | ✔️    |                                          |
-| [Procedures](ddl.md#procedures)                                 | ✔️    | ACL management and cluster configuration |
+| [Procedures](procedures.md)                                      | ✔️    | ACL management and cluster configuration |
 | [SQL Select](reads.md)                                          | ✔️    | Support both streaming and batch mode.   |
 | [SQL Limit](reads.md#limit-read)                                | ✔️    | Only for Log Table                       |
 | [SQL Insert Into](writes.md)                                    | ✔️    | Support both streaming and batch mode.   |

--- a/website/src/pages/downloads.md
+++ b/website/src/pages/downloads.md
@@ -4,6 +4,8 @@
 
 Apache Fluss 0.9.1 is the latest stable release.
 
+<a id="fluss-connector"></a>
+
 ## Apache Fluss 0.9.1
 
 | Artifact                                                                                                                            | Signature | SHA |
@@ -27,6 +29,14 @@ Read the [release blog](/blog/releases/0.9/) about the new features and signific
 Read the [release blog](/blog/releases/0.8/) about the new features and significant improvements in the Apache Fluss 0.8.0 release.
 
 ------------------
+
+<a id="filesystem-jars"></a>
+
+## Fluss Connector and Filesystem JARs
+
+Fluss connector and filesystem JARs are published to Maven Central. Use the
+artifact names documented in the Flink engine dependencies and tiered-storage
+filesystem guides for your Flink and storage setup.
 
 ## Verifying Downloads
 


### PR DESCRIPTION
## What changed

- Fix the Flink feature-support table link for Procedures so it points to the dedicated procedures page instead of a non-existent `ddl.md#procedures` anchor.
- Add stable `fluss-connector` and `filesystem-jars` anchors to the downloads page so existing docs links resolve.
- Document the `-Pjava8` Maven profile for compiling artifacts that target Java 8 bytecode.

## Why

This addresses the broken-anchor report in #3038 and completes the Java 11 / Java 8 profile documentation requested in #1519.

## Validation

- `npm run typecheck`
- `git diff --check`

I also ran `npm run build`. The client/server/service-worker compilation completed, but Docusaurus stopped during broken-link checking on existing site-wide links such as `/docs/quickstart/flink/` and existing downloads blog links (`/blog/releases/0.9/`, `/blog/releases/0.8/`). The output did not include the fixed `ddl.md#procedures` anchor or the newly added downloads anchors as failures.
