### PR TITLE
[server] add support of `KvPreWriteBuffer` backpressure

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -799,6 +799,32 @@ public class ConfigOptions {
                                     + ". "
                                     + "This option allows to allocate memory in batches to have better CPU-cached friendliness due to contiguous segments.");
 
+    public static final ConfigOption<Double>
+            SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO =
+                    key("server.kv.pre-write-buffer.memory-high-watermark-ratio")
+                            .doubleType()
+                            .noDefaultValue()
+                            .withDescription(
+                                    "The optional defensive high watermark, as a ratio of the TabletServer JVM maximum "
+                                            + "heap size, for memory retained by all KV pre-write buffers. KV writes are "
+                                            + "rejected with storage backpressure when usage reaches this watermark. "
+                                            + "This fallback guard is disabled unless both this option and "
+                                            + "server.kv.pre-write-buffer.memory-low-watermark-ratio are explicitly "
+                                            + "configured. The valid range is "
+                                            + "(server.kv.pre-write-buffer.memory-low-watermark-ratio, 1.0].");
+
+    public static final ConfigOption<Double> SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO =
+            key("server.kv.pre-write-buffer.memory-low-watermark-ratio")
+                    .doubleType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The optional low watermark, as a ratio of the TabletServer JVM maximum heap size, "
+                                    + "for memory retained by all KV pre-write buffers. KV writes resume after "
+                                    + "usage reaches or drops below this watermark. This fallback guard is disabled "
+                                    + "unless both this option and server.kv.pre-write-buffer.memory-high-watermark-ratio "
+                                    + "are explicitly configured. The valid range is "
+                                    + "[0.0, server.kv.pre-write-buffer.memory-high-watermark-ratio).");
+
     public static final ConfigOption<Duration> SERVER_BUFFER_POOL_WAIT_TIMEOUT =
             key("server.buffer.wait-timeout")
                     .durationType()

--- a/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
@@ -132,6 +132,52 @@ public class FlussConfigUtils {
                             "Configuration %s must be set.", ConfigOptions.TABLET_SERVER_ID.key()));
         }
         validMinValue(ConfigOptions.TABLET_SERVER_ID, serverId.get(), 0);
+        validateKvPreWriteBufferMemoryWatermarks(conf);
+    }
+
+    private static void validateKvPreWriteBufferMemoryWatermarks(Configuration conf) {
+        Optional<Double> highWatermarkRatioOptional =
+                conf.getOptional(
+                        ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO);
+        Optional<Double> lowWatermarkRatioOptional =
+                conf.getOptional(
+                        ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO);
+        if (!highWatermarkRatioOptional.isPresent() && !lowWatermarkRatioOptional.isPresent()) {
+            return;
+        }
+        if (!highWatermarkRatioOptional.isPresent() || !lowWatermarkRatioOptional.isPresent()) {
+            throw new IllegalConfigurationException(
+                    String.format(
+                            "Configurations %s and %s must be configured together to enable the "
+                                    + "defensive KV pre-write-buffer memory guard.",
+                            ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO
+                                    .key(),
+                            ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO
+                                    .key()));
+        }
+
+        double highWatermarkRatio = highWatermarkRatioOptional.get();
+        double lowWatermarkRatio = lowWatermarkRatioOptional.get();
+        if (!(highWatermarkRatio > 0.0 && highWatermarkRatio <= 1.0)) {
+            throw new IllegalConfigurationException(
+                    String.format(
+                            "Invalid configuration for %s: %s. It must be within (0.0, 1.0].",
+                            ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO
+                                    .key(),
+                            highWatermarkRatio));
+        }
+        if (!(lowWatermarkRatio >= 0.0 && lowWatermarkRatio < highWatermarkRatio)) {
+            throw new IllegalConfigurationException(
+                    String.format(
+                            "Invalid configuration for %s: %s. It must be within [0.0, %s), "
+                                    + "where %s is the configured high watermark ratio.",
+                            ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO
+                                    .key(),
+                            lowWatermarkRatio,
+                            highWatermarkRatio,
+                            ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO
+                                    .key()));
+        }
     }
 
     public static void validateRemoteDataDirs(Configuration conf) {

--- a/fluss-common/src/main/java/org/apache/fluss/exception/StorageBackpressureException.java
+++ b/fluss-common/src/main/java/org/apache/fluss/exception/StorageBackpressureException.java
@@ -20,14 +20,14 @@ package org.apache.fluss.exception;
 import org.apache.fluss.annotation.PublicEvolving;
 
 /**
- * Thrown by a tablet server to reject writes when the underlying KV storage is close to, or already
- * under, RocksDB write pressure.
+ * Thrown by a tablet server to reject writes when a KV write-pressure source reaches its defensive
+ * limit, such as RocksDB write pressure or the TabletServer-wide KV pre-write-buffer memory limit.
  *
  * <p>This is the second tier of the cooperative backpressure model: the first tier is the proactive
- * client-side throttle (driven by per-bucket pressure piggybacked on responses); once the storage
- * engine itself is about to enter internal write delay or rejects a no-slowdown write, the server
- * short-circuits the write and returns this retriable exception so that request processing threads
- * are not blocked by the storage engine's internal sleep.
+ * client-side throttle (driven by pressure piggybacked on responses); once a hard limit is reached,
+ * the server short-circuits the write and returns this retriable exception. This prevents request
+ * processing threads from blocking on the storage engine and provides a last line of defense
+ * against memory exhaustion.
  *
  * <p>Clients should retry after a backoff equal to the configured throttle ceiling.
  *

--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -158,6 +158,8 @@ public class MetricNames {
             "preWriteBufferTruncateAsDuplicatedPerSecond";
     public static final String KV_PRE_WRITE_BUFFER_TRUNCATE_AS_ERROR_RATE =
             "preWriteBufferTruncateAsErrorPerSecond";
+    public static final String KV_PRE_WRITE_BUFFER_MEMORY_USAGE = "preWriteBufferMemoryUsage";
+    public static final String KV_PRE_WRITE_BUFFER_UNDER_PRESSURE = "preWriteBufferUnderPressure";
 
     // --------------------------------------------------------------------------------------------
     // RocksDB metrics
@@ -190,14 +192,15 @@ public class MetricNames {
     // --------------------------------------------------------------------------------------------
     /**
      * Maximum normalized backpressure value across all buckets of this table, in {@code [0, 1]}.
-     * Reflects how close the hottest bucket is to the storage engine's hard-rejection trigger.
+     * Reflects how close the hottest bucket or the TabletServer-wide pre-write memory pool is to a
+     * hard-rejection trigger.
      */
     public static final String KV_BACKPRESSURE_MAX_PRESSURE = "kvBackpressureMaxPressure";
 
     /**
      * Total number of write requests rejected with {@code StorageBackpressureException} on this
-     * table since process start. The rate of this counter reflects how often the storage engine
-     * crosses its hard-rejection trigger.
+     * table since process start. The rate of this counter reflects how often a KV write-pressure
+     * source crosses its hard-rejection trigger.
      */
     public static final String KV_BACKPRESSURE_REJECTIONS_TOTAL = "kvBackpressureRejectionsTotal";
 

--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -159,7 +159,6 @@ public class MetricNames {
     public static final String KV_PRE_WRITE_BUFFER_TRUNCATE_AS_ERROR_RATE =
             "preWriteBufferTruncateAsErrorPerSecond";
     public static final String KV_PRE_WRITE_BUFFER_MEMORY_USAGE = "preWriteBufferMemoryUsage";
-    public static final String KV_PRE_WRITE_BUFFER_UNDER_PRESSURE = "preWriteBufferUnderPressure";
 
     // --------------------------------------------------------------------------------------------
     // RocksDB metrics

--- a/fluss-common/src/test/java/org/apache/fluss/config/FlussConfigUtilsTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/config/FlussConfigUtilsTest.java
@@ -192,6 +192,65 @@ class FlussConfigUtilsTest {
     }
 
     @Test
+    void testValidateKvPreWriteBufferMemoryWatermarks() {
+        Configuration conf = new Configuration();
+        conf.set(ConfigOptions.REMOTE_DATA_DIR, "s3://bucket/path");
+        conf.set(ConfigOptions.TABLET_SERVER_ID, 0);
+        assertThat(
+                        conf.getOptional(
+                                ConfigOptions
+                                        .SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO))
+                .isNotPresent();
+        assertThat(
+                        conf.getOptional(
+                                ConfigOptions
+                                        .SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO))
+                .isNotPresent();
+        validateTabletConfigs(conf);
+
+        Configuration highWatermarkOnlyConf = new Configuration();
+        highWatermarkOnlyConf.set(ConfigOptions.REMOTE_DATA_DIR, "s3://bucket/path");
+        highWatermarkOnlyConf.set(ConfigOptions.TABLET_SERVER_ID, 0);
+        highWatermarkOnlyConf.set(
+                ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO, 0.6);
+        assertThatThrownBy(() -> validateTabletConfigs(highWatermarkOnlyConf))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must be configured together")
+                .hasMessageContaining(
+                        ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO.key());
+
+        Configuration lowWatermarkOnlyConf = new Configuration();
+        lowWatermarkOnlyConf.set(ConfigOptions.REMOTE_DATA_DIR, "s3://bucket/path");
+        lowWatermarkOnlyConf.set(ConfigOptions.TABLET_SERVER_ID, 0);
+        lowWatermarkOnlyConf.set(
+                ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO, 0.5);
+        assertThatThrownBy(() -> validateTabletConfigs(lowWatermarkOnlyConf))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must be configured together")
+                .hasMessageContaining(
+                        ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO.key());
+
+        conf.set(ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO, 0.0);
+        conf.set(ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO, 0.0);
+        assertThatThrownBy(() -> validateTabletConfigs(conf))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining(
+                        ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO.key())
+                .hasMessageContaining("(0.0, 1.0]");
+
+        conf.set(ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO, 0.5);
+        conf.set(ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO, 0.5);
+        assertThatThrownBy(() -> validateTabletConfigs(conf))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining(
+                        ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO.key())
+                .hasMessageContaining("[0.0, 0.5)");
+
+        conf.set(ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO, 0.4);
+        validateTabletConfigs(conf);
+    }
+
+    @Test
     void testValidateLogRetentionCheckInterval() {
         assertThat(ConfigOptions.LOG_RETENTION_CHECK_INTERVAL.key())
                 .isEqualTo("log.retention.check-interval");

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/protocol/Errors.java
@@ -280,7 +280,7 @@ public enum Errors {
             InsufficientKvLeaderReplicaCapacityException::new),
     STORAGE_BACKPRESSURE_EXCEPTION(
             72,
-            "The tablet server has rejected the write because the KV storage engine has reached its write-pressure threshold.",
+            "The tablet server has rejected the write because a KV write-pressure source has reached its defensive threshold.",
             StorageBackpressureException::new),
     HISTORICAL_PARTITION_THROTTLED(
             73,

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/KvManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/KvManager.java
@@ -25,6 +25,7 @@ import org.apache.fluss.config.MemorySize;
 import org.apache.fluss.config.TableConfig;
 import org.apache.fluss.config.cluster.ServerReconfigurable;
 import org.apache.fluss.exception.ConfigException;
+import org.apache.fluss.exception.IllegalConfigurationException;
 import org.apache.fluss.exception.KvStorageException;
 import org.apache.fluss.fs.FileSystem;
 import org.apache.fluss.fs.FsPath;
@@ -39,6 +40,7 @@ import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.server.TabletManagerBase;
 import org.apache.fluss.server.kv.autoinc.AutoIncrementManager;
 import org.apache.fluss.server.kv.autoinc.ZkSequenceGeneratorFactory;
+import org.apache.fluss.server.kv.prewrite.KvPreWriteBufferMemoryManager;
 import org.apache.fluss.server.kv.rowmerger.RowMerger;
 import org.apache.fluss.server.log.LogManager;
 import org.apache.fluss.server.log.LogTablet;
@@ -118,6 +120,9 @@ public final class KvManager extends TabletManagerBase implements ServerReconfig
 
     private final TabletServerMetricGroup serverMetricGroup;
 
+    /** TabletServer-wide memory guard shared by all KV pre-write buffers. */
+    private final KvPreWriteBufferMemoryManager preWriteBufferMemoryManager;
+
     private final ZooKeeperClient zkClient;
 
     private final Map<TableBucket, KvTablet> currentKvs = new ConcurrentHashMap<>();
@@ -165,11 +170,40 @@ public final class KvManager extends TabletManagerBase implements ServerReconfig
         this.remoteKvDir = FlussPaths.remoteKvDir(conf);
         this.remoteFileSystem = remoteKvDir.getFileSystem();
         this.serverMetricGroup = tabletServerMetricGroup;
+        this.preWriteBufferMemoryManager = createPreWriteBufferMemoryManager(conf);
+        tabletServerMetricGroup.registerKvPreWriteBufferMemoryManager(preWriteBufferMemoryManager);
         this.sharedRocksDBRateLimiter = createSharedRateLimiter(conf);
         this.currentSharedRateLimitBytesPerSec =
                 conf.get(ConfigOptions.KV_SHARED_RATE_LIMITER_BYTES_PER_SEC).getBytes();
         this.kvFlushScheduler =
                 kvFlushScheduler != null ? kvFlushScheduler : new KvFlushScheduler(conf);
+    }
+
+    private static KvPreWriteBufferMemoryManager createPreWriteBufferMemoryManager(
+            Configuration conf) {
+        Optional<Double> highWatermarkRatio =
+                conf.getOptional(
+                        ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO);
+        Optional<Double> lowWatermarkRatio =
+                conf.getOptional(
+                        ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO);
+        if (!highWatermarkRatio.isPresent() && !lowWatermarkRatio.isPresent()) {
+            return KvPreWriteBufferMemoryManager.disabled();
+        }
+        if (!highWatermarkRatio.isPresent() || !lowWatermarkRatio.isPresent()) {
+            throw new IllegalConfigurationException(
+                    "Configurations %s and %s must be configured together to enable the "
+                            + "defensive KV pre-write-buffer memory guard.",
+                    ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_HIGH_WATERMARK_RATIO.key(),
+                    ConfigOptions.SERVER_KV_PRE_WRITE_BUFFER_MEMORY_LOW_WATERMARK_RATIO.key());
+        }
+
+        long maxHeapMemory = Runtime.getRuntime().maxMemory();
+        long highWatermarkBytes =
+                new MemorySize(maxHeapMemory).multiply(highWatermarkRatio.get()).getBytes();
+        long lowWatermarkBytes =
+                new MemorySize(maxHeapMemory).multiply(lowWatermarkRatio.get()).getBytes();
+        return new KvPreWriteBufferMemoryManager(highWatermarkBytes, lowWatermarkBytes);
     }
 
     private static RateLimiter createSharedRateLimiter(Configuration conf) {
@@ -320,7 +354,8 @@ public final class KvManager extends TabletManagerBase implements ServerReconfig
                                     sharedRocksDBRateLimiter,
                                     kvFlushScheduler,
                                     flushCompleteListener,
-                                    autoIncrementManager);
+                                    autoIncrementManager,
+                                    preWriteBufferMemoryManager);
                     currentKvs.put(tableBucket, tablet);
 
                     LOG.info(
@@ -353,6 +388,11 @@ public final class KvManager extends TabletManagerBase implements ServerReconfig
 
     public Optional<KvTablet> getKv(TableBucket tableBucket) {
         return Optional.ofNullable(currentKvs.get(tableBucket));
+    }
+
+    @VisibleForTesting
+    KvPreWriteBufferMemoryManager preWriteBufferMemoryManager() {
+        return preWriteBufferMemoryManager;
     }
 
     public void dropKv(TableBucket tableBucket) {
@@ -442,7 +482,8 @@ public final class KvManager extends TabletManagerBase implements ServerReconfig
                         sharedRocksDBRateLimiter,
                         kvFlushScheduler,
                         flushCompleteListener,
-                        autoIncrementManager);
+                        autoIncrementManager,
+                        preWriteBufferMemoryManager);
         if (this.currentKvs.containsKey(tableBucket)) {
             throw new IllegalStateException(
                     String.format(

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/KvTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/KvTablet.java
@@ -54,6 +54,7 @@ import org.apache.fluss.server.kv.autoinc.AutoIncrementUpdater;
 import org.apache.fluss.server.kv.prewrite.KvPreWriteBuffer;
 import org.apache.fluss.server.kv.prewrite.KvPreWriteBuffer.PreparedFlush;
 import org.apache.fluss.server.kv.prewrite.KvPreWriteBuffer.TruncateReason;
+import org.apache.fluss.server.kv.prewrite.KvPreWriteBufferMemoryManager;
 import org.apache.fluss.server.kv.rocksdb.RocksDBKv;
 import org.apache.fluss.server.kv.rocksdb.RocksDBKvBuilder;
 import org.apache.fluss.server.kv.rocksdb.RocksDBResourceContainer;
@@ -213,7 +214,8 @@ public final class KvTablet {
             KvFlushScheduler kvFlushScheduler,
             boolean closeFlushScheduler,
             @Nullable Runnable flushCompleteListener,
-            AutoIncrementManager autoIncrementManager) {
+            AutoIncrementManager autoIncrementManager,
+            KvPreWriteBufferMemoryManager preWriteBufferMemoryManager) {
         this.physicalPath = physicalPath;
         this.tableBucket = tableBucket;
         this.logTablet = logTablet;
@@ -223,7 +225,8 @@ public final class KvTablet {
         this.serverMetricGroup = serverMetricGroup;
         this.kvFlushScheduler = kvFlushScheduler;
         this.closeFlushScheduler = closeFlushScheduler;
-        this.kvPreWriteBuffer = new KvPreWriteBuffer(serverMetricGroup);
+        this.kvPreWriteBuffer =
+                new KvPreWriteBuffer(serverMetricGroup, preWriteBufferMemoryManager);
         this.logFormat = logFormat;
         this.arrowWriterProvider = new ArrowWriterPool(arrowBufferAllocator);
         this.memorySegmentPool = memorySegmentPool;
@@ -283,10 +286,49 @@ public final class KvTablet {
                 schemaGetter,
                 changelogImage,
                 sharedRateLimiter,
+                autoIncrementManager,
+                KvPreWriteBufferMemoryManager.disabled());
+    }
+
+    @VisibleForTesting
+    static KvTablet create(
+            PhysicalTablePath tablePath,
+            TableBucket tableBucket,
+            LogTablet logTablet,
+            File kvTabletDir,
+            Configuration serverConf,
+            TabletServerMetricGroup serverMetricGroup,
+            BufferAllocator arrowBufferAllocator,
+            MemorySegmentPool memorySegmentPool,
+            KvFormat kvFormat,
+            RowMerger rowMerger,
+            ArrowCompressionInfo arrowCompressionInfo,
+            SchemaGetter schemaGetter,
+            ChangelogImage changelogImage,
+            RateLimiter sharedRateLimiter,
+            AutoIncrementManager autoIncrementManager,
+            KvPreWriteBufferMemoryManager preWriteBufferMemoryManager)
+            throws IOException {
+        return create(
+                tablePath,
+                tableBucket,
+                logTablet,
+                kvTabletDir,
+                serverConf,
+                serverMetricGroup,
+                arrowBufferAllocator,
+                memorySegmentPool,
+                kvFormat,
+                rowMerger,
+                arrowCompressionInfo,
+                schemaGetter,
+                changelogImage,
+                sharedRateLimiter,
                 new KvFlushScheduler(serverConf),
                 true,
                 null,
-                autoIncrementManager);
+                autoIncrementManager,
+                preWriteBufferMemoryManager);
     }
 
     public static KvTablet create(
@@ -324,9 +366,51 @@ public final class KvTablet {
                 changelogImage,
                 sharedRateLimiter,
                 kvFlushScheduler,
+                flushCompleteListener,
+                autoIncrementManager,
+                KvPreWriteBufferMemoryManager.disabled());
+    }
+
+    public static KvTablet create(
+            PhysicalTablePath tablePath,
+            TableBucket tableBucket,
+            LogTablet logTablet,
+            File kvTabletDir,
+            Configuration serverConf,
+            TabletServerMetricGroup serverMetricGroup,
+            BufferAllocator arrowBufferAllocator,
+            MemorySegmentPool memorySegmentPool,
+            KvFormat kvFormat,
+            RowMerger rowMerger,
+            ArrowCompressionInfo arrowCompressionInfo,
+            SchemaGetter schemaGetter,
+            ChangelogImage changelogImage,
+            RateLimiter sharedRateLimiter,
+            KvFlushScheduler kvFlushScheduler,
+            @Nullable Runnable flushCompleteListener,
+            AutoIncrementManager autoIncrementManager,
+            KvPreWriteBufferMemoryManager preWriteBufferMemoryManager)
+            throws IOException {
+        return create(
+                tablePath,
+                tableBucket,
+                logTablet,
+                kvTabletDir,
+                serverConf,
+                serverMetricGroup,
+                arrowBufferAllocator,
+                memorySegmentPool,
+                kvFormat,
+                rowMerger,
+                arrowCompressionInfo,
+                schemaGetter,
+                changelogImage,
+                sharedRateLimiter,
+                kvFlushScheduler,
                 false,
                 flushCompleteListener,
-                autoIncrementManager);
+                autoIncrementManager,
+                preWriteBufferMemoryManager);
     }
 
     private static KvTablet create(
@@ -347,7 +431,8 @@ public final class KvTablet {
             KvFlushScheduler kvFlushScheduler,
             boolean closeFlushScheduler,
             @Nullable Runnable flushCompleteListener,
-            AutoIncrementManager autoIncrementManager)
+            AutoIncrementManager autoIncrementManager,
+            KvPreWriteBufferMemoryManager preWriteBufferMemoryManager)
             throws IOException {
         RocksDBKv kv = buildRocksDBKv(serverConf, kvTabletDir, sharedRateLimiter);
 
@@ -383,7 +468,8 @@ public final class KvTablet {
                 kvFlushScheduler,
                 closeFlushScheduler,
                 flushCompleteListener,
-                autoIncrementManager);
+                autoIncrementManager,
+                preWriteBufferMemoryManager);
     }
 
     private static RocksDBKv buildRocksDBKv(
@@ -1308,6 +1394,7 @@ public final class KvTablet {
                             // Terminal transition: closing forces IDLE regardless of the current
                             // state, see the FlushState state graph.
                             flushState = FlushState.IDLE;
+                            kvPreWriteBuffer.close();
                             return true;
                         });
         if (shouldClose && closeFlushScheduler) {
@@ -1359,7 +1446,7 @@ public final class KvTablet {
 
     /** Returns the recent normalized backpressure pressure in {@code [0, 1)}. */
     public float currentPressure() {
-        return rocksDBKv.currentPressure();
+        return Math.max(rocksDBKv.currentPressure(), kvPreWriteBuffer.currentPressure());
     }
 
     /**

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvMemoryConsumer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvMemoryConsumer.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.kv.prewrite;
+
+import org.apache.fluss.annotation.Internal;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import static org.apache.fluss.utils.Preconditions.checkArgument;
+import static org.apache.fluss.utils.Preconditions.checkNotNull;
+import static org.apache.fluss.utils.Preconditions.checkState;
+
+/** A per-buffer consumer of the TabletServer-wide KV pre-write-buffer memory guard. */
+@Internal
+@NotThreadSafe
+abstract class KvMemoryConsumer {
+
+    private final KvPreWriteBufferMemoryManager memoryManager;
+    private long acquiredBytes;
+
+    protected KvMemoryConsumer(KvPreWriteBufferMemoryManager memoryManager) {
+        this.memoryManager = checkNotNull(memoryManager, "Memory manager must not be null.");
+    }
+
+    protected final boolean tryAcquireMemory(long bytes) {
+        checkArgument(bytes >= 0, "The number of bytes to acquire must not be negative.");
+        if (!memoryManager.isEnabled()) {
+            return true;
+        }
+        if (!memoryManager.tryReserve(bytes)) {
+            return false;
+        }
+        acquiredBytes += bytes;
+        return true;
+    }
+
+    protected final void freeMemory(long bytes) {
+        checkArgument(bytes >= 0, "The number of bytes to free must not be negative.");
+        if (!memoryManager.isEnabled()) {
+            return;
+        }
+        checkState(
+                bytes <= acquiredBytes,
+                "Cannot free %s bytes when this consumer has only acquired %s bytes.",
+                bytes,
+                acquiredBytes);
+        if (bytes > 0) {
+            memoryManager.release(bytes);
+            acquiredBytes -= bytes;
+        }
+    }
+
+    protected final void freeAllMemory() {
+        if (acquiredBytes > 0) {
+            memoryManager.release(acquiredBytes);
+            acquiredBytes = 0;
+        }
+    }
+
+    protected final boolean isMemoryGuardEnabled() {
+        return memoryManager.isEnabled();
+    }
+
+    protected final KvPreWriteBufferMemoryManager memoryManager() {
+        return memoryManager;
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBuffer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBuffer.java
@@ -18,6 +18,8 @@
 package org.apache.fluss.server.kv.prewrite;
 
 import org.apache.fluss.annotation.VisibleForTesting;
+import org.apache.fluss.exception.RecordTooLargeException;
+import org.apache.fluss.exception.StorageBackpressureException;
 import org.apache.fluss.memory.MemorySegment;
 import org.apache.fluss.metrics.Counter;
 import org.apache.fluss.record.ChangeType;
@@ -87,7 +89,11 @@ import static org.apache.fluss.utils.UnsafeUtils.BYTE_ARRAY_BASE_OFFSET;
  * head to tail, it will stop flush.
  */
 @NotThreadSafe
-public class KvPreWriteBuffer {
+public class KvPreWriteBuffer extends KvMemoryConsumer implements AutoCloseable {
+
+    // A conservative estimate of heap retained by a KvEntry, its wrappers, the linked-list node,
+    // the hash-map entry, and associated object/array headers. Payload bytes are added separately.
+    private static final long ENTRY_OVERHEAD_BYTES = 128L;
 
     // a mapping from the key to the kv-entry
     private final Map<Key, KvEntry> kvEntryMap = new HashMap<>();
@@ -105,7 +111,16 @@ public class KvPreWriteBuffer {
     // Accumulated byte size of entries not yet completed by a flush.
     private long pendingFlushBytes = 0;
 
+    /** Creates a pre-write buffer with the defensive memory guard disabled. */
     public KvPreWriteBuffer(TabletServerMetricGroup serverMetricGroup) {
+        this(serverMetricGroup, KvPreWriteBufferMemoryManager.disabled());
+    }
+
+    /** Creates a pre-write buffer backed by the TabletServer-wide memory guard. */
+    public KvPreWriteBuffer(
+            TabletServerMetricGroup serverMetricGroup,
+            KvPreWriteBufferMemoryManager memoryManager) {
+        super(memoryManager);
         truncateAsDuplicatedCount = serverMetricGroup.kvTruncateAsDuplicatedCount();
         truncateAsErrorCount = serverMetricGroup.kvTruncateAsErrorCount();
     }
@@ -146,6 +161,8 @@ public class KvPreWriteBuffer {
                             + ", but the new log sequence number is "
                             + lsn);
         }
+
+        reserveMemory(key, value);
 
         // create the kv entry with previous pointer if exists, and put the new entry to the map
         KvEntry kvEntry =
@@ -205,6 +222,7 @@ public class KvPreWriteBuffer {
                                 + targetLogSequenceNumber);
             }
             pendingFlushBytes -= entryBytes(entry.getKey(), entry.getValue());
+            releaseMemory(entry);
             boolean removed = kvEntryMap.remove(entry.getKey(), entry);
             // if the latest entry is removed, we need to rollback the previous entry to the map
             if (removed) {
@@ -260,6 +278,7 @@ public class KvPreWriteBuffer {
             }
             entry.state = EntryState.FLUSHED;
             pendingFlushBytes -= entryBytes(entry.getKey(), entry.getValue());
+            releaseMemory(entry);
             kvEntryMap.remove(entry.getKey(), entry);
         }
         if (allKvEntries.isEmpty()) {
@@ -289,8 +308,53 @@ public class KvPreWriteBuffer {
         }
     }
 
+    /** Returns the normalized TabletServer-wide pre-write-buffer memory pressure. */
+    public float currentPressure() {
+        return memoryManager().currentPressure();
+    }
+
+    /** Releases every memory reservation still owned by this buffer. */
+    @Override
+    public void close() {
+        freeAllMemory();
+    }
+
     private static long entryBytes(Key key, Value value) {
         return (long) key.key.length + (value.value != null ? value.value.length : 0L);
+    }
+
+    private static long estimatedRetainedBytes(Key key, Value value) {
+        return ENTRY_OVERHEAD_BYTES + entryBytes(key, value);
+    }
+
+    private void reserveMemory(Key key, Value value) {
+        if (!isMemoryGuardEnabled()) {
+            return;
+        }
+        long memorySize = estimatedRetainedBytes(key, value);
+        if (memorySize > memoryManager().highWatermarkBytes()) {
+            throw new RecordTooLargeException(
+                    String.format(
+                            "The KV entry requires %s bytes, which exceeds the global KV "
+                                    + "pre-write-buffer high watermark of %s bytes.",
+                            memorySize, memoryManager().highWatermarkBytes()));
+        }
+        if (!tryAcquireMemory(memorySize)) {
+            throw new StorageBackpressureException(
+                    String.format(
+                            "Write rejected by the TabletServer-wide KV pre-write-buffer memory "
+                                    + "guard (requested: %s bytes, used: %s bytes, high watermark: "
+                                    + "%s bytes). Retry after backoff.",
+                            memorySize,
+                            memoryManager().usedBytes(),
+                            memoryManager().highWatermarkBytes()));
+        }
+    }
+
+    private void releaseMemory(KvEntry entry) {
+        if (isMemoryGuardEnabled()) {
+            freeMemory(estimatedRetainedBytes(entry.getKey(), entry.getValue()));
+        }
     }
 
     /** Contribution of one entry to the table row count: +1 for INSERT, -1 for DELETE. */

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferMemoryManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferMemoryManager.java
@@ -21,6 +21,8 @@ import org.apache.fluss.annotation.Internal;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import static org.apache.fluss.utils.Preconditions.checkArgument;
 import static org.apache.fluss.utils.Preconditions.checkState;
 
@@ -30,12 +32,19 @@ import static org.apache.fluss.utils.Preconditions.checkState;
  * <p>This is a defensive memory guard rather than the primary backpressure mechanism. Every
  * pre-write-buffer entry reserves its estimated retained heap before it is admitted. Once the high
  * watermark is reached, reservations remain blocked until usage falls to the low watermark.
+ *
+ * <p>The usage and the pressure latch are kept in one {@link AtomicLong}. The low 63 bits store the
+ * reserved bytes and the sign bit stores whether the manager is latched under pressure. Keeping
+ * both values in one compare-and-set word prevents a concurrent release from being overwritten by a
+ * reservation that was calculated from an older state.
  */
 @Internal
 @ThreadSafe
 public final class KvPreWriteBufferMemoryManager {
 
     private static final float MAX_PRESSURE = 0.999f;
+    private static final long UNDER_PRESSURE_FLAG = Long.MIN_VALUE;
+    private static final long USED_BYTES_MASK = Long.MAX_VALUE;
     private static final KvPreWriteBufferMemoryManager DISABLED =
             new KvPreWriteBufferMemoryManager();
 
@@ -43,8 +52,7 @@ public final class KvPreWriteBufferMemoryManager {
     private final long highWatermarkBytes;
     private final long lowWatermarkBytes;
 
-    private long usedBytes;
-    private boolean underPressure;
+    private final AtomicLong used = new AtomicLong();
 
     /** Creates a TabletServer-wide pre-write-buffer memory guard. */
     public KvPreWriteBufferMemoryManager(long highWatermarkBytes, long lowWatermarkBytes) {
@@ -88,21 +96,37 @@ public final class KvPreWriteBufferMemoryManager {
         if (bytes == 0) {
             return true;
         }
-        synchronized (this) {
-            if (underPressure) {
+
+        long currentState = used.get();
+        while (true) {
+            long currentUsedBytes = usedBytes(currentState);
+            if (isUnderPressure(currentState)) {
                 return false;
             }
-            if (bytes > highWatermarkBytes - usedBytes) {
+            if (bytes > highWatermarkBytes - currentUsedBytes) {
                 // Do not latch pressure at or below the low watermark. Otherwise, a single large
                 // reservation could block all writes even though no release is required to cross
                 // the resume threshold.
-                underPressure = usedBytes > lowWatermarkBytes;
-                return false;
+                long nextState =
+                        currentUsedBytes > lowWatermarkBytes
+                                ? underPressureState(currentUsedBytes)
+                                : currentUsedBytes;
+                if (used.compareAndSet(currentState, nextState)) {
+                    return false;
+                }
+                currentState = used.get();
+                continue;
             }
 
-            usedBytes += bytes;
-            underPressure = usedBytes >= highWatermarkBytes;
-            return true;
+            long nextUsedBytes = currentUsedBytes + bytes;
+            long nextState =
+                    nextUsedBytes >= highWatermarkBytes
+                            ? underPressureState(nextUsedBytes)
+                            : nextUsedBytes;
+            if (used.compareAndSet(currentState, nextState)) {
+                return true;
+            }
+            currentState = used.get();
         }
     }
 
@@ -115,16 +139,29 @@ public final class KvPreWriteBufferMemoryManager {
         if (bytes == 0) {
             return;
         }
-        synchronized (this) {
+
+        long currentState = used.get();
+        while (true) {
+            long currentUsedBytes = usedBytes(currentState);
             checkState(
-                    bytes <= usedBytes,
+                    bytes <= currentUsedBytes,
                     "Cannot release %s bytes when only %s bytes are reserved.",
                     bytes,
-                    usedBytes);
-            usedBytes -= bytes;
-            if (usedBytes <= lowWatermarkBytes) {
-                underPressure = false;
+                    currentUsedBytes);
+
+            long nextUsedBytes = currentUsedBytes - bytes;
+            // Preserve the pressure latch above the low watermark and clear it once the resume
+            // threshold is reached. This transition is part of the same CAS as the counter update.
+            long nextState =
+                    nextUsedBytes <= lowWatermarkBytes
+                            ? nextUsedBytes
+                            : (isUnderPressure(currentState)
+                                    ? underPressureState(nextUsedBytes)
+                                    : nextUsedBytes);
+            if (used.compareAndSet(currentState, nextState)) {
+                return;
             }
+            currentState = used.get();
         }
     }
 
@@ -133,9 +170,7 @@ public final class KvPreWriteBufferMemoryManager {
         if (!enabled) {
             return 0;
         }
-        synchronized (this) {
-            return usedBytes;
-        }
+        return usedBytes(used.get());
     }
 
     /** Returns the usage at which writes are rejected. */
@@ -153,9 +188,7 @@ public final class KvPreWriteBufferMemoryManager {
         if (!enabled) {
             return false;
         }
-        synchronized (this) {
-            return underPressure;
-        }
+        return isUnderPressure(used.get());
     }
 
     /**
@@ -169,17 +202,29 @@ public final class KvPreWriteBufferMemoryManager {
         if (!enabled) {
             return 0f;
         }
-        synchronized (this) {
-            if (underPressure) {
-                return MAX_PRESSURE;
-            }
-            if (usedBytes <= lowWatermarkBytes) {
-                return 0f;
-            }
-            double pressure =
-                    (double) (usedBytes - lowWatermarkBytes)
-                            / (highWatermarkBytes - lowWatermarkBytes);
-            return (float) Math.min(pressure, MAX_PRESSURE);
+        long currentState = used.get();
+        long currentUsedBytes = usedBytes(currentState);
+        if (isUnderPressure(currentState)) {
+            return MAX_PRESSURE;
         }
+        if (currentUsedBytes <= lowWatermarkBytes) {
+            return 0f;
+        }
+        double pressure =
+                (double) (currentUsedBytes - lowWatermarkBytes)
+                        / (highWatermarkBytes - lowWatermarkBytes);
+        return (float) Math.min(pressure, MAX_PRESSURE);
+    }
+
+    private static long usedBytes(long memoryState) {
+        return memoryState & USED_BYTES_MASK;
+    }
+
+    private static boolean isUnderPressure(long memoryState) {
+        return (memoryState & UNDER_PRESSURE_FLAG) != 0;
+    }
+
+    private static long underPressureState(long usedBytes) {
+        return usedBytes | UNDER_PRESSURE_FLAG;
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferMemoryManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferMemoryManager.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.kv.prewrite;
+
+import org.apache.fluss.annotation.Internal;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import static org.apache.fluss.utils.Preconditions.checkArgument;
+import static org.apache.fluss.utils.Preconditions.checkState;
+
+/**
+ * TabletServer-wide memory watermarks shared by all KV pre-write buffers.
+ *
+ * <p>This is a defensive memory guard rather than the primary backpressure mechanism. Every
+ * pre-write-buffer entry reserves its estimated retained heap before it is admitted. Once the high
+ * watermark is reached, reservations remain blocked until usage falls to the low watermark.
+ */
+@Internal
+@ThreadSafe
+public final class KvPreWriteBufferMemoryManager {
+
+    private static final float MAX_PRESSURE = 0.999f;
+    private static final KvPreWriteBufferMemoryManager DISABLED =
+            new KvPreWriteBufferMemoryManager();
+
+    private final boolean enabled;
+    private final long highWatermarkBytes;
+    private final long lowWatermarkBytes;
+
+    private long usedBytes;
+    private boolean underPressure;
+
+    /** Creates a TabletServer-wide pre-write-buffer memory guard. */
+    public KvPreWriteBufferMemoryManager(long highWatermarkBytes, long lowWatermarkBytes) {
+        checkArgument(highWatermarkBytes > 0, "High watermark must be greater than 0.");
+        checkArgument(lowWatermarkBytes >= 0, "Low watermark must not be negative.");
+        checkArgument(
+                lowWatermarkBytes < highWatermarkBytes,
+                "Low watermark must be less than high watermark.");
+        this.enabled = true;
+        this.highWatermarkBytes = highWatermarkBytes;
+        this.lowWatermarkBytes = lowWatermarkBytes;
+    }
+
+    private KvPreWriteBufferMemoryManager() {
+        this.enabled = false;
+        this.highWatermarkBytes = Long.MAX_VALUE;
+        this.lowWatermarkBytes = 0;
+    }
+
+    /** Returns a disabled manager which performs no accounting or synchronization. */
+    public static KvPreWriteBufferMemoryManager disabled() {
+        return DISABLED;
+    }
+
+    /** Returns whether the defensive memory guard is enabled. */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Attempts to reserve bytes from the global memory guard.
+     *
+     * <p>Reservations are rejected while the manager is under pressure or when the reservation
+     * would exceed the high watermark.
+     */
+    public boolean tryReserve(long bytes) {
+        checkArgument(bytes >= 0, "The number of bytes to reserve must not be negative.");
+        if (!enabled) {
+            return true;
+        }
+        if (bytes == 0) {
+            return true;
+        }
+        synchronized (this) {
+            if (underPressure) {
+                return false;
+            }
+            if (bytes > highWatermarkBytes - usedBytes) {
+                // Do not latch pressure at or below the low watermark. Otherwise, a single large
+                // reservation could block all writes even though no release is required to cross
+                // the resume threshold.
+                underPressure = usedBytes > lowWatermarkBytes;
+                return false;
+            }
+
+            usedBytes += bytes;
+            underPressure = usedBytes >= highWatermarkBytes;
+            return true;
+        }
+    }
+
+    /** Releases bytes previously reserved from this manager. */
+    public void release(long bytes) {
+        checkArgument(bytes >= 0, "The number of bytes to release must not be negative.");
+        if (!enabled) {
+            return;
+        }
+        if (bytes == 0) {
+            return;
+        }
+        synchronized (this) {
+            checkState(
+                    bytes <= usedBytes,
+                    "Cannot release %s bytes when only %s bytes are reserved.",
+                    bytes,
+                    usedBytes);
+            usedBytes -= bytes;
+            if (usedBytes <= lowWatermarkBytes) {
+                underPressure = false;
+            }
+        }
+    }
+
+    /** Returns the currently reserved bytes across all KV pre-write buffers. */
+    public long usedBytes() {
+        if (!enabled) {
+            return 0;
+        }
+        synchronized (this) {
+            return usedBytes;
+        }
+    }
+
+    /** Returns the usage at which writes are rejected. */
+    public long highWatermarkBytes() {
+        return highWatermarkBytes;
+    }
+
+    /** Returns the usage at or below which writes resume. */
+    public long lowWatermarkBytes() {
+        return lowWatermarkBytes;
+    }
+
+    /** Returns whether new reservations are currently blocked by the memory guard. */
+    public boolean isUnderPressure() {
+        if (!enabled) {
+            return false;
+        }
+        synchronized (this) {
+            return underPressure;
+        }
+    }
+
+    /**
+     * Returns normalized pre-write-buffer memory pressure in {@code [0, 1)}.
+     *
+     * <p>Pressure ramps from zero at the low watermark to the maximum wire value at the high
+     * watermark. Once the hard guard is latched, maximum pressure is reported until usage falls to
+     * the low watermark.
+     */
+    public float currentPressure() {
+        if (!enabled) {
+            return 0f;
+        }
+        synchronized (this) {
+            if (underPressure) {
+                return MAX_PRESSURE;
+            }
+            if (usedBytes <= lowWatermarkBytes) {
+                return 0f;
+            }
+            double pressure =
+                    (double) (usedBytes - lowWatermarkBytes)
+                            / (highWatermarkBytes - lowWatermarkBytes);
+            return (float) Math.min(pressure, MAX_PRESSURE);
+        }
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferMemoryManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferMemoryManager.java
@@ -52,7 +52,8 @@ public final class KvPreWriteBufferMemoryManager {
     private final long highWatermarkBytes;
     private final long lowWatermarkBytes;
 
-    private final AtomicLong used = new AtomicLong();
+    // Stores reserved bytes in the low 63 bits and the under-pressure latch in the sign bit.
+    private final AtomicLong state = new AtomicLong();
 
     /** Creates a TabletServer-wide pre-write-buffer memory guard. */
     public KvPreWriteBufferMemoryManager(long highWatermarkBytes, long lowWatermarkBytes) {
@@ -88,45 +89,47 @@ public final class KvPreWriteBufferMemoryManager {
      * <p>Reservations are rejected while the manager is under pressure or when the reservation
      * would exceed the high watermark.
      */
-    public boolean tryReserve(long bytes) {
-        checkArgument(bytes >= 0, "The number of bytes to reserve must not be negative.");
+    public boolean tryReserve(long requiredBytes) {
+        checkArgument(requiredBytes >= 0, "The number of bytes to reserve must not be negative.");
         if (!enabled) {
             return true;
         }
-        if (bytes == 0) {
+        if (requiredBytes == 0) {
             return true;
         }
 
-        long currentState = used.get();
+        long currentState = state.get();
+        // Retry with the latest state when another thread changes it before the CAS succeeds.
         while (true) {
-            long currentUsedBytes = usedBytes(currentState);
+            long usedBytes = usedBytes(currentState);
             if (isUnderPressure(currentState)) {
                 return false;
             }
-            if (bytes > highWatermarkBytes - currentUsedBytes) {
+            long remainingBytes = highWatermarkBytes - usedBytes;
+            if (requiredBytes > remainingBytes) {
                 // Do not latch pressure at or below the low watermark. Otherwise, a single large
                 // reservation could block all writes even though no release is required to cross
                 // the resume threshold.
                 long nextState =
-                        currentUsedBytes > lowWatermarkBytes
-                                ? underPressureState(currentUsedBytes)
-                                : currentUsedBytes;
-                if (used.compareAndSet(currentState, nextState)) {
+                        usedBytes > lowWatermarkBytes
+                                ? withUnderPressureFlag(usedBytes)
+                                : usedBytes;
+                if (state.compareAndSet(currentState, nextState)) {
                     return false;
                 }
-                currentState = used.get();
+                currentState = state.get();
                 continue;
             }
 
-            long nextUsedBytes = currentUsedBytes + bytes;
+            long nextUsedBytes = usedBytes + requiredBytes;
             long nextState =
                     nextUsedBytes >= highWatermarkBytes
-                            ? underPressureState(nextUsedBytes)
+                            ? withUnderPressureFlag(nextUsedBytes)
                             : nextUsedBytes;
-            if (used.compareAndSet(currentState, nextState)) {
+            if (state.compareAndSet(currentState, nextState)) {
                 return true;
             }
-            currentState = used.get();
+            currentState = state.get();
         }
     }
 
@@ -140,7 +143,8 @@ public final class KvPreWriteBufferMemoryManager {
             return;
         }
 
-        long currentState = used.get();
+        long currentState = state.get();
+        // Retry with the latest state when another thread changes it before the CAS succeeds.
         while (true) {
             long currentUsedBytes = usedBytes(currentState);
             checkState(
@@ -156,12 +160,12 @@ public final class KvPreWriteBufferMemoryManager {
                     nextUsedBytes <= lowWatermarkBytes
                             ? nextUsedBytes
                             : (isUnderPressure(currentState)
-                                    ? underPressureState(nextUsedBytes)
+                                    ? withUnderPressureFlag(nextUsedBytes)
                                     : nextUsedBytes);
-            if (used.compareAndSet(currentState, nextState)) {
+            if (state.compareAndSet(currentState, nextState)) {
                 return;
             }
-            currentState = used.get();
+            currentState = state.get();
         }
     }
 
@@ -170,7 +174,7 @@ public final class KvPreWriteBufferMemoryManager {
         if (!enabled) {
             return 0;
         }
-        return usedBytes(used.get());
+        return usedBytes(state.get());
     }
 
     /** Returns the usage at which writes are rejected. */
@@ -188,7 +192,7 @@ public final class KvPreWriteBufferMemoryManager {
         if (!enabled) {
             return false;
         }
-        return isUnderPressure(used.get());
+        return isUnderPressure(state.get());
     }
 
     /**
@@ -202,7 +206,7 @@ public final class KvPreWriteBufferMemoryManager {
         if (!enabled) {
             return 0f;
         }
-        long currentState = used.get();
+        long currentState = state.get();
         long currentUsedBytes = usedBytes(currentState);
         if (isUnderPressure(currentState)) {
             return MAX_PRESSURE;
@@ -224,7 +228,7 @@ public final class KvPreWriteBufferMemoryManager {
         return (memoryState & UNDER_PRESSURE_FLAG) != 0;
     }
 
-    private static long underPressureState(long usedBytes) {
+    private static long withUnderPressureFlag(long usedBytes) {
         return usedBytes | UNDER_PRESSURE_FLAG;
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
@@ -30,6 +30,7 @@ import org.apache.fluss.metrics.SimpleCounter;
 import org.apache.fluss.metrics.ThreadSafeSimpleCounter;
 import org.apache.fluss.metrics.groups.AbstractMetricGroup;
 import org.apache.fluss.metrics.registry.MetricRegistry;
+import org.apache.fluss.server.kv.prewrite.KvPreWriteBufferMemoryManager;
 import org.apache.fluss.server.kv.rocksdb.RocksDBStatistics;
 
 import java.util.Map;
@@ -225,6 +226,14 @@ public class TabletServerMetricGroup extends AbstractMetricGroup {
 
     public Counter kvTruncateAsErrorCount() {
         return kvTruncateAsErrorCount;
+    }
+
+    /** Registers TabletServer-wide metrics for the global KV pre-write-buffer memory guard. */
+    public void registerKvPreWriteBufferMemoryManager(KvPreWriteBufferMemoryManager memoryManager) {
+        gauge(MetricNames.KV_PRE_WRITE_BUFFER_MEMORY_USAGE, memoryManager::usedBytes);
+        gauge(
+                MetricNames.KV_PRE_WRITE_BUFFER_UNDER_PRESSURE,
+                () -> memoryManager.isUnderPressure() ? 1 : 0);
     }
 
     public Counter isrShrinks() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
@@ -231,9 +231,6 @@ public class TabletServerMetricGroup extends AbstractMetricGroup {
     /** Registers TabletServer-wide metrics for the global KV pre-write-buffer memory guard. */
     public void registerKvPreWriteBufferMemoryManager(KvPreWriteBufferMemoryManager memoryManager) {
         gauge(MetricNames.KV_PRE_WRITE_BUFFER_MEMORY_USAGE, memoryManager::usedBytes);
-        gauge(
-                MetricNames.KV_PRE_WRITE_BUFFER_UNDER_PRESSURE,
-                () -> memoryManager.isUnderPressure() ? 1 : 0);
     }
 
     public Counter isrShrinks() {

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/KvManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/KvManagerTest.java
@@ -34,6 +34,7 @@ import org.apache.fluss.record.KvRecordTestUtils;
 import org.apache.fluss.record.TestData;
 import org.apache.fluss.record.TestingSchemaGetter;
 import org.apache.fluss.row.encode.ValueEncoder;
+import org.apache.fluss.server.kv.prewrite.KvPreWriteBufferMemoryManager;
 import org.apache.fluss.server.log.LogManager;
 import org.apache.fluss.server.log.LogTablet;
 import org.apache.fluss.server.metrics.group.TestingMetricGroups;
@@ -144,6 +145,14 @@ final class KvManagerTest {
                         TestingMetricGroups.TABLET_SERVER_METRICS,
                         localDiskManager);
         kvManager.startup();
+    }
+
+    @Test
+    void testPreWriteBufferMemoryGuardDisabledByDefault() {
+        KvPreWriteBufferMemoryManager memoryManager = kvManager.preWriteBufferMemoryManager();
+
+        assertThat(memoryManager.isEnabled()).isFalse();
+        assertThat(memoryManager.usedBytes()).isZero();
     }
 
     @AfterEach

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
@@ -58,6 +58,7 @@ import org.apache.fluss.server.kv.prewrite.KvPreWriteBuffer.Key;
 import org.apache.fluss.server.kv.prewrite.KvPreWriteBuffer.KvEntry;
 import org.apache.fluss.server.kv.prewrite.KvPreWriteBuffer.PreparedFlush;
 import org.apache.fluss.server.kv.prewrite.KvPreWriteBuffer.Value;
+import org.apache.fluss.server.kv.prewrite.KvPreWriteBufferMemoryManager;
 import org.apache.fluss.server.kv.rocksdb.RocksDBKv;
 import org.apache.fluss.server.kv.rocksdb.RocksDBKvTestUtils;
 import org.apache.fluss.server.kv.rocksdb.RocksDBStatistics;
@@ -223,6 +224,27 @@ class KvTabletTest {
             Map<String, String> tableConfig,
             @Nullable KvFlushScheduler kvFlushScheduler)
             throws Exception {
+        return createKvTablet(
+                tablePath,
+                tableBucket,
+                logTablet,
+                tmpKvDir,
+                schemaGetter,
+                tableConfig,
+                kvFlushScheduler,
+                KvPreWriteBufferMemoryManager.disabled());
+    }
+
+    private KvTablet createKvTablet(
+            PhysicalTablePath tablePath,
+            TableBucket tableBucket,
+            LogTablet logTablet,
+            File tmpKvDir,
+            SchemaGetter schemaGetter,
+            Map<String, String> tableConfig,
+            @Nullable KvFlushScheduler kvFlushScheduler,
+            KvPreWriteBufferMemoryManager preWriteBufferMemoryManager)
+            throws Exception {
         TableConfig tableConf = new TableConfig(Configuration.fromMap(tableConfig));
         RowMerger rowMerger = RowMerger.create(tableConf, KvFormat.COMPACTED, schemaGetter);
         AutoIncrementManager autoIncrementManager =
@@ -248,7 +270,8 @@ class KvTabletTest {
                     schemaGetter,
                     tableConf.getChangelogImage(),
                     KvManager.getDefaultRateLimiter(),
-                    autoIncrementManager);
+                    autoIncrementManager,
+                    preWriteBufferMemoryManager);
         }
         return KvTablet.create(
                 tablePath,
@@ -267,7 +290,8 @@ class KvTabletTest {
                 KvManager.getDefaultRateLimiter(),
                 kvFlushScheduler,
                 null,
-                autoIncrementManager);
+                autoIncrementManager,
+                preWriteBufferMemoryManager);
     }
 
     @Test
@@ -1591,6 +1615,38 @@ class KvTabletTest {
         assertThatThrownBy(() -> kvTablet.putAsLeader(largeBatch, null))
                 .isInstanceOf(StorageBackpressureException.class);
         assertThat(logTablet.localLogEndOffset()).isEqualTo(0L);
+    }
+
+    @Test
+    void testPreWriteBufferMemoryPressureAndCloseRelease() throws Exception {
+        KvPreWriteBufferMemoryManager memoryManager = new KvPreWriteBufferMemoryManager(10_000, 0);
+        ManualKvFlushScheduler manualScheduler = new ManualKvFlushScheduler(conf);
+        PhysicalTablePath physicalTablePath = PhysicalTablePath.of(TablePath.of("testDb", "t1"));
+        schemaGetter = new TestingSchemaGetter(new SchemaInfo(DATA1_SCHEMA_PK, schemaId));
+        logTablet = createLogTablet(tempLogDir, 0L, physicalTablePath);
+        kvTablet =
+                createKvTablet(
+                        physicalTablePath,
+                        logTablet.getTableBucket(),
+                        logTablet,
+                        tmpKvDir,
+                        schemaGetter,
+                        new HashMap<>(),
+                        manualScheduler,
+                        memoryManager);
+
+        assertThat(memoryManager.tryReserve(5_000)).isTrue();
+        assertThat(kvTablet.currentPressure()).isEqualTo(0.5f);
+        memoryManager.release(5_000);
+
+        kvTablet.putAsLeader(
+                kvRecordBatchFactory.ofRecords(
+                        kvRecordFactory.ofRecord("key".getBytes(), new Object[] {1, "value"})),
+                null);
+        assertThat(memoryManager.usedBytes()).isPositive();
+
+        kvTablet.close();
+        assertThat(memoryManager.usedBytes()).isZero();
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferMemoryManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferMemoryManagerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.kv.prewrite;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link KvPreWriteBufferMemoryManager}. */
+class KvPreWriteBufferMemoryManagerTest {
+
+    @Test
+    void testDisabledManagerIsNoOp() {
+        KvPreWriteBufferMemoryManager manager = KvPreWriteBufferMemoryManager.disabled();
+
+        assertThat(manager.isEnabled()).isFalse();
+        assertThat(manager.tryReserve(Long.MAX_VALUE)).isTrue();
+        assertThat(manager.usedBytes()).isZero();
+        assertThat(manager.isUnderPressure()).isFalse();
+        assertThat(manager.currentPressure()).isZero();
+
+        manager.release(Long.MAX_VALUE);
+        assertThat(manager.usedBytes()).isZero();
+    }
+
+    @Test
+    void testPressureAndResumeHysteresis() {
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(100, 80);
+
+        assertThat(manager.isEnabled()).isTrue();
+        assertThat(manager.currentPressure()).isZero();
+        assertThat(manager.tryReserve(90)).isTrue();
+        assertThat(manager.currentPressure()).isEqualTo(0.5f);
+
+        assertThat(manager.tryReserve(10)).isTrue();
+        assertThat(manager.isUnderPressure()).isTrue();
+        assertThat(manager.currentPressure()).isEqualTo(0.999f);
+        assertThat(manager.tryReserve(1)).isFalse();
+
+        manager.release(19);
+        assertThat(manager.usedBytes()).isEqualTo(81);
+        assertThat(manager.isUnderPressure()).isTrue();
+        assertThat(manager.tryReserve(1)).isFalse();
+
+        manager.release(1);
+        assertThat(manager.isUnderPressure()).isFalse();
+        assertThat(manager.currentPressure()).isZero();
+        assertThat(manager.tryReserve(20)).isTrue();
+    }
+
+    @Test
+    void testRejectedReservationDoesNotChangeUsage() {
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(100, 80);
+
+        assertThat(manager.tryReserve(101)).isFalse();
+        assertThat(manager.usedBytes()).isZero();
+        assertThat(manager.isUnderPressure()).isFalse();
+    }
+
+    @Test
+    void testRejectedReservationLatchesOnlyAboveLowWatermark() {
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(100, 80);
+
+        assertThat(manager.tryReserve(80)).isTrue();
+        assertThat(manager.tryReserve(21)).isFalse();
+        assertThat(manager.isUnderPressure()).isFalse();
+
+        assertThat(manager.tryReserve(1)).isTrue();
+        assertThat(manager.tryReserve(20)).isFalse();
+        assertThat(manager.isUnderPressure()).isTrue();
+
+        manager.release(1);
+        assertThat(manager.usedBytes()).isEqualTo(80);
+        assertThat(manager.isUnderPressure()).isFalse();
+    }
+
+    @Test
+    void testInvalidReservationAndRelease() {
+        assertThatThrownBy(() -> new KvPreWriteBufferMemoryManager(0, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new KvPreWriteBufferMemoryManager(100, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new KvPreWriteBufferMemoryManager(100, 100))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(100, 80);
+        assertThatThrownBy(() -> manager.tryReserve(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> manager.release(-1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> manager.release(1)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testConcurrentReservationsDoNotExceedLimit() throws Exception {
+        int threadCount = 8;
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(10_000, 8_000);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            List<Callable<Integer>> reservationTasks = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                reservationTasks.add(
+                        () -> {
+                            int reservations = 0;
+                            while (manager.tryReserve(1)) {
+                                reservations++;
+                            }
+                            return reservations;
+                        });
+            }
+
+            List<Future<Integer>> results = executor.invokeAll(reservationTasks);
+            int successfulReservations = 0;
+            for (Future<Integer> result : results) {
+                successfulReservations += result.get();
+            }
+
+            assertThat(successfulReservations).isEqualTo(10_000);
+            assertThat(manager.usedBytes()).isEqualTo(10_000);
+            assertThat(manager.isUnderPressure()).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.fluss.server.kv.prewrite;
 
+import org.apache.fluss.exception.RecordTooLargeException;
+import org.apache.fluss.exception.StorageBackpressureException;
 import org.apache.fluss.server.kv.prewrite.KvPreWriteBuffer.PreparedFlush;
 import org.apache.fluss.server.kv.prewrite.KvPreWriteBuffer.TruncateReason;
 import org.apache.fluss.server.metrics.group.TestingMetricGroups;
@@ -452,6 +454,93 @@ class KvPreWriteBufferTest {
         // Flush remaining (key2): decreases by 11
         flushBuffer(buffer, Long.MAX_VALUE);
         assertThat(buffer.pendingFlushBytes()).isEqualTo(0);
+    }
+
+    @Test
+    void testDisabledMemoryGuardDoesNotAccount() {
+        KvPreWriteBufferMemoryManager manager = KvPreWriteBufferMemoryManager.disabled();
+        KvPreWriteBuffer buffer =
+                new KvPreWriteBuffer(TestingMetricGroups.TABLET_SERVER_METRICS, manager);
+
+        bufferInsert(buffer, "key1", "value1", 1);
+
+        assertThat(manager.usedBytes()).isZero();
+        assertThat(buffer.currentPressure()).isZero();
+    }
+
+    @Test
+    void testGlobalMemoryGuardAcrossBuffers() {
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(300, 200);
+        KvPreWriteBuffer first =
+                new KvPreWriteBuffer(TestingMetricGroups.TABLET_SERVER_METRICS, manager);
+        KvPreWriteBuffer second =
+                new KvPreWriteBuffer(TestingMetricGroups.TABLET_SERVER_METRICS, manager);
+
+        bufferInsert(first, "key1", "value1", 1);
+        bufferInsert(second, "key2", "value2", 1);
+        assertThat(manager.usedBytes()).isEqualTo(276);
+
+        assertThatThrownBy(() -> bufferInsert(first, "key3", "value3", 2))
+                .isInstanceOf(StorageBackpressureException.class)
+                .hasMessageContaining("TabletServer-wide KV pre-write-buffer memory guard");
+        assertThat(manager.usedBytes()).isEqualTo(276);
+        assertThat(manager.isUnderPressure()).isTrue();
+
+        first.close();
+        assertThat(manager.usedBytes()).isEqualTo(138);
+        assertThat(manager.isUnderPressure()).isFalse();
+        bufferInsert(second, "key3", "value3", 2);
+    }
+
+    @Test
+    void testRejectedReservationDoesNotMutateBuffer() {
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(200, 160);
+        KvPreWriteBuffer buffer =
+                new KvPreWriteBuffer(TestingMetricGroups.TABLET_SERVER_METRICS, manager);
+
+        bufferInsert(buffer, "key1", "value1", 1);
+        assertThatThrownBy(() -> bufferInsert(buffer, "key2", "value2", 2))
+                .isInstanceOf(StorageBackpressureException.class);
+
+        assertThat(buffer.getMaxLSN()).isEqualTo(1);
+        assertThat(buffer.getAllKvEntries()).hasSize(1);
+        assertThat(buffer.getKvEntryMap()).hasSize(1);
+        assertThat(manager.usedBytes()).isEqualTo(138);
+    }
+
+    @Test
+    void testMemoryReleasedOnlyAfterFlushCompletion() {
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(1_000, 800);
+        KvPreWriteBuffer buffer =
+                new KvPreWriteBuffer(TestingMetricGroups.TABLET_SERVER_METRICS, manager);
+
+        bufferInsert(buffer, "key1", "value1", 1);
+        bufferInsert(buffer, "key2", "value2", 2);
+        assertThat(manager.usedBytes()).isEqualTo(276);
+
+        PreparedFlush prepared = buffer.prepareFlush(2);
+        assertThat(manager.usedBytes()).isEqualTo(276);
+        buffer.abortFlush(prepared);
+        assertThat(manager.usedBytes()).isEqualTo(276);
+
+        prepared = buffer.prepareFlush(2);
+        buffer.completeFlush(prepared);
+        assertThat(manager.usedBytes()).isEqualTo(138);
+
+        buffer.truncateTo(2, TruncateReason.ERROR);
+        assertThat(manager.usedBytes()).isZero();
+    }
+
+    @Test
+    void testEntryLargerThanGlobalGuardIsNotRetriable() {
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(128, 64);
+        KvPreWriteBuffer buffer =
+                new KvPreWriteBuffer(TestingMetricGroups.TABLET_SERVER_METRICS, manager);
+
+        assertThatThrownBy(() -> bufferInsert(buffer, "key", "value", 1))
+                .isInstanceOf(RecordTooLargeException.class)
+                .hasMessageContaining("exceeds the global KV pre-write-buffer high watermark");
+        assertThat(manager.usedBytes()).isZero();
     }
 
     private static String getValue(KvPreWriteBuffer preWriteBuffer, String keyStr) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroupTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroupTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.metrics.group;
+
+import org.apache.fluss.metrics.Gauge;
+import org.apache.fluss.metrics.MetricNames;
+import org.apache.fluss.metrics.registry.NOPMetricRegistry;
+import org.apache.fluss.server.kv.prewrite.KvPreWriteBufferMemoryManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TabletServerMetricGroup}. */
+class TabletServerMetricGroupTest {
+
+    @Test
+    void testKvPreWriteBufferMemoryMetrics() {
+        TabletServerMetricGroup metricGroup =
+                new TabletServerMetricGroup(
+                        NOPMetricRegistry.INSTANCE, "cluster", "rack", "host", 1);
+        KvPreWriteBufferMemoryManager manager = new KvPreWriteBufferMemoryManager(100, 80);
+        metricGroup.registerKvPreWriteBufferMemoryManager(manager);
+
+        assertThat(gaugeValue(metricGroup, MetricNames.KV_PRE_WRITE_BUFFER_MEMORY_USAGE))
+                .isEqualTo(0L);
+        assertThat(gaugeValue(metricGroup, MetricNames.KV_PRE_WRITE_BUFFER_UNDER_PRESSURE))
+                .isEqualTo(0);
+
+        assertThat(manager.tryReserve(100)).isTrue();
+
+        assertThat(gaugeValue(metricGroup, MetricNames.KV_PRE_WRITE_BUFFER_MEMORY_USAGE))
+                .isEqualTo(100L);
+        assertThat(gaugeValue(metricGroup, MetricNames.KV_PRE_WRITE_BUFFER_UNDER_PRESSURE))
+                .isEqualTo(1);
+    }
+
+    private static Object gaugeValue(TabletServerMetricGroup metricGroup, String metricName) {
+        return ((Gauge<?>) metricGroup.getMetrics().get(metricName)).getValue();
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroupTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroupTest.java
@@ -39,15 +39,11 @@ class TabletServerMetricGroupTest {
 
         assertThat(gaugeValue(metricGroup, MetricNames.KV_PRE_WRITE_BUFFER_MEMORY_USAGE))
                 .isEqualTo(0L);
-        assertThat(gaugeValue(metricGroup, MetricNames.KV_PRE_WRITE_BUFFER_UNDER_PRESSURE))
-                .isEqualTo(0);
 
         assertThat(manager.tryReserve(100)).isTrue();
 
         assertThat(gaugeValue(metricGroup, MetricNames.KV_PRE_WRITE_BUFFER_MEMORY_USAGE))
                 .isEqualTo(100L);
-        assertThat(gaugeValue(metricGroup, MetricNames.KV_PRE_WRITE_BUFFER_UNDER_PRESSURE))
-                .isEqualTo(1);
     }
 
     private static Object gaugeValue(TabletServerMetricGroup metricGroup, String metricName) {


### PR DESCRIPTION
### Purpose

Linked issue: close #3532

Without a backpressure mechanism for `KvPreWriteBuffer` , the tablet server is at risk of OOM, particularly when ingestion throughput is high but replication is slow. A similar issue can occur during recovery: if the follower is not yet ready while the leader continues accepting client writes, buffered data may accumulate rapidly, causing the leader tablet server to run out of memory and exit.

### Brief change log

1. Introduce a global `KvPreWriteBuffer` memory pool for each tablet server. When memory usage reaches the configured high watermark, incoming client writes are temporarily rejected and retried until usage falls below the low watermark.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
