### PR TITLE
[rust] Update release tooling and documentation for TLP releases

### DIFF
--- a/fluss-rust/scripts/release.sh
+++ b/fluss-rust/scripts/release.sh
@@ -15,10 +15,9 @@
 # limitations under the License.
 #
 # Create ASF source release artifacts under dist/ (aligned with Fluss release package format):
-#   fluss-rust-{version}-incubating.tgz
-#   fluss-rust-{version}-incubating.tgz.asc
-#   fluss-rust-{version}-incubating.tgz.sha512
-# (Incubator policy requires "incubating" in the artifact name.)
+#   fluss-rust-{version}.tgz
+#   fluss-rust-{version}.tgz.asc
+#   fluss-rust-{version}.tgz.sha512
 # Run from repo root. Check out the release tag first (e.g. git checkout v0.1.0-rc1).
 # Usage: ./scripts/release.sh [version]
 #   If version is omitted, it is read from Cargo.toml (workspace.package.version).
@@ -38,7 +37,7 @@ else
   fi
 fi
 
-PREFIX="fluss-rust-${VERSION}-incubating"
+PREFIX="fluss-rust-${VERSION}"
 DIST_DIR="${REPO_ROOT}/dist"
 TARBALL="${PREFIX}.tgz"
 
@@ -64,4 +63,4 @@ echo "Verifying signature"
 echo "Done. Artifacts in dist/:"
 ls -la "${DIST_DIR}/"
 echo ""
-echo "Next: upload contents of dist/ to SVN (see docs/creating-a-release.md)."
+echo "Next: upload contents of dist/ to SVN (see website/docs/release/create-release.md)."

--- a/fluss-rust/website/docs/release/create-release.md
+++ b/fluss-rust/website/docs/release/create-release.md
@@ -43,7 +43,7 @@ For GitHub Actions publishing, configure the repository secret `CARGO_REGISTRY_T
 
 **Checklist (one-time)**
 
-- [ ] GPG key set up and published to [KEYS](https://downloads.apache.org/incubator/fluss/KEYS) or Apache account
+- [ ] GPG key set up and published to [KEYS](https://downloads.apache.org/fluss/KEYS) or Apache account
 - [ ] Git configured to use your GPG key for signing tags
 - [ ] GitHub Actions secret `CARGO_REGISTRY_TOKEN` configured for crates.io publishing
 
@@ -207,42 +207,40 @@ just release $RELEASE_VERSION
 
 This creates under `dist/`:
 
-- `fluss-rust-${RELEASE_VERSION}-incubating.tgz`
-- `fluss-rust-${RELEASE_VERSION}-incubating.tgz.sha512`
-- `fluss-rust-${RELEASE_VERSION}-incubating.tgz.asc`
+- `fluss-rust-${RELEASE_VERSION}.tgz`
+- `fluss-rust-${RELEASE_VERSION}.tgz.sha512`
+- `fluss-rust-${RELEASE_VERSION}.tgz.asc`
 
-(Incubator policy requires the word "incubating" in release artifact names.)
-
-Verify with: `gpg --verify dist/fluss-rust-${RELEASE_VERSION}-incubating.tgz.asc dist/fluss-rust-${RELEASE_VERSION}-incubating.tgz`
+Verify with: `gpg --verify dist/fluss-rust-${RELEASE_VERSION}.tgz.asc dist/fluss-rust-${RELEASE_VERSION}.tgz`
 
 ### 4. Stage artifacts to SVN (dist.apache.org dev)
 
 From the **fluss-rust** repo root, check out the Fluss dev area and add the release artifacts.
 
 ```bash
-svn checkout https://dist.apache.org/repos/dist/dev/incubator/fluss fluss-dist-dev --depth=immediates
+svn checkout https://dist.apache.org/repos/dist/dev/fluss fluss-dist-dev --depth=immediates
 cd fluss-dist-dev
 mkdir $SVN_RC_DIR
-cp ../dist/fluss-rust-${RELEASE_VERSION}-incubating.* $SVN_RC_DIR/
+cp ../dist/fluss-rust-${RELEASE_VERSION}.* $SVN_RC_DIR/
 svn add $SVN_RC_DIR
 svn status
 svn commit -m "Add fluss-rust ${RELEASE_VERSION} RC${RC_NUM}"
 ```
 
-Verify: [https://dist.apache.org/repos/dist/dev/incubator/fluss/](https://dist.apache.org/repos/dist/dev/incubator/fluss/)
+Verify: [https://dist.apache.org/repos/dist/dev/fluss/](https://dist.apache.org/repos/dist/dev/fluss/)
 
 ---
 
 **Checklist to proceed to the next step**
 
 - [ ] Source distribution built and signed under `dist/`
-- [ ] Artifacts staged to [dist.apache.org dev](https://dist.apache.org/repos/dist/dev/incubator/fluss/) under `$SVN_RC_DIR`
+- [ ] Artifacts staged to [dist.apache.org dev](https://dist.apache.org/repos/dist/dev/fluss/) under `$SVN_RC_DIR`
 - [ ] RC (or release) tag pushed to GitHub
 - [ ] CI for Release Rust / Release Python succeeded
 
 ## Vote on the release candidate
 
-Share the release candidate for community review. If the project is in incubation, a [two-phase vote](https://incubator.apache.org/cookbook/#two_phase_vote_on_podling_releases) (Fluss community then Incubator PMC) may be required; otherwise one community vote is enough.
+Share the release candidate for community review.
 
 ### Fluss community vote
 
@@ -262,10 +260,10 @@ Please review and vote on release candidate #${RC_NUM} for Apache Fluss clients 
 [ ] -1 Do not approve (please provide specific comments)
 
 The release candidate (source distribution) is available at:
-* https://dist.apache.org/repos/dist/dev/incubator/fluss/$SVN_RC_DIR/
+* https://dist.apache.org/repos/dist/dev/fluss/$SVN_RC_DIR/
 
 KEYS for signature verification:
-* https://downloads.apache.org/incubator/fluss/KEYS
+* https://downloads.apache.org/fluss/KEYS
 
 Git tag:
 * https://github.com/apache/fluss/releases/tag/$RC_TAG
@@ -276,7 +274,7 @@ PyPI (release) / TestPyPI (RC):
 
 Please download, verify, and test. Verification steps are in [How to Verify a Release Candidate](verifying-a-release-candidate.md).
 
-The vote will be open for at least 72 hours. It is adopted by majority approval with at least 3 PPMC affirmative votes (or as per project policy).
+The vote will be open for at least 72 hours. It is adopted by majority approval with at least 3 PMC affirmative votes (or as per project policy).
 
 Thanks,
 Release Manager
@@ -288,16 +286,11 @@ If issues are found, cancel the vote and go to [Fix any issues](#fix-any-issues)
 
 **Body:** Summarize binding and non-binding votes and link to the vote thread.
 
-### Incubator PMC vote (if applicable)
-
-If the project is in incubation, start a vote on general@incubator.apache.org after the Fluss community vote passes. Use the same structure: link to the community vote thread, release candidate URL, KEYS, tag, and ask IPMC to vote within 72 hours. Then send the result to the same list.
-
 ---
 
 **Checklist to proceed to finalization**
 
 - [ ] Community vote passed (at least 3 binding +1, more +1 than -1)
-- [ ] (If incubating) Incubator PMC vote passed
 
 ## Fix any issues
 
@@ -307,7 +300,7 @@ If the vote revealed issues:
 2. Remove the old RC from dist.apache.org dev (optional but recommended):
 
 ```bash
-svn checkout https://dist.apache.org/repos/dist/dev/incubator/fluss fluss-dist-dev --depth=immediates
+svn checkout https://dist.apache.org/repos/dist/dev/fluss fluss-dist-dev --depth=immediates
 cd fluss-dist-dev
 svn remove $SVN_RC_DIR
 svn commit -m "Remove fluss-rust ${RELEASE_VERSION} RC${RC_NUM} (superseded)"
@@ -340,11 +333,11 @@ Move the staged artifacts from dev to release:
 
 ```bash
 svn mv -m "Release fluss-rust ${RELEASE_VERSION}" \
-  https://dist.apache.org/repos/dist/dev/incubator/fluss/$SVN_RC_DIR \
-  https://dist.apache.org/repos/dist/release/incubator/fluss/$SVN_RELEASE_DIR
+  https://dist.apache.org/repos/dist/dev/fluss/$SVN_RC_DIR \
+  https://dist.apache.org/repos/dist/release/fluss/$SVN_RELEASE_DIR
 ```
 
-(Only PPMC members may have write access to the release repository; if you get permission errors, ask on the mailing list.)
+(Only PMC members may have write access to the release repository; if you get permission errors, ask on the mailing list.)
 
 ### 3. Remove old RC(s) from dev (optional)
 
@@ -368,7 +361,7 @@ svn commit -m "Remove RC after release fluss-rust ${RELEASE_VERSION}"
 2. Choose tag `$RELEASE_TAG`.
 3. Set the target to the release branch `release-${RELEASE_VERSION}` (i.e., the branch/commit used to create `$RELEASE_TAG`).
 4. Click **Generate release notes**, then add: notable changes, breaking changes (if any) from component upgrade docs, **official download link** (source archive and verification), and install instructions for fluss-rust, fluss-python, fluss-cpp.
-    - **Download link:** `https://downloads.apache.org/incubator/fluss/fluss-rust-${RELEASE_VERSION}/` (or the project download page). In the release description, include checksums and GPG verification steps.
+    - **Download link:** `https://downloads.apache.org/fluss/fluss-rust-${RELEASE_VERSION}/` (or the project download page). In the release description, include checksums and GPG verification steps.
 5. Click **Publish release**.
 
 ### 6. Update CHANGELOG.md on main
@@ -380,7 +373,7 @@ Add an entry for `$RELEASE_VERSION` with the list of changes (use [Generate Rele
 **Checklist to proceed to promotion**
 
 - [ ] Release tag pushed; CI published to crates.io and PyPI
-- [ ] Source artifacts in [dist release](https://dist.apache.org/repos/dist/release/incubator/fluss/)
+- [ ] Source artifacts in [dist release](https://dist.apache.org/repos/dist/release/fluss/)
 - [ ] GitHub Release created
 - [ ] CHANGELOG.md updated on main
 
@@ -411,8 +404,8 @@ This release includes ...
 (Notable changes; link to CHANGELOG or release notes.)
 
 Download and verification:
-* https://downloads.apache.org/incubator/fluss/$SVN_RELEASE_DIR/
-* KEYS: https://downloads.apache.org/incubator/fluss/KEYS (or https://downloads.apache.org/fluss/KEYS after graduation)
+* https://downloads.apache.org/fluss/$SVN_RELEASE_DIR/
+* KEYS: https://downloads.apache.org/fluss/KEYS
 
 Rust:    cargo add fluss-rs
 Python:  pip install pyfluss

--- a/fluss-rust/website/docs/release/verifying-a-release-candidate.md
+++ b/fluss-rust/website/docs/release/verifying-a-release-candidate.md
@@ -6,10 +6,10 @@ This document describes how to verify a release candidate (RC) of the **Fluss cl
 
 The release vote email includes links to:
 
-- **Distribution archive:** source tarball (`fluss-rust-${RELEASE_VERSION}-incubating.tgz`) on [dist.apache.org dev](https://dist.apache.org/repos/dist/dev/incubator/fluss/)
-- **Signature file:** `fluss-rust-${RELEASE_VERSION}-incubating.tgz.asc`
-- **Checksum file:** `fluss-rust-${RELEASE_VERSION}-incubating.tgz.sha512`
-- **KEYS file:** [https://downloads.apache.org/incubator/fluss/KEYS](https://downloads.apache.org/incubator/fluss/KEYS)
+- **Distribution archive:** source tarball (`fluss-rust-${RELEASE_VERSION}.tgz`) on [dist.apache.org dev](https://dist.apache.org/repos/dist/dev/fluss/)
+- **Signature file:** `fluss-rust-${RELEASE_VERSION}.tgz.asc`
+- **Checksum file:** `fluss-rust-${RELEASE_VERSION}.tgz.sha512`
+- **KEYS file:** [https://downloads.apache.org/fluss/KEYS](https://downloads.apache.org/fluss/KEYS)
 
 Download the archive (`.tgz`), `.asc`, and `.sha512` from the RC directory (e.g. `fluss-rust-0.1.0-rc1/`) and the KEYS file. Then follow the steps below to verify signatures and checksums.
 
@@ -18,7 +18,7 @@ Download the archive (`.tgz`), `.asc`, and `.sha512` from the RC directory (e.g.
 First, import the keys into your local keyring:
 
 ```bash
-curl https://downloads.apache.org/incubator/fluss/KEYS -o KEYS
+curl https://downloads.apache.org/fluss/KEYS -o KEYS
 gpg --import KEYS
 ```
 
@@ -43,13 +43,13 @@ Next, verify the tarball(s) using the provided `.sha512` file(s). Each `.sha512`
 **On macOS (shasum):**
 
 ```bash
-shasum -a 512 -c fluss-rust-${RELEASE_VERSION}-incubating.tgz.sha512
+shasum -a 512 -c fluss-rust-${RELEASE_VERSION}.tgz.sha512
 ```
 
 **On Linux (sha512sum):**
 
 ```bash
-sha512sum -c fluss-rust-${RELEASE_VERSION}-incubating.tgz.sha512
+sha512sum -c fluss-rust-${RELEASE_VERSION}.tgz.sha512
 ```
 
 If you have multiple archives, run `-c` on each `.sha512` file (or use `shasum -a 512 -c *.sha512` / `sha512sum -c *.sha512`).
@@ -57,7 +57,7 @@ If you have multiple archives, run `-c` on each `.sha512` file (or use `shasum -
 If the verification is successful, you will see a message like this:
 
 ```text
-fluss-rust-0.1.0-incubating.tgz: OK
+fluss-rust-0.1.0.tgz: OK
 ```
 
 ## Verifying build
@@ -65,8 +65,8 @@ fluss-rust-0.1.0-incubating.tgz: OK
 Extract the source release archive and verify that it builds (and optionally that tests pass). You need **Rust** (see [rust-toolchain.toml](https://github.com/apache/fluss/blob/main/fluss-rust/rust-toolchain.toml) for the expected version) and, for full builds, **protobuf** and **Python 3.9+** for bindings.
 
 ```bash
-tar -xzf fluss-rust-${RELEASE_VERSION}-incubating.tgz
-cd fluss-rust-${RELEASE_VERSION}-incubating
+tar -xzf fluss-rust-${RELEASE_VERSION}.tgz
+cd fluss-rust-${RELEASE_VERSION}
 ```
 
 Build the workspace:
@@ -98,17 +98,11 @@ For any user-facing feature included in a release, we aim to ensure it is functi
 - **Python bindings:** See [Python Installation Guide](../user-guide/python/installation.md) for how to add the Python client (for an RC, install from **TestPyPI**: `pip install -i https://test.pypi.org/simple/ pyfluss==${RELEASE_VERSION}`); then write test cases to verify.
 - **C++ bindings:** See [C++ Installation Guide](../user-guide/cpp/installation.md) for how to build and link the C++ client; then write test cases to verify.
 
-## Incubator release checklist
-
-If the project is in incubation, the ASF Incubator provides a release checklist. You can refer to it when verifying the release:
-
-- [Incubator Release Checklist](https://cwiki.apache.org/confluence/display/INCUBATOR/Incubator+Release+Checklist)
-
 ## Voting
 
 Votes are cast by replying to the vote email on the dev mailing list with **+1**, **0**, or **-1**.
 
-In addition to your vote, it is customary to state whether your vote is **binding** or **non-binding**. Only members of the PPMC and mentors have formally binding votes (and the IPMC on the Incubator general list). If unsure, you can state that your vote is non-binding. See [Apache Foundation Voting](https://www.apache.org/foundation/voting.html).
+In addition to your vote, it is customary to state whether your vote is **binding** or **non-binding**. Only PMC members have formally binding votes. If unsure, you can state that your vote is non-binding. See [Apache Foundation Voting](https://www.apache.org/foundation/voting.html).
 
 It is recommended to include a short list of what you verified (e.g. signatures, checksums, build, tests, LICENSE/NOTICE). This helps the community see what has been checked and what might still be missing.
 
@@ -120,5 +114,4 @@ It is recommended to include a short list of what you verified (e.g. signatures,
 - [ ] [Verifying build](#verifying-build)
 - [ ] [Verifying LICENSE and NOTICE](#verifying-license-and-notice)
 - [ ] [Testing features](#testing-features)
-- [ ] [Incubator release checklist](#incubator-release-checklist) (if applicable)
 


### PR DESCRIPTION
Closes #3784

- Drop `-incubating` from source archive names in `scripts/release.sh` and all verification commands/examples in the release guides.
- Switch distribution and KEYS URLs from `/incubator/fluss` to `/fluss` (verified the new locations already exist).
- Replace PPMC with PMC; remove the Incubator PMC second-vote instructions and the Incubator-only release checklist.

