### PR TITLE
Attached Blog Posts to Docs

### DIFF
--- a/website/docs/maintenance/tiered-storage/overview.mdx
+++ b/website/docs/maintenance/tiered-storage/overview.mdx
@@ -12,6 +12,10 @@ allows faster maintenance.
 
 Fluss organizes data into different storage layers based on its access patterns, performance requirements, and cost considerations.
 
+For a deep dive into how Fluss organizes its storage layers, see the blog post:
+
+- [Fluss Storage Hierarchy](https://fluss.apache.org/blog/fluss-storage-hierarchy/)
+
 Fluss ensures the recent data is stored in local for higher write/read performance and the historical data is stored in [remote storage](remote-storage.md) for lower cost.
 
 What's more, since the native format of Fluss's data is optimized for real-time write/read which is inevitable unfriendly to batch analytics, Fluss also introduces a [lakehouse storage](lakehouse-storage.md) which stores the data

--- a/website/docs/streaming-lakehouse/tiering-service.md
+++ b/website/docs/streaming-lakehouse/tiering-service.md
@@ -15,6 +15,12 @@ The Tiering Service is implemented as an Apache Flink job that:
 - Maintains exactly-once semantics between Fluss and the data lake
 - Operates incrementally, syncing only missing data segments
 
+For an in-depth look at the Tiering Service internals, see the blog series:
+
+- [Tiering Service Deep Dive — Part 1](https://fluss.apache.org/blog/fluss-tiering-service-deep-dive-part1/)
+- [Tiering Service Deep Dive — Part 2](https://fluss.apache.org/blog/fluss-tiering-service-deep-dive-part2/)
+- [Tiering Service Deep Dive — Part 3](https://fluss.apache.org/blog/fluss-tiering-service-deep-dive-part3/)
+
 For deployment instructions, see [Deploying Streaming Lakehouse](../install-deploy/deploying-streaming-lakehouse.md).
 
 ## Architecture


### PR DESCRIPTION
A while back we generated a few blog posts to go deep into fluss storage hierarchy and lake tiering.
However these blog posts sit on the blog and might be harder to find, or lost as time goes by.

This PR links these deep dive blog posts to the documentation pages, so people can easily find more information just by navigating the docs .