### PR TITLE
[client][rust] Align fixed-schema Arrow reads by stable column ID

### DIFF
--- a/fluss-rust/crates/fluss/src/client/table/log_fetch_buffer.rs
+++ b/fluss-rust/crates/fluss/src/client/table/log_fetch_buffer.rs
@@ -991,6 +991,7 @@ mod tests {
     };
     use crate::row::GenericRow;
     use crate::test_utils::{build_table_info, build_table_info_with_columns};
+    use arrow::array::{Array, StringArray};
     use std::sync::Arc;
 
     fn expect_data<T>(result: FetchResult<T>) -> T {
@@ -1193,7 +1194,8 @@ mod tests {
                 .with_fluss_row_type(new_row_type_arc),
         );
         let resolver = Arc::new(
-            ReadContextResolver::new(1, local_ctx, remote_ctx, None).with_fixed_schema(true),
+            ReadContextResolver::new(1, local_ctx, remote_ctx, None)
+                .with_fixed_schema(true, new_table_info.get_schema()),
         );
 
         let mut fetch = DefaultCompletedFetch::new(
@@ -1219,6 +1221,119 @@ mod tests {
         assert_eq!(batch.num_columns(), 2);
         assert_eq!(batch.column(1).null_count(), 1);
 
+        Ok(())
+    }
+
+    #[test]
+    fn fixed_schema_fetch_batches_preserves_renamed_column_by_id() -> Result<()> {
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let old_table_info = Arc::new(build_table_info_with_columns(
+            table_path.clone(),
+            1,
+            1,
+            vec![
+                DataField::new("id", DataTypes::int(), None),
+                DataField::new("old_name", DataTypes::string(), None),
+            ],
+        ));
+        let new_table_info = build_table_info_with_columns(
+            table_path.clone(),
+            1,
+            1,
+            vec![
+                DataField::new("id", DataTypes::int(), None),
+                DataField::new("new_name", DataTypes::string(), None),
+            ],
+        );
+        let physical_table_path = Arc::new(PhysicalTablePath::of(Arc::new(table_path)));
+
+        let mut builder = MemoryLogRecordsArrowBuilder::new(
+            0,
+            old_table_info.get_row_type(),
+            false,
+            ArrowCompressionInfo {
+                compression_type: ArrowCompressionType::None,
+                compression_level: DEFAULT_NON_ZSTD_COMPRESSION_LEVEL,
+            },
+            usize::MAX,
+            Arc::new(ArrowCompressionRatioEstimator::default()),
+        )?;
+        let mut row = GenericRow::new(2);
+        row.set_field(0, 1_i32);
+        row.set_field(1, "alice");
+        let record =
+            WriteRecord::for_append(Arc::clone(&old_table_info), physical_table_path, 1, &row);
+        builder.append(&record)?;
+
+        let data = builder.build()?;
+        let target_arrow_schema = to_arrow_schema(new_table_info.get_row_type())?;
+        let target_row_type = Arc::new(new_table_info.get_row_type().clone());
+        let local_ctx = Arc::new(
+            ReadContext::new(
+                target_arrow_schema.clone(),
+                Arc::clone(&target_row_type),
+                false,
+            )
+            .with_fluss_row_type(Arc::clone(&target_row_type)),
+        );
+        let remote_ctx = Arc::new(
+            ReadContext::new(
+                target_arrow_schema.clone(),
+                Arc::clone(&target_row_type),
+                true,
+            )
+            .with_fluss_row_type(target_row_type),
+        );
+        let resolver = Arc::new(
+            ReadContextResolver::new(1, local_ctx, remote_ctx, None)
+                .with_fixed_schema(true, new_table_info.get_schema()),
+        );
+        let mut fetch = DefaultCompletedFetch::new(
+            TableBucket::new(1, 0),
+            LogRecordsBatches::new(data.clone()),
+            data.len(),
+            Arc::clone(&resolver),
+            false,
+            0,
+            0,
+        );
+
+        assert!(matches!(
+            fetch.fetch_batches(10)?,
+            FetchResult::SchemaRequired(0)
+        ));
+        resolver.register_schema(0, old_table_info.get_schema())?;
+
+        let batches = expect_data(fetch.fetch_batches(10)?);
+        let batch = &batches[0].0;
+        assert_eq!(batch.schema().field(1).name(), "new_name");
+        let names = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("renamed string column");
+        assert_eq!(names.null_count(), 0);
+        assert_eq!(names.value(0), "alice");
+
+        let mut remote_fetch = DefaultCompletedFetch::new(
+            TableBucket::new(1, 0),
+            LogRecordsBatches::new(data.clone()),
+            data.len(),
+            resolver,
+            true,
+            0,
+            0,
+        );
+        let remote_batches = expect_data(remote_fetch.fetch_batches(10)?);
+        let remote_batch = &remote_batches[0].0;
+        assert_eq!(remote_batch.schema().field(1).name(), "new_name");
+        let remote_names = remote_batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("remote renamed string column");
+        assert_eq!(remote_names.null_count(), 0);
+        assert_eq!(remote_names.value(0), "alice");
         Ok(())
     }
 

--- a/fluss-rust/crates/fluss/src/client/table/read_context_resolver.rs
+++ b/fluss-rust/crates/fluss/src/client/table/read_context_resolver.rs
@@ -29,7 +29,7 @@
 
 use crate::client::ClientSchemaGetter;
 use crate::error::{Error, Result};
-use crate::metadata::{RowType, Schema};
+use crate::metadata::{RowType, Schema, UNEXIST_MAPPING, index_mapping};
 use crate::record::{ReadContext, to_arrow_schema};
 use arrow_schema::SchemaRef;
 use parking_lot::RwLock;
@@ -50,7 +50,8 @@ pub(crate) struct ReadContextResolver {
     /// When true, contexts for older schemas still decode with their write-time
     /// schema, then align the output to the scanner creation schema.
     fixed_schema: bool,
-    fixed_target_schema: Option<SchemaRef>,
+    fixed_target_arrow_schema: Option<SchemaRef>,
+    fixed_target_fluss_schema: Option<Schema>,
     fixed_target_row_type: Option<Arc<RowType>>,
 }
 
@@ -82,7 +83,8 @@ impl ReadContextResolver {
             projected_fields,
             schema_getter: None,
             fixed_schema: false,
-            fixed_target_schema: None,
+            fixed_target_arrow_schema: None,
+            fixed_target_fluss_schema: None,
             fixed_target_row_type: None,
         }
     }
@@ -92,9 +94,10 @@ impl ReadContextResolver {
         self
     }
 
-    pub fn with_fixed_schema(mut self, fixed_schema: bool) -> Self {
+    pub fn with_fixed_schema(mut self, fixed_schema: bool, target_fluss_schema: &Schema) -> Self {
         self.fixed_schema = fixed_schema;
         if fixed_schema {
+            self.fixed_target_fluss_schema = Some(target_fluss_schema.clone());
             let fixed_target = {
                 let guard = self.contexts.read();
                 guard
@@ -102,11 +105,12 @@ impl ReadContextResolver {
                     .map(|ctx| (ctx.local.target_schema(), ctx.local.row_type_arc()))
             };
             if let Some((target_schema, target_row_type)) = fixed_target {
-                self.fixed_target_schema = Some(target_schema);
+                self.fixed_target_arrow_schema = Some(target_schema);
                 self.fixed_target_row_type = Some(target_row_type);
             }
         } else {
-            self.fixed_target_schema = None;
+            self.fixed_target_arrow_schema = None;
+            self.fixed_target_fluss_schema = None;
             self.fixed_target_row_type = None;
         }
         self
@@ -170,6 +174,29 @@ impl ReadContextResolver {
         let source_row_type = schema.row_type();
         let source_arrow_schema = to_arrow_schema(source_row_type)?;
         let source_row_type_arc = Arc::new(source_row_type.clone());
+        let source_indexes = if self.fixed_schema {
+            let target_schema =
+                self.fixed_target_fluss_schema
+                    .as_ref()
+                    .ok_or_else(|| Error::UnexpectedError {
+                        message: "Fixed-schema resolver has no target Fluss schema".to_string(),
+                        source: None,
+                    })?;
+            Some(
+                index_mapping(schema, target_schema)?
+                    .into_iter()
+                    .map(|index| {
+                        if index == UNEXIST_MAPPING {
+                            None
+                        } else {
+                            Some(index as usize)
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            None
+        };
         let output_row_type = self
             .fixed_target_row_type
             .clone()
@@ -183,10 +210,21 @@ impl ReadContextResolver {
                 .with_fluss_row_type(output_row_type);
 
         if self.fixed_schema {
-            if let Some(target_schema) = &self.fixed_target_schema {
-                local_context = local_context.with_target_schema_alignment(target_schema.clone());
-                remote_context = remote_context.with_target_schema_alignment(target_schema.clone());
-            }
+            let target_schema =
+                self.fixed_target_arrow_schema
+                    .as_ref()
+                    .ok_or_else(|| Error::UnexpectedError {
+                        message: "Fixed-schema resolver has no target Arrow schema".to_string(),
+                        source: None,
+                    })?;
+            let source_indexes = source_indexes.ok_or_else(|| Error::UnexpectedError {
+                message: "Fixed-schema resolver has no source-index mapping".to_string(),
+                source: None,
+            })?;
+            local_context = local_context
+                .with_target_schema_alignment(target_schema.clone(), source_indexes.clone());
+            remote_context =
+                remote_context.with_target_schema_alignment(target_schema.clone(), source_indexes);
         }
 
         let local_context = Arc::new(local_context);

--- a/fluss-rust/crates/fluss/src/client/table/scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/scanner.rs
@@ -1242,7 +1242,7 @@ impl LogFetcher {
                 projected_fields,
             )
             .with_schema_getter(Arc::clone(&schema_getter))
-            .with_fixed_schema(fixed_schema),
+            .with_fixed_schema(fixed_schema, table_info.get_schema()),
         );
 
         let tmp_dir = TempDir::with_prefix("fluss-remote-logs")?;

--- a/fluss-rust/crates/fluss/src/record/arrow.rs
+++ b/fluss-rust/crates/fluss/src/record/arrow.rs
@@ -1440,7 +1440,7 @@ pub struct ReadContext {
     projection: Option<Projection>,
     is_from_remote: bool,
     fluss_row_type: Option<Arc<RowType>>,
-    align_to_target_schema: bool,
+    schema_alignment: Option<Vec<Option<usize>>>,
 }
 
 #[derive(Clone)]
@@ -1466,7 +1466,7 @@ impl ReadContext {
             projection: None,
             is_from_remote,
             fluss_row_type: None,
-            align_to_target_schema: false,
+            schema_alignment: None,
         }
     }
 
@@ -1487,13 +1487,17 @@ impl ReadContext {
         self.row_type.clone()
     }
 
-    pub(crate) fn with_target_schema_alignment(mut self, target_schema: SchemaRef) -> ReadContext {
+    pub(crate) fn with_target_schema_alignment(
+        mut self,
+        target_schema: SchemaRef,
+        source_indexes: Vec<Option<usize>>,
+    ) -> ReadContext {
         debug_assert!(
             self.projection.is_none(),
             "target schema alignment is not supported with projection"
         );
         self.target_schema = target_schema;
-        self.align_to_target_schema = true;
+        self.schema_alignment = Some(source_indexes);
         self
     }
 
@@ -1568,7 +1572,7 @@ impl ReadContext {
             projection: Some(project),
             is_from_remote,
             fluss_row_type: None,
-            align_to_target_schema: false,
+            schema_alignment: None,
         })
     }
 
@@ -1611,7 +1615,7 @@ impl ReadContext {
 
         let resolve_schema = {
             // if from remote, no projection, need to use full schema
-            if self.is_from_remote || self.align_to_target_schema {
+            if self.is_from_remote || self.schema_alignment.is_some() {
                 self.full_schema.clone()
             } else {
                 // the record batch from server must be ordered by field pos,
@@ -1664,10 +1668,13 @@ impl ReadContext {
             }
             _ => record_batch,
         };
-        let record_batch = if self.align_to_target_schema {
-            align_record_batch_to_schema(record_batch, self.target_schema.clone())?
-        } else {
-            record_batch
+        let record_batch = match &self.schema_alignment {
+            Some(source_indexes) => align_record_batch_to_schema(
+                record_batch,
+                self.target_schema.clone(),
+                source_indexes,
+            )?,
+            None => record_batch,
         };
         Ok(record_batch)
     }
@@ -1695,10 +1702,13 @@ impl ReadContext {
             }
             None => record_batch,
         };
-        let record_batch = if self.align_to_target_schema {
-            align_record_batch_to_schema(record_batch, self.target_schema.clone())?
-        } else {
-            record_batch
+        let record_batch = match &self.schema_alignment {
+            Some(source_indexes) => align_record_batch_to_schema(
+                record_batch,
+                self.target_schema.clone(),
+                source_indexes,
+            )?,
+            None => record_batch,
         };
         Ok(Some(record_batch))
     }
@@ -1707,19 +1717,34 @@ impl ReadContext {
 fn align_record_batch_to_schema(
     record_batch: RecordBatch,
     target_schema: SchemaRef,
+    source_indexes: &[Option<usize>],
 ) -> Result<RecordBatch> {
-    if record_batch.schema_ref() == &target_schema {
-        return Ok(record_batch);
+    if source_indexes.len() != target_schema.fields().len() {
+        return Err(Error::UnexpectedError {
+            message: format!(
+                "Schema alignment has {} indexes for {} target fields",
+                source_indexes.len(),
+                target_schema.fields().len()
+            ),
+            source: None,
+        });
     }
 
     let row_count = record_batch.num_rows();
-    let source_schema = record_batch.schema();
     let mut columns = Vec::with_capacity(target_schema.fields().len());
 
-    for target_field in target_schema.fields() {
-        match source_schema.index_of(target_field.name()) {
-            Ok(source_idx) => {
-                let column = record_batch.column(source_idx);
+    for (target_field, source_index) in target_schema.fields().iter().zip(source_indexes.iter()) {
+        match source_index {
+            Some(index) => {
+                let column = record_batch.columns().get(*index).ok_or_else(|| {
+                    Error::UnexpectedError {
+                        message: format!(
+                            "Schema alignment source index {index} is out of bounds for {} columns",
+                            record_batch.num_columns()
+                        ),
+                        source: None,
+                    }
+                })?;
                 if column.data_type() != target_field.data_type() {
                     return Err(Error::UnexpectedError {
                         message: format!(
@@ -1733,7 +1758,7 @@ fn align_record_batch_to_schema(
                 }
                 columns.push(column.clone());
             }
-            Err(_) => columns.push(new_null_array(target_field.data_type(), row_count)),
+            None => columns.push(new_null_array(target_field.data_type(), row_count)),
         }
     }
 

--- a/fluss-rust/crates/fluss/tests/integration/log_table.rs
+++ b/fluss-rust/crates/fluss/tests/integration/log_table.rs
@@ -25,11 +25,11 @@ mod table_test {
         poll_until_count, poll_until_nonempty, row_dt_basics_columns, scalar_dt_columns,
         wait_for_partitions_ready, wait_for_table_buckets_ready, wait_for_table_ready,
     };
-    use arrow::array::record_batch;
+    use arrow::array::{Array, StringArray, record_batch};
     use fluss::client::{EARLIEST_OFFSET, FlussTable, TableScan};
     use fluss::metadata::{
-        AddColumn, AlterTableChanges, ColumnPositionType, DataField, DataTypes, JsonSerde, Schema,
-        TableDescriptor, TablePath,
+        AddColumn, AlterTableChanges, ColumnPositionType, DataField, DataTypes, JsonSerde,
+        RenameColumn, Schema, TableDescriptor, TablePath,
     };
     use fluss::record::ScanRecord;
     use fluss::row::binary_array::FlussArrayWriter;
@@ -2180,6 +2180,112 @@ mod table_test {
             .drop_table(&table_path, false)
             .await
             .expect("Failed to drop table");
+    }
+
+    #[tokio::test]
+    async fn schema_evolution_rename_column_log_scanner_fixed_schema() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("admin");
+        let table_path = TablePath::new(
+            "fluss",
+            "test_schema_evolution_rename_column_log_scanner_fixed_schema",
+        );
+        let descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("id", DataTypes::int())
+                    .column("old_name", DataTypes::string())
+                    .build()
+                    .expect("schema"),
+            )
+            .build()
+            .expect("descriptor");
+
+        create_table(&admin, &table_path, &descriptor).await;
+        wait_for_table_ready(&admin, &table_path).await;
+
+        let old_table = connection.get_table(&table_path).await.expect("old table");
+        let writer = old_table
+            .new_append()
+            .expect("append")
+            .create_writer()
+            .expect("writer");
+        writer
+            .append_arrow_batch(
+                record_batch!(("id", Int32, [1, 2]), ("old_name", Utf8, ["alice", "bob"]))
+                    .expect("batch"),
+            )
+            .expect("append old batch");
+        writer.flush().await.expect("flush");
+
+        admin
+            .alter_table(
+                &table_path,
+                false,
+                AlterTableChanges {
+                    rename_columns: vec![RenameColumn {
+                        old_column_name: "old_name".to_string(),
+                        new_column_name: "new_name".to_string(),
+                    }],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("rename column");
+
+        let renamed_table = connection
+            .get_table(&table_path)
+            .await
+            .expect("renamed table");
+        let scanner = renamed_table
+            .new_scan()
+            .with_fixed_schema(true)
+            .create_record_batch_log_scanner()
+            .expect("scanner");
+        for bucket_id in 0..renamed_table.get_table_info().get_num_buckets() {
+            scanner
+                .subscribe(bucket_id, EARLIEST_OFFSET)
+                .await
+                .expect("subscribe");
+        }
+        assert_eq!(scanner.schema().field(1).name(), "new_name");
+
+        let mut names = poll_until_count(
+            2,
+            DEFAULT_POLL_TIMEOUT,
+            Duration::from_millis(500),
+            async |timeout| {
+                scanner
+                    .poll(timeout)
+                    .await
+                    .expect("poll")
+                    .iter()
+                    .flat_map(|scan_batch| {
+                        let values = scan_batch
+                            .batch()
+                            .column(1)
+                            .as_any()
+                            .downcast_ref::<StringArray>()
+                            .expect("renamed string column");
+                        (0..values.len())
+                            .map(|index| {
+                                assert!(!values.is_null(index), "renamed value must not be null");
+                                values.value(index).to_string()
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>()
+            },
+        )
+        .await;
+        names.sort();
+        assert_eq!(names, vec!["alice".to_string(), "bob".to_string()]);
+
+        admin
+            .drop_table(&table_path, false)
+            .await
+            .expect("drop table");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3768

<!-- What is the purpose of the change -->

### Brief change log

The Rust fixed-schema log scanner previously aligned historical Arrow batches with the scanner schema by field name.

This behavior was inconsistent with the KV `FixedSchemaDecoder`, which uses stable Fluss column IDs. Name-based alignment may lose values when a column keeps the same ID but changes its name, or incorrectly reuse values when
different column IDs have the same name.

This PR aligns fixed-schema log reads by column ID, consistent with `FixedSchemaDecoder`.

### Tests

Added Rust unit tests.

### API and Format

This change does not affect the public API or storage format.

### Documentation

No.