### PR TITLE
[filesystem] avoid zero-skip loop in HadoopDataInputStream

### DIFF
--- a/fluss-filesystems/fluss-fs-hadoop/src/main/java/org/apache/fluss/fs/hdfs/HadoopDataInputStream.java
+++ b/fluss-filesystems/fluss-fs-hadoop/src/main/java/org/apache/fluss/fs/hdfs/HadoopDataInputStream.java
@@ -19,6 +19,8 @@ package org.apache.fluss.fs.hdfs;
 
 import org.apache.fluss.fs.FSDataInputStream;
 
+import org.apache.hadoop.io.IOUtils;
+
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
@@ -72,7 +74,7 @@ public final class HadoopDataInputStream extends FSDataInputStream {
 
         if (delta > 0L && delta <= MIN_SKIP_BYTES) {
             // Instead of a small forward seek, we skip over the gap
-            skipFully(delta);
+            IOUtils.skipFully(fsDataInputStream, delta);
         } else if (delta != 0L) {
             // For larger gaps and backward seeks, we do a real seek
             forceSeek(seekPos);
@@ -121,17 +123,5 @@ public final class HadoopDataInputStream extends FSDataInputStream {
      */
     public void forceSeek(long seekPos) throws IOException {
         fsDataInputStream.seek(seekPos);
-    }
-
-    /**
-     * Skips over a given amount of bytes in the stream.
-     *
-     * @param bytes the number of bytes to skip.
-     * @throws IOException
-     */
-    public void skipFully(long bytes) throws IOException {
-        while (bytes > 0) {
-            bytes -= fsDataInputStream.skip(bytes);
-        }
     }
 }

--- a/fluss-filesystems/fluss-fs-hadoop/src/test/java/org/apache/fluss/fs/hdfs/HadoopDataInputStreamTest.java
+++ b/fluss-filesystems/fluss-fs-hadoop/src/test/java/org/apache/fluss/fs/hdfs/HadoopDataInputStreamTest.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.junit.jupiter.api.Test;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -67,6 +68,18 @@ class HadoopDataInputStreamTest {
 
         assertThatThrownBy(() -> seekAndAssert(-HadoopDataInputStream.MIN_SKIP_BYTES - 1))
                 .isInstanceOf(Exception.class);
+    }
+
+    @Test
+    void testSeekPastEndOfStreamThrowsEOFException() {
+        ZeroSkipSeekableInputStream input = new ZeroSkipSeekableInputStream(1);
+        testInputStream = new HadoopDataInputStream(new FSDataInputStream(input));
+
+        assertThatThrownBy(() -> testInputStream.seek(2))
+                .isInstanceOf(EOFException.class)
+                .hasMessageContaining("Premature EOF");
+        assertThat(input.skipCalls).isOne();
+        assertThat(input.readCalls).isOne();
     }
 
     private void seekAndAssert(long seekPos) throws IOException {
@@ -132,6 +145,64 @@ class HadoopDataInputStreamTest {
         @Override
         public int read() {
             return (position < count) ? 0xFF & (buffer[position++]) : -1;
+        }
+
+        @Override
+        public int read(long position, byte[] buffer, int offset, int length) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer, int offset, int length) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class ZeroSkipSeekableInputStream extends InputStream
+            implements Seekable, PositionedReadable {
+        private final int count;
+        private int position;
+        private int skipCalls;
+        private int readCalls;
+
+        private ZeroSkipSeekableInputStream(int count) {
+            this.count = count;
+        }
+
+        @Override
+        public void seek(long pos) {
+            checkArgument(pos >= 0 && pos <= count, "Position out of bounds.");
+            this.position = (int) pos;
+        }
+
+        @Override
+        public long getPos() {
+            return position;
+        }
+
+        @Override
+        public boolean seekToNewSource(long targetPos) {
+            return false;
+        }
+
+        @Override
+        public long skip(long n) {
+            skipCalls++;
+            if (skipCalls > 1) {
+                throw new AssertionError("skip was retried after making no progress");
+            }
+            return 0;
+        }
+
+        @Override
+        public int read() {
+            readCalls++;
+            return -1;
         }
 
         @Override


### PR DESCRIPTION
Fixes #3718.

## Root Cause

`HadoopDataInputStream.seek()` optimizes small forward seeks by skipping instead of issuing a Hadoop `seek()`.

The old local `skipFully()` loop assumed every `FSDataInputStream.skip(bytes)` call makes forward progress. Some streams return `0` at EOF or when no bytes can currently be skipped. In that case the remaining byte count never decreases and the loop can spin forever.

## Changes

- Delegate small forward skips to Hadoop's `org.apache.hadoop.io.IOUtils.skipFully(InputStream, long)`.
- Remove the local `skipFully` implementation.
- Add a regression test using a seekable stream that returns one zero-byte skip and then EOF on read, verifying `EOFException` and that zero-progress skip is not retried.

## Validation

- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-filesystems/fluss-fs-hadoop -am -Dtest=HadoopDataInputStreamTest#testSeekPastEndOfStreamThrowsEOFException -DfailIfNoTests=false test`
- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-filesystems/fluss-fs-hadoop -am -Dtest=HadoopDataInputStreamTest -DfailIfNoTests=false test`
- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-filesystems/fluss-fs-hadoop -am -DfailIfNoTests=false test`
- `git diff --check upstream/main...HEAD`