### PR TITLE
[server] Fix tmp file cleanup in remote log index cache init

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogIndexCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogIndexCache.java
@@ -370,7 +370,7 @@ public class RemoteLogIndexCache implements Closeable {
         try (Stream<Path> paths = Files.list(cacheDir.toPath())) {
             paths.forEach(
                     path -> {
-                        if (path.endsWith(TMP_FILE_SUFFIX)) {
+                        if (path.getFileName().toString().endsWith(TMP_FILE_SUFFIX)) {
                             try {
                                 if (Files.deleteIfExists(path)) {
                                     LOG.debug("Deleted file path {} on cache initialization", path);

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogIndexCacheTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogIndexCacheTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
@@ -155,6 +156,24 @@ class RemoteLogIndexCacheTest extends RemoteLogTestBase {
         long resultOffset =
                 rlIndexCache.lookupOffsetForTimestamp(remoteLogSegment, timestampOffset.timestamp);
         assertThat(offsetPosition.getOffset()).isEqualTo(resultOffset);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testInitDeletesOrphanedTmpFiles(boolean partitionTable) throws Exception {
+        LogTablet logTablet = makeLogTabletAndAddSegments(partitionTable);
+        RemoteLogSegment remoteLogSegment = copyLogSegmentToRemote(logTablet, remoteLogStorage, 0);
+
+        rlIndexCache = new RemoteLogIndexCache(1024 * 1024L, remoteLogStorage, tempDir);
+        File offsetIndexFile = rlIndexCache.getIndexEntry(remoteLogSegment).offsetIndex().file();
+        File tmpFile =
+                new File(offsetIndexFile.getParentFile(), offsetIndexFile.getName() + ".tmp");
+        Files.write(tmpFile.toPath(), new byte[] {0});
+
+        rlIndexCache = new RemoteLogIndexCache(1024 * 1024L, remoteLogStorage, tempDir);
+        assertThat(tmpFile).doesNotExist();
+        assertThat(rlIndexCache.getInternalCache().asMap())
+                .containsKey(remoteLogSegment.remoteLogSegmentId());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/3754

The .tmp cleanup in RemoteLogIndexCache.init() never fires, Path.endsWith(".tmp") compares path elements, not filename suffixes. Use the filename string instead, so orphaned partial downloads are actually deleted on startup.