### PR TITLE
[server] release remote log index cache entries on deletion

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/LogTieringTask.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/LogTieringTask.java
@@ -158,16 +158,16 @@ public class LogTieringTask implements Runnable {
 
                 if (success) {
                     if (!expiredRemoteLogSegments.isEmpty()) {
-                        // Release the mmap-backed local indexes before deleting the remote files.
-                        remoteLogIndexCache.removeAll(
-                                expiredRemoteLogSegments.stream()
-                                        .map(RemoteLogSegment::remoteLogSegmentId)
-                                        .collect(Collectors.toList()));
                         // 3. For these expiredRemoteLogSegments, we will delete remote log
                         // segment files from remote after commit the remote log manifest.
                         // TODO introduce the read reference count to avoid deleting remote log
                         // segments while there are readers is in progress.
                         deleteRemoteLogSegmentFiles(expiredRemoteLogSegments, metricGroup);
+
+                        remoteLogIndexCache.removeAll(
+                                expiredRemoteLogSegments.stream()
+                                        .map(RemoteLogSegment::remoteLogSegmentId)
+                                        .collect(Collectors.toList()));
                     }
 
                     if (endOffset > 0) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/LogTieringTask.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/LogTieringTask.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.apache.fluss.server.utils.ServerRpcMessageUtils.makeCommitRemoteLogManifestRequest;
 
@@ -57,6 +58,7 @@ public class LogTieringTask implements Runnable {
     private final PhysicalTablePath physicalTablePath;
     private final TableBucket tableBucket;
     private final RemoteLogStorage remoteLogStorage;
+    private final RemoteLogIndexCache remoteLogIndexCache;
     private final CoordinatorGateway coordinatorGateway;
     private final Clock clock;
     private final int maxUploadSegmentsPerTask;
@@ -71,6 +73,7 @@ public class LogTieringTask implements Runnable {
             Replica replica,
             RemoteLogTablet remoteLog,
             RemoteLogStorage remoteLogStorage,
+            RemoteLogIndexCache remoteLogIndexCache,
             CoordinatorGateway coordinatorGateway,
             Clock clock,
             int maxUploadSegmentsPerTask) {
@@ -79,6 +82,7 @@ public class LogTieringTask implements Runnable {
         this.physicalTablePath = replica.getPhysicalTablePath();
         this.tableBucket = replica.getTableBucket();
         this.remoteLogStorage = remoteLogStorage;
+        this.remoteLogIndexCache = remoteLogIndexCache;
         this.coordinatorGateway = coordinatorGateway;
         this.clock = clock;
         this.maxUploadSegmentsPerTask = maxUploadSegmentsPerTask;
@@ -154,6 +158,11 @@ public class LogTieringTask implements Runnable {
 
                 if (success) {
                     if (!expiredRemoteLogSegments.isEmpty()) {
+                        // Release the mmap-backed local indexes before deleting the remote files.
+                        remoteLogIndexCache.removeAll(
+                                expiredRemoteLogSegments.stream()
+                                        .map(RemoteLogSegment::remoteLogSegmentId)
+                                        .collect(Collectors.toList()));
                         // 3. For these expiredRemoteLogSegments, we will delete remote log
                         // segment files from remote after commit the remote log manifest.
                         // TODO introduce the read reference count to avoid deleting remote log

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogManager.java
@@ -315,6 +315,7 @@ public class RemoteLogManager implements Closeable {
                                     replica,
                                     remoteLog,
                                     remoteLogStorage,
+                                    remoteLogIndexCache(replica.getLogTablet().getDataDir()),
                                     coordinatorGateway,
                                     clock,
                                     maxUploadSegmentsPerTask);

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTTLTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTTLTest.java
@@ -18,11 +18,13 @@
 package org.apache.fluss.server.log.remote;
 
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.remote.RemoteLogSegment;
 import org.apache.fluss.rpc.entity.FetchLogResultForBucket;
 import org.apache.fluss.rpc.protocol.Errors;
 import org.apache.fluss.server.entity.FetchReqInfo;
 import org.apache.fluss.server.log.FetchParams;
 import org.apache.fluss.server.log.LogTablet;
+import org.apache.fluss.server.log.remote.RemoteLogIndexCache.Entry;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -69,6 +71,31 @@ final class RemoteLogTTLTest extends RemoteLogTestBase {
         assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(0L);
         assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(40L);
 
+        // Materialize the index cache entries for all remote log segments.
+        RemoteLogIndexCache indexCache =
+                remoteLogManager.getRemoteLogIndexCache(logTablet.getDataDir());
+        for (RemoteLogSegment remoteLogSegment : remoteLog.allRemoteLogSegments()) {
+            remoteLogManager.lookupPositionForOffset(
+                    remoteLogSegment, remoteLogSegment.remoteLogStartOffset());
+        }
+        assertThat(indexCache.getInternalCache().asMap()).hasSize(4);
+        RemoteLogSegment expiredSegment =
+                remoteLog.allRemoteLogSegments().stream()
+                        .filter(segment -> segment.remoteLogStartOffset() < 20L)
+                        .findFirst()
+                        .get();
+        RemoteLogSegment retainedSegment =
+                remoteLog.allRemoteLogSegments().stream()
+                        .filter(segment -> segment.remoteLogStartOffset() >= 20L)
+                        .findFirst()
+                        .get();
+        Entry expiredIndexEntry =
+                indexCache.getInternalCache().getIfPresent(expiredSegment.remoteLogSegmentId());
+        Entry retainedIndexEntry =
+                indexCache.getInternalCache().getIfPresent(retainedSegment.remoteLogSegmentId());
+        assertThat(expiredIndexEntry).isNotNull();
+        assertThat(retainedIndexEntry).isNotNull();
+
         // advance time past TTL (7 days)
         manualClock.advanceTime(Duration.ofDays(7).plusHours(1));
 
@@ -96,6 +123,14 @@ final class RemoteLogTTLTest extends RemoteLogTestBase {
                         segment ->
                                 assertThat(segment.remoteLogStartOffset())
                                         .isGreaterThanOrEqualTo(20L));
+        assertThat(indexCache.getInternalCache().asMap())
+                .hasSize(2)
+                .doesNotContainKeys(expiredSegment.remoteLogSegmentId())
+                .containsKey(retainedSegment.remoteLogSegmentId());
+        assertThat(expiredIndexEntry.offsetIndex().file()).doesNotExist();
+        assertThat(expiredIndexEntry.timeIndex().file()).doesNotExist();
+        assertThat(retainedIndexEntry.offsetIndex().file()).exists();
+        assertThat(retainedIndexEntry.timeIndex().file()).exists();
 
         // now advance lake log end offset to include all remaining segments
         logTablet.updateLakeLogEndOffset(40L);


### PR DESCRIPTION
### Purpose

Explicitly release remote log index cache entries on deletion.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
