### PR TITLE
[client] Prevent EOF during concurrent remote log downloads

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/RemoteFileDownloader.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/RemoteFileDownloader.java
@@ -24,6 +24,7 @@ import org.apache.fluss.fs.FsPathAndFileName;
 import org.apache.fluss.fs.utils.FileDownloadSpec;
 import org.apache.fluss.fs.utils.FileDownloadUtils;
 import org.apache.fluss.utils.CloseableRegistry;
+import org.apache.fluss.utils.FileUtils;
 import org.apache.fluss.utils.IOUtils;
 import org.apache.fluss.utils.concurrent.ExecutorThreadFactory;
 
@@ -32,7 +33,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -88,21 +88,31 @@ public class RemoteFileDownloader implements Closeable {
      * downloaded bytes.
      */
     protected long downloadFile(Path targetFilePath, FsPath remoteFilePath) throws IOException {
-        List<Closeable> closeableRegistry = new ArrayList<>(2);
+        Path temporaryFile = null;
         try {
-            FileSystem fileSystem = remoteFilePath.getFileSystem();
-            FSDataInputStream inputStream = fileSystem.open(remoteFilePath);
-            closeableRegistry.add(inputStream);
-
             Files.createDirectories(targetFilePath.getParent());
-            OutputStream outputStream = Files.newOutputStream(targetFilePath);
-            closeableRegistry.add(outputStream);
+            temporaryFile =
+                    Files.createTempFile(targetFilePath.getParent(), ".fluss-download-", ".tmp");
 
-            return IOUtils.copyBytes(inputStream, outputStream, false);
+            FileSystem fileSystem = remoteFilePath.getFileSystem();
+            long downloadBytes;
+            try (FSDataInputStream inputStream = fileSystem.open(remoteFilePath);
+                    OutputStream outputStream = Files.newOutputStream(temporaryFile)) {
+                downloadBytes = IOUtils.copyBytes(inputStream, outputStream, false);
+            }
+
+            FileUtils.atomicMoveWithFallback(temporaryFile, targetFilePath, false);
+            return downloadBytes;
         } catch (Exception ex) {
-            throw new IOException(ex);
-        } finally {
-            closeableRegistry.forEach(IOUtils::closeQuietly);
+            IOException failure = new IOException(ex);
+            if (temporaryFile != null) {
+                try {
+                    Files.deleteIfExists(temporaryFile);
+                } catch (IOException cleanupException) {
+                    failure.addSuppressed(cleanupException);
+                }
+            }
+            throw failure;
         }
     }
 

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/RemoteFileDownloader.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/RemoteFileDownloader.java
@@ -108,7 +108,9 @@ public class RemoteFileDownloader implements Closeable {
         } finally {
             if (temporaryFile != null) {
                 Path fileToDelete = temporaryFile;
-                IOUtils.closeQuietly(() -> Files.deleteIfExists(fileToDelete));
+                IOUtils.closeQuietly(
+                        () -> Files.deleteIfExists(fileToDelete),
+                        "temporary download file " + fileToDelete);
             }
         }
     }

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/RemoteFileDownloader.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/RemoteFileDownloader.java
@@ -104,15 +104,12 @@ public class RemoteFileDownloader implements Closeable {
             FileUtils.atomicMoveWithFallback(temporaryFile, targetFilePath, false);
             return downloadBytes;
         } catch (Exception ex) {
-            IOException failure = new IOException(ex);
+            throw new IOException(ex);
+        } finally {
             if (temporaryFile != null) {
-                try {
-                    Files.deleteIfExists(temporaryFile);
-                } catch (IOException cleanupException) {
-                    failure.addSuppressed(cleanupException);
-                }
+                Path fileToDelete = temporaryFile;
+                IOUtils.closeQuietly(() -> Files.deleteIfExists(fileToDelete));
             }
-            throw failure;
         }
     }
 

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/LogFetcher.java
@@ -209,8 +209,7 @@ public class LogFetcher implements Closeable {
      * have an in-flight fetch or pending fetch data.
      */
     public void sendFetches() {
-        List<TableBucket> fetchable = fetchableBuckets();
-        checkAndUpdateMetadata(fetchable);
+        checkAndUpdateMetadata(fetchableBuckets());
         synchronized (this) {
             // Recompute after metadata update because response callbacks can populate the buffer.
             // Don't perform heavy I/O operations or synchronous waits here.

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/LogFetcher.java
@@ -212,9 +212,10 @@ public class LogFetcher implements Closeable {
         List<TableBucket> fetchable = fetchableBuckets();
         checkAndUpdateMetadata(fetchable);
         synchronized (this) {
-            // NOTE: Don't perform heavy I/O operations or synchronous waits inside this lock to
-            // avoid blocking the future complete of FetchLogResponse.
-            Map<Integer, FetchLogRequest> fetchRequestMap = prepareFetchLogRequests(fetchable);
+            // Recompute after metadata update because response callbacks can populate the buffer.
+            // Don't perform heavy I/O operations or synchronous waits here.
+            Map<Integer, FetchLogRequest> fetchRequestMap =
+                    prepareFetchLogRequests(fetchableBuckets());
             fetchRequestMap.forEach(
                     (nodeId, fetchLogRequest) -> {
                         LOG.debug("Adding pending request for node id {}", nodeId);

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetcherTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetcherTest.java
@@ -23,12 +23,14 @@ import org.apache.fluss.client.metadata.TestingMetadataUpdater;
 import org.apache.fluss.client.metrics.TestingScannerMetricGroup;
 import org.apache.fluss.client.table.scanner.RemoteFileDownloader;
 import org.apache.fluss.cluster.BucketLocation;
+import org.apache.fluss.cluster.Cluster;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.NotLeaderOrFollowerException;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.SchemaInfo;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.record.LogRecordReadContext;
 import org.apache.fluss.rpc.entity.FetchLogResultForBucket;
 import org.apache.fluss.rpc.messages.FetchLogRequest;
@@ -50,6 +52,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.fluss.client.metadata.TestingMetadataUpdater.NODE1;
 import static org.apache.fluss.client.metadata.TestingMetadataUpdater.NODE2;
@@ -166,6 +171,33 @@ public class LogFetcherTest {
     }
 
     @Test
+    void testSendFetchesRechecksFetchableBucketsAfterMetadataUpdate() throws Exception {
+        IOUtils.closeQuietly(logFetcher);
+        DelayedTabletServerGateway delayedGateway = new DelayedTabletServerGateway();
+        BlockingMetadataUpdater blockingMetadataUpdater =
+                new BlockingMetadataUpdater(delayedGateway);
+        metadataUpdater = blockingMetadataUpdater;
+        logFetcher = createLogFetcher(new Configuration());
+
+        logFetcher.sendFetches();
+        assertThat(delayedGateway.getRequestCount()).isOne();
+
+        blockingMetadataUpdater.invalidateTableMetadata();
+        CompletableFuture<Void> secondSend = CompletableFuture.runAsync(logFetcher::sendFetches);
+        try {
+            assertThat(blockingMetadataUpdater.awaitMetadataUpdateStarted()).isTrue();
+            delayedGateway.completeResponse();
+            assertThat(logFetcher.getCompletedFetchesSize()).isOne();
+        } finally {
+            blockingMetadataUpdater.continueMetadataUpdate();
+            delayedGateway.completeResponse();
+        }
+
+        secondSend.get(30, TimeUnit.SECONDS);
+        assertThat(delayedGateway.getRequestCount()).isOne();
+    }
+
+    @Test
     void testPrepareFetchLogRequestWithReadPreference() throws Exception {
         Map<Integer, FetchLogRequest> defaultRequestMap =
                 logFetcher.prepareFetchLogRequests(Collections.singletonList(tb1));
@@ -227,16 +259,67 @@ public class LogFetcherTest {
     private static class DelayedTabletServerGateway extends TestingTabletServerGateway {
         private final CompletableFuture<FetchLogResponse> responseFuture =
                 new CompletableFuture<>();
+        private final AtomicInteger requestCount = new AtomicInteger();
         private FetchLogResponse response;
 
         @Override
         public CompletableFuture<FetchLogResponse> fetchLog(FetchLogRequest request) {
+            requestCount.incrementAndGet();
             response = super.fetchLog(request).join();
             return responseFuture;
         }
 
+        private int getRequestCount() {
+            return requestCount.get();
+        }
+
         private void completeResponse() {
             responseFuture.complete(response);
+        }
+    }
+
+    private static class BlockingMetadataUpdater extends TestingMetadataUpdater {
+        private final CountDownLatch metadataUpdateStarted = new CountDownLatch(1);
+        private final CountDownLatch continueMetadataUpdate = new CountDownLatch(1);
+        private final Cluster refreshedCluster;
+
+        private BlockingMetadataUpdater(TestTabletServerGateway gateway) {
+            super(
+                    COORDINATOR,
+                    Arrays.asList(NODE1, NODE2, NODE3),
+                    Collections.singletonMap(DATA1_TABLE_PATH, DATA1_TABLE_INFO),
+                    Collections.singletonMap(1, gateway),
+                    new Configuration());
+            refreshedCluster = getCluster();
+        }
+
+        @Override
+        public void updateTableOrPartitionMetadata(TablePath tablePath, Long partitionId) {
+            metadataUpdateStarted.countDown();
+            try {
+                if (!continueMetadataUpdate.await(30, TimeUnit.SECONDS)) {
+                    throw new AssertionError("Timed out waiting to continue metadata update");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError("Interrupted while blocking metadata update", e);
+            }
+            updateCluster(refreshedCluster);
+        }
+
+        private void invalidateTableMetadata() {
+            updateCluster(
+                    getCluster()
+                            .invalidPhysicalTableBucketMeta(
+                                    Collections.singleton(PhysicalTablePath.of(DATA1_TABLE_PATH))));
+        }
+
+        private boolean awaitMetadataUpdateStarted() throws InterruptedException {
+            return metadataUpdateStarted.await(30, TimeUnit.SECONDS);
+        }
+
+        private void continueMetadataUpdate() {
+            continueMetadataUpdate.countDown();
         }
     }
 

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
@@ -23,9 +23,14 @@ import org.apache.fluss.client.table.scanner.RemoteFileDownloader;
 import org.apache.fluss.client.table.scanner.log.RemoteLogDownloader.RemoteLogDownloadRequest;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.fs.FSDataInputStream;
+import org.apache.fluss.fs.FSDataInputStreamWrapper;
+import org.apache.fluss.fs.FileSystem;
 import org.apache.fluss.fs.FsPath;
+import org.apache.fluss.fs.local.LocalFileSystem;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.record.FileLogRecords;
 import org.apache.fluss.remote.RemoteLogSegment;
 import org.apache.fluss.utils.FileUtils;
 import org.apache.fluss.utils.IOUtils;
@@ -145,6 +150,99 @@ class RemoteLogDownloaderTest {
         } finally {
             IOUtils.closeQuietly(remoteLogDownloader);
             IOUtils.closeQuietly(remoteFileDownloader);
+        }
+    }
+
+    @Test
+    void testDuplicateRemoteLogDownloadDoesNotBreakOpenReader() throws Exception {
+        CountDownLatch duplicateDownloadCopyStarted = new CountDownLatch(1);
+        CountDownLatch continueDuplicateDownload = new CountDownLatch(1);
+
+        class BlockingRemoteFileDownloader extends RemoteFileDownloader {
+            private final AtomicInteger downloadCount = new AtomicInteger();
+
+            private BlockingRemoteFileDownloader() {
+                super(1);
+            }
+
+            @Override
+            protected long downloadFile(Path targetFilePath, FsPath remoteFilePath)
+                    throws IOException {
+                if (downloadCount.incrementAndGet() == 2) {
+                    FileSystem blockingFileSystem =
+                            new LocalFileSystem() {
+                                @Override
+                                public FSDataInputStream open(FsPath path) throws IOException {
+                                    return new FSDataInputStreamWrapper(super.open(path)) {
+                                        @Override
+                                        public int read(byte[] buffer) throws IOException {
+                                            duplicateDownloadCopyStarted.countDown();
+                                            try {
+                                                if (!continueDuplicateDownload.await(
+                                                        30, TimeUnit.SECONDS)) {
+                                                    throw new IOException(
+                                                            "Timed out waiting to continue duplicate download");
+                                                }
+                                            } catch (InterruptedException e) {
+                                                Thread.currentThread().interrupt();
+                                                throw new IOException(
+                                                        "Interrupted while blocking duplicate download",
+                                                        e);
+                                            }
+                                            return super.read(buffer);
+                                        }
+                                    };
+                                }
+                            };
+                    remoteFilePath =
+                            new FsPath(remoteFilePath.toUri()) {
+                                @Override
+                                public FileSystem getFileSystem() {
+                                    return blockingFileSystem;
+                                }
+                            };
+                }
+                return super.downloadFile(targetFilePath, remoteFilePath);
+            }
+        }
+
+        BlockingRemoteFileDownloader fileDownloader = new BlockingRemoteFileDownloader();
+        RemoteLogDownloader downloader =
+                new RemoteLogDownloader(
+                        DATA1_TABLE_PATH.toString(), conf, fileDownloader, scannerMetricGroup, 10L);
+        try {
+            TableBucket tableBucket = new TableBucket(DATA1_TABLE_ID, 0);
+            RemoteLogSegment segment =
+                    buildRemoteLogSegmentList(tableBucket, DATA1_PHYSICAL_TABLE_PATH, 1, conf, 10)
+                            .get(0);
+            FsPath tabletDir =
+                    remoteLogTabletDir(remoteLogDir, DATA1_PHYSICAL_TABLE_PATH, tableBucket);
+
+            RemoteLogDownloadFuture firstDownload = downloader.requestRemoteLog(tabletDir, segment);
+            downloader.fetchOnce();
+            retry(Duration.ofSeconds(30), () -> assertThat(firstDownload.isDone()).isTrue());
+
+            RemoteLogDownloadFuture duplicateDownload =
+                    downloader.requestRemoteLog(tabletDir, segment);
+            FileLogRecords openReader = firstDownload.getFileLogRecords(0);
+            try {
+                downloader.fetchOnce();
+                assertThat(duplicateDownloadCopyStarted.await(30, TimeUnit.SECONDS)).isTrue();
+                assertThat(openReader.batches().iterator().hasNext()).isTrue();
+                continueDuplicateDownload.countDown();
+                retry(
+                        Duration.ofSeconds(30),
+                        () -> assertThat(duplicateDownload.isDone()).isTrue());
+                duplicateDownload.getFileLogRecords(0).closeHandlers();
+            } finally {
+                continueDuplicateDownload.countDown();
+                openReader.closeHandlers();
+            }
+
+            assertThat(FileUtils.listDirectory(downloader.getLocalLogDir())).hasSize(1);
+        } finally {
+            IOUtils.closeQuietly(downloader);
+            IOUtils.closeQuietly(fileDownloader);
         }
     }
 

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
@@ -27,6 +27,7 @@ import org.apache.fluss.fs.FSDataInputStream;
 import org.apache.fluss.fs.FSDataInputStreamWrapper;
 import org.apache.fluss.fs.FileSystem;
 import org.apache.fluss.fs.FsPath;
+import org.apache.fluss.fs.FsPathAndFileName;
 import org.apache.fluss.fs.local.LocalFileSystem;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -67,6 +69,7 @@ import static org.apache.fluss.testutils.common.CommonTestUtils.waitUntil;
 import static org.apache.fluss.utils.FlussPaths.remoteLogDir;
 import static org.apache.fluss.utils.FlussPaths.remoteLogTabletDir;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link RemoteLogDownloader}. */
 class RemoteLogDownloaderTest {
@@ -244,6 +247,43 @@ class RemoteLogDownloaderTest {
             IOUtils.closeQuietly(downloader);
             IOUtils.closeQuietly(fileDownloader);
         }
+    }
+
+    @Test
+    void testTemporaryFileCleanupOnError() throws Exception {
+        Path remoteFile = remoteDataDir.toPath().resolve("remote.log");
+        Files.write(remoteFile, new byte[] {1});
+        FileSystem failingFileSystem =
+                new LocalFileSystem() {
+                    @Override
+                    public FSDataInputStream open(FsPath path) throws IOException {
+                        return new FSDataInputStreamWrapper(super.open(path)) {
+                            @Override
+                            public int read(byte[] buffer) {
+                                throw new OutOfMemoryError("test");
+                            }
+                        };
+                    }
+                };
+        FsPath remotePath =
+                new FsPath(remoteFile.toUri()) {
+                    @Override
+                    public FileSystem getFileSystem() {
+                        return failingFileSystem;
+                    }
+                };
+
+        try (RemoteFileDownloader downloader = new RemoteFileDownloader(1)) {
+            assertThatThrownBy(
+                            () ->
+                                    downloader
+                                            .downloadFileAsync(
+                                                    new FsPathAndFileName(remotePath, "local.log"),
+                                                    localDir.toPath())
+                                            .get())
+                    .hasCauseInstanceOf(OutOfMemoryError.class);
+        }
+        assertThat(FileUtils.listDirectory(localDir.toPath())).isEmpty();
     }
 
     @Test

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
@@ -161,55 +161,9 @@ class RemoteLogDownloaderTest {
         CountDownLatch duplicateDownloadCopyStarted = new CountDownLatch(1);
         CountDownLatch continueDuplicateDownload = new CountDownLatch(1);
 
-        class BlockingRemoteFileDownloader extends RemoteFileDownloader {
-            private final AtomicInteger downloadCount = new AtomicInteger();
-
-            private BlockingRemoteFileDownloader() {
-                super(1);
-            }
-
-            @Override
-            protected long downloadFile(Path targetFilePath, FsPath remoteFilePath)
-                    throws IOException {
-                if (downloadCount.incrementAndGet() == 2) {
-                    FileSystem blockingFileSystem =
-                            new LocalFileSystem() {
-                                @Override
-                                public FSDataInputStream open(FsPath path) throws IOException {
-                                    return new FSDataInputStreamWrapper(super.open(path)) {
-                                        @Override
-                                        public int read(byte[] buffer) throws IOException {
-                                            duplicateDownloadCopyStarted.countDown();
-                                            try {
-                                                if (!continueDuplicateDownload.await(
-                                                        30, TimeUnit.SECONDS)) {
-                                                    throw new IOException(
-                                                            "Timed out waiting to continue duplicate download");
-                                                }
-                                            } catch (InterruptedException e) {
-                                                Thread.currentThread().interrupt();
-                                                throw new IOException(
-                                                        "Interrupted while blocking duplicate download",
-                                                        e);
-                                            }
-                                            return super.read(buffer);
-                                        }
-                                    };
-                                }
-                            };
-                    remoteFilePath =
-                            new FsPath(remoteFilePath.toUri()) {
-                                @Override
-                                public FileSystem getFileSystem() {
-                                    return blockingFileSystem;
-                                }
-                            };
-                }
-                return super.downloadFile(targetFilePath, remoteFilePath);
-            }
-        }
-
-        BlockingRemoteFileDownloader fileDownloader = new BlockingRemoteFileDownloader();
+        BlockingRemoteFileDownloader fileDownloader =
+                new BlockingRemoteFileDownloader(
+                        duplicateDownloadCopyStarted, continueDuplicateDownload);
         RemoteLogDownloader downloader =
                 new RemoteLogDownloader(
                         DATA1_TABLE_PATH.toString(), conf, fileDownloader, scannerMetricGroup, 10L);
@@ -639,6 +593,59 @@ class RemoteLogDownloaderTest {
             blockLatch.countDown(); // ensure latch is released even on test failure
             IOUtils.closeQuietly(downloader);
             IOUtils.closeQuietly(fileDownloader);
+        }
+    }
+
+    private static class BlockingRemoteFileDownloader extends RemoteFileDownloader {
+        private final CountDownLatch duplicateDownloadCopyStarted;
+        private final CountDownLatch continueDuplicateDownload;
+        private final AtomicInteger downloadCount = new AtomicInteger();
+
+        private BlockingRemoteFileDownloader(
+                CountDownLatch duplicateDownloadCopyStarted,
+                CountDownLatch continueDuplicateDownload) {
+            super(1);
+            this.duplicateDownloadCopyStarted = duplicateDownloadCopyStarted;
+            this.continueDuplicateDownload = continueDuplicateDownload;
+        }
+
+        @Override
+        protected long downloadFile(Path targetFilePath, FsPath remoteFilePath) throws IOException {
+            if (downloadCount.incrementAndGet() == 2) {
+                FileSystem blockingFileSystem =
+                        new LocalFileSystem() {
+                            @Override
+                            public FSDataInputStream open(FsPath path) throws IOException {
+                                return new FSDataInputStreamWrapper(super.open(path)) {
+                                    @Override
+                                    public int read(byte[] buffer) throws IOException {
+                                        duplicateDownloadCopyStarted.countDown();
+                                        try {
+                                            if (!continueDuplicateDownload.await(
+                                                    30, TimeUnit.SECONDS)) {
+                                                throw new IOException(
+                                                        "Timed out waiting to continue duplicate download");
+                                            }
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                            throw new IOException(
+                                                    "Interrupted while blocking duplicate download",
+                                                    e);
+                                        }
+                                        return super.read(buffer);
+                                    }
+                                };
+                            }
+                        };
+                remoteFilePath =
+                        new FsPath(remoteFilePath.toUri()) {
+                            @Override
+                            public FileSystem getFileSystem() {
+                                return blockingFileSystem;
+                            }
+                        };
+            }
+            return super.downloadFile(targetFilePath, remoteFilePath);
         }
     }
 


### PR DESCRIPTION
### Purpose

Linked issue: close #3815

`LogFetcher` could reuse a fetchable-bucket snapshot captured before a metadata update. If a response populated the buffer during that update, the same bucket could be fetched again. A duplicate remote-log download then truncated the local segment while an existing reader was still using it, causing `Unexpected EOF`.

### Brief change log

- Recompute fetchable buckets under the `LogFetcher` lock after metadata updates.
- Download each remote segment to a unique same-directory temporary file, then atomically publish the completed file.
- Clean up temporary files when a download or publish fails.

### Tests

- `LogFetcherTest` and `RemoteLogDownloaderTest`: 13 tests passed.
- `./mvnw -o -pl fluss-client validate`

### API and Format

No public API or storage format changes.

### Documentation

No documentation changes are required.

### Generative AI disclosure

Yes. OpenAI Codex was used to assist with implementation and review.
