### PR TITLE
[rust] Fix Arrow limit scan across schema evolution

### DIFF
--- a/fluss-rust/crates/fluss/src/client/table/batch_scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/batch_scanner.rs
@@ -18,12 +18,14 @@
 //! Bounded batch scanner backed by a single `LimitScanRequest`, polled with
 //! `next_batch` until it returns `None` (like `RecordBatchLogReader`).
 //!
-//! The KV branch decodes a [`ValueRecordBatch`], decoding each record against
-//! its own schema id via [`FixedSchemaDecoder`] so older records are projected
-//! onto the current schema (the same path as lookup).
+//! Both log and KV batches are decoded against their write-time schema id and
+//! aligned to the current table schema. The KV branch uses [`FixedSchemaDecoder`]
+//! (the same path as lookup), while the log branch resolves an Arrow read
+//! context per batch.
 
 use crate::client::ClientSchemaGetter;
 use crate::client::metadata::Metadata;
+use crate::client::table::read_context_resolver::ReadContextResolver;
 use crate::error::{ApiError, Error, FlussError, Result};
 use crate::metadata::{KvFormat, RowType, Schema, TableBucket, TableInfo};
 use crate::proto::ErrorResponse;
@@ -158,7 +160,9 @@ async fn run_limit_scan(pending: &PendingScan, bucket: &TableBucket) -> Result<S
     // Choose the payload format from table metadata, not the response's advisory
     // `is_log_table` flag.
     let (batch, base_offset) = if !pending.table_info.has_primary_key() {
-        decode_log_batch(&pending.table_info, projected, raw, limit)?
+        let resolver = create_log_read_context_resolver(&pending.table_info)?
+            .with_schema_getter(Arc::clone(&pending.schema_getter));
+        decode_log_batch(&pending.table_info, &resolver, projected, raw, limit).await?
     } else {
         // KV (primary-key) limit scan: no log offset, so base_offset is 0.
         let batch = decode_kv_batch(
@@ -175,21 +179,18 @@ async fn run_limit_scan(pending: &PendingScan, bucket: &TableBucket) -> Result<S
     Ok(ScanBatch::new(bucket.clone(), batch, base_offset))
 }
 
-/// Decode the log payload into a single Arrow `RecordBatch`, concatenating any
-/// inner batches. If more than `limit` rows are returned, the last `limit` are
+/// Decode each log batch with its write-time schema, align it to the current
+/// table schema, and concatenate the aligned batches into one Arrow
+/// `RecordBatch`. If more than `limit` rows are returned, the last `limit` are
 /// kept and `base_offset` is advanced by the number dropped.
-fn decode_log_batch(
+async fn decode_log_batch(
     table_info: &TableInfo,
+    resolver: &ReadContextResolver,
     projected_fields: Option<&[usize]>,
     raw: Vec<u8>,
     limit: usize,
 ) -> Result<(RecordBatch, i64)> {
-    let row_type = Arc::new(table_info.get_row_type().clone());
     let full_schema = to_arrow_schema(table_info.get_row_type())?;
-    // A limit scan returns every column (never projected server-side); decode
-    // the full batch and project after, like the KV path. Pushdown here would
-    // misparse the full-column body and corrupt the buffers.
-    let read_context = ArrowReadContext::new(full_schema.clone(), row_type.clone(), false);
 
     if raw.is_empty() {
         let empty = RecordBatch::new_empty(full_schema);
@@ -206,6 +207,19 @@ fn decode_log_batch(
         if base_offset.is_none() {
             base_offset = Some(log_batch.base_log_offset());
         }
+        let schema_id = log_batch.schema_id();
+        let read_context = match resolver.resolve(schema_id, false) {
+            Some(read_context) => read_context,
+            None => {
+                resolver.fetch_and_register(schema_id).await?;
+                resolver
+                    .resolve(schema_id, false)
+                    .ok_or_else(|| Error::UnexpectedError {
+                        message: format!("No read context built for schema id {schema_id}"),
+                        source: None,
+                    })?
+            }
+        };
         let rb = log_batch.record_batch(&read_context)?;
         batches.push(rb);
     }
@@ -227,6 +241,31 @@ fn decode_log_batch(
         project_batch(trimmed, table_info.get_row_type(), projected_fields)?,
         base_offset,
     ))
+}
+
+fn create_log_read_context_resolver(table_info: &TableInfo) -> Result<ReadContextResolver> {
+    let row_type = Arc::new(table_info.get_row_type().clone());
+    let arrow_schema = to_arrow_schema(table_info.get_row_type())?;
+    let local_context = Arc::new(
+        ArrowReadContext::new(arrow_schema.clone(), Arc::clone(&row_type), false)
+            .with_fluss_row_type(Arc::clone(&row_type)),
+    );
+    let remote_context = Arc::new(
+        ArrowReadContext::new(arrow_schema, Arc::clone(&row_type), true)
+            .with_fluss_row_type(row_type),
+    );
+    let schema_id =
+        i16::try_from(table_info.get_schema_id()).map_err(|_| Error::UnexpectedError {
+            message: format!(
+                "Schema id {} does not fit in 16 bits — wire format violated",
+                table_info.get_schema_id()
+            ),
+            source: None,
+        })?;
+    Ok(
+        ReadContextResolver::new(schema_id, local_context, remote_context, None)
+            .with_fixed_schema(table_info.get_schema()),
+    )
 }
 
 /// Decode a KV limit-scan [`ValueRecordBatch`] into a single Arrow
@@ -413,7 +452,8 @@ mod tests {
         DEFAULT_NON_ZSTD_COMPRESSION_LEVEL,
     };
     use crate::metadata::{
-        Column, DataField, DataType, DataTypes, PhysicalTablePath, Schema, TableInfo, TablePath,
+        Column, DataField, DataType, DataTypes, PhysicalTablePath, Schema, TableDescriptor,
+        TableInfo, TablePath,
     };
     use crate::record::MemoryLogRecordsArrowBuilder;
     use crate::row::GenericRow;
@@ -434,6 +474,25 @@ mod tests {
         )
     }
 
+    fn build_table_info_at_schema(
+        table_path: TablePath,
+        table_id: i64,
+        schema_id: i32,
+        fields: Vec<DataField>,
+    ) -> TableInfo {
+        let row_type = DataTypes::row(fields);
+        let schema = Schema::builder()
+            .with_row_type(&row_type)
+            .build()
+            .expect("schema");
+        let descriptor = TableDescriptor::builder()
+            .schema(schema)
+            .distributed_by(Some(1), vec![])
+            .build()
+            .expect("descriptor");
+        TableInfo::of(table_path, table_id, schema_id, descriptor, 0, 0)
+    }
+
     /// Encode `rows` (built against `table_info`'s row type) as one Arrow log batch.
     fn build_log_batch(table_info: &TableInfo, rows: &[GenericRow]) -> Vec<u8> {
         let table_info_arc = Arc::new(table_info.clone());
@@ -441,7 +500,7 @@ mod tests {
             table_info.table_path.clone(),
         )));
         let mut builder = MemoryLogRecordsArrowBuilder::new(
-            1,
+            table_info.get_schema_id(),
             table_info.get_row_type(),
             false,
             ArrowCompressionInfo {
@@ -488,46 +547,60 @@ mod tests {
 
     // ---- log path ----------------------------------------------------------
 
-    #[test]
-    fn decode_log_batch_empty_returns_empty_record_batch() {
+    #[tokio::test]
+    async fn decode_log_batch_empty_returns_empty_record_batch() {
         let table_info = build_two_col_table_info();
+        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
         let (batch, base_offset) =
-            decode_log_batch(&table_info, None, Vec::new(), usize::MAX).expect("decode empty");
+            decode_log_batch(&table_info, &resolver, None, Vec::new(), usize::MAX)
+                .await
+                .expect("decode empty");
         assert_eq!(batch.num_rows(), 0);
         assert_eq!(batch.num_columns(), 2);
         assert_eq!(base_offset, 0);
     }
 
-    #[test]
-    fn decode_log_batch_empty_with_projection() {
+    #[tokio::test]
+    async fn decode_log_batch_empty_with_projection() {
         let table_info = build_two_col_table_info();
-        let (batch, base_offset) =
-            decode_log_batch(&table_info, Some(&[1usize]), Vec::new(), usize::MAX)
-                .expect("decode empty");
+        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
+        let (batch, base_offset) = decode_log_batch(
+            &table_info,
+            &resolver,
+            Some(&[1usize]),
+            Vec::new(),
+            usize::MAX,
+        )
+        .await
+        .expect("decode empty");
         assert_eq!(batch.num_rows(), 0);
         assert_eq!(batch.num_columns(), 1);
         assert_eq!(batch.schema().field(0).name(), "name");
         assert_eq!(base_offset, 0);
     }
 
-    #[test]
-    fn decode_log_batch_extracts_base_offset_and_rows() {
+    #[tokio::test]
+    async fn decode_log_batch_extracts_base_offset_and_rows() {
         let table_info = build_two_col_table_info();
+        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
         let raw = build_log_records(&table_info, 17, &[(1, "alice"), (2, "bob"), (3, "carol")]);
 
-        let (batch, base_offset) =
-            decode_log_batch(&table_info, None, raw, usize::MAX).expect("decode populated");
+        let (batch, base_offset) = decode_log_batch(&table_info, &resolver, None, raw, usize::MAX)
+            .await
+            .expect("decode populated");
         assert_eq!(batch.num_rows(), 3);
         assert_eq!(batch.num_columns(), 2);
         assert_eq!(base_offset, 17);
     }
 
-    #[test]
-    fn decode_log_batch_projection_keeps_requested_columns() {
+    #[tokio::test]
+    async fn decode_log_batch_projection_keeps_requested_columns() {
         let table_info = build_two_col_table_info();
+        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
         let raw = build_log_records(&table_info, 0, &[(7, "x"), (8, "y")]);
 
-        let (batch, _) = decode_log_batch(&table_info, Some(&[0usize]), raw, usize::MAX)
+        let (batch, _) = decode_log_batch(&table_info, &resolver, Some(&[0usize]), raw, usize::MAX)
+            .await
             .expect("decode projected");
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 1);
@@ -536,8 +609,8 @@ mod tests {
 
     /// Projection skipping a middle variable-length column — catches a
     /// full-column body being misparsed as the projected schema.
-    #[test]
-    fn decode_log_batch_projection_skips_middle_variable_length_column() {
+    #[tokio::test]
+    async fn decode_log_batch_projection_skips_middle_variable_length_column() {
         let table_info = build_table_info_with_columns(
             TablePath::new("db".to_string(), "tbl".to_string()),
             43,
@@ -559,9 +632,17 @@ mod tests {
             })
             .collect();
         let raw = build_log_batch(&table_info, &rows);
+        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
 
-        let (batch, _) = decode_log_batch(&table_info, Some(&[0usize, 2usize]), raw, usize::MAX)
-            .expect("decode projected");
+        let (batch, _) = decode_log_batch(
+            &table_info,
+            &resolver,
+            Some(&[0usize, 2usize]),
+            raw,
+            usize::MAX,
+        )
+        .await
+        .expect("decode projected");
         assert_eq!(batch.num_columns(), 2);
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.schema().field(0).name(), "c1");
@@ -580,14 +661,22 @@ mod tests {
         assert_eq!((c3.value(0), c3.value(1)), (100, 200));
     }
 
-    #[test]
-    fn decode_log_batch_non_prefix_projection_reorders_columns() {
+    #[tokio::test]
+    async fn decode_log_batch_non_prefix_projection_reorders_columns() {
         let table_info = build_two_col_table_info();
+        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
         let raw = build_log_records(&table_info, 0, &[(1, "alice"), (2, "bob")]);
 
         // `[name, id]`: reversed, so neither a leading prefix nor in source order.
-        let (batch, _) = decode_log_batch(&table_info, Some(&[1usize, 0usize]), raw, usize::MAX)
-            .expect("decode reordered projection");
+        let (batch, _) = decode_log_batch(
+            &table_info,
+            &resolver,
+            Some(&[1usize, 0usize]),
+            raw,
+            usize::MAX,
+        )
+        .await
+        .expect("decode reordered projection");
 
         assert_eq!(batch.num_columns(), 2);
         assert_eq!(batch.schema().field(0).name(), "name");
@@ -610,13 +699,16 @@ mod tests {
         assert_eq!(ids.value(1), 2);
     }
 
-    #[test]
-    fn decode_log_batch_truncates_to_last_limit_rows() {
+    #[tokio::test]
+    async fn decode_log_batch_truncates_to_last_limit_rows() {
         let table_info = build_two_col_table_info();
+        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
         // Server returned 4 rows starting at offset 100, but limit is 2.
         let raw = build_log_records(&table_info, 100, &[(1, "a"), (2, "b"), (3, "c"), (4, "d")]);
 
-        let (batch, base_offset) = decode_log_batch(&table_info, None, raw, 2).expect("decode");
+        let (batch, base_offset) = decode_log_batch(&table_info, &resolver, None, raw, 2)
+            .await
+            .expect("decode");
         assert_eq!(batch.num_rows(), 2);
         // The last two rows are kept, so the base offset advances by 2.
         assert_eq!(base_offset, 102);
@@ -627,6 +719,71 @@ mod tests {
             .unwrap();
         assert_eq!(ids.value(0), 3);
         assert_eq!(ids.value(1), 4);
+    }
+
+    #[tokio::test]
+    async fn decode_log_batch_projects_old_schema_after_add_column() {
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let source_table_info = build_table_info_at_schema(
+            table_path.clone(),
+            42,
+            1,
+            vec![
+                DataField::new("id", DataTypes::int(), None),
+                DataField::new("name", DataTypes::string(), None),
+            ],
+        );
+        let target_table_info = build_table_info_at_schema(
+            table_path,
+            42,
+            2,
+            vec![
+                DataField::new("id", DataTypes::int(), None),
+                DataField::new("name", DataTypes::string(), None),
+                DataField::new("age", DataTypes::bigint(), None),
+            ],
+        );
+        let mut row = GenericRow::new(2);
+        row.set_field(0, 1_i32);
+        row.set_field(1, "alice");
+        let mut raw = build_log_batch(&source_table_info, &[row]);
+        let mut current_row = GenericRow::new(3);
+        current_row.set_field(0, 2_i32);
+        current_row.set_field(1, "bob");
+        current_row.set_field(2, 30_i64);
+        raw.extend(build_log_batch(&target_table_info, &[current_row]));
+        let resolver = create_log_read_context_resolver(&target_table_info).expect("resolver");
+        resolver
+            .register_schema(1, source_table_info.get_schema())
+            .expect("register source schema");
+
+        let (batch, _) = decode_log_batch(&target_table_info, &resolver, None, raw, usize::MAX)
+            .await
+            .expect("decode old-schema batch with current schema");
+
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_columns(), 3);
+        assert_eq!(batch.column(2).null_count(), 1);
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("id column");
+        let names = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name column");
+        let ages = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("age column");
+        assert_eq!(ids.values(), &[1, 2]);
+        assert_eq!(names.value(0), "alice");
+        assert_eq!(names.value(1), "bob");
+        assert!(ages.is_null(0));
+        assert_eq!(ages.value(1), 30);
     }
 
     // ---- KV path -----------------------------------------------------------

--- a/fluss-rust/crates/fluss/src/client/table/batch_scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/batch_scanner.rs
@@ -544,6 +544,51 @@ mod tests {
         data
     }
 
+    fn build_schema_evolution_log_fixture() -> (TableInfo, ReadContextResolver, SchemaRef, Vec<u8>)
+    {
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let source_table_info = build_table_info_with_columns(
+            table_path.clone(),
+            42,
+            1,
+            vec![
+                DataField::new("id", DataTypes::int(), None),
+                DataField::new("name", DataTypes::string(), None),
+            ],
+        );
+        let target_table_info = build_table_info_with_columns(
+            table_path,
+            42,
+            1,
+            vec![
+                DataField::new("id", DataTypes::int(), None),
+                DataField::new("name", DataTypes::string(), None),
+                DataField::new("age", DataTypes::bigint(), None),
+            ],
+        );
+        let old_rows: Vec<GenericRow> = [(1, "alice"), (2, "bob")]
+            .iter()
+            .map(|(id, name)| {
+                let mut row = GenericRow::new(2);
+                row.set_field(0, *id);
+                row.set_field(1, *name);
+                row
+            })
+            .collect();
+        let mut raw = build_log_batch(&source_table_info, 0, &old_rows);
+        let mut current_row = GenericRow::new(3);
+        current_row.set_field(0, 3_i32);
+        current_row.set_field(1, "carol");
+        current_row.set_field(2, 30_i64);
+        raw.extend(build_log_batch(&target_table_info, 1, &[current_row]));
+
+        let (resolver, full_schema) = create_test_log_decoder(&target_table_info);
+        resolver
+            .register_schema(0, source_table_info.get_schema())
+            .expect("register source schema");
+        (target_table_info, resolver, full_schema, raw)
+    }
+
     // ---- log path ----------------------------------------------------------
 
     #[tokio::test]
@@ -739,40 +784,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn decode_log_batch_projects_old_schema_after_add_column() {
-        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
-        let source_table_info = build_table_info_with_columns(
-            table_path.clone(),
-            42,
-            1,
-            vec![
-                DataField::new("id", DataTypes::int(), None),
-                DataField::new("name", DataTypes::string(), None),
-            ],
-        );
-        let target_table_info = build_table_info_with_columns(
-            table_path,
-            42,
-            1,
-            vec![
-                DataField::new("id", DataTypes::int(), None),
-                DataField::new("name", DataTypes::string(), None),
-                DataField::new("age", DataTypes::bigint(), None),
-            ],
-        );
-        let mut row = GenericRow::new(2);
-        row.set_field(0, 1_i32);
-        row.set_field(1, "alice");
-        let mut raw = build_log_batch(&source_table_info, 0, &[row]);
-        let mut current_row = GenericRow::new(3);
-        current_row.set_field(0, 2_i32);
-        current_row.set_field(1, "bob");
-        current_row.set_field(2, 30_i64);
-        raw.extend(build_log_batch(&target_table_info, 1, &[current_row]));
-        let (resolver, full_schema) = create_test_log_decoder(&target_table_info);
-        resolver
-            .register_schema(0, source_table_info.get_schema())
-            .expect("register source schema");
+    async fn decode_log_batch_aligns_old_schema_after_add_column() {
+        let (target_table_info, resolver, full_schema, raw) = build_schema_evolution_log_fixture();
 
         let (batch, _) = decode_log_batch(
             &target_table_info,
@@ -785,9 +798,9 @@ mod tests {
         .await
         .expect("decode old-schema batch with current schema");
 
-        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_rows(), 3);
         assert_eq!(batch.num_columns(), 3);
-        assert_eq!(batch.column(2).null_count(), 1);
+        assert_eq!(batch.column(2).null_count(), 2);
         let ids = batch
             .column(0)
             .as_any()
@@ -803,9 +816,73 @@ mod tests {
             .as_any()
             .downcast_ref::<Int64Array>()
             .expect("age column");
-        assert_eq!(ids.values(), &[1, 2]);
+        assert_eq!(ids.values(), &[1, 2, 3]);
         assert_eq!(names.value(0), "alice");
         assert_eq!(names.value(1), "bob");
+        assert_eq!(names.value(2), "carol");
+        assert!(ages.is_null(0));
+        assert!(ages.is_null(1));
+        assert_eq!(ages.value(2), 30);
+    }
+
+    #[tokio::test]
+    async fn decode_log_batch_projects_added_column_after_schema_evolution() {
+        let (target_table_info, resolver, full_schema, raw) = build_schema_evolution_log_fixture();
+
+        let (batch, base_offset) = decode_log_batch(
+            &target_table_info,
+            &resolver,
+            full_schema,
+            Some(&[2]),
+            raw,
+            usize::MAX,
+        )
+        .await
+        .expect("project added column");
+
+        assert_eq!(base_offset, 0);
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(batch.schema().field(0).name(), "age");
+        let ages = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("age column");
+        assert!(ages.is_null(0));
+        assert!(ages.is_null(1));
+        assert_eq!(ages.value(2), 30);
+    }
+
+    #[tokio::test]
+    async fn decode_log_batch_limits_rows_across_schema_evolution() {
+        let (target_table_info, resolver, full_schema, raw) = build_schema_evolution_log_fixture();
+
+        let (batch, base_offset) =
+            decode_log_batch(&target_table_info, &resolver, full_schema, None, raw, 2)
+                .await
+                .expect("limit across schema versions");
+
+        assert_eq!(base_offset, 1);
+        assert_eq!(batch.num_rows(), 2);
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("id column");
+        let names = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name column");
+        let ages = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("age column");
+        assert_eq!(ids.values(), &[2, 3]);
+        assert_eq!(names.value(0), "bob");
+        assert_eq!(names.value(1), "carol");
         assert!(ages.is_null(0));
         assert_eq!(ages.value(1), 30);
     }

--- a/fluss-rust/crates/fluss/src/client/table/batch_scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/batch_scanner.rs
@@ -464,8 +464,7 @@ mod tests {
         DEFAULT_NON_ZSTD_COMPRESSION_LEVEL,
     };
     use crate::metadata::{
-        Column, DataField, DataType, DataTypes, PhysicalTablePath, Schema, TableDescriptor,
-        TableInfo, TablePath,
+        Column, DataField, DataType, DataTypes, PhysicalTablePath, Schema, TableInfo, TablePath,
     };
     use crate::record::MemoryLogRecordsArrowBuilder;
     use crate::row::GenericRow;
@@ -493,33 +492,14 @@ mod tests {
         (resolver, full_schema)
     }
 
-    fn build_table_info_at_schema(
-        table_path: TablePath,
-        table_id: i64,
-        schema_id: i32,
-        fields: Vec<DataField>,
-    ) -> TableInfo {
-        let row_type = DataTypes::row(fields);
-        let schema = Schema::builder()
-            .with_row_type(&row_type)
-            .build()
-            .expect("schema");
-        let descriptor = TableDescriptor::builder()
-            .schema(schema)
-            .distributed_by(Some(1), vec![])
-            .build()
-            .expect("descriptor");
-        TableInfo::of(table_path, table_id, schema_id, descriptor, 0, 0)
-    }
-
     /// Encode `rows` (built against `table_info`'s row type) as one Arrow log batch.
-    fn build_log_batch(table_info: &TableInfo, rows: &[GenericRow]) -> Vec<u8> {
+    fn build_log_batch(table_info: &TableInfo, schema_id: i32, rows: &[GenericRow]) -> Vec<u8> {
         let table_info_arc = Arc::new(table_info.clone());
         let physical = Arc::new(PhysicalTablePath::of(Arc::new(
             table_info.table_path.clone(),
         )));
         let mut builder = MemoryLogRecordsArrowBuilder::new(
-            table_info.get_schema_id(),
+            schema_id,
             table_info.get_row_type(),
             false,
             ArrowCompressionInfo {
@@ -556,7 +536,7 @@ mod tests {
                 row
             })
             .collect();
-        let mut data = build_log_batch(table_info, &rows);
+        let mut data = build_log_batch(table_info, table_info.get_schema_id(), &rows);
         // Builder always writes base_log_offset=0; patch it so tests can verify
         // BatchScanner faithfully propagates whatever offset the server returned.
         let bytes = base_offset.to_le_bytes();
@@ -665,7 +645,7 @@ mod tests {
                 row
             })
             .collect();
-        let raw = build_log_batch(&table_info, &rows);
+        let raw = build_log_batch(&table_info, table_info.get_schema_id(), &rows);
         let (resolver, full_schema) = create_test_log_decoder(&table_info);
 
         let (batch, _) = decode_log_batch(
@@ -761,7 +741,7 @@ mod tests {
     #[tokio::test]
     async fn decode_log_batch_projects_old_schema_after_add_column() {
         let table_path = TablePath::new("db".to_string(), "tbl".to_string());
-        let source_table_info = build_table_info_at_schema(
+        let source_table_info = build_table_info_with_columns(
             table_path.clone(),
             42,
             1,
@@ -770,10 +750,10 @@ mod tests {
                 DataField::new("name", DataTypes::string(), None),
             ],
         );
-        let target_table_info = build_table_info_at_schema(
+        let target_table_info = build_table_info_with_columns(
             table_path,
             42,
-            2,
+            1,
             vec![
                 DataField::new("id", DataTypes::int(), None),
                 DataField::new("name", DataTypes::string(), None),
@@ -783,15 +763,15 @@ mod tests {
         let mut row = GenericRow::new(2);
         row.set_field(0, 1_i32);
         row.set_field(1, "alice");
-        let mut raw = build_log_batch(&source_table_info, &[row]);
+        let mut raw = build_log_batch(&source_table_info, 0, &[row]);
         let mut current_row = GenericRow::new(3);
         current_row.set_field(0, 2_i32);
         current_row.set_field(1, "bob");
         current_row.set_field(2, 30_i64);
-        raw.extend(build_log_batch(&target_table_info, &[current_row]));
+        raw.extend(build_log_batch(&target_table_info, 1, &[current_row]));
         let (resolver, full_schema) = create_test_log_decoder(&target_table_info);
         resolver
-            .register_schema(1, source_table_info.get_schema())
+            .register_schema(0, source_table_info.get_schema())
             .expect("register source schema");
 
         let (batch, _) = decode_log_batch(

--- a/fluss-rust/crates/fluss/src/client/table/batch_scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/batch_scanner.rs
@@ -39,6 +39,7 @@ use crate::rpc::RpcClient;
 use crate::rpc::message::LimitScanRequest;
 use arrow::array::RecordBatch;
 use arrow::compute::concat_batches;
+use arrow_schema::SchemaRef;
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::Bytes;
 use futures::Stream;
@@ -160,9 +161,19 @@ async fn run_limit_scan(pending: &PendingScan, bucket: &TableBucket) -> Result<S
     // Choose the payload format from table metadata, not the response's advisory
     // `is_log_table` flag.
     let (batch, base_offset) = if !pending.table_info.has_primary_key() {
-        let resolver = create_log_read_context_resolver(&pending.table_info)?
-            .with_schema_getter(Arc::clone(&pending.schema_getter));
-        decode_log_batch(&pending.table_info, &resolver, projected, raw, limit).await?
+        let full_schema = to_arrow_schema(pending.table_info.get_row_type())?;
+        let resolver =
+            create_log_read_context_resolver(&pending.table_info, Arc::clone(&full_schema))?
+                .with_schema_getter(Arc::clone(&pending.schema_getter));
+        decode_log_batch(
+            &pending.table_info,
+            &resolver,
+            full_schema,
+            projected,
+            raw,
+            limit,
+        )
+        .await?
     } else {
         // KV (primary-key) limit scan: no log offset, so base_offset is 0.
         let batch = decode_kv_batch(
@@ -186,12 +197,11 @@ async fn run_limit_scan(pending: &PendingScan, bucket: &TableBucket) -> Result<S
 async fn decode_log_batch(
     table_info: &TableInfo,
     resolver: &ReadContextResolver,
+    full_schema: SchemaRef,
     projected_fields: Option<&[usize]>,
     raw: Vec<u8>,
     limit: usize,
 ) -> Result<(RecordBatch, i64)> {
-    let full_schema = to_arrow_schema(table_info.get_row_type())?;
-
     if raw.is_empty() {
         let empty = RecordBatch::new_empty(full_schema);
         return Ok((
@@ -243,9 +253,11 @@ async fn decode_log_batch(
     ))
 }
 
-fn create_log_read_context_resolver(table_info: &TableInfo) -> Result<ReadContextResolver> {
+fn create_log_read_context_resolver(
+    table_info: &TableInfo,
+    arrow_schema: SchemaRef,
+) -> Result<ReadContextResolver> {
     let row_type = Arc::new(table_info.get_row_type().clone());
-    let arrow_schema = to_arrow_schema(table_info.get_row_type())?;
     let local_context = Arc::new(
         ArrowReadContext::new(arrow_schema.clone(), Arc::clone(&row_type), false)
             .with_fluss_row_type(Arc::clone(&row_type)),
@@ -474,6 +486,13 @@ mod tests {
         )
     }
 
+    fn create_test_log_decoder(table_info: &TableInfo) -> (ReadContextResolver, SchemaRef) {
+        let full_schema = to_arrow_schema(table_info.get_row_type()).expect("arrow schema");
+        let resolver = create_log_read_context_resolver(table_info, Arc::clone(&full_schema))
+            .expect("resolver");
+        (resolver, full_schema)
+    }
+
     fn build_table_info_at_schema(
         table_path: TablePath,
         table_id: i64,
@@ -550,11 +569,17 @@ mod tests {
     #[tokio::test]
     async fn decode_log_batch_empty_returns_empty_record_batch() {
         let table_info = build_two_col_table_info();
-        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
-        let (batch, base_offset) =
-            decode_log_batch(&table_info, &resolver, None, Vec::new(), usize::MAX)
-                .await
-                .expect("decode empty");
+        let (resolver, full_schema) = create_test_log_decoder(&table_info);
+        let (batch, base_offset) = decode_log_batch(
+            &table_info,
+            &resolver,
+            full_schema,
+            None,
+            Vec::new(),
+            usize::MAX,
+        )
+        .await
+        .expect("decode empty");
         assert_eq!(batch.num_rows(), 0);
         assert_eq!(batch.num_columns(), 2);
         assert_eq!(base_offset, 0);
@@ -563,10 +588,11 @@ mod tests {
     #[tokio::test]
     async fn decode_log_batch_empty_with_projection() {
         let table_info = build_two_col_table_info();
-        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
+        let (resolver, full_schema) = create_test_log_decoder(&table_info);
         let (batch, base_offset) = decode_log_batch(
             &table_info,
             &resolver,
+            full_schema,
             Some(&[1usize]),
             Vec::new(),
             usize::MAX,
@@ -582,12 +608,13 @@ mod tests {
     #[tokio::test]
     async fn decode_log_batch_extracts_base_offset_and_rows() {
         let table_info = build_two_col_table_info();
-        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
+        let (resolver, full_schema) = create_test_log_decoder(&table_info);
         let raw = build_log_records(&table_info, 17, &[(1, "alice"), (2, "bob"), (3, "carol")]);
 
-        let (batch, base_offset) = decode_log_batch(&table_info, &resolver, None, raw, usize::MAX)
-            .await
-            .expect("decode populated");
+        let (batch, base_offset) =
+            decode_log_batch(&table_info, &resolver, full_schema, None, raw, usize::MAX)
+                .await
+                .expect("decode populated");
         assert_eq!(batch.num_rows(), 3);
         assert_eq!(batch.num_columns(), 2);
         assert_eq!(base_offset, 17);
@@ -596,12 +623,19 @@ mod tests {
     #[tokio::test]
     async fn decode_log_batch_projection_keeps_requested_columns() {
         let table_info = build_two_col_table_info();
-        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
+        let (resolver, full_schema) = create_test_log_decoder(&table_info);
         let raw = build_log_records(&table_info, 0, &[(7, "x"), (8, "y")]);
 
-        let (batch, _) = decode_log_batch(&table_info, &resolver, Some(&[0usize]), raw, usize::MAX)
-            .await
-            .expect("decode projected");
+        let (batch, _) = decode_log_batch(
+            &table_info,
+            &resolver,
+            full_schema,
+            Some(&[0usize]),
+            raw,
+            usize::MAX,
+        )
+        .await
+        .expect("decode projected");
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 1);
         assert_eq!(batch.schema().field(0).name(), "id");
@@ -632,11 +666,12 @@ mod tests {
             })
             .collect();
         let raw = build_log_batch(&table_info, &rows);
-        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
+        let (resolver, full_schema) = create_test_log_decoder(&table_info);
 
         let (batch, _) = decode_log_batch(
             &table_info,
             &resolver,
+            full_schema,
             Some(&[0usize, 2usize]),
             raw,
             usize::MAX,
@@ -664,13 +699,14 @@ mod tests {
     #[tokio::test]
     async fn decode_log_batch_non_prefix_projection_reorders_columns() {
         let table_info = build_two_col_table_info();
-        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
+        let (resolver, full_schema) = create_test_log_decoder(&table_info);
         let raw = build_log_records(&table_info, 0, &[(1, "alice"), (2, "bob")]);
 
         // `[name, id]`: reversed, so neither a leading prefix nor in source order.
         let (batch, _) = decode_log_batch(
             &table_info,
             &resolver,
+            full_schema,
             Some(&[1usize, 0usize]),
             raw,
             usize::MAX,
@@ -702,13 +738,14 @@ mod tests {
     #[tokio::test]
     async fn decode_log_batch_truncates_to_last_limit_rows() {
         let table_info = build_two_col_table_info();
-        let resolver = create_log_read_context_resolver(&table_info).expect("resolver");
+        let (resolver, full_schema) = create_test_log_decoder(&table_info);
         // Server returned 4 rows starting at offset 100, but limit is 2.
         let raw = build_log_records(&table_info, 100, &[(1, "a"), (2, "b"), (3, "c"), (4, "d")]);
 
-        let (batch, base_offset) = decode_log_batch(&table_info, &resolver, None, raw, 2)
-            .await
-            .expect("decode");
+        let (batch, base_offset) =
+            decode_log_batch(&table_info, &resolver, full_schema, None, raw, 2)
+                .await
+                .expect("decode");
         assert_eq!(batch.num_rows(), 2);
         // The last two rows are kept, so the base offset advances by 2.
         assert_eq!(base_offset, 102);
@@ -752,14 +789,21 @@ mod tests {
         current_row.set_field(1, "bob");
         current_row.set_field(2, 30_i64);
         raw.extend(build_log_batch(&target_table_info, &[current_row]));
-        let resolver = create_log_read_context_resolver(&target_table_info).expect("resolver");
+        let (resolver, full_schema) = create_test_log_decoder(&target_table_info);
         resolver
             .register_schema(1, source_table_info.get_schema())
             .expect("register source schema");
 
-        let (batch, _) = decode_log_batch(&target_table_info, &resolver, None, raw, usize::MAX)
-            .await
-            .expect("decode old-schema batch with current schema");
+        let (batch, _) = decode_log_batch(
+            &target_table_info,
+            &resolver,
+            full_schema,
+            None,
+            raw,
+            usize::MAX,
+        )
+        .await
+        .expect("decode old-schema batch with current schema");
 
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 3);

--- a/fluss-rust/crates/fluss/src/client/table/scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/scanner.rs
@@ -161,8 +161,8 @@ impl<'a> TableScan<'a> {
         if !self.table_info.has_primary_key() {
             validate_scan_support(&self.table_info.table_path, &self.table_info)?;
         }
-        // Pre-seed the current schema; older versions are fetched lazily during
-        // KV decode. Mirrors `Table::new_lookup`.
+        // Pre-seed the current schema; older versions are fetched lazily while
+        // decoding log or KV batches. Mirrors `Table::new_lookup`.
         let latest = SchemaInfo::new(
             self.table_info.get_schema().clone(),
             self.table_info.get_schema_id(),

--- a/fluss-rust/crates/fluss/src/client/table/scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/scanner.rs
@@ -91,7 +91,8 @@ impl<'a> TableScan<'a> {
     /// default for both row and batch log scanners, ensuring that a scan exposes
     /// one stable schema. When explicitly disabled, records and batches keep
     /// their write-time schema and may have different column counts across
-    /// schema changes.
+    /// schema changes. Log-table [`LimitBatchScanner`]s require fixed-schema mode
+    /// because they return all decoded log batches as one `RecordBatch`.
     pub fn with_fixed_schema(mut self, fixed_schema: bool) -> Self {
         self.fixed_schema = fixed_schema;
         self
@@ -138,6 +139,7 @@ impl<'a> TableScan<'a> {
             message: "create_bucket_batch_scanner requires a limit configured via .limit(n)"
                 .to_string(),
         })?;
+        validate_limit_scan_fixed_schema(&self.table_info, self.fixed_schema)?;
         if table_bucket.table_id() != self.table_info.table_id {
             return Err(Error::IllegalArgument {
                 message: format!(
@@ -2350,6 +2352,16 @@ fn validate_scan_support(table_path: &TablePath, table_info: &TableInfo) -> Resu
     validate_scan_support_inner(table_path, table_info, false)
 }
 
+fn validate_limit_scan_fixed_schema(table_info: &TableInfo, fixed_schema: bool) -> Result<()> {
+    if !fixed_schema && !table_info.has_primary_key() {
+        return Err(Error::IllegalArgument {
+            message: "LimitBatchScanner doesn't support with_fixed_schema(false) for log tables"
+                .to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Validates that `table_info` can be scanned as a log. ARROW log format is
 /// required; INDEXED is not supported by the client decoder.
 ///
@@ -2461,6 +2473,21 @@ mod tests {
             WriteRecord::for_append(Arc::new(table_info.clone()), physical_table_path, 1, &row);
         builder.append(&record)?;
         builder.build()
+    }
+
+    #[test]
+    fn limit_batch_scanner_rejects_dynamic_schema_for_log_table() {
+        let table_info =
+            build_table_info(TablePath::new("db".to_string(), "tbl".to_string()), 1, 1);
+
+        let error = validate_limit_scan_fixed_schema(&table_info, false)
+            .expect_err("dynamic schema must be rejected for a log limit scan");
+
+        assert!(matches!(
+            error,
+            Error::IllegalArgument { message }
+                if message.contains("with_fixed_schema(false)")
+        ));
     }
 
     #[tokio::test]

--- a/fluss-rust/crates/fluss/tests/integration/batch_scanner.rs
+++ b/fluss-rust/crates/fluss/tests/integration/batch_scanner.rs
@@ -308,23 +308,6 @@ mod batch_scanner_test {
             .get_table(&table_path)
             .await
             .expect("updated table");
-        let current_writer = current_table
-            .new_append()
-            .expect("append")
-            .create_writer()
-            .expect("writer");
-        current_writer
-            .append_arrow_batch(
-                record_batch!(
-                    ("id", Int32, [3]),
-                    ("name", Utf8, ["carol"]),
-                    ("age", Int32, [30])
-                )
-                .expect("current-schema batch"),
-            )
-            .expect("append current-schema batch");
-        current_writer.flush().await.expect("flush");
-
         let table_info = current_table.get_table_info();
         let mut scanner = current_table
             .new_scan()
@@ -339,7 +322,7 @@ mod batch_scanner_test {
             .expect("scan old-schema batch")
             .expect("batch");
         let batch = scan_batch.batch();
-        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 3);
         assert_eq!(batch.schema().field(2).name(), "age");
         assert_eq!(batch.column(2).null_count(), 2);
@@ -358,13 +341,11 @@ mod batch_scanner_test {
             .as_any()
             .downcast_ref::<Int32Array>()
             .expect("age column");
-        assert_eq!(ids.values(), &[1, 2, 3]);
+        assert_eq!(ids.values(), &[1, 2]);
         assert_eq!(names.value(0), "alice");
         assert_eq!(names.value(1), "bob");
-        assert_eq!(names.value(2), "carol");
         assert!(ages.is_null(0));
         assert!(ages.is_null(1));
-        assert_eq!(ages.value(2), 30);
     }
 
     /// Limit scan on a primary-key table: decodes the value-record batch and

--- a/fluss-rust/crates/fluss/tests/integration/batch_scanner.rs
+++ b/fluss-rust/crates/fluss/tests/integration/batch_scanner.rs
@@ -18,9 +18,12 @@
 
 #[cfg(test)]
 mod batch_scanner_test {
-    use crate::integration::utils::{create_table, get_shared_cluster};
-    use arrow::array::{Int32Array, Int64Array, StringArray, record_batch};
-    use fluss::metadata::{DataTypes, LogFormat, Schema, TableBucket, TableDescriptor, TablePath};
+    use crate::integration::utils::{create_table, get_shared_cluster, wait_for_table_ready};
+    use arrow::array::{Array, Int32Array, Int64Array, StringArray, record_batch};
+    use fluss::metadata::{
+        AddColumn, AlterTableChanges, ColumnPositionType, DataTypes, JsonSerde, LogFormat, Schema,
+        TableBucket, TableDescriptor, TablePath,
+    };
     use fluss::row::GenericRow;
     use futures::TryStreamExt;
     use std::collections::HashMap;
@@ -241,6 +244,127 @@ mod batch_scanner_test {
                 c3.value(i)
             );
         }
+    }
+
+    #[tokio::test]
+    async fn batch_scanner_reads_old_arrow_batches_after_add_column() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("admin");
+
+        let table_path = TablePath::new("fluss", "test_batch_scanner_add_column");
+        let descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("id", DataTypes::int())
+                    .column("name", DataTypes::string())
+                    .build()
+                    .expect("schema"),
+            )
+            .distributed_by(Some(1), vec!["id".to_string()])
+            .build()
+            .expect("descriptor");
+        create_table(&admin, &table_path, &descriptor).await;
+        wait_for_table_ready(&admin, &table_path).await;
+
+        let table = connection.get_table(&table_path).await.expect("table");
+        let writer = table
+            .new_append()
+            .expect("append")
+            .create_writer()
+            .expect("writer");
+        writer
+            .append_arrow_batch(
+                record_batch!(("id", Int32, [1, 2]), ("name", Utf8, ["alice", "bob"]))
+                    .expect("old-schema batch"),
+            )
+            .expect("append old-schema batch");
+        writer.flush().await.expect("flush");
+
+        let age_type_json = serde_json::to_vec(
+            &DataTypes::int()
+                .serialize_json()
+                .expect("serialize INT type"),
+        )
+        .expect("serialize data type JSON");
+        admin
+            .alter_table(
+                &table_path,
+                false,
+                AlterTableChanges {
+                    add_columns: vec![AddColumn {
+                        column_name: "age".to_string(),
+                        data_type_json: age_type_json,
+                        comment: None,
+                        position: ColumnPositionType::Last,
+                    }],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("add age column");
+
+        let current_table = connection
+            .get_table(&table_path)
+            .await
+            .expect("updated table");
+        let current_writer = current_table
+            .new_append()
+            .expect("append")
+            .create_writer()
+            .expect("writer");
+        current_writer
+            .append_arrow_batch(
+                record_batch!(
+                    ("id", Int32, [3]),
+                    ("name", Utf8, ["carol"]),
+                    ("age", Int32, [30])
+                )
+                .expect("current-schema batch"),
+            )
+            .expect("append current-schema batch");
+        current_writer.flush().await.expect("flush");
+
+        let table_info = current_table.get_table_info();
+        let mut scanner = current_table
+            .new_scan()
+            .limit(10)
+            .expect("limit")
+            .create_bucket_batch_scanner(TableBucket::new(table_info.table_id, 0))
+            .expect("create batch scanner");
+
+        let scan_batch = scanner
+            .next_batch()
+            .await
+            .expect("scan old-schema batch")
+            .expect("batch");
+        let batch = scan_batch.batch();
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.num_columns(), 3);
+        assert_eq!(batch.schema().field(2).name(), "age");
+        assert_eq!(batch.column(2).null_count(), 2);
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("id column");
+        let names = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name column");
+        let ages = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("age column");
+        assert_eq!(ids.values(), &[1, 2, 3]);
+        assert_eq!(names.value(0), "alice");
+        assert_eq!(names.value(1), "bob");
+        assert_eq!(names.value(2), "carol");
+        assert!(ages.is_null(0));
+        assert!(ages.is_null(1));
+        assert_eq!(ages.value(2), 30);
     }
 
     /// Limit scan on a primary-key table: decodes the value-record batch and


### PR DESCRIPTION
### Purpose

Linked issue: close #3808

The Rust `LimitBatchScanner` previously decoded every Arrow log batch using the current table schema, without considering the `schema_id` stored in each batch.

As a result, a limit scan could fail when reading batches written before an `ADD COLUMN`, because the decoder expected fields that were not present in the older Arrow batch.

This change makes the Arrow limit-scan path decode each batch using its write-time schema and align it with the current table schema, consistent with the regular log-fetch and KV read paths.

### Brief change log

- Build a fixed-schema `ReadContextResolver` for Arrow log limit scans.
- Resolve the source schema from each `LogRecordBatch` using its `schema_id`.
- Lazily fetch and cache historical schemas when they are not already available.
- Align decoded batches with the current target schema by stable column ID.
- Concatenate batches only after schema alignment.
- Apply column projection after batches have been aligned and concatenated.
- Add unit and integration coverage for batches written before and after `ADD COLUMN`.

### Tests

Add Some Test.

### API and Format

No.

### Documentation

No.