### PR TITLE
[server] include time index in remote log cache weight

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogIndexCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogIndexCache.java
@@ -324,7 +324,9 @@ public class RemoteLogIndexCache implements Closeable {
     private Cache<UUID, Entry> initEmptyCache(long maxSize) {
         return Caffeine.newBuilder()
                 .maximumWeight(maxSize)
-                .weigher((UUID key, Entry entry) -> (int) entry.entrySizeBytes)
+                .weigher(
+                        (UUID key, Entry entry) ->
+                                (int) Math.min(entry.entrySizeBytes, Integer.MAX_VALUE))
                 // This listener is invoked each time an entry is being automatically removed due to
                 // eviction. The cache will invoke this listener during the atomic operation to
                 // remove the entry (refer: https://github.com/ben-manes/caffeine/wiki/Removal),
@@ -568,7 +570,8 @@ public class RemoteLogIndexCache implements Closeable {
         }
 
         private long estimatedEntrySize() {
-            return inReadLock(entryLock, offsetIndex::sizeInBytes);
+            return inReadLock(
+                    entryLock, () -> (long) offsetIndex.sizeInBytes() + timeIndex.sizeInBytes());
         }
 
         public OffsetPosition lookupOffset(long targetOffset) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogIndexCacheTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogIndexCacheTest.java
@@ -112,6 +112,25 @@ class RemoteLogIndexCacheTest extends RemoteLogTestBase {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    void testCacheWeightIncludesOffsetAndTimeIndexes(boolean partitionTable) throws Exception {
+        LogTablet logTablet = makeLogTabletAndAddSegments(partitionTable);
+        RemoteLogSegment remoteLogSegment = copyLogSegmentToRemote(logTablet, remoteLogStorage, 0);
+
+        Entry entry = rlIndexCache.getIndexEntry(remoteLogSegment);
+        int expectedWeight = entry.offsetIndex().sizeInBytes() + entry.timeIndex().sizeInBytes();
+
+        assertThat(
+                        rlIndexCache
+                                .getInternalCache()
+                                .policy()
+                                .eviction()
+                                .get()
+                                .weightOf(remoteLogSegment.remoteLogSegmentId()))
+                .hasValue(expectedWeight);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     void testInitWithCorruptIndex(boolean partitionTable) throws Exception {
         LogTablet logTablet = makeLogTabletAndAddSegments(partitionTable);
         // 1. first upload one segment to remote.


### PR DESCRIPTION
### Purpose

Linked issue: close #3732 

The time index size is not included in the cache weight. As a result, the cache underestimates its actual storage usage and may retain more index files than allowed by `remote.log.index.file.cache.size` .

### Brief change log

- Include both offset index and time index sizes in the remote log cache weight.
- Prevent integer overflow when converting the cache weight for Caffeine.
- Add a regression test to verify the corrected weight calculation.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
