### PR TITLE
[server] Recognize Hadoop missing snapshot files

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManager.java
@@ -203,8 +203,7 @@ public class CompletedSnapshotStoreManager {
                 retrievedSnapshots.add(
                         checkNotNull(snapshotStateHandle.retrieveCompleteSnapshot()));
             } catch (Exception e) {
-                if (e.getMessage()
-                        .contains(CompletedSnapshot.SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE)) {
+                if (CompletedSnapshot.isSnapshotDataNotExists(e)) {
                     LOG.error(
                             "Metadata not found for snapshot {} of table bucket {}, maybe snapshot already removed or broken.",
                             snapshotStateHandle.getSnapshotId(),

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshot.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshot.java
@@ -88,6 +88,9 @@ public class CompletedSnapshot {
 
     public static final String SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE = "No such file or directory";
 
+    private static final String HADOOP_SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE =
+            "File does not exist";
+
     public CompletedSnapshot(
             TableBucket tableBucket,
             long snapshotID,
@@ -193,6 +196,24 @@ public class CompletedSnapshot {
 
     public static FsPath getMetadataFilePath(FsPath snapshotLocation) {
         return new FsPath(snapshotLocation, SNAPSHOT_METADATA_FILE_NAME);
+    }
+
+    /**
+     * Returns whether the throwable or any of its causes indicates that snapshot data no longer
+     * exists in the remote storage.
+     */
+    public static boolean isSnapshotDataNotExists(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            String message = cause.getMessage();
+            if (message != null
+                    && (message.contains(SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE)
+                            || message.contains(HADOOP_SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE))) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 
     private void disposeMetadata() throws IOException {

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -854,7 +854,7 @@ public final class Replica {
         try {
             kvSnapshotDataDownloader.transferAllDataToDirectory(downloadSpec, closeableRegistry);
         } catch (Exception e) {
-            if (e.getMessage().contains(CompletedSnapshot.SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE)) {
+            if (CompletedSnapshot.isSnapshotDataNotExists(e)) {
                 try {
                     snapshotContext.handleSnapshotBroken(completedSnapshot);
                 } catch (Exception t) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
@@ -186,6 +186,18 @@ class CompletedSnapshotStoreManagerTest {
 
     @Test
     void testMetadataInconsistencyWithMetadataNotExistsException() throws Exception {
+        testMetadataInconsistencyWithMetadataNotExistsException(
+                CompletedSnapshot.SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE);
+    }
+
+    @Test
+    void testMetadataInconsistencyWithHadoopFileDoesNotExistException() throws Exception {
+        testMetadataInconsistencyWithMetadataNotExistsException(
+                "File does not exist: /remote/snapshot/CURRENT");
+    }
+
+    private void testMetadataInconsistencyWithMetadataNotExistsException(String errorMessage)
+            throws Exception {
         // setup test data with mixed valid and invalid snapshots
         TableBucket tableBucket = new TableBucket(1, 1);
         CompletedSnapshot validSnapshot =
@@ -196,7 +208,7 @@ class CompletedSnapshotStoreManagerTest {
         CompletedSnapshot invalidSnapshot =
                 KvTestUtils.mockCompletedSnapshot(tempDir, tableBucket, 2L);
         TestingCompletedSnapshotHandle invalidSnapshotHandle =
-                new TestingCompletedSnapshotHandleWithFileNotFound(invalidSnapshot);
+                new TestingCompletedSnapshotHandleWithFileNotFound(invalidSnapshot, errorMessage);
 
         // create CompletedSnapshotHandleStore with real implementations
         CompletedSnapshotHandleStore completedSnapshotHandleStore =
@@ -284,14 +296,17 @@ class CompletedSnapshotStoreManagerTest {
     private static class TestingCompletedSnapshotHandleWithFileNotFound
             extends TestingCompletedSnapshotHandle {
 
-        public TestingCompletedSnapshotHandleWithFileNotFound(CompletedSnapshot snapshot) {
+        private final String errorMessage;
+
+        public TestingCompletedSnapshotHandleWithFileNotFound(
+                CompletedSnapshot snapshot, String errorMessage) {
             super(snapshot, false);
+            this.errorMessage = errorMessage;
         }
 
         @Override
         public CompletedSnapshot retrieveCompleteSnapshot() throws IOException {
-            throw new FileNotFoundException(
-                    CompletedSnapshot.SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE);
+            throw new FileNotFoundException(errorMessage);
         }
     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotTest.java
@@ -105,6 +105,28 @@ class CompletedSnapshotTest {
         assertThat(snapshot.getKvSnapshotHandle().getSnapshotSize()).isEqualTo(400L);
     }
 
+    @Test
+    void testIsSnapshotDataNotExists() {
+        assertThat(
+                        CompletedSnapshot.isSnapshotDataNotExists(
+                                new IOException(
+                                        CompletedSnapshot.SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE)))
+                .isTrue();
+        assertThat(
+                        CompletedSnapshot.isSnapshotDataNotExists(
+                                new IOException("File does not exist: /remote/snapshot/CURRENT")))
+                .isTrue();
+        assertThat(
+                        CompletedSnapshot.isSnapshotDataNotExists(
+                                new IOException(
+                                        "Failed to download snapshot.",
+                                        new IOException(
+                                                "File does not exist: /remote/snapshot/CURRENT"))))
+                .isTrue();
+        assertThat(CompletedSnapshot.isSnapshotDataNotExists(new IOException("Access denied")))
+                .isFalse();
+    }
+
     private void checkCompletedSnapshotCleanUp(
             Path snapshotPath, KvSnapshotHandle kvSnapshotHandle, boolean isShareFileShouldDelete) {
         // private should be deleted, but the local file should still remain


### PR DESCRIPTION
## Summary
- Treat Hadoop/HDFS `File does not exist` snapshot download failures as missing snapshot data.
- Reuse the existing broken snapshot cleanup/fallback path in coordinator recovery and replica snapshot download.
- Add regression coverage for the Hadoop error message and wrapped causes.

Fixes #3740

## Test Plan
- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-server -am -Dtest=CompletedSnapshotStoreManagerTest#testMetadataInconsistencyWithHadoopFileDoesNotExistException -DfailIfNoTests=false test`
  - RED before fix: failed with `FileNotFoundException: File does not exist: /remote/snapshot/CURRENT`
  - GREEN after fix: Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-server -am -Dtest=CompletedSnapshotTest,CompletedSnapshotStoreManagerTest#testMetadataInconsistencyWithHadoopFileDoesNotExistException -DfailIfNoTests=false test`
  - Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
- `git diff --check`
- `JAVA_HOME=/Users/cc/Library/Java/JavaVirtualMachines/corretto-18.0.2/Contents/Home mvn -pl fluss-server -am -DfailIfNoTests=false test`
  - Tests run: 1136, Failures: 0, Errors: 0, Skipped: 0

🤖 AI-assisted changes - reviewed by human developer