### PR TITLE
[server] fix KV snapshot restoring fallback

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManager.java
@@ -203,8 +203,7 @@ public class CompletedSnapshotStoreManager {
                 retrievedSnapshots.add(
                         checkNotNull(snapshotStateHandle.retrieveCompleteSnapshot()));
             } catch (Exception e) {
-                if (e.getMessage()
-                        .contains(CompletedSnapshot.SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE)) {
+                if (CompletedSnapshot.isSnapshotDataNotExists(e)) {
                     LOG.error(
                             "Metadata not found for snapshot {} of table bucket {}, maybe snapshot already removed or broken.",
                             snapshotStateHandle.getSnapshotId(),

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManager.java
@@ -203,7 +203,8 @@ public class CompletedSnapshotStoreManager {
                 retrievedSnapshots.add(
                         checkNotNull(snapshotStateHandle.retrieveCompleteSnapshot()));
             } catch (Exception e) {
-                if (CompletedSnapshot.isSnapshotDataNotExists(e)) {
+                if (CompletedSnapshot.isSnapshotDataNotExists(
+                        e, snapshotStateHandle.getMetadataFilePath())) {
                     LOG.error(
                             "Metadata not found for snapshot {} of table bucket {}, maybe snapshot already removed or broken.",
                             snapshotStateHandle.getSnapshotId(),

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshot.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshot.java
@@ -27,7 +27,9 @@ import org.apache.fluss.utils.concurrent.FutureUtils;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -204,6 +206,9 @@ public class CompletedSnapshot {
     public static boolean isSnapshotDataNotExists(Throwable throwable) {
         Throwable cause = throwable;
         while (cause != null) {
+            if (cause instanceof FileNotFoundException || cause instanceof NoSuchFileException) {
+                return true;
+            }
             String message = cause.getMessage();
             if (message != null
                     && (message.contains(SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE)
@@ -213,6 +218,27 @@ public class CompletedSnapshot {
             cause = cause.getCause();
         }
         return false;
+    }
+
+    /**
+     * Returns whether the throwable indicates missing snapshot data and the given path is confirmed
+     * to be absent from remote storage.
+     *
+     * <p>If checking the path fails, this method conservatively returns {@code false} so callers do
+     * not perform destructive cleanup. The verification failure is attached to the original
+     * throwable as a suppressed exception for diagnostics.
+     */
+    public static boolean isSnapshotDataNotExists(Throwable throwable, FsPath dataPath) {
+        if (!isSnapshotDataNotExists(throwable)) {
+            return false;
+        }
+
+        try {
+            return !dataPath.getFileSystem().exists(dataPath);
+        } catch (Exception verificationException) {
+            throwable.addSuppressed(verificationException);
+            return false;
+        }
     }
 
     private void disposeMetadata() throws IOException {

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshot.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshot.java
@@ -88,6 +88,9 @@ public class CompletedSnapshot {
 
     public static final String SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE = "No such file or directory";
 
+    private static final String HADOOP_SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE =
+            "File does not exist";
+
     public CompletedSnapshot(
             TableBucket tableBucket,
             long snapshotID,
@@ -163,9 +166,8 @@ public class CompletedSnapshot {
     }
 
     public CompletableFuture<Void> discardAsync(Executor ioExecutor) {
-        // it'll discard the snapshot files for kv, it'll always discard
-        // the private files; for shared files, only if they're not be registered in
-        // SharedKvRegistry, can the files be deleted.
+        // Always discard private files. Shared files are discarded directly only when the handle
+        // represents a newly created snapshot that has not been registered.
         CompletableFuture<Void> discardKvFuture =
                 FutureUtils.runAsync(kvSnapshotHandle::discard, ioExecutor);
 
@@ -193,6 +195,24 @@ public class CompletedSnapshot {
 
     public static FsPath getMetadataFilePath(FsPath snapshotLocation) {
         return new FsPath(snapshotLocation, SNAPSHOT_METADATA_FILE_NAME);
+    }
+
+    /**
+     * Returns whether the throwable or any of its causes indicates that snapshot data no longer
+     * exists in remote storage.
+     */
+    public static boolean isSnapshotDataNotExists(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            String message = cause.getMessage();
+            if (message != null
+                    && (message.contains(SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE)
+                            || message.contains(HADOOP_SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE))) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 
     private void disposeMetadata() throws IOException {

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotJsonSerde.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotJsonSerde.java
@@ -193,7 +193,7 @@ public class CompletedSnapshotJsonSerde
 
         // construct CompletedSnapshot
         KvSnapshotHandle kvSnapshotHandle =
-                new KvSnapshotHandle(sharedFileHandles, privateFileHandles, incrementalSize);
+                KvSnapshotHandle.restore(sharedFileHandles, privateFileHandles, incrementalSize);
 
         Long rowCount = null;
         if (node.has(ROW_COUNT)) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvSnapshotHandle.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvSnapshotHandle.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
+import static org.apache.fluss.utils.Preconditions.checkState;
 
 /**
  * A handle to the snapshot of a kv tablet. It contains the share file handles and the private file
@@ -50,6 +51,11 @@ public class KvSnapshotHandle {
      */
     private boolean ownsSharedFiles;
 
+    /**
+     * The registry where shared files were registered, or null if registration has not happened.
+     */
+    private transient SharedKvFileRegistry sharedKvFileRegistry;
+
     KvSnapshotHandle(
             List<KvFileHandleAndLocalPath> sharedFileHandles,
             List<KvFileHandleAndLocalPath> privateFileHandles,
@@ -69,7 +75,13 @@ public class KvSnapshotHandle {
         return new KvSnapshotHandle(sharedFileHandles, privateFileHandles, incrementalSize, true);
     }
 
-    /** Restores a handle that only references already-persisted shared files. */
+    /**
+     * Restores a handle that only references already-persisted shared files.
+     *
+     * <p>A restored handle never directly deletes shared files because it cannot prove that no
+     * other snapshot references them. Shared files are reclaimed only through registry-based
+     * cleanup; retaining an untracked file is preferred over deleting a file that is still in use.
+     */
     static KvSnapshotHandle restore(
             List<KvFileHandleAndLocalPath> sharedFileHandles,
             List<KvFileHandleAndLocalPath> privateFileHandles,
@@ -133,7 +145,11 @@ public class KvSnapshotHandle {
     }
 
     public void registerKvFileHandles(SharedKvFileRegistry registry, long snapshotID) {
-        checkNotNull(registry);
+        checkState(
+                sharedKvFileRegistry != registry,
+                "The kv file handle has already registered its shared kv files to the given registry.");
+
+        sharedKvFileRegistry = checkNotNull(registry);
         ownsSharedFiles = false;
 
         for (KvFileHandleAndLocalPath handleAndLocalPath : sharedFileHandles) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvSnapshotHandle.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvSnapshotHandle.java
@@ -50,7 +50,7 @@ public class KvSnapshotHandle {
      */
     private boolean ownsSharedFiles;
 
-    private KvSnapshotHandle(
+    KvSnapshotHandle(
             List<KvFileHandleAndLocalPath> sharedFileHandles,
             List<KvFileHandleAndLocalPath> privateFileHandles,
             long incrementalSize,

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvSnapshotHandle.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvSnapshotHandle.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
-import static org.apache.fluss.utils.Preconditions.checkState;
 
 /**
  * A handle to the snapshot of a kv tablet. It contains the share file handles and the private file
@@ -46,22 +45,36 @@ public class KvSnapshotHandle {
     private final long incrementalSize;
 
     /**
-     * Once the shared states are registered, it is the {@link SharedKvFileRegistry}'s
-     * responsibility to cleanup those shared states. But in the cases where the state handle is
-     * discarded before performing the registration, the handle should delete all the shared states
-     * created by it.
-     *
-     * <p>This variable is not null iff the handles was registered.
+     * Whether {@link #discard()} should directly delete the shared files. This is true for newly
+     * created handles until registration and false for restored handles.
      */
-    private transient SharedKvFileRegistry sharedKvFileRegistry;
+    private boolean ownsSharedFiles;
 
-    public KvSnapshotHandle(
+    private KvSnapshotHandle(
             List<KvFileHandleAndLocalPath> sharedFileHandles,
             List<KvFileHandleAndLocalPath> privateFileHandles,
-            long incrementalSize) {
+            long incrementalSize,
+            boolean ownsSharedFiles) {
         this.sharedFileHandles = sharedFileHandles;
         this.privateFileHandles = privateFileHandles;
         this.incrementalSize = incrementalSize;
+        this.ownsSharedFiles = ownsSharedFiles;
+    }
+
+    /** Creates a handle that directly discards its shared files until they are registered. */
+    public static KvSnapshotHandle create(
+            List<KvFileHandleAndLocalPath> sharedFileHandles,
+            List<KvFileHandleAndLocalPath> privateFileHandles,
+            long incrementalSize) {
+        return new KvSnapshotHandle(sharedFileHandles, privateFileHandles, incrementalSize, true);
+    }
+
+    /** Restores a handle that only references already-persisted shared files. */
+    static KvSnapshotHandle restore(
+            List<KvFileHandleAndLocalPath> sharedFileHandles,
+            List<KvFileHandleAndLocalPath> privateFileHandles,
+            long incrementalSize) {
+        return new KvSnapshotHandle(sharedFileHandles, privateFileHandles, incrementalSize, false);
     }
 
     public List<KvFileHandleAndLocalPath> getSharedKvFileHandles() {
@@ -98,9 +111,6 @@ public class KvSnapshotHandle {
     }
 
     public void discard() {
-        SharedKvFileRegistry registry = this.sharedKvFileRegistry;
-        final boolean isRegistered = (registry != null);
-
         try {
             SnapshotUtil.bestEffortDiscardAllKvFiles(
                     privateFileHandles.stream()
@@ -110,7 +120,7 @@ public class KvSnapshotHandle {
             LOG.warn("Could not properly discard misc file states.", e);
         }
 
-        if (!isRegistered) {
+        if (ownsSharedFiles) {
             try {
                 SnapshotUtil.bestEffortDiscardAllKvFiles(
                         sharedFileHandles.stream()
@@ -123,11 +133,8 @@ public class KvSnapshotHandle {
     }
 
     public void registerKvFileHandles(SharedKvFileRegistry registry, long snapshotID) {
-        checkState(
-                sharedKvFileRegistry != registry,
-                "The kv file handle has already registered its shared kv files to the given registry.");
-
-        sharedKvFileRegistry = checkNotNull(registry);
+        checkNotNull(registry);
+        ownsSharedFiles = false;
 
         for (KvFileHandleAndLocalPath handleAndLocalPath : sharedFileHandles) {
             registry.registerReference(

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvSnapshotHandle.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvSnapshotHandle.java
@@ -79,8 +79,9 @@ public class KvSnapshotHandle {
      * Restores a handle that only references already-persisted shared files.
      *
      * <p>A restored handle never directly deletes shared files because it cannot prove that no
-     * other snapshot references them. Shared files are reclaimed only through registry-based
-     * cleanup; retaining an untracked file is preferred over deleting a file that is still in use.
+     * other snapshot references them. If such a handle is discarded before registration, shared
+     * files referenced only by this handle remain orphaned until the table directory is cleaned up.
+     * Retaining those files is preferred over deleting a file that is still in use.
      */
     static KvSnapshotHandle restore(
             List<KvFileHandleAndLocalPath> sharedFileHandles,

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/RocksIncrementalSnapshot.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/RocksIncrementalSnapshot.java
@@ -221,7 +221,7 @@ public class RocksIncrementalSnapshot implements AutoCloseable {
                 completed = true;
                 // We make the 'sstFiles' as the 'shared' in KvSnapshotHandle,
                 final KvSnapshotHandle kvSnapshotHandle =
-                        new KvSnapshotHandle(sstFiles, miscFiles, snapshotIncrementalSize);
+                        KvSnapshotHandle.create(sstFiles, miscFiles, snapshotIncrementalSize);
                 return new SnapshotResult(
                         kvSnapshotHandle, snapshotLocation.getSnapshotDirectory(), tabletState);
             } finally {

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -854,7 +854,7 @@ public final class Replica {
         try {
             kvSnapshotDataDownloader.transferAllDataToDirectory(downloadSpec, closeableRegistry);
         } catch (Exception e) {
-            if (e.getMessage().contains(CompletedSnapshot.SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE)) {
+            if (CompletedSnapshot.isSnapshotDataNotExists(e)) {
                 try {
                     snapshotContext.handleSnapshotBroken(completedSnapshot);
                 } catch (Exception t) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -70,6 +70,7 @@ import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
 import org.apache.fluss.server.kv.snapshot.KvFileHandleAndLocalPath;
 import org.apache.fluss.server.kv.snapshot.KvSnapshotDataDownloader;
 import org.apache.fluss.server.kv.snapshot.KvSnapshotDownloadSpec;
+import org.apache.fluss.server.kv.snapshot.KvSnapshotHandle;
 import org.apache.fluss.server.kv.snapshot.KvTabletSnapshotTarget;
 import org.apache.fluss.server.kv.snapshot.PeriodicSnapshotManager;
 import org.apache.fluss.server.kv.snapshot.RocksIncrementalSnapshot;
@@ -854,7 +855,7 @@ public final class Replica {
         try {
             kvSnapshotDataDownloader.transferAllDataToDirectory(downloadSpec, closeableRegistry);
         } catch (Exception e) {
-            if (CompletedSnapshot.isSnapshotDataNotExists(e)) {
+            if (isSnapshotDataNotExists(e, downloadSpec)) {
                 try {
                     snapshotContext.handleSnapshotBroken(completedSnapshot);
                 } catch (Exception t) {
@@ -869,6 +870,26 @@ public final class Replica {
                 completedSnapshot,
                 kvDbPath,
                 end - start);
+    }
+
+    private static boolean isSnapshotDataNotExists(
+            Throwable throwable, KvSnapshotDownloadSpec downloadSpec) {
+        if (!CompletedSnapshot.isSnapshotDataNotExists(throwable)) {
+            return false;
+        }
+
+        List<KvFileHandleAndLocalPath> fileHandles = new ArrayList<>();
+        KvSnapshotHandle handle = downloadSpec.getKvSnapshotHandle();
+        fileHandles.addAll(handle.getSharedKvFileHandles());
+        fileHandles.addAll(handle.getPrivateFileHandles());
+
+        for (KvFileHandleAndLocalPath fileHandle : fileHandles) {
+            FsPath filePath = new FsPath(fileHandle.getKvFileHandle().getFilePath());
+            if (CompletedSnapshot.isSnapshotDataNotExists(throwable, filePath)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Optional<CompletedSnapshot> getLatestSnapshot(TableBucket tableBucket) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.fluss.server.coordinator;
 
+import org.apache.fluss.fs.FsPath;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
 import org.apache.fluss.server.kv.snapshot.CompletedSnapshotHandle;
@@ -40,8 +41,10 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -56,6 +59,7 @@ import java.util.concurrent.Executors;
 
 import static org.apache.fluss.record.TestData.DATA1_TABLE_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link CompletedSnapshotStoreManager}. */
 class CompletedSnapshotStoreManagerTest {
@@ -199,6 +203,41 @@ class CompletedSnapshotStoreManagerTest {
                         new IOException("File does not exist: /remote/snapshot/_METADATA")));
     }
 
+    @Test
+    void testMetadataRetrievalFailureKeepsHandleWhenMetadataExists() throws Exception {
+        TableBucket tableBucket = new TableBucket(1, 1);
+        CompletedSnapshot snapshot = KvTestUtils.mockCompletedSnapshot(tempDir, tableBucket, 1L);
+        Files.createDirectories(new File(snapshot.getSnapshotLocation().getPath()).toPath());
+        Files.createFile(new File(snapshot.getMetadataFilePath().getPath()).toPath());
+
+        CompletedSnapshotHandleStore completedSnapshotHandleStore =
+                new InMemoryCompletedSnapshotHandleStore();
+        completedSnapshotHandleStore.add(
+                tableBucket,
+                1L,
+                new TestingBrokenCompletedSnapshotHandle(
+                        snapshot,
+                        new IOException(
+                                "Failed to open snapshot metadata.",
+                                new IOException(
+                                        "File does not exist: temporary standby response"))));
+        CompletedSnapshotStoreManager completedSnapshotStoreManager =
+                new CompletedSnapshotStoreManager(
+                        10,
+                        ioExecutor,
+                        zookeeperClient,
+                        zooKeeperClient -> completedSnapshotHandleStore,
+                        TestingMetricGroups.COORDINATOR_METRICS,
+                        bucket -> true);
+
+        assertThatThrownBy(
+                        () ->
+                                completedSnapshotStoreManager.getOrCreateCompletedSnapshotStore(
+                                        DATA1_TABLE_PATH, tableBucket))
+                .hasRootCauseInstanceOf(IOException.class);
+        assertThat(completedSnapshotHandleStore.get(tableBucket, 1L)).isPresent();
+    }
+
     private void verifyMissingSnapshotMetadataIsCleanedUp(IOException exception) throws Exception {
         // setup test data with mixed valid and invalid snapshots
         TableBucket tableBucket = new TableBucket(1, 1);
@@ -292,24 +331,28 @@ class CompletedSnapshotStoreManagerTest {
         return tableBuckets;
     }
 
-    /**
-     * A test-specific implementation of CompletedSnapshotHandle that throws FileNotFoundException
-     * with the specific error message expected by CompletedSnapshotStoreManager.
-     */
+    /** A test-specific handle that throws the configured exception during retrieval. */
     private static class TestingBrokenCompletedSnapshotHandle
             extends TestingCompletedSnapshotHandle {
 
         private final IOException exception;
+        private final FsPath metadataFilePath;
 
         public TestingBrokenCompletedSnapshotHandle(
                 CompletedSnapshot snapshot, IOException exception) {
             super(snapshot, false);
             this.exception = exception;
+            this.metadataFilePath = snapshot.getMetadataFilePath();
         }
 
         @Override
         public CompletedSnapshot retrieveCompleteSnapshot() throws IOException {
             throw exception;
+        }
+
+        @Override
+        public FsPath getMetadataFilePath() {
+            return metadataFilePath;
         }
     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
@@ -186,6 +186,20 @@ class CompletedSnapshotStoreManagerTest {
 
     @Test
     void testMetadataInconsistencyWithMetadataNotExistsException() throws Exception {
+        verifyMissingSnapshotMetadataIsCleanedUp(
+                new FileNotFoundException(
+                        CompletedSnapshot.SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE));
+    }
+
+    @Test
+    void testMetadataInconsistencyWithHadoopFileDoesNotExistException() throws Exception {
+        verifyMissingSnapshotMetadataIsCleanedUp(
+                new IOException(
+                        "Failed to open snapshot metadata.",
+                        new IOException("File does not exist: /remote/snapshot/_METADATA")));
+    }
+
+    private void verifyMissingSnapshotMetadataIsCleanedUp(IOException exception) throws Exception {
         // setup test data with mixed valid and invalid snapshots
         TableBucket tableBucket = new TableBucket(1, 1);
         CompletedSnapshot validSnapshot =
@@ -196,7 +210,7 @@ class CompletedSnapshotStoreManagerTest {
         CompletedSnapshot invalidSnapshot =
                 KvTestUtils.mockCompletedSnapshot(tempDir, tableBucket, 2L);
         TestingCompletedSnapshotHandle invalidSnapshotHandle =
-                new TestingCompletedSnapshotHandleWithFileNotFound(invalidSnapshot);
+                new TestingBrokenCompletedSnapshotHandle(invalidSnapshot, exception);
 
         // create CompletedSnapshotHandleStore with real implementations
         CompletedSnapshotHandleStore completedSnapshotHandleStore =
@@ -220,6 +234,7 @@ class CompletedSnapshotStoreManagerTest {
                         DATA1_TABLE_PATH, tableBucket);
         assertThat(completedSnapshotStore.getAllSnapshots()).hasSize(1);
         assertThat(completedSnapshotStore.getAllSnapshots().get(0).getSnapshotID()).isEqualTo(1L);
+        assertThat(completedSnapshotHandleStore.get(tableBucket, 2L)).isEmpty();
     }
 
     private CompletedSnapshotStoreManager createCompletedSnapshotStoreManager(
@@ -281,17 +296,20 @@ class CompletedSnapshotStoreManagerTest {
      * A test-specific implementation of CompletedSnapshotHandle that throws FileNotFoundException
      * with the specific error message expected by CompletedSnapshotStoreManager.
      */
-    private static class TestingCompletedSnapshotHandleWithFileNotFound
+    private static class TestingBrokenCompletedSnapshotHandle
             extends TestingCompletedSnapshotHandle {
 
-        public TestingCompletedSnapshotHandleWithFileNotFound(CompletedSnapshot snapshot) {
+        private final IOException exception;
+
+        public TestingBrokenCompletedSnapshotHandle(
+                CompletedSnapshot snapshot, IOException exception) {
             super(snapshot, false);
+            this.exception = exception;
         }
 
         @Override
         public CompletedSnapshot retrieveCompleteSnapshot() throws IOException {
-            throw new FileNotFoundException(
-                    CompletedSnapshot.SNAPSHOT_DATA_NOT_EXISTS_ERROR_MESSAGE);
+            throw exception;
         }
     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorServiceOrphanRpcsITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorServiceOrphanRpcsITCase.java
@@ -221,7 +221,7 @@ class CoordinatorServiceOrphanRpcsITCase {
                 tb,
                 snapshotId,
                 new FsPath(snapDir.resolve("_metadata").toUri().toString()),
-                new KvSnapshotHandle(Collections.emptyList(), Collections.emptyList(), 0L),
+                KvSnapshotHandle.create(Collections.emptyList(), Collections.emptyList(), 0L),
                 snapshotId,
                 null,
                 null);

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotJsonSerdeTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotJsonSerdeTest.java
@@ -56,7 +56,7 @@ class CompletedSnapshotJsonSerdeTest extends JsonSerdeTestBase<CompletedSnapshot
                         new TableBucket(1, 1),
                         1,
                         new FsPath("oss://bucket/snapshot"),
-                        new KvSnapshotHandle(sharedFileHandles, privateFileHandles, 5),
+                        KvSnapshotHandle.create(sharedFileHandles, privateFileHandles, 5),
                         10,
                         null,
                         null);
@@ -65,7 +65,7 @@ class CompletedSnapshotJsonSerdeTest extends JsonSerdeTestBase<CompletedSnapshot
                         new TableBucket(1, 10L, 1),
                         1,
                         new FsPath("oss://bucket/snapshot"),
-                        new KvSnapshotHandle(sharedFileHandles, privateFileHandles, 5),
+                        KvSnapshotHandle.create(sharedFileHandles, privateFileHandles, 5),
                         10,
                         1234L,
                         Collections.singletonList(new AutoIncIDRange(2, 10000, 20000)));

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotStoreTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotStoreTest.java
@@ -746,7 +746,7 @@ class CompletedSnapshotStoreTest {
                 tableBucket,
                 id,
                 new FsPath(tempDir.toString(), "test_snapshot"),
-                new KvSnapshotHandle(Collections.emptyList(), Collections.emptyList(), 0));
+                KvSnapshotHandle.create(Collections.emptyList(), Collections.emptyList(), 0));
     }
 
     private CompletedSnapshot getSnapshotWithSharedFiles(
@@ -756,7 +756,7 @@ class CompletedSnapshotStoreTest {
                 tableBucket,
                 id,
                 new FsPath(tempDir.toString(), "snapshot_" + id),
-                new KvSnapshotHandle(sharedFiles, Collections.emptyList(), 0));
+                KvSnapshotHandle.create(sharedFiles, Collections.emptyList(), 0));
     }
 
     private void testSnapshotRetention(
@@ -804,7 +804,7 @@ class CompletedSnapshotStoreTest {
                             new TableBucket(1, 1),
                             i,
                             new FsPath("test_snapshot"),
-                            new KvSnapshotHandle(
+                            KvSnapshotHandle.create(
                                     Collections.emptyList(), Collections.emptyList(), -1));
             final CompletedSnapshotHandle snapshotStateHandle =
                     new TestingCompletedSnapshotHandle(

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -105,8 +106,32 @@ class CompletedSnapshotTest {
         assertThat(snapshot.getKvSnapshotHandle().getSnapshotSize()).isEqualTo(400L);
     }
 
+    @Test
+    void testDiscardRestoredSnapshotKeepsSharedFiles(@TempDir Path tempDir) throws Exception {
+        TableBucket tableBucket = new TableBucket(1, 1);
+        Path localFileDir = makeDir(tempDir, "local");
+        Path snapshotBaseLocation = makeDir(tempDir, "snapshot");
+        Path shareDir = makeDir(snapshotBaseLocation, "share");
+        Path snapshotPath = makeDir(snapshotBaseLocation, "snapshot-1");
+        KvSnapshotHandle kvSnapshotHandle =
+                makeSnapshotHandle(localFileDir, snapshotPath, shareDir, 100);
+        CompletedSnapshot snapshot =
+                new CompletedSnapshot(
+                        tableBucket,
+                        1,
+                        FsPath.fromLocalFile(snapshotPath.toFile()),
+                        kvSnapshotHandle);
+        Files.createFile(snapshotPath.resolve("_METADATA"));
+
+        CompletedSnapshot restoredSnapshot =
+                CompletedSnapshotJsonSerde.fromJson(CompletedSnapshotJsonSerde.toJson(snapshot));
+        restoredSnapshot.discardAsync(Executors.directExecutor()).get();
+
+        checkCompletedSnapshotCleanUp(snapshotPath, restoredSnapshot.getKvSnapshotHandle(), false);
+    }
+
     private void checkCompletedSnapshotCleanUp(
-            Path snapshotPath, KvSnapshotHandle kvSnapshotHandle, boolean isShareFileShouldDelete) {
+            Path snapshotPath, KvSnapshotHandle kvSnapshotHandle, boolean shouldDeleteSharedFiles) {
         // private should be deleted, but the local file should still remain
         for (KvFileHandleAndLocalPath kvFileHandleAndLocalPath :
                 kvSnapshotHandle.getPrivateFileHandles()) {
@@ -118,8 +143,8 @@ class CompletedSnapshotTest {
         // check the share files is as expected, and the local file should still remain
         for (KvFileHandleAndLocalPath kvFileHandleAndLocalPath :
                 kvSnapshotHandle.getSharedKvFileHandles()) {
-            // share files should also be deleted, but the local file should still remain
-            if (isShareFileShouldDelete) {
+            // shared files should also be deleted, but the local file should still remain
+            if (shouldDeleteSharedFiles) {
                 assertThat(new File(kvFileHandleAndLocalPath.getKvFileHandle().getFilePath()))
                         .doesNotExist();
             } else {
@@ -168,7 +193,7 @@ class CompletedSnapshotTest {
                             new KvFileHandle(privateFile.getPath(), privateFile.length()),
                             localFile.getPath()));
         }
-        return new KvSnapshotHandle(sharedFileHandles, privateFileHandles, 10);
+        return KvSnapshotHandle.create(sharedFileHandles, privateFileHandles, 10);
     }
 
     private Path makeDir(Path basePath, String dirName) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotTest.java
@@ -25,15 +25,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link org.apache.fluss.server.kv.snapshot.CompletedSnapshot} . */
 class CompletedSnapshotTest {
@@ -62,6 +65,13 @@ class CompletedSnapshotTest {
         SharedKvFileRegistry sharedKvFileRegistry = new SharedKvFileRegistry();
         // register the snapshot to a registry
         snapshot.registerSharedKvFilesAfterRestored(sharedKvFileRegistry);
+        CompletedSnapshot registeredSnapshot = snapshot;
+        assertThatThrownBy(
+                        () ->
+                                registeredSnapshot.registerSharedKvFilesAfterRestored(
+                                        sharedKvFileRegistry))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already registered");
         Executor ioExecutor = Executors.directExecutor();
         snapshot.discardAsync(ioExecutor).get();
 
@@ -128,6 +138,37 @@ class CompletedSnapshotTest {
         restoredSnapshot.discardAsync(Executors.directExecutor()).get();
 
         checkCompletedSnapshotCleanUp(snapshotPath, restoredSnapshot.getKvSnapshotHandle(), false);
+    }
+
+    @Test
+    void testSnapshotDataNotExistsDetection(@TempDir Path tempDir) throws Exception {
+        IOException nestedMissingException =
+                new IOException(
+                        "wrapper", new IOException("File does not exist: /remote/snapshot/file"));
+        assertThat(
+                        CompletedSnapshot.isSnapshotDataNotExists(
+                                new IOException("wrapper", new FileNotFoundException("missing"))))
+                .isTrue();
+        assertThat(
+                        CompletedSnapshot.isSnapshotDataNotExists(
+                                new IOException("wrapper", new NoSuchFileException("missing"))))
+                .isTrue();
+        assertThat(CompletedSnapshot.isSnapshotDataNotExists(nestedMissingException)).isTrue();
+        assertThat(CompletedSnapshot.isSnapshotDataNotExists(new IOException("Access denied")))
+                .isFalse();
+
+        Path snapshotDataFile = Files.createFile(tempDir.resolve("snapshot-data"));
+        FsPath snapshotDataPath = FsPath.fromLocalFile(snapshotDataFile.toFile());
+        assertThat(
+                        CompletedSnapshot.isSnapshotDataNotExists(
+                                nestedMissingException, snapshotDataPath))
+                .isFalse();
+
+        Files.delete(snapshotDataFile);
+        assertThat(
+                        CompletedSnapshot.isSnapshotDataNotExists(
+                                nestedMissingException, snapshotDataPath))
+                .isTrue();
     }
 
     private void checkCompletedSnapshotCleanUp(

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/KvSnapshotDataDownloaderTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/KvSnapshotDataDownloaderTest.java
@@ -162,7 +162,8 @@ class KvSnapshotDataDownloaderTest {
                             handles.get(i), String.format("private-%d-%d", remoteHandleId, i)));
         }
 
-        KvSnapshotHandle kvSnapshotHandle = new KvSnapshotHandle(sharedStates, privateStates, -1);
+        KvSnapshotHandle kvSnapshotHandle =
+                KvSnapshotHandle.create(sharedStates, privateStates, -1);
 
         return new KvSnapshotDownloadSpec(kvSnapshotHandle, dstPath);
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/SnapshotsCleanerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/SnapshotsCleanerTest.java
@@ -118,7 +118,7 @@ class SnapshotsCleanerTest {
         public TestKvSnapshotHandle(
                 List<KvFileHandleAndLocalPath> sharedFileHandles,
                 List<KvFileHandleAndLocalPath> privateFileHandles) {
-            super(sharedFileHandles, privateFileHandles, -1);
+            super(sharedFileHandles, privateFileHandles, -1, true);
         }
 
         @Override

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
@@ -701,9 +701,6 @@ final class ReplicaTest extends ReplicaTestBase {
                                 Tuple2.of("k2", new Object[] {2, "b"}),
                                 Tuple2.of("k3", new Object[] {4, "d"})));
         verifyGetKeyValues(kvTablet, expectedKeyValues);
-
-        File metadataFile = new File(snapshot2.getMetadataFilePath().getPath());
-        assertThat(metadataFile.exists()).isFalse();
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
@@ -41,7 +41,6 @@ import org.apache.fluss.rpc.protocol.MergeMode;
 import org.apache.fluss.server.entity.NotifyLeaderAndIsrData;
 import org.apache.fluss.server.kv.KvTablet;
 import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
-import org.apache.fluss.server.kv.snapshot.CompletedSnapshotJsonSerde;
 import org.apache.fluss.server.kv.snapshot.TestingCompletedKvSnapshotCommitter;
 import org.apache.fluss.server.log.FetchParams;
 import org.apache.fluss.server.log.LogAppendInfo;
@@ -657,15 +656,14 @@ final class ReplicaTest extends ReplicaTestBase {
                     @Override
                     public FunctionWithException<TableBucket, CompletedSnapshot, Exception>
                             getLatestCompletedSnapshotProvider() {
+                        FunctionWithException<TableBucket, CompletedSnapshot, Exception>
+                                snapshotProvider = super.getLatestCompletedSnapshotProvider();
                         return bucket -> {
-                            CompletedSnapshot snapshot =
-                                    testKvSnapshotStore.getLatestCompletedSnapshot(bucket);
+                            CompletedSnapshot snapshot = snapshotProvider.apply(bucket);
                             if (snapshot != null) {
                                 attemptedSnapshotIds.add(snapshot.getSnapshotID());
-                                return CompletedSnapshotJsonSerde.fromJson(
-                                        CompletedSnapshotJsonSerde.toJson(snapshot));
                             }
-                            return null;
+                            return snapshot;
                         };
                     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
@@ -41,6 +41,8 @@ import org.apache.fluss.rpc.protocol.MergeMode;
 import org.apache.fluss.server.entity.NotifyLeaderAndIsrData;
 import org.apache.fluss.server.kv.KvTablet;
 import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
+import org.apache.fluss.server.kv.snapshot.KvSnapshotDataDownloader;
+import org.apache.fluss.server.kv.snapshot.KvSnapshotDownloadSpec;
 import org.apache.fluss.server.kv.snapshot.TestingCompletedKvSnapshotCommitter;
 import org.apache.fluss.server.log.FetchParams;
 import org.apache.fluss.server.log.LogAppendInfo;
@@ -51,6 +53,7 @@ import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.testutils.DataTestUtils;
 import org.apache.fluss.testutils.common.ManuallyTriggeredScheduledExecutorService;
 import org.apache.fluss.types.RowType;
+import org.apache.fluss.utils.CloseableRegistry;
 import org.apache.fluss.utils.concurrent.Executors;
 import org.apache.fluss.utils.function.FunctionWithException;
 import org.apache.fluss.utils.types.Tuple2;
@@ -59,6 +62,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -70,6 +74,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static org.apache.fluss.compression.ArrowCompressionInfo.DEFAULT_COMPRESSION;
@@ -567,6 +572,103 @@ final class ReplicaTest extends ReplicaTestBase {
         kvSnapshotStore.waitUntilSnapshotComplete(tableBucket, snapshot);
         assertThat(kvSnapshotStore.getSnapshotLeaderEpoch(tableBucket, snapshot))
                 .isEqualTo(latestLeaderEpoch);
+    }
+
+    @Test
+    void testTransientMissingSnapshotExceptionKeepsHealthySnapshot(
+            @TempDir File snapshotKvTabletDir) throws Exception {
+        TableBucket tableBucket = new TableBucket(DATA1_TABLE_ID_PK, 1);
+        TestSnapshotContext testKvSnapshotContext =
+                new TestSnapshotContext(snapshotKvTabletDir.getPath());
+        ManuallyTriggeredScheduledExecutorService scheduledExecutorService =
+                testKvSnapshotContext.scheduledExecutorService;
+        TestingCompletedKvSnapshotCommitter kvSnapshotStore =
+                testKvSnapshotContext.testKvSnapshotStore;
+
+        Replica kvReplica =
+                makeKvReplica(DATA1_PHYSICAL_TABLE_PATH_PK, tableBucket, testKvSnapshotContext);
+        makeKvReplicaAsLeader(kvReplica);
+        KvRecordBatch kvRecords =
+                genKvRecordBatch(
+                        Tuple2.of("k1", new Object[] {1, "a"}),
+                        Tuple2.of("k2", new Object[] {2, "b"}));
+        putRecordsToLeader(kvReplica, kvRecords);
+
+        scheduledExecutorService.triggerAllNonPeriodicTasks();
+        CompletedSnapshot snapshot = kvSnapshotStore.waitUntilSnapshotComplete(tableBucket, 0);
+        assertThat(snapshot.getKvSnapshotHandle().getSharedKvFileHandles()).isNotEmpty();
+        String existingSnapshotFilePath =
+                snapshot.getKvSnapshotHandle()
+                        .getSharedKvFileHandles()
+                        .get(0)
+                        .getKvFileHandle()
+                        .getFilePath();
+        FsPath existingSnapshotFile = new FsPath(existingSnapshotFilePath);
+        assertThat(existingSnapshotFile.getFileSystem().exists(existingSnapshotFile)).isTrue();
+
+        makeKvReplicaAsFollower(kvReplica, 1);
+
+        AtomicBoolean failNextDownload = new AtomicBoolean(true);
+        List<Long> attemptedSnapshotIds = new ArrayList<>();
+        List<Long> brokenSnapshotIds = new ArrayList<>();
+        testKvSnapshotContext =
+                new TestSnapshotContext(snapshotKvTabletDir.getPath(), kvSnapshotStore) {
+                    @Override
+                    public FunctionWithException<TableBucket, CompletedSnapshot, Exception>
+                            getLatestCompletedSnapshotProvider() {
+                        FunctionWithException<TableBucket, CompletedSnapshot, Exception>
+                                snapshotProvider = super.getLatestCompletedSnapshotProvider();
+                        return bucket -> {
+                            CompletedSnapshot latestSnapshot = snapshotProvider.apply(bucket);
+                            if (latestSnapshot != null) {
+                                attemptedSnapshotIds.add(latestSnapshot.getSnapshotID());
+                            }
+                            return latestSnapshot;
+                        };
+                    }
+
+                    @Override
+                    public KvSnapshotDataDownloader getSnapshotDataDownloader() {
+                        return new KvSnapshotDataDownloader(executorService) {
+                            @Override
+                            public void transferAllDataToDirectory(
+                                    KvSnapshotDownloadSpec downloadSpec,
+                                    CloseableRegistry closeableRegistry)
+                                    throws Exception {
+                                if (failNextDownload.compareAndSet(true, false)) {
+                                    throw new IOException(
+                                            "Fail to download kv snapshot.",
+                                            new FileNotFoundException(
+                                                    "File does not exist: "
+                                                            + existingSnapshotFilePath));
+                                }
+                                super.transferAllDataToDirectory(downloadSpec, closeableRegistry);
+                            }
+                        };
+                    }
+
+                    @Override
+                    public void handleSnapshotBroken(CompletedSnapshot snapshot) throws Exception {
+                        brokenSnapshotIds.add(snapshot.getSnapshotID());
+                        super.handleSnapshotBroken(snapshot);
+                    }
+                };
+        kvReplica = makeKvReplica(DATA1_PHYSICAL_TABLE_PATH_PK, tableBucket, testKvSnapshotContext);
+        makeKvReplicaAsLeader(kvReplica, 2);
+
+        assertThat(failNextDownload).isFalse();
+        assertThat(attemptedSnapshotIds).containsExactly(0L, 0L);
+        assertThat(brokenSnapshotIds).isEmpty();
+        assertThat(kvSnapshotStore.getLatestCompletedSnapshot(tableBucket).getSnapshotID())
+                .isEqualTo(0);
+        assertThat(existingSnapshotFile.getFileSystem().exists(existingSnapshotFile)).isTrue();
+        assertThat(kvReplica.getKvTablet()).isNotNull();
+        verifyGetKeyValues(
+                kvReplica.getKvTablet(),
+                getKeyValuePairs(
+                        genKvRecords(
+                                Tuple2.of("k1", new Object[] {1, "a"}),
+                                Tuple2.of("k2", new Object[] {2, "b"}))));
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
@@ -19,6 +19,7 @@ package org.apache.fluss.server.replica;
 
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.exception.OutOfOrderSequenceException;
+import org.apache.fluss.fs.FsPath;
 import org.apache.fluss.metadata.LogFormat;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.SchemaGetter;
@@ -40,6 +41,7 @@ import org.apache.fluss.rpc.protocol.MergeMode;
 import org.apache.fluss.server.entity.NotifyLeaderAndIsrData;
 import org.apache.fluss.server.kv.KvTablet;
 import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
+import org.apache.fluss.server.kv.snapshot.CompletedSnapshotJsonSerde;
 import org.apache.fluss.server.kv.snapshot.TestingCompletedKvSnapshotCommitter;
 import org.apache.fluss.server.log.FetchParams;
 import org.apache.fluss.server.log.LogAppendInfo;
@@ -50,6 +52,8 @@ import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.testutils.DataTestUtils;
 import org.apache.fluss.testutils.common.ManuallyTriggeredScheduledExecutorService;
 import org.apache.fluss.types.RowType;
+import org.apache.fluss.utils.concurrent.Executors;
+import org.apache.fluss.utils.function.FunctionWithException;
 import org.apache.fluss.utils.types.Tuple2;
 
 import org.junit.jupiter.api.Test;
@@ -64,8 +68,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.apache.fluss.compression.ArrowCompressionInfo.DEFAULT_COMPRESSION;
 import static org.apache.fluss.record.LogRecordBatch.CURRENT_LOG_MAGIC_VALUE;
@@ -601,7 +607,7 @@ final class ReplicaTest extends ReplicaTestBase {
 
         // trigger second snapshot (may need to wait the task being scheduled)
         scheduledExecutorService.triggerNextNonPeriodicScheduledTask(Duration.ofSeconds(30));
-        kvSnapshotStore.waitUntilSnapshotComplete(tableBucket, 1);
+        CompletedSnapshot snapshot1 = kvSnapshotStore.waitUntilSnapshotComplete(tableBucket, 1);
 
         // put more data and create third snapshot (this will be the broken one)
         kvRecords =
@@ -618,13 +624,24 @@ final class ReplicaTest extends ReplicaTestBase {
         assertThat(kvSnapshotStore.getLatestCompletedSnapshot(tableBucket).getSnapshotID())
                 .isEqualTo(2);
 
-        // now simulate the latest snapshot (snapshot2) being broken by
-        // deleting its metadata files and unshared SST files
-        // This simulates file corruption while ZK metadata remains intact
-        snapshot2.getKvSnapshotHandle().discard();
+        Set<String> sharedFilePathsUsedByBothSnapshots =
+                snapshot1.getKvSnapshotHandle().getSharedKvFileHandles().stream()
+                        .map(handle -> handle.getKvFileHandle().getFilePath())
+                        .collect(Collectors.toSet());
+        sharedFilePathsUsedByBothSnapshots.retainAll(
+                snapshot2.getKvSnapshotHandle().getSharedKvFileHandles().stream()
+                        .map(handle -> handle.getKvFileHandle().getFilePath())
+                        .collect(Collectors.toSet()));
+        assertThat(sharedFilePathsUsedByBothSnapshots).isNotEmpty();
+        for (String sharedFilePath : sharedFilePathsUsedByBothSnapshots) {
+            FsPath path = new FsPath(sharedFilePath);
+            assertThat(path.getFileSystem().exists(path)).isTrue();
+        }
 
-        // ZK metadata should still show snapshot2 as latest (file corruption hasn't been detected
-        // yet)
+        // Simulate snapshot corruption by deleting only one private file while its metadata and
+        // shared files remain intact.
+        assertThat(snapshot2.getKvSnapshotHandle().getPrivateFileHandles()).isNotEmpty();
+        snapshot2.getKvSnapshotHandle().getPrivateFileHandles().get(0).getKvFileHandle().discard();
         assertThat(kvSnapshotStore.getLatestCompletedSnapshot(tableBucket).getSnapshotID())
                 .isEqualTo(2);
 
@@ -634,8 +651,31 @@ final class ReplicaTest extends ReplicaTestBase {
         // create a new replica with the same snapshot context
         // During initialization, it will try to use snapshot2 but find it broken,
         // then handle the broken snapshot and fall back to snapshot1
+        List<Long> attemptedSnapshotIds = new ArrayList<>();
         testKvSnapshotContext =
-                new TestSnapshotContext(snapshotKvTabletDir.getPath(), kvSnapshotStore);
+                new TestSnapshotContext(snapshotKvTabletDir.getPath(), kvSnapshotStore) {
+                    @Override
+                    public FunctionWithException<TableBucket, CompletedSnapshot, Exception>
+                            getLatestCompletedSnapshotProvider() {
+                        return bucket -> {
+                            CompletedSnapshot snapshot =
+                                    testKvSnapshotStore.getLatestCompletedSnapshot(bucket);
+                            if (snapshot != null) {
+                                attemptedSnapshotIds.add(snapshot.getSnapshotID());
+                                return CompletedSnapshotJsonSerde.fromJson(
+                                        CompletedSnapshotJsonSerde.toJson(snapshot));
+                            }
+                            return null;
+                        };
+                    }
+
+                    @Override
+                    public void handleSnapshotBroken(CompletedSnapshot snapshot) throws Exception {
+                        testKvSnapshotStore.removeSnapshot(
+                                snapshot.getTableBucket(), snapshot.getSnapshotID());
+                        snapshot.discardAsync(Executors.directExecutor()).get();
+                    }
+                };
         kvReplica = makeKvReplica(DATA1_PHYSICAL_TABLE_PATH_PK, tableBucket, testKvSnapshotContext);
 
         // make it leader again - this should trigger the broken snapshot recovery logic
@@ -647,19 +687,23 @@ final class ReplicaTest extends ReplicaTestBase {
         assertThat(kvReplica.getKvTablet()).isNotNull();
         KvTablet kvTablet = kvReplica.getKvTablet();
 
-        // verify that the data from snapshot1 is restored (snapshot2 was broken and cleaned up)
-        // snapshot1 should contain: k1->3,c and k3->4,d
+        assertThat(attemptedSnapshotIds).containsExactly(2L, 1L);
+        assertThat(kvSnapshotStore.getLatestCompletedSnapshot(tableBucket).getSnapshotID())
+                .isEqualTo(1);
+        for (String sharedFilePath : sharedFilePathsUsedByBothSnapshots) {
+            FsPath path = new FsPath(sharedFilePath);
+            assertThat(path.getFileSystem().exists(path)).isTrue();
+        }
+
+        // Snapshot1 is restored after snapshot2 is discarded.
         List<Tuple2<byte[], byte[]>> expectedKeyValues =
                 getKeyValuePairs(
                         genKvRecords(
                                 Tuple2.of("k1", new Object[] {3, "c"}),
+                                Tuple2.of("k2", new Object[] {2, "b"}),
                                 Tuple2.of("k3", new Object[] {4, "d"})));
         verifyGetKeyValues(kvTablet, expectedKeyValues);
 
-        // Verify the core functionality: KvTablet successfully initialized despite broken snapshot
-        // The key test is that the system can handle broken snapshots and recover correctly
-
-        // Verify that we successfully simulated the broken snapshot condition
         File metadataFile = new File(snapshot2.getMetadataFilePath().getPath());
         assertThat(metadataFile.exists()).isFalse();
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
@@ -627,7 +627,7 @@ public class ReplicaTestBase {
         private final FsPath remoteKvTabletDir;
         protected ManuallyTriggeredScheduledExecutorService scheduledExecutorService;
         protected final TestingCompletedKvSnapshotCommitter testKvSnapshotStore;
-        private final ExecutorService executorService;
+        protected final ExecutorService executorService;
 
         public TestSnapshotContext(
                 String remoteKvTabletDir, TestingCompletedKvSnapshotCommitter testKvSnapshotStore)

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
@@ -40,6 +40,7 @@ import org.apache.fluss.server.kv.KvManager;
 import org.apache.fluss.server.kv.scan.ScannerManager;
 import org.apache.fluss.server.kv.snapshot.CompletedKvSnapshotCommitter;
 import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
+import org.apache.fluss.server.kv.snapshot.CompletedSnapshotJsonSerde;
 import org.apache.fluss.server.kv.snapshot.KvSnapshotDataDownloader;
 import org.apache.fluss.server.kv.snapshot.KvSnapshotDataUploader;
 import org.apache.fluss.server.kv.snapshot.SnapshotContext;
@@ -715,7 +716,14 @@ public class ReplicaTestBase {
         @Override
         public FunctionWithException<TableBucket, CompletedSnapshot, Exception>
                 getLatestCompletedSnapshotProvider() {
-            return testKvSnapshotStore::getLatestCompletedSnapshot;
+            return tableBucket -> {
+                CompletedSnapshot snapshot =
+                        testKvSnapshotStore.getLatestCompletedSnapshot(tableBucket);
+                return snapshot == null
+                        ? null
+                        : CompletedSnapshotJsonSerde.fromJson(
+                                CompletedSnapshotJsonSerde.toJson(snapshot));
+            };
         }
 
         @Override

--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/KvTestUtils.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/KvTestUtils.java
@@ -128,7 +128,7 @@ public class KvTestUtils {
                                         tableBucket.getTableId(),
                                         tableBucket.getBucket(),
                                         snapshotId)),
-                new KvSnapshotHandle(Collections.emptyList(), Collections.emptyList(), 0),
+                KvSnapshotHandle.create(Collections.emptyList(), Collections.emptyList(), 0),
                 0,
                 null,
                 null);


### PR DESCRIPTION
### Purpose

Fix KV tablet recovery when the latest remote snapshot is broken or missing. The recovery process now correctly detects missing snapshot files reported by different filesystem implementations, removes the broken snapshot metadata, and safely falls back to the previous available snapshot.

Close #3740

### Brief change log

- Detect missing snapshot data through the exception cause chain, including Hadoop's `File does not exist` error message.
- Distinguish newly created and restored snapshot handles so discarding a restored broken snapshot does not delete shared files referenced by older snapshots.
- Add regression coverage for broken snapshot cleanup and the `latest snapshot → previous snapshot` fallback flow.


### Tests



### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
