### PR TITLE
[test] Fix unstable testKvSnapshotLeaseAfterCoordinatorServerRestart

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
@@ -1175,7 +1175,6 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isPresent();
 
         restartCoordinatorServer(zkClient);
-        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
 
         lease.dropLease().get();
         assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isNotPresent();
@@ -1188,6 +1187,10 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
                 Duration.ofMinutes(1),
                 "Coordinator server node still exists in ZooKeeper");
         FLUSS_CLUSTER_EXTENSION.startCoordinatorServer();
+        // The retryable gateway proxy refreshes metadata from a tablet server and retries only
+        // once, so wait until the tablet servers have learned the new coordinator address before
+        // issuing the next lease request; the client itself still holds the stale address.
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes the unstable test `FlussAdminITCase.testKvSnapshotLeaseAfterCoordinatorServerRestart` (fixes issue #3735)
- Root cause: `RetryableGatewayClientProxy` retries a failed lease RPC exactly once, after refreshing metadata **from a tablet server**. After a coordinator restart, tablet servers learn the new coordinator address asynchronously (via `UpdateMetadataRequest` sent once the new coordinator's event processor initializes). If the client's refresh raced ahead of that propagation, it fetched the stale coordinator address, the single retry hit the dead port again, and `NetworkException: Disconnected from node cs-0` surfaced.
- Fix: move `waitUntilAllGatewayHasSameMetadata()` into the `restartCoordinatorServer()` helper so every restart (previously only the third one, before `dropLease`) waits for tablet servers to learn the new coordinator address before the next lease request. The test's intent is preserved: the client still holds the stale cached coordinator address, so the retry-with-metadata-refresh path is still exercised on every operation.

## Test Plan
- Ran `FlussAdminITCase#testKvSnapshotLeaseAfterCoordinatorServerRestart` 6 consecutive times locally: 6/6 passed (previously failed intermittently in CI).

🤖 AI-assisted changes - reviewed by human developer