### PR TITLE
[FLUSS-3628] Fix primary key hashCode contract

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/metadata/Schema.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metadata/Schema.java
@@ -732,7 +732,7 @@ public final class Schema implements Serializable {
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), columnNames);
+            return Objects.hash(columnNames);
         }
     }
 

--- a/fluss-common/src/test/java/org/apache/fluss/metadata/TableSchemaTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/metadata/TableSchemaTest.java
@@ -126,6 +126,15 @@ class TableSchemaTest {
     }
 
     @Test
+    void testPrimaryKeyHashCodeMatchesEquals() {
+        Schema.PrimaryKey primaryKey = new Schema.PrimaryKey("pk", Arrays.asList("f0", "f1"));
+        Schema.PrimaryKey samePrimaryKey = new Schema.PrimaryKey("pk", Arrays.asList("f0", "f1"));
+
+        assertThat(primaryKey).isEqualTo(samePrimaryKey);
+        assertThat(primaryKey.hashCode()).isEqualTo(samePrimaryKey.hashCode());
+    }
+
+    @Test
     void testReassignFieldId() {
         // Schema.Builder.column will reassign field id in flatten order.
         Schema schema =


### PR DESCRIPTION
### What changed

`Schema.PrimaryKey.hashCode()` now uses the same field set as `equals()`.

Previously, `equals()` compared only `columnNames`, but `hashCode()` also included `super.hashCode()`, which is object-identity based. Two equal `PrimaryKey` instances could therefore produce different hash codes and behave incorrectly in hash-based collections.

### Validation

- RED: `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-common -am -Dtest=TableSchemaTest#testPrimaryKeyHashCodeMatchesEquals -DfailIfNoTests=false test`
  - failed before the fix with different hash codes for two equal `Schema.PrimaryKey` instances
- GREEN: same targeted test passed after the fix
- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-common -am -Dtest=TableSchemaTest -DfailIfNoTests=false test`
  - `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0`
- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-common -am -DfailIfNoTests=false test`
  - `Tests run: 1729, Failures: 0, Errors: 0, Skipped: 1`
  - reactor result: `BUILD SUCCESS`
- `git diff --check`
