### PR TITLE
[server] Roll expired active segments for remote retention

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -959,6 +959,14 @@ public class ConfigOptions {
                                     + "segments are eligible for TTL cleanup. The value must be "
                                     + "greater than 0.");
 
+    public static final ConfigOption<Boolean> LOG_RETENTION_ROLL_ACTIVE_SEGMENT_ENABLED =
+            key("log.retention.roll-active-segment.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to roll a non-empty active log segment when it has expired "
+                                    + "according to the table log TTL. Disabled by default.");
+
     public static final ConfigOption<Duration> LOG_REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL =
             key("log.replica.high-watermark.checkpoint-interval")
                     .durationType()

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -109,7 +109,6 @@ public final class LogTablet {
     private final Clock clock;
     private final boolean isChangeLog;
     private final long logTtlMs;
-    private final boolean remoteLogEnabled;
 
     @GuardedBy("lock")
     private volatile LogOffsetMetadata highWatermarkMetadata;
@@ -161,8 +160,6 @@ public final class LogTablet {
         this.writerStateManager = writerStateManager;
         this.highWatermarkMetadata = new LogOffsetMetadata(0L);
         this.logTtlMs = logTtlMs;
-        this.remoteLogEnabled =
-                conf.get(ConfigOptions.REMOTE_LOG_TASK_INTERVAL_DURATION).toMillis() > 0L;
 
         this.scheduler = scheduler;
         // scheduler the writer expiration interval check.
@@ -1362,30 +1359,28 @@ public final class LogTablet {
         List<LogSegment> deletableSegments = new ArrayList<>();
         List<LogSegment> logSegments = localLog.getSegments().values();
         long now = clock.milliseconds();
-        boolean shouldRoll = false;
 
-        for (int i = 0; i < logSegments.size(); i++) {
-            LogSegment segment = logSegments.get(i);
-            boolean active = i == logSegments.size() - 1;
-            if ((!active && logSegments.get(i + 1).getBaseOffset() > endOffset)
-                    || !isSegmentExpired(now, segment, logTtlMs)) {
+        for (int i = 0; i < logSegments.size() - 1; i++) {
+            if (logSegments.get(i + 1).getBaseOffset() > endOffset
+                    || !isSegmentExpired(now, logSegments.get(i), logTtlMs)) {
                 break;
             }
-
-            if (active) {
-                shouldRoll =
-                        remoteLogEnabled
-                                && segment.getSizeInBytes() > 0
-                                && getHighWatermark() >= localLogEndOffset();
-                break;
-            }
-            deletableSegments.add(segment);
+            deletableSegments.add(logSegments.get(i));
         }
 
-        if (shouldRoll) {
-            roll(Optional.empty());
+        if (deletableSegments.size() == logSegments.size() - 1) {
+            maybeRollExpiredActiveSegment(now, logSegments.get(logSegments.size() - 1));
         }
         return deletableSegments;
+    }
+
+    private void maybeRollExpiredActiveSegment(long now, LogSegment activeSegment)
+            throws IOException {
+        if (activeSegment.getSizeInBytes() > 0
+                && isSegmentExpired(now, activeSegment, logTtlMs)
+                && getHighWatermark() >= localLogEndOffset()) {
+            roll(Optional.empty());
+        }
     }
 
     @FunctionalInterface

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -1350,7 +1350,12 @@ public final class LogTablet {
         return deletableSegments;
     }
 
-    /** Returns the contiguous prefix of expired segments and rolls an expired active segment. */
+    /**
+     * Returns the contiguous prefix of expired inactive segments.
+     *
+     * <p>If all inactive segments are deletable, this also checks whether the active segment should
+     * be rolled.
+     */
     private List<LogSegment> deletableExpiredSegments(long endOffset) throws IOException {
         if (localLog.getSegments().isEmpty()) {
             return Collections.emptyList();
@@ -1374,6 +1379,7 @@ public final class LogTablet {
         return deletableSegments;
     }
 
+    /** Rolls the active segment when it is non-empty, expired, and fully committed. */
     private void maybeRollExpiredActiveSegment(long now, LogSegment activeSegment)
             throws IOException {
         if (activeSegment.getSizeInBytes() > 0

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -109,6 +109,7 @@ public final class LogTablet {
     private final Clock clock;
     private final boolean isChangeLog;
     private final long logTtlMs;
+    private final boolean remoteLogEnabled;
 
     @GuardedBy("lock")
     private volatile LogOffsetMetadata highWatermarkMetadata;
@@ -160,6 +161,8 @@ public final class LogTablet {
         this.writerStateManager = writerStateManager;
         this.highWatermarkMetadata = new LogOffsetMetadata(0L);
         this.logTtlMs = logTtlMs;
+        this.remoteLogEnabled =
+                conf.get(ConfigOptions.REMOTE_LOG_TASK_INTERVAL_DURATION).toMillis() > 0L;
 
         this.scheduler = scheduler;
         // scheduler the writer expiration interval check.
@@ -1048,7 +1051,7 @@ public final class LogTablet {
      */
     @VisibleForTesting
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    public void roll(Optional<Long> expectedNextOffset) throws Exception {
+    public void roll(Optional<Long> expectedNextOffset) throws IOException {
         synchronized (lock) {
             LogSegment segment = localLog.roll(expectedNextOffset);
             // Take a snapshot of the writer state to facilitate recovery. It is useful to have
@@ -1350,7 +1353,7 @@ public final class LogTablet {
         return deletableSegments;
     }
 
-    /** Returns the contiguous prefix of inactive segments that has expired. */
+    /** Returns the contiguous prefix of expired segments and rolls an expired active segment. */
     private List<LogSegment> deletableExpiredSegments(long endOffset) throws IOException {
         if (localLog.getSegments().isEmpty()) {
             return Collections.emptyList();
@@ -1359,13 +1362,28 @@ public final class LogTablet {
         List<LogSegment> deletableSegments = new ArrayList<>();
         List<LogSegment> logSegments = localLog.getSegments().values();
         long now = clock.milliseconds();
+        boolean shouldRoll = false;
 
-        for (int i = 0; i < logSegments.size() - 1; i++) {
-            if (logSegments.get(i + 1).getBaseOffset() > endOffset
-                    || !isSegmentExpired(now, logSegments.get(i), logTtlMs)) {
+        for (int i = 0; i < logSegments.size(); i++) {
+            LogSegment segment = logSegments.get(i);
+            boolean active = i == logSegments.size() - 1;
+            if ((!active && logSegments.get(i + 1).getBaseOffset() > endOffset)
+                    || !isSegmentExpired(now, segment, logTtlMs)) {
                 break;
             }
-            deletableSegments.add(logSegments.get(i));
+
+            if (active) {
+                shouldRoll =
+                        remoteLogEnabled
+                                && segment.getSizeInBytes() > 0
+                                && getHighWatermark() >= localLogEndOffset();
+                break;
+            }
+            deletableSegments.add(segment);
+        }
+
+        if (shouldRoll) {
+            roll(Optional.empty());
         }
         return deletableSegments;
     }

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -109,6 +109,7 @@ public final class LogTablet {
     private final Clock clock;
     private final boolean isChangeLog;
     private final long logTtlMs;
+    private final boolean rollExpiredActiveSegmentEnabled;
 
     @GuardedBy("lock")
     private volatile LogOffsetMetadata highWatermarkMetadata;
@@ -160,6 +161,8 @@ public final class LogTablet {
         this.writerStateManager = writerStateManager;
         this.highWatermarkMetadata = new LogOffsetMetadata(0L);
         this.logTtlMs = logTtlMs;
+        this.rollExpiredActiveSegmentEnabled =
+                conf.get(ConfigOptions.LOG_RETENTION_ROLL_ACTIVE_SEGMENT_ENABLED);
 
         this.scheduler = scheduler;
         // scheduler the writer expiration interval check.
@@ -1382,7 +1385,8 @@ public final class LogTablet {
     /** Rolls the active segment when it is non-empty, expired, and fully committed. */
     private void maybeRollExpiredActiveSegment(long now, LogSegment activeSegment)
             throws IOException {
-        if (activeSegment.getSizeInBytes() > 0
+        if (rollExpiredActiveSegmentEnabled
+                && activeSegment.getSizeInBytes() > 0
                 && isSegmentExpired(now, activeSegment, logTtlMs)
                 && getHighWatermark() >= localLogEndOffset()) {
             roll(Optional.empty());

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LocalSegmentTTLTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LocalSegmentTTLTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.log;
+
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.server.replica.ReplicaTestBase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.apache.fluss.record.TestData.DATA1_SCHEMA;
+import static org.apache.fluss.record.TestData.DATA1_TABLE_ID;
+import static org.apache.fluss.record.TestData.DATA1_TABLE_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests TTL-based cleanup when remote log is disabled. */
+final class LocalSegmentTTLTest extends ReplicaTestBase {
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        registerTableInZkClient(
+                DATA1_TABLE_PATH,
+                DATA1_SCHEMA,
+                DATA1_TABLE_ID,
+                Collections.emptyList(),
+                Collections.singletonMap(ConfigOptions.TABLE_LOG_TTL.key(), "1h"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testExpiredActiveSegmentCleaned(boolean partitionTable) throws Exception {
+        TableBucket tb =
+                partitionTable
+                        ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
+                        : new TableBucket(DATA1_TABLE_ID, 0);
+        makeLogTableAsLeader(tb, partitionTable);
+        LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
+
+        assertThatThrownBy(() -> remoteLogManager.remoteLogTablet(tb))
+                .isInstanceOf(IllegalStateException.class);
+        addMultiSegmentsToLogTablet(logTablet, 1);
+        logManager.cleanupExpiredLocalLogSegments();
+
+        assertThat(logTablet.getSegments()).hasSize(1);
+        assertThat(logTablet.localLogStartOffset()).isEqualTo(0L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(0L);
+
+        manualClock.advanceTime(Duration.ofHours(2));
+        logManager.cleanupExpiredLocalLogSegments();
+
+        assertThat(logTablet.getSegments()).hasSize(2);
+        assertThat(logTablet.localLogStartOffset()).isEqualTo(0L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(10L);
+
+        logManager.cleanupExpiredLocalLogSegments();
+
+        assertThat(logTablet.getSegments()).hasSize(1);
+        assertThat(logTablet.localLogStartOffset()).isEqualTo(10L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(10L);
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LocalSegmentTTLTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LocalSegmentTTLTest.java
@@ -55,6 +55,7 @@ final class LocalSegmentTTLTest extends ReplicaTestBase {
                 partitionTable
                         ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
                         : new TableBucket(DATA1_TABLE_ID, 0);
+        conf.set(ConfigOptions.LOG_RETENTION_ROLL_ACTIVE_SEGMENT_ENABLED, true);
         makeLogTableAsLeader(tb, partitionTable);
         LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
 
@@ -79,5 +80,24 @@ final class LocalSegmentTTLTest extends ReplicaTestBase {
         assertThat(logTablet.getSegments()).hasSize(1);
         assertThat(logTablet.localLogStartOffset()).isEqualTo(10L);
         assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(10L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testExpiredActiveSegmentNotRolledByDefault(boolean partitionTable) throws Exception {
+        TableBucket tb =
+                partitionTable
+                        ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
+                        : new TableBucket(DATA1_TABLE_ID, 0);
+        makeLogTableAsLeader(tb, partitionTable);
+        LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
+
+        addMultiSegmentsToLogTablet(logTablet, 5);
+        manualClock.advanceTime(Duration.ofHours(2));
+        logManager.cleanupExpiredLocalLogSegments();
+
+        assertThat(logTablet.getSegments()).hasSize(1);
+        assertThat(logTablet.localLogStartOffset()).isEqualTo(40L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(40L);
     }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/TieredLocalSegmentTTLTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/TieredLocalSegmentTTLTest.java
@@ -55,6 +55,7 @@ final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
                 partitionTable
                         ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
                         : new TableBucket(DATA1_TABLE_ID, 0);
+        conf.set(ConfigOptions.LOG_RETENTION_ROLL_ACTIVE_SEGMENT_ENABLED, true);
         makeLogTableAsLeader(tb, partitionTable);
         LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
 
@@ -98,6 +99,7 @@ final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
                 partitionTable
                         ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
                         : new TableBucket(DATA1_TABLE_ID, 0);
+        conf.set(ConfigOptions.LOG_RETENTION_ROLL_ACTIVE_SEGMENT_ENABLED, true);
         makeLogTableAsLeader(tb, partitionTable);
         LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
 
@@ -133,6 +135,7 @@ final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
                 partitionTable
                         ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
                         : new TableBucket(DATA1_TABLE_ID, 0);
+        conf.set(ConfigOptions.LOG_RETENTION_ROLL_ACTIVE_SEGMENT_ENABLED, true);
         makeLogTableAsLeader(tb, partitionTable);
         LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
 
@@ -152,6 +155,7 @@ final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
                 partitionTable
                         ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
                         : new TableBucket(DATA1_TABLE_ID, 0);
+        conf.set(ConfigOptions.LOG_RETENTION_ROLL_ACTIVE_SEGMENT_ENABLED, true);
         makeLogTableAsLeader(tb, partitionTable);
         LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/TieredLocalSegmentTTLTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/TieredLocalSegmentTTLTest.java
@@ -33,7 +33,7 @@ import static org.apache.fluss.record.TestData.DATA1_TABLE_ID;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests TTL-based cleanup of inactive local segments retained by tiered storage. */
+/** Tests TTL-based cleanup of local segments retained by tiered storage. */
 final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
 
     @BeforeEach
@@ -71,17 +71,29 @@ final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
         // Run local retention without updating the remote manifest or uploading another segment.
         logManager.cleanupExpiredLocalLogSegments();
 
-        // The inactive segment is expired and deleted, while the active segment is retained.
+        // The expired active segment is rolled, but is not deleted in the same retention pass.
         assertThat(remoteLog.allRemoteLogSegments()).hasSize(4);
-        assertThat(logTablet.getSegments()).hasSize(1);
+        assertThat(logTablet.getSegments()).hasSize(2);
         assertThat(logTablet.localLogStartOffset()).isEqualTo(40L);
-        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(40L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(50L);
+
+        // An empty active segment must not be rolled again while the previous segment is waiting
+        // for remote upload.
+        logManager.cleanupExpiredLocalLogSegments();
+        assertThat(logTablet.getSegments()).hasSize(2);
+
+        remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
+        assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(50L);
+        logManager.cleanupExpiredLocalLogSegments();
+        assertThat(logTablet.getSegments()).hasSize(1);
+        assertThat(logTablet.localLogStartOffset()).isEqualTo(50L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(50L);
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testExpiredLocalSegmentsRemovedWithoutRemoteLogEndOffset(boolean partitionTable)
-            throws Exception {
+    void testExpiredActiveSegmentWaitsForHighWatermarkWithoutRemoteLogEndOffset(
+            boolean partitionTable) throws Exception {
         TableBucket tb =
                 partitionTable
                         ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
@@ -93,10 +105,64 @@ final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
         assertThat(remoteLogManager.remoteLogTablet(tb).getRemoteLogEndOffset()).isEmpty();
 
         manualClock.advanceTime(Duration.ofHours(2));
+        logTablet.updateHighWatermark(logTablet.localLogEndOffset() - 1L);
         logManager.cleanupExpiredLocalLogSegments();
 
         assertThat(logTablet.getSegments()).hasSize(1);
         assertThat(logTablet.localLogStartOffset()).isEqualTo(40L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(40L);
+
+        logTablet.updateHighWatermark(logTablet.localLogEndOffset());
+        logManager.cleanupExpiredLocalLogSegments();
+
+        assertThat(logTablet.getSegments()).hasSize(2);
+        assertThat(logTablet.localLogStartOffset()).isEqualTo(40L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(50L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testExpiredActiveSegmentNotRolledWhenRemoteLogDisabled(boolean partitionTable)
+            throws Exception {
+        conf.set(ConfigOptions.REMOTE_LOG_TASK_INTERVAL_DURATION, Duration.ZERO);
+        TableBucket tb =
+                partitionTable
+                        ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
+                        : new TableBucket(DATA1_TABLE_ID, 0);
+        makeLogTableAsLeader(tb, partitionTable);
+        LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
+
+        addMultiSegmentsToLogTablet(logTablet, 5);
+        manualClock.advanceTime(Duration.ofHours(2));
+        logManager.cleanupExpiredLocalLogSegments();
+
+        assertThat(logTablet.getSegments()).hasSize(1);
+        assertThat(logTablet.localLogStartOffset()).isEqualTo(40L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(40L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testExpiredActiveSegmentNotRolledWhenTtlDisabled(boolean partitionTable) throws Exception {
+        registerTableInZkClient(
+                DATA1_TABLE_PATH,
+                DATA1_SCHEMA,
+                DATA1_TABLE_ID,
+                Collections.emptyList(),
+                Collections.singletonMap(ConfigOptions.TABLE_LOG_TTL.key(), "0ms"));
+        TableBucket tb =
+                partitionTable
+                        ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
+                        : new TableBucket(DATA1_TABLE_ID, 0);
+        makeLogTableAsLeader(tb, partitionTable);
+        LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
+
+        addMultiSegmentsToLogTablet(logTablet, 5);
+        manualClock.advanceTime(Duration.ofHours(2));
+        logManager.cleanupExpiredLocalLogSegments();
+
+        assertThat(logTablet.getSegments()).hasSize(5);
+        assertThat(logTablet.localLogStartOffset()).isEqualTo(0L);
         assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(40L);
     }
 
@@ -120,5 +186,12 @@ final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
         assertThat(logTablet.getSegments()).hasSize(3);
         assertThat(logTablet.localLogStartOffset()).isEqualTo(20L);
         assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(40L);
+
+        logTablet.updateRemoteLogEndOffset(40L);
+        logManager.cleanupExpiredLocalLogSegments();
+
+        assertThat(logTablet.getSegments()).hasSize(2);
+        assertThat(logTablet.localLogStartOffset()).isEqualTo(40L);
+        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(50L);
     }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/TieredLocalSegmentTTLTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/TieredLocalSegmentTTLTest.java
@@ -19,6 +19,7 @@ package org.apache.fluss.server.log.remote;
 
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.server.log.LogSegment;
 import org.apache.fluss.server.log.LogTablet;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -77,17 +78,16 @@ final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
         assertThat(logTablet.localLogStartOffset()).isEqualTo(40L);
         assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(50L);
 
-        // An empty active segment must not be rolled again while the previous segment is waiting
-        // for remote upload.
-        logManager.cleanupExpiredLocalLogSegments();
-        assertThat(logTablet.getSegments()).hasSize(2);
-
         remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
         assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(50L);
         logManager.cleanupExpiredLocalLogSegments();
         assertThat(logTablet.getSegments()).hasSize(1);
         assertThat(logTablet.localLogStartOffset()).isEqualTo(50L);
         assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(50L);
+
+        LogSegment emptyActiveSegment = logTablet.activeLogSegment();
+        logManager.cleanupExpiredLocalLogSegments();
+        assertThat(logTablet.activeLogSegment()).isSameAs(emptyActiveSegment);
     }
 
     @ParameterizedTest
@@ -118,27 +118,6 @@ final class TieredLocalSegmentTTLTest extends RemoteLogTestBase {
         assertThat(logTablet.getSegments()).hasSize(2);
         assertThat(logTablet.localLogStartOffset()).isEqualTo(40L);
         assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(50L);
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testExpiredActiveSegmentNotRolledWhenRemoteLogDisabled(boolean partitionTable)
-            throws Exception {
-        conf.set(ConfigOptions.REMOTE_LOG_TASK_INTERVAL_DURATION, Duration.ZERO);
-        TableBucket tb =
-                partitionTable
-                        ? new TableBucket(DATA1_TABLE_ID, 0L, 0)
-                        : new TableBucket(DATA1_TABLE_ID, 0);
-        makeLogTableAsLeader(tb, partitionTable);
-        LogTablet logTablet = replicaManager.getReplicaOrException(tb).getLogTablet();
-
-        addMultiSegmentsToLogTablet(logTablet, 5);
-        manualClock.advanceTime(Duration.ofHours(2));
-        logManager.cleanupExpiredLocalLogSegments();
-
-        assertThat(logTablet.getSegments()).hasSize(1);
-        assertThat(logTablet.localLogStartOffset()).isEqualTo(40L);
-        assertThat(logTablet.activeLogSegment().getBaseOffset()).isEqualTo(40L);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Purpose

Linked issue: close #3830

Local TTL cleanup currently scans only inactive log segments. When a table becomes idle after its active segment exceeds `table.log.ttl`, that segment remains active and cannot be uploaded to remote storage or removed by subsequent local retention.

This change rolls a non-empty expired active segment during periodic local retention once the high watermark reaches the log end offset. The rolled segment is not deleted in the same cleanup pass; it can first be uploaded and then removed by a later cleanup.

Leader/follower segment boundary alignment during timestamp-based roll is intentionally out of scope.

### Brief change log

- Cache whether remote log is enabled from `remote.log.task-interval-duration`.
- Extend the contiguous TTL scan to inspect the active segment while preserving the existing `remoteLogEndOffset` and `minRetainOffset` boundaries for inactive segments.
- Roll the active segment only when remote log is enabled, the segment is non-empty and expired, and `highWatermark >= logEndOffset`.
- Do not require `remoteLogEndOffset` to cover the active segment before rolling, because rolling is required before the segment can be uploaded.
- Use the existing `LogTablet.roll(Optional.empty())` path and narrow its exception declaration to `IOException`.
- Extend `TieredLocalSegmentTTLTest` for partitioned and non-partitioned tables, covering:
  - upload and cleanup lifecycle;
  - high-watermark gating;
  - remote offset boundaries;
  - disabled remote log;
  - disabled table TTL;
  - empty active segments.

### Tests

- `./mvnw -pl fluss-server -DskipITs -Dcheckstyle.skip -Drat.skip -Dspotless.check.skip=true -Dtest=TieredLocalSegmentTTLTest test`
  - 10 tests passed.
- `./mvnw -pl fluss-server spotless:check`

### API and Format

No public API, RPC protocol, configuration, or storage format changes.

### Documentation

No documentation changes are required.

### Generative AI disclosure

Yes. OpenAI Codex was used to assist with implementation and review.
