### PR TITLE
[FLUSS-3716] Tolerate removed tablet servers in wait helpers

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
@@ -638,7 +638,8 @@ public final class FlussClusterExtension
             assertThat(leaderAndIsrOpt).isPresent();
             List<Integer> isr = leaderAndIsrOpt.get().isr();
             for (int replicaId : isr) {
-                ReplicaManager replicaManager = getTabletServerById(replicaId).getReplicaManager();
+                TabletServer tabletServer = getTabletServerOrFail(replicaId, tb);
+                ReplicaManager replicaManager = tabletServer.getReplicaManager();
                 assertThat(replicaManager.getReplica(tb))
                         .isInstanceOf(ReplicaManager.OnlineReplica.class);
             }
@@ -682,7 +683,7 @@ public final class FlussClusterExtension
                     LeaderAndIsr leaderAndIsr = leaderAndIsrOpt.get();
                     List<Integer> isr = leaderAndIsr.isr();
                     for (int replicaId : isr) {
-                        TabletServer tabletServer = getTabletServerById(replicaId);
+                        TabletServer tabletServer = getTabletServerOrFail(replicaId, tableBucket);
                         ReplicaManager replicaManager = tabletServer.getReplicaManager();
                         assertThat(replicaManager.getReplica(tableBucket))
                                 .isInstanceOf(ReplicaManager.OnlineReplica.class);
@@ -695,10 +696,21 @@ public final class FlussClusterExtension
                     }
 
                     int leader = leaderAndIsr.leader();
-                    ReplicaManager replicaManager = getTabletServerById(leader).getReplicaManager();
+                    TabletServer tabletServer = getTabletServerOrFail(leader, tableBucket);
+                    ReplicaManager replicaManager = tabletServer.getReplicaManager();
                     assertThat(replicaManager.getReplicaOrException(tableBucket).isLeader())
                             .isTrue();
                 });
+    }
+
+    private TabletServer getTabletServerOrFail(int serverId, TableBucket tableBucket) {
+        TabletServer tabletServer = getTabletServerById(serverId);
+        assertThat(tabletServer)
+                .as(
+                        "Tablet server %s is still referenced by %s but is not running",
+                        serverId, tableBucket)
+                .isNotNull();
+        return tabletServer;
     }
 
     /**

--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtensionTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtensionTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.testutils;
+
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.server.zk.ZooKeeperClient;
+import org.apache.fluss.server.zk.data.LeaderAndIsr;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link FlussClusterExtension}. */
+class FlussClusterExtensionTest {
+
+    @RegisterExtension
+    static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
+            FlussClusterExtension.builder().setNumOfTabletServers(3).build();
+
+    @Test
+    void testWaitUntilAllReplicaReadyRetriesWhenIsrContainsRemovedTabletServer() throws Exception {
+        TablePath tablePath = TablePath.of("test_db", "stale_isr_test");
+        TableDescriptor tableDescriptor = DATA1_TABLE_DESCRIPTOR.withReplicationFactor(3);
+        long tableId =
+                RpcMessageTestUtils.createTable(
+                        FLUSS_CLUSTER_EXTENSION, tablePath, tableDescriptor);
+        TableBucket tableBucket = new TableBucket(tableId, 0);
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(tableBucket);
+
+        ZooKeeperClient zkClient = FLUSS_CLUSTER_EXTENSION.getZooKeeperClient();
+        LeaderAndIsr originalLeaderAndIsr = zkClient.getLeaderAndIsr(tableBucket).get();
+        int stoppedServer =
+                originalLeaderAndIsr.isr().stream()
+                        .filter(serverId -> serverId != originalLeaderAndIsr.leader())
+                        .findFirst()
+                        .get();
+        List<Integer> shrunkIsr = new ArrayList<>(originalLeaderAndIsr.isr());
+        shrunkIsr.remove(Integer.valueOf(stoppedServer));
+        LeaderAndIsr shrunkLeaderAndIsr = originalLeaderAndIsr.newLeaderAndIsr(shrunkIsr);
+
+        AtomicReference<Throwable> asyncFailure = new AtomicReference<>();
+        Thread convergeIsrThread =
+                new Thread(
+                        () -> {
+                            try {
+                                Thread.sleep(50);
+                                zkClient.updateLeaderAndIsr(
+                                        tableBucket,
+                                        shrunkLeaderAndIsr,
+                                        zkClient.getCurrentEpoch().getCoordinatorEpochZkVersion());
+                            } catch (Throwable t) {
+                                asyncFailure.set(t);
+                            }
+                        });
+
+        try {
+            FLUSS_CLUSTER_EXTENSION.stopTabletServer(stoppedServer);
+            FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(2);
+
+            zkClient.updateLeaderAndIsr(
+                    tableBucket,
+                    originalLeaderAndIsr,
+                    zkClient.getCurrentEpoch().getCoordinatorEpochZkVersion());
+
+            convergeIsrThread.start();
+            FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(tableBucket);
+            convergeIsrThread.join();
+
+            assertThat(asyncFailure.get()).isNull();
+            assertThat(zkClient.getLeaderAndIsr(tableBucket)).hasValue(shrunkLeaderAndIsr);
+        } finally {
+            if (convergeIsrThread.isAlive()) {
+                convergeIsrThread.join();
+            }
+            if (FLUSS_CLUSTER_EXTENSION.getTabletServerById(stoppedServer) == null) {
+                FLUSS_CLUSTER_EXTENSION.startTabletServer(stoppedServer);
+                FLUSS_CLUSTER_EXTENSION.assertHasTabletServerNumber(3);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What changed

`FlussClusterExtension` now treats tablet servers that are still referenced by `LeaderAndIsr` but have already been removed from the local test cluster as a retryable wait condition instead of throwing a `NullPointerException`.

This covers the remaining wait-helper call sites from FLUSS-3716:

- `waitUntilTableReady(...)` via `waitReplicaInAssignmentReady(...)`
- `waitUntilTablePartitionReady(...)` via `waitReplicaInAssignmentReady(...)`
- `waitUntilAllReplicaReady(...)`

### Why

During tablet-server shutdown or failover, ZooKeeper metadata can temporarily still reference the removed server while the in-process `FlussClusterExtension` map has already dropped it. `CommonTestUtils.retry(...)` retries `AssertionError`, but the old direct `getTabletServerById(...).getReplicaManager()` call produced an immediate NPE, turning a transient state into a flaky test failure.

### Validation

- RED: `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-server -am -Dtest=FlussClusterExtensionTest#testWaitUntilAllReplicaReadyRetriesWhenIsrContainsRemovedTabletServer -DfailIfNoTests=false test`
  - failed before the fix with `NullPointerException` from `FlussClusterExtension.waitUntilAllReplicaReady(...)`
- GREEN: same targeted test passed after the fix
- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-server -am -Dtest=FlussClusterExtensionTest,StopReplicaITCase,TabletServerShutdownITCase -DfailIfNoTests=false test`
  - `Tests run: 10, Failures: 0, Errors: 0, Skipped: 0`
- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-server -am -DfailIfNoTests=false test`
  - `fluss-server`: `Tests run: 1135, Failures: 0, Errors: 0, Skipped: 0`
  - reactor result: `BUILD SUCCESS`
- `git diff --check`
