### PR TITLE
[flink][client] Close writer immediately on sink failover

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/Connection.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/Connection.java
@@ -26,6 +26,8 @@ import org.apache.fluss.metadata.TablePath;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.time.Duration;
+
 /**
  * A cluster connection encapsulating lower level individual connections to actual Fluss servers.
  * Connections are instantiated through the {@link ConnectionFactory} class. The lifecycle of the
@@ -67,7 +69,26 @@ public interface Connection extends AutoCloseable {
      */
     MultiTable getMultiTable();
 
-    /** Close the connection and release all resources. */
+    /**
+     * Close the connection and release all resources.
+     *
+     * <p>This is equivalent to closing with an unbounded timeout: it waits for all pending write
+     * and lookup requests to be processed before releasing the resources.
+     */
     @Override
     void close() throws Exception;
+
+    /**
+     * Close the connection, waiting for at most the given timeout for pending write and lookup
+     * requests to complete.
+     *
+     * <p>A zero or negative timeout closes the connection immediately, abandoning any unsent or
+     * in-flight requests. This is useful for fail-fast scenarios such as task failover or
+     * cancellation, where waiting for pending requests may block indefinitely.
+     *
+     * @param timeout the maximum time to wait for pending requests to complete
+     */
+    default void close(Duration timeout) throws Exception {
+        close();
+    }
 }

--- a/fluss-client/src/main/java/org/apache/fluss/client/FlussConnection.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/FlussConnection.java
@@ -203,14 +203,18 @@ public final class FlussConnection implements Connection {
 
     @Override
     public void close() throws Exception {
+        // graceful close: wait for all pending write/lookup requests to be processed
+        close(Duration.ofMillis(Long.MAX_VALUE));
+    }
+
+    @Override
+    public void close(Duration timeout) throws Exception {
         if (writerClient != null) {
-            writerClient.close(Duration.ofMillis(Long.MAX_VALUE));
+            writerClient.close(timeout);
         }
 
         if (lookupClient != null) {
-            // timeout is Long.MAX_VALUE to make the pending get request
-            // to be processed
-            lookupClient.close(Duration.ofMillis(Long.MAX_VALUE));
+            lookupClient.close(timeout);
         }
 
         if (remoteFileDownloader != null) {

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/WriterClient.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/WriterClient.java
@@ -332,47 +332,40 @@ public class WriterClient {
         writerMetricGroup.close();
 
         if (sender != null) {
-            if (timeoutMs > 0) {
-                // graceful close: stop accepting new records, but keep the sender running to
-                // send out the pending records.
-                sender.initiateClose();
-            } else {
-                // immediate close: abandon all unsent and in-flight requests right away so
-                // that close never blocks (e.g. during Flink task failover/cancellation).
-                sender.forceClose();
-            }
+            sender.initiateClose();
         }
 
         if (ioThreadPool != null) {
             ioThreadPool.shutdown();
 
-            try {
-                if (!ioThreadPool.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
-                    // the graceful close didn't finish within the timeout (or an immediate
-                    // close was requested): abandon the pending requests so that the sender
-                    // thread can exit its drain loop, and interrupt it to break any blocking
-                    // waits.
-                    if (sender != null) {
-                        sender.forceClose();
+            if (timeoutMs > 0) {
+                try {
+                    if (!ioThreadPool.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+                        LOG.warn("Writer graceful close timed out after {} ms.", timeoutMs);
                     }
-                    ioThreadPool.shutdownNow();
-
-                    if (!ioThreadPool.awaitTermination(
-                            FORCE_CLOSE_TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                        LOG.error("Failed to shutdown writer.");
-                    }
+                } catch (InterruptedException e) {
+                    LOG.error("Interrupted while waiting for writer sender thread.", e);
+                    Thread.currentThread().interrupt();
                 }
-            } catch (InterruptedException e) {
-                if (sender != null) {
-                    sender.forceClose();
-                }
-                ioThreadPool.shutdownNow();
-                Thread.currentThread().interrupt();
             }
         }
 
-        if (sender != null) {
+        if (sender != null && ioThreadPool != null && !ioThreadPool.isTerminated()) {
+            LOG.info(
+                    "Proceeding to force close the writer since pending requests could not be completed "
+                            + "within timeout {} ms.",
+                    timeoutMs);
             sender.forceClose();
+            ioThreadPool.shutdownNow();
+            try {
+                if (!ioThreadPool.awaitTermination(
+                        FORCE_CLOSE_TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    LOG.error("Failed to shutdown writer.");
+                }
+            } catch (InterruptedException e) {
+                LOG.error("Interrupted while force closing writer sender thread.", e);
+                Thread.currentThread().interrupt();
+            }
         }
 
         LOG.info("Writer closed.");

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/WriterClient.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/WriterClient.java
@@ -76,6 +76,13 @@ public class WriterClient {
      */
     private static final int MAX_IN_FLIGHT_REQUESTS_PER_BUCKET_FOR_IDEMPOTENCE = 5;
 
+    /**
+     * The bounded time to wait for the sender thread to exit after it has been force closed. Once
+     * force closed, the sender abandons all pending requests and exits promptly, so this is only a
+     * safety net to avoid blocking close forever.
+     */
+    private static final long FORCE_CLOSE_TERMINATION_TIMEOUT_MS = 5000;
+
     private final Configuration conf;
     private final int maxRequestSize;
     private final RecordAccumulator accumulator;
@@ -319,26 +326,46 @@ public class WriterClient {
     }
 
     public void close(Duration timeout) {
-        LOG.info("Closing writer.");
+        long timeoutMs = timeout.toMillis();
+        LOG.info("Closing writer with timeout {} ms.", timeoutMs);
 
         writerMetricGroup.close();
 
         if (sender != null) {
-            sender.initiateClose();
+            if (timeoutMs > 0) {
+                // graceful close: stop accepting new records, but keep the sender running to
+                // send out the pending records.
+                sender.initiateClose();
+            } else {
+                // immediate close: abandon all unsent and in-flight requests right away so
+                // that close never blocks (e.g. during Flink task failover/cancellation).
+                sender.forceClose();
+            }
         }
 
         if (ioThreadPool != null) {
             ioThreadPool.shutdown();
 
             try {
-                if (!ioThreadPool.awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                if (!ioThreadPool.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+                    // the graceful close didn't finish within the timeout (or an immediate
+                    // close was requested): abandon the pending requests so that the sender
+                    // thread can exit its drain loop, and interrupt it to break any blocking
+                    // waits.
+                    if (sender != null) {
+                        sender.forceClose();
+                    }
                     ioThreadPool.shutdownNow();
 
-                    if (!ioThreadPool.awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                    if (!ioThreadPool.awaitTermination(
+                            FORCE_CLOSE_TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
                         LOG.error("Failed to shutdown writer.");
                     }
                 }
             } catch (InterruptedException e) {
+                if (sender != null) {
+                    sender.forceClose();
+                }
                 ioThreadPool.shutdownNow();
                 Thread.currentThread().interrupt();
             }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/sink/writer/FlinkSinkWriter.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/sink/writer/FlinkSinkWriter.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
@@ -182,7 +183,13 @@ public abstract class FlinkSinkWriter<InputT> implements SinkWriter<InputT> {
 
         try {
             if (connection != null) {
-                connection.close();
+                // Close the connection immediately without waiting for pending write requests:
+                // all records that must be persisted have already been flushed on checkpoints
+                // (see #flush), and on failover/cancellation the un-flushed records will be
+                // replayed from the last checkpoint anyway. A graceful close could block the
+                // task indefinitely when the Fluss cluster is unavailable, preventing failover
+                // from proceeding. This mirrors Kafka's FlinkKafkaInternalProducer#close().
+                connection.close(Duration.ZERO);
             }
         } catch (Exception e) {
             LOG.warn("Exception occurs while closing Fluss Connection.", e);

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/writer/FlinkSinkWriterTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/writer/FlinkSinkWriterTest.java
@@ -51,7 +51,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Duration;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -199,6 +201,55 @@ public class FlinkSinkWriterTest extends FlinkTestBase {
                     assertThatThrownBy(writer::close)
                             .hasRootCauseExactlyInstanceOf(NetworkException.class);
                 });
+    }
+
+    @Test
+    void testCloseReturnsPromptlyWhenFlussUnavailable() throws Exception {
+        // Regression test for the sink blocking in close during failover: with pending records
+        // that can never be sent (cluster down + infinite writer retries by default), a graceful
+        // close would wait indefinitely. The sink must close the connection immediately instead.
+        FlussClusterExtension flussClusterExtension = FlussClusterExtension.builder().build();
+        try {
+            flussClusterExtension.start();
+
+            Configuration clientConfig = flussClusterExtension.getClientConfig();
+            // keep the default infinite retries so that pending records are never given up,
+            // which is exactly the situation that used to block close forever
+            try (Connection connection = ConnectionFactory.createConnection(clientConfig);
+                    Admin admin = connection.getAdmin()) {
+                admin.createDatabase(
+                                DEFAULT_SINK_TABLE_PATH.getDatabaseName(),
+                                DatabaseDescriptor.EMPTY,
+                                true)
+                        .get();
+                admin.createTable(DEFAULT_SINK_TABLE_PATH, TABLE_DESCRIPTOR, true).get();
+            }
+
+            MockWriterInitContext mockWriterInitContext =
+                    new MockWriterInitContext(new InterceptingOperatorMetricGroup());
+            FlinkSinkWriter<RowData> writer =
+                    createSinkWriter(clientConfig, mockWriterInitContext.getMailboxExecutor());
+            writer.initialize(mockWriterInitContext.metricGroup());
+            // make the cluster unavailable while a record is still pending in the writer
+            flussClusterExtension.close();
+            writer.write(
+                    GenericRowData.of(1, StringData.fromString("a")), new MockSinkWriterContext());
+
+            // close must return promptly instead of waiting for the pending record
+            CompletableFuture<Void> closeFuture =
+                    CompletableFuture.runAsync(
+                            () -> {
+                                try {
+                                    writer.close();
+                                } catch (Exception e) {
+                                    // exceptions (e.g. pending record failures) are
+                                    // acceptable; blocking is not
+                                }
+                            });
+            assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(30));
+        } finally {
+            flussClusterExtension.close();
+        }
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -67,6 +67,7 @@ import org.apache.fluss.server.entity.NotifyLeaderAndIsrResultForBucket;
 import org.apache.fluss.server.entity.StopReplicaData;
 import org.apache.fluss.server.entity.StopReplicaResultForBucket;
 import org.apache.fluss.server.kv.KvTablet;
+import org.apache.fluss.server.kv.KvTabletTestUtils;
 import org.apache.fluss.server.kv.rocksdb.RocksDBKv;
 import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
 import org.apache.fluss.server.log.FetchParams;
@@ -1339,6 +1340,10 @@ class ReplicaManagerTest extends ReplicaTestBase {
                 PUT_KV_VERSION,
                 future::complete);
         assertThat(future.get()).containsOnly(new PutKvResultForBucket(tb, 4));
+
+        // flush the pre-write buffer to RocksDB so that prefix lookup can see the records
+        KvTabletTestUtils.flushAndWait(
+                replicaManager.getReplicaOrException(tb).getKvTablet(), Long.MAX_VALUE);
 
         // second prefix lookup in table, prefix key = (1, "a").
         Object[] prefixKey1 = new Object[] {1, "a"};

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -67,7 +67,6 @@ import org.apache.fluss.server.entity.NotifyLeaderAndIsrResultForBucket;
 import org.apache.fluss.server.entity.StopReplicaData;
 import org.apache.fluss.server.entity.StopReplicaResultForBucket;
 import org.apache.fluss.server.kv.KvTablet;
-import org.apache.fluss.server.kv.KvTabletTestUtils;
 import org.apache.fluss.server.kv.rocksdb.RocksDBKv;
 import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
 import org.apache.fluss.server.log.FetchParams;
@@ -1340,10 +1339,6 @@ class ReplicaManagerTest extends ReplicaTestBase {
                 PUT_KV_VERSION,
                 future::complete);
         assertThat(future.get()).containsOnly(new PutKvResultForBucket(tb, 4));
-
-        // flush the pre-write buffer to RocksDB so that prefix lookup can see the records
-        KvTabletTestUtils.flushAndWait(
-                replicaManager.getReplicaOrException(tb).getKvTablet(), Long.MAX_VALUE);
 
         // second prefix lookup in table, prefix key = (1, "a").
         Object[] prefixKey1 = new Object[] {1, "a"};


### PR DESCRIPTION
### Purpose

Linked issue: close #3809

The Flink sink closed the client via `Connection.close()`, which closes the underlying `WriterClient` with an unbounded timeout. With pending records that cannot be sent (e.g. cluster unavailable during failover, with infinite writer retries by default), the sender's drain loop never exits and the task blocks in close, preventing failover from proceeding.

### Brief change log

- `Connection`: add a timeout-based `close(Duration)` API (default method, delegating to `close()`); zero/negative timeout means immediate close, abandoning unsent and in-flight requests.
- `FlussConnection`: implement `close(Duration)`; the no-arg `close()` keeps the previous graceful semantics (unbounded timeout).
- `WriterClient#close(Duration)`: a non-positive timeout now force-closes the sender up front instead of initiating a graceful close; when a graceful close times out, force-close the sender before interrupting the io thread, and bound the final wait (5s safety net) instead of reusing the caller timeout.
- `FlinkSinkWriter#close`: close the connection with `Duration.ZERO`. Data correctness is unaffected: records are flushed on checkpoints, and on failover/cancellation un-flushed records are replayed from the last checkpoint. This mirrors Kafka's `FlinkKafkaInternalProducer#close()`.

### Tests

- `FlinkSinkWriterTest#testCloseReturnsPromptlyWhenFlussUnavailable`: reproduces the failover scenario (cluster down + pending record + default infinite retries) and asserts close returns promptly. Verified it hangs and fails without the fix.
- Existing `FlinkSinkWriterTest` tests still pass, including `testCloseExceptionWhenFlussUnavailable` (close still surfaces async write errors).

### API and Format

Adds `Connection#close(Duration)` as a default method on the `@PublicEvolving` interface; existing implementations and callers are unaffected. No storage format changes.

### Documentation

No documentation changes.