### PR TITLE
[client] Introduce dedicated client.lookup.close-timeout config option

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/FlussConnection.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/FlussConnection.java
@@ -201,9 +201,9 @@ public final class FlussConnection implements Connection {
         }
 
         if (lookupClient != null) {
-            // timeout is Long.MAX_VALUE to make the pending get request
-            // to be processed
-            lookupClient.close(Duration.ofMillis(Long.MAX_VALUE));
+            // use the configured close timeout; by default it is Long.MAX_VALUE to let
+            // pending lookup requests be processed before close
+            lookupClient.close(conf.get(ConfigOptions.CLIENT_LOOKUP_CLOSE_TIMEOUT));
         }
 
         if (remoteFileDownloader != null) {

--- a/fluss-client/src/test/java/org/apache/fluss/client/lookup/LookupClientCloseTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/lookup/LookupClientCloseTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.client.lookup;
+
+import org.apache.fluss.client.metadata.TestingMetadataUpdater;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.metadata.TableInfo;
+import org.apache.fluss.metadata.TablePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/** Tests for {@link LookupClient} close behavior with configurable timeout. */
+class LookupClientCloseTest {
+
+    @Test
+    void testCloseWithVeryShortTimeoutReturnsNormally() {
+        // Create a lookup client with default config (no pending lookups)
+        LookupClient lookupClient = createLookupClient();
+
+        // Closing with a 1ms timeout should return normally without throwing
+        // InterruptedException, even though there are no pending requests to wait for.
+        assertThatCode(() -> lookupClient.close(Duration.ofMillis(1))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testCloseWithZeroTimeoutReturnsNormally() {
+        LookupClient lookupClient = createLookupClient();
+
+        // A zero-duration close should also return without error.
+        assertThatCode(() -> lookupClient.close(Duration.ZERO)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testCloseWithLargeTimeoutReturnsNormally() {
+        LookupClient lookupClient = createLookupClient();
+
+        // Closing with a large timeout should also work fine when there are no pending requests.
+        assertThatCode(() -> lookupClient.close(Duration.ofSeconds(5))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testCloseIsIdempotent() {
+        LookupClient lookupClient = createLookupClient();
+
+        // First close should succeed
+        lookupClient.close(Duration.ofMillis(100));
+
+        // Second close should also return without throwing
+        assertThatCode(() -> lookupClient.close(Duration.ofMillis(100))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testDefaultCloseTimeoutConfigValue() {
+        // Verify the default value of CLIENT_LOOKUP_CLOSE_TIMEOUT is Long.MAX_VALUE
+        // which preserves the previous behavior of waiting indefinitely.
+        Configuration conf = new Configuration();
+        assertThat(conf.get(ConfigOptions.CLIENT_LOOKUP_CLOSE_TIMEOUT))
+                .isEqualTo(Duration.ofMillis(Long.MAX_VALUE));
+    }
+
+    private LookupClient createLookupClient() {
+        Map<TablePath, TableInfo> tableInfos = new HashMap<>();
+        TestingMetadataUpdater metadataUpdater = TestingMetadataUpdater.builder(tableInfos).build();
+        Configuration conf = new Configuration();
+        // Use small queue to avoid resource waste
+        conf.set(ConfigOptions.CLIENT_LOOKUP_QUEUE_SIZE, 5);
+        conf.set(ConfigOptions.CLIENT_LOOKUP_MAX_BATCH_SIZE, 10);
+        return new LookupClient(conf, metadataUpdater);
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -1518,6 +1518,17 @@ public class ConfigOptions {
                             "Setting a value greater than zero will cause the client to resend any lookup request "
                                     + "that fails with a potentially transient error.");
 
+    public static final ConfigOption<Duration> CLIENT_LOOKUP_CLOSE_TIMEOUT =
+            key("client.lookup.close-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(Long.MAX_VALUE))
+                    .withDescription(
+                            "The timeout for closing the lookup client. By default, the lookup client "
+                                    + "will wait indefinitely for pending lookup requests to complete during "
+                                    + "close. Set a smaller value to bound the close time, which is useful "
+                                    + "in scenarios where the client must shut down within a bounded time "
+                                    + "(e.g., on SIGTERM in Kubernetes).");
+
     public static final ConfigOption<Integer> CLIENT_SCANNER_REMOTE_LOG_PREFETCH_NUM =
             key("client.scanner.remote-log.prefetch-num")
                     .intType()


### PR DESCRIPTION
## Purpose

`LookupClient#close(Duration timeout)` already accepts a `Duration` parameter,
but the only caller in `FlussConnection#close()` was hard-coding
`Duration.ofMillis(Long.MAX_VALUE)` to let pending lookup requests drain.
That hard-coded value is undesirable in K8s / graceful-shutdown scenarios
where the client must finish within a bounded budget (e.g. before SIGTERM
SIGKILL grace period elapses), and it is also harder to tune per-deployment.

This PR introduces a dedicated, user-tunable config option
`client.lookup.close-timeout` and wires it through the only existing caller,
while keeping the public `LookupClient#close(Duration)` signature intact so
that no downstream code is broken.

Linked issue: N/A (usability / K8s shutdown observability improvement)

## Brief change log

- **Add** new `ConfigOption<Duration> CLIENT_LOOKUP_CLOSE_TIMEOUT`
  (`client.lookup.close-timeout`) in
  `fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java`,
  with default value `Long.MAX_VALUE` (preserves previous behavior) and a
  javadoc-style description explaining the K8s / SIGTERM use case.
- **Update** `FlussConnection#close()` in
  `fluss-client/src/main/java/org/apache/fluss/client/FlussConnection.java`:
  read the new option from the connection's `Configuration` and pass it to
  `lookupClient.close(...)` instead of the hard-coded
  `Duration.ofMillis(Long.MAX_VALUE)`. The previous comment is updated to
  reflect the new behavior.
- **No change** to `LookupClient#close(Duration)` itself — its public
  signature is preserved, so existing direct callers keep working.
- **Add** new test class
  `fluss-client/src/test/java/org/apache/fluss/client/lookup/LookupClientCloseTest.java`
  covering 5 close-timeout scenarios (see Tests).

## Tests

- `LookupClientCloseTest#testCloseWithVeryShortTimeoutReturnsNormally` — closes
  a fresh `LookupClient` with `Duration.ofMillis(1)`; asserts no exception is
  thrown and no `InterruptedException` leaks.
- `LookupClientCloseTest#testCloseWithZeroTimeoutReturnsNormally` — closes
  with `Duration.ZERO`; verifies the API tolerates a zero-duration close.
- `LookupClientCloseTest#testCloseWithLargeTimeoutReturnsNormally` — closes
  with `Duration.ofSeconds(5)`; sanity check for the normal happy-path
  duration.
- `LookupClientCloseTest#testCloseIsIdempotent` — closes the same client
  twice in a row; verifies the second call also returns without error.
- `LookupClientCloseTest#testDefaultCloseTimeoutConfigValue` — asserts the
  default value of `CLIENT_LOOKUP_CLOSE_TIMEOUT` is
  `Duration.ofMillis(Long.MAX_VALUE)`, locking in backwards compatibility.

All 5 tests are unit tests (no real cluster required); they build a
`LookupClient` via a `TestingMetadataUpdater`. Pre-existing
`fluss-client` tests are unaffected — no regression observed locally.

## API and Format

- **No public API removed or renamed.** `LookupClient#close(Duration)` keeps
  the same signature.
- New config option follows the
  [AGENTS.md §8 Configuration Patterns](AGENTS.md): `durationType()`,
  explicit `defaultValue(...)`, javadoc `withDescription(...)`,
  hierarchical key `client.lookup.close-timeout`.
- `mvn spotless:apply` clean.
- Java 8 compatible: no `var`, no `Optional.isEmpty`, no `List.of`.
- All test assertions use AssertJ (`assertThat(...).isEqualTo(...)` /
  `assertThatCode(...).doesNotThrowAnyException()`).
- Commit title `[client] Introduce dedicated client.lookup.close-timeout
  config option` follows the `<component>` prefix convention.
- `./mvnw clean install -DskipTests -T 32` passes locally on JDK
  `11.0.23-kona`.

## Documentation

- The new option's javadoc / `withDescription` already documents the K8s
  SIGTERM use case, so it will be picked up by the doc generator
  (`./mvnw -pl fluss-docgen verify`) automatically.
- No changes to the public website are needed beyond the auto-generated
  config reference entry.
