### PR TITLE
[docs] Fix website broken links

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -293,8 +293,8 @@ const config: Config = {
         {
           title: 'Product',
           items: [
-            {label: 'Documentation', to: '/docs/quickstart/flink'},
-            {label: 'Quickstart', to: '/docs/quickstart/flink'},
+            {label: 'Documentation', to: '/docs/next/quickstart/flink'},
+            {label: 'Quickstart', to: '/docs/next/quickstart/flink'},
             {label: 'Roadmap', to: '/roadmap'},
             {label: 'Downloads', to: '/downloads'},
             {label: 'Blog', to: '/blog'},

--- a/website/src/pages/compare/kafka.mdx
+++ b/website/src/pages/compare/kafka.mdx
@@ -104,5 +104,5 @@ Pick Fluss when these are your dominant needs:
 | **Engines that read** (the storage layer) | Kafka clients only | Flink · Spark · DuckDB· **_planned:** Trino · StarRocks |
 | **Strong fit** | Event-driven systems · log ingestion · microservice pub/sub · cross-language transport | Large-scale Flink stream processing · real-time analytics · AI/ML · streaming lakehouse · dimension joins · CDC |
 
-Ready to try Fluss? [Get started with the Flink quickstart](/docs/quickstart/flink),
-or read the [architecture overview](/docs/concepts/architecture).
+Ready to try Fluss? [Get started with the Flink quickstart](/docs/next/quickstart/flink),
+or read the [architecture overview](/docs/next/concepts/architecture).

--- a/website/src/pages/downloads.md
+++ b/website/src/pages/downloads.md
@@ -12,7 +12,7 @@ Apache Fluss 0.9.1 is the latest stable release.
 | [Fluss Source Release](https://www.apache.org/dyn/closer.lua/incubator/fluss/fluss-0.9.1-incubating/fluss-0.9.1-incubating-src.tgz) | [.asc](https://downloads.apache.org/incubator/fluss/fluss-0.9.1-incubating/fluss-0.9.1-incubating-src.tgz.asc) | [.sha512](https://downloads.apache.org/incubator/fluss/fluss-0.9.1-incubating/fluss-0.9.1-incubating-src.tgz.sha512) |
 | [Fluss Helm Chart](https://www.apache.org/dyn/closer.lua/incubator/fluss/helm-chart/0.9.1-incubating/fluss-0.9.1-incubating.tgz)    | [.asc](https://downloads.apache.org/incubator/fluss/helm-chart/0.9.1-incubating/fluss-0.9.1-incubating.tgz.asc) | [.sha512](https://downloads.apache.org/incubator/fluss/helm-chart/0.9.1-incubating/fluss-0.9.1-incubating.tgz.sha512) |
 
-Read the [release blog](/blog/releases/0.9/) about the new features and significant improvements in the Apache Fluss v0.9 release.
+Read the [release notes](https://github.com/apache/fluss/releases/tag/v0.9.1-incubating) for the Apache Fluss 0.9.1 release.
 
 ------------------
 
@@ -24,7 +24,7 @@ Read the [release blog](/blog/releases/0.9/) about the new features and signific
 | [Fluss Source Release](https://www.apache.org/dyn/closer.lua/incubator/fluss/fluss-0.8.0-incubating/fluss-0.8.0-incubating-src.tgz) | [.asc](https://downloads.apache.org/incubator/fluss/fluss-0.8.0-incubating/fluss-0.8.0-incubating-src.tgz.asc) | [.sha512](https://downloads.apache.org/incubator/fluss/fluss-0.8.0-incubating/fluss-0.8.0-incubating-src.tgz.sha512) |
 | [Fluss Helm Chart](https://www.apache.org/dyn/closer.lua/incubator/fluss/helm-chart/0.8.0-incubating/fluss-0.8.0-incubating.tgz)    | [.asc](https://downloads.apache.org/incubator/fluss/helm-chart/0.8.0-incubating/fluss-0.8.0-incubating.tgz.asc) | [.sha512](https://downloads.apache.org/incubator/fluss/helm-chart/0.8.0-incubating/fluss-0.8.0-incubating.tgz.sha512) |
 
-Read the [release blog](/blog/releases/0.8/) about the new features and significant improvements in the Apache Fluss 0.8.0 release.
+Read the [release notes](https://github.com/apache/fluss/releases/tag/v0.8.0-incubating) for the Apache Fluss 0.8.0 release.
 
 ------------------
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -518,7 +518,7 @@ function HomepageHeader({heroRef}: {heroRef: React.RefObject<HTMLElement>}) {
                         <div className={styles.heroCtas}>
                             <Link
                                 className={styles.btnPrimary}
-                                to="/docs/quickstart/flink">
+                                to="/docs/next/quickstart/flink">
                                 Get Started
                                 <span aria-hidden="true">→</span>
                             </Link>


### PR DESCRIPTION
### What changed

This fixes internal website links that currently make the Docusaurus production build fail:

- point Quickstart/Documentation links at the generated current-docs route under /docs/next/quickstart/flink
- point the Kafka comparison architecture link at /docs/next/concepts/architecture
- replace downloads-page links to missing internal release blog pages with GitHub release-note links for the corresponding tags

### Root cause

The current docs version is configured with the path next, so links to /docs/quickstart/flink and /docs/concepts/architecture no longer resolve in the generated site. The downloads page also linked to /blog/releases/0.9/ and /blog/releases/0.8/, but those blog routes do not exist in the website tree.

### Verification

RED on upstream/main:

- npm run build failed with Docusaurus broken links for /docs/quickstart/flink/, /docs/concepts/architecture/, /blog/releases/0.9/, and /blog/releases/0.8/

GREEN on this branch:

- npm run build completed successfully and generated static files
- git diff --check passed

Note: the build still reports existing broken-anchor warnings for anchors such as /downloads/#filesystem-jars and #using-java-client. Those warnings do not fail the build and are outside this broken-link fix; some overlap with already-open docs anchor work.