### PR TITLE
[common] Close input when copy output close fails

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/utils/IOUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/utils/IOUtils.java
@@ -73,8 +73,23 @@ public class IOUtils {
             return totalBytes;
         } finally {
             if (close) {
-                out.close();
-                in.close();
+                Throwable closeException = null;
+                try {
+                    out.close();
+                } catch (Throwable t) {
+                    closeException = t;
+                }
+                try {
+                    in.close();
+                } catch (Throwable t) {
+                    closeException = ExceptionUtils.firstOrSuppressed(t, closeException);
+                }
+                if (closeException != null) {
+                    if (closeException instanceof IOException) {
+                        throw (IOException) closeException;
+                    }
+                    ExceptionUtils.rethrow(closeException);
+                }
             }
         }
     }

--- a/fluss-common/src/test/java/org/apache/fluss/utils/IOUtilsTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/utils/IOUtilsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,6 +76,17 @@ class IOUtilsTest {
     }
 
     @Test
+    void testCopyBytesClosesInputWhenOutputCloseFails() {
+        TrackingInputStream in = new TrackingInputStream("hello".getBytes());
+        OutputStream out = new CloseFailingOutputStream();
+
+        assertThatThrownBy(() -> IOUtils.copyBytes(in, out, true))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Fail to close output");
+        assertThat(in.closed).isTrue();
+    }
+
+    @Test
     void testReadFully() throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         out.write("hello".getBytes());
@@ -106,6 +118,32 @@ class IOUtilsTest {
         public void close() throws Exception {
             // don't throw exception
             closed = true;
+        }
+    }
+
+    private static class TrackingInputStream extends ByteArrayInputStream {
+
+        private boolean closed;
+
+        private TrackingInputStream(byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    private static class CloseFailingOutputStream extends OutputStream {
+
+        @Override
+        public void write(int b) {}
+
+        @Override
+        public void close() throws IOException {
+            throw new IOException("Fail to close output");
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`IOUtils.copyBytes(..., close = true)` currently closes the output stream before the input stream in a single finally block. If `out.close()` throws, `in.close()` is skipped even though the method contract says both streams are closed in the finally clause.

This patch makes the close path attempt both closes and preserves the first close failure, adding any later close failure as suppressed.

## Brief change log

- Close both output and input streams when `copyBytes` owns stream closure, even if the first close fails.
- Add a regression test covering an output close failure and verifying the input stream is still closed.

## Verifying this change

RED:
- `mvn -pl fluss-common -am -DskipITs -Dcheckstyle.skip -Dspotless.check.skip=true -DfailIfNoTests=false -Dtest=IOUtilsTest#testCopyBytesClosesInputWhenOutputCloseFails test`
  - failed before the fix because the input stream was not closed

GREEN:
- `mvn -pl fluss-common -am -DskipITs -Dcheckstyle.skip -Dspotless.check.skip=true -DfailIfNoTests=false -Dtest=IOUtilsTest#testCopyBytesClosesInputWhenOutputCloseFails test`
- `mvn -pl fluss-common -am -DskipITs -Dcheckstyle.skip -Dspotless.check.skip=true -DfailIfNoTests=false -Dtest=IOUtilsTest test`
- `mvn -pl fluss-common -am -DskipITs -Dspotless.check.skip=true -DfailIfNoTests=false -Dtest=IOUtilsTest test`
- `git diff --check`

Note: running the same Maven test command without `-Dspotless.check.skip=true` fails in this local JDK environment before reaching `fluss-common`, in `fluss-test-utils` spotless/google-java-format with `NoSuchMethodError: com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()`.
