### PR TITLE
[server] fix zk notification purge race

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/authorizer/ZkNodeChangeNotificationWatcher.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/authorizer/ZkNodeChangeNotificationWatcher.java
@@ -139,8 +139,14 @@ public class ZkNodeChangeNotificationWatcher {
         for (String notification : sortedNotifications) {
             String notificationNode = seqNodeRoot + "/" + notification;
             try {
-                Stat state = zooKeeperClient.getStat(notificationNode).get();
-                if (now - state.getCtime() >= changeExpirationMs) {
+                Optional<Stat> state = zooKeeperClient.getStat(notificationNode);
+                if (!state.isPresent()) {
+                    LOG.debug(
+                            "Notification {} has already been purged by another watcher",
+                            notificationNode);
+                    continue;
+                }
+                if (now - state.get().getCtime() >= changeExpirationMs) {
                     LOG.debug("Purging change notification {}", notificationNode);
                     zooKeeperClient.deletePath(notificationNode);
                 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/authorizer/ZkNodeChangeNotificationWatcherTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/authorizer/ZkNodeChangeNotificationWatcherTest.java
@@ -25,10 +25,13 @@ import org.apache.fluss.server.zk.data.ZkData;
 import org.apache.fluss.testutils.common.AllCallbackWrapper;
 import org.apache.fluss.utils.clock.ManualClock;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -37,16 +40,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 
 /** Test for {@link ZkNodeChangeNotificationWatcher }. */
 public class ZkNodeChangeNotificationWatcherTest {
@@ -139,40 +138,56 @@ public class ZkNodeChangeNotificationWatcherTest {
         Resource resource = Resource.cluster();
         zooKeeperClient.insertAclChangeNotification(resource);
 
-        ZooKeeperClient spyingZooKeeperClient = spy(zooKeeperClient);
-        doAnswer(
-                        invocation -> {
-                            zooKeeperClient.deletePath(invocation.getArgument(0));
-                            return Optional.empty();
-                        })
-                .when(spyingZooKeeperClient)
-                .getStat(anyString());
-
-        TestingNotificationHandler handler = new TestingNotificationHandler();
+        TestingNotificationHandler handler =
+                new TestingNotificationHandler() {
+                    @Override
+                    public void processNotification(byte[] notification) {
+                        super.processNotification(notification);
+                        try {
+                            for (String child : zooKeeperClient.getChildren(seqNodeRoot)) {
+                                zooKeeperClient.deletePath(seqNodeRoot + "/" + child);
+                            }
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                };
         ZkNodeChangeNotificationWatcher watcher =
                 new ZkNodeChangeNotificationWatcher(
-                        spyingZooKeeperClient,
+                        zooKeeperClient,
                         seqNodeRoot,
                         seqNodePrefix,
                         Duration.ofMinutes(5).toMillis(),
                         handler,
                         new ManualClock());
 
-        Logger logger = (Logger) LogManager.getLogger(ZkNodeChangeNotificationWatcher.class);
         TestingAppender appender = new TestingAppender();
         appender.start();
-        logger.addAppender(appender);
+        LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+        Configuration configuration = loggerContext.getConfiguration();
+        LoggerConfig loggerConfig =
+                new LoggerConfig(
+                        ZkNodeChangeNotificationWatcher.class.getName(), Level.DEBUG, false);
+        loggerConfig.addAppender(appender, Level.DEBUG, null);
+        configuration.addLogger(loggerConfig.getName(), loggerConfig);
+        loggerContext.updateLoggers();
         try {
             watcher.start();
             assertThat(handler.resourceNotifications).containsExactly(resource);
             assertThat(appender.messages)
-                    .noneMatch(
+                    .anyMatch(
                             message ->
-                                    message.contains(
-                                            "Error while purging obsolete notification change"));
+                                    message.startsWith(
+                                                    "Notification "
+                                                            + seqNodeRoot
+                                                            + "/"
+                                                            + seqNodePrefix)
+                                            && message.endsWith(
+                                                    " has already been purged by another watcher"));
         } finally {
             watcher.stop();
-            logger.removeAppender(appender);
+            configuration.removeLogger(loggerConfig.getName());
+            loggerContext.updateLoggers();
             appender.stop();
         }
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/authorizer/ZkNodeChangeNotificationWatcherTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/authorizer/ZkNodeChangeNotificationWatcherTest.java
@@ -25,6 +25,11 @@ import org.apache.fluss.server.zk.data.ZkData;
 import org.apache.fluss.testutils.common.AllCallbackWrapper;
 import org.apache.fluss.utils.clock.ManualClock;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -32,12 +37,16 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 /** Test for {@link ZkNodeChangeNotificationWatcher }. */
 public class ZkNodeChangeNotificationWatcherTest {
@@ -119,6 +128,55 @@ public class ZkNodeChangeNotificationWatcherTest {
                 () -> assertThat(zookeeperClient.getChildren(seqNodeRoot)).hasSize(2));
     }
 
+    @Test
+    void testNotificationDeletedByAnotherWatcherDuringPurge() throws Exception {
+        String seqNodeRoot = ZkData.AclChangesNode.path();
+        String seqNodePrefix = ZkData.AclChangeNotificationNode.prefix();
+        ZooKeeperClient zooKeeperClient =
+                ZOO_KEEPER_EXTENSION_WRAPPER
+                        .getCustomExtension()
+                        .getZooKeeperClient(NOPErrorHandler.INSTANCE);
+        Resource resource = Resource.cluster();
+        zooKeeperClient.insertAclChangeNotification(resource);
+
+        ZooKeeperClient spyingZooKeeperClient = spy(zooKeeperClient);
+        doAnswer(
+                        invocation -> {
+                            zooKeeperClient.deletePath(invocation.getArgument(0));
+                            return Optional.empty();
+                        })
+                .when(spyingZooKeeperClient)
+                .getStat(anyString());
+
+        TestingNotificationHandler handler = new TestingNotificationHandler();
+        ZkNodeChangeNotificationWatcher watcher =
+                new ZkNodeChangeNotificationWatcher(
+                        spyingZooKeeperClient,
+                        seqNodeRoot,
+                        seqNodePrefix,
+                        Duration.ofMinutes(5).toMillis(),
+                        handler,
+                        new ManualClock());
+
+        Logger logger = (Logger) LogManager.getLogger(ZkNodeChangeNotificationWatcher.class);
+        TestingAppender appender = new TestingAppender();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            watcher.start();
+            assertThat(handler.resourceNotifications).containsExactly(resource);
+            assertThat(appender.messages)
+                    .noneMatch(
+                            message ->
+                                    message.contains(
+                                            "Error while purging obsolete notification change"));
+        } finally {
+            watcher.stop();
+            logger.removeAppender(appender);
+            appender.stop();
+        }
+    }
+
     private static class TestingNotificationHandler
             implements ZkNodeChangeNotificationWatcher.NotificationHandler {
         public BlockingQueue<Resource> resourceNotifications = new LinkedBlockingQueue<>();
@@ -127,6 +185,19 @@ public class ZkNodeChangeNotificationWatcherTest {
         public void processNotification(byte[] notification) {
             Resource resource = ZkData.AclChangeNotificationNode.decode(notification);
             resourceNotifications.add(resource);
+        }
+    }
+
+    private static class TestingAppender extends AbstractAppender {
+        private final List<String> messages = new ArrayList<>();
+
+        private TestingAppender() {
+            super("testing", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
         }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3753 

<!-- What is the purpose of the change -->

### Brief change log

empty check for zk stats

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
