### PR TITLE
[server] Expose local log physical size at bucket level

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -259,6 +259,9 @@ public class MetricNames {
     public static final String REMOTE_LOG_SIZE = "size";
     public static final String LOG_LAKE_TIMESTAMP_LAG = "timestampLag";
 
+    // for physical storage
+    public static final String BUCKET_PHYSICAL_STORAGE_LOCAL_LOG_SIZE = "localLogSize";
+
     // for logic storage
     public static final String LOCAL_STORAGE_LOG_SIZE = "logSize";
     public static final String LOCAL_STORAGE_KV_SIZE = "kvSize";

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -435,10 +435,6 @@ public final class LogTablet {
 
     /** Register metrics for this log tablet in the metric group. */
     public void registerMetrics(BucketMetricGroup bucketMetricGroup) {
-        MetricGroup physicalStorageMetricGroup = bucketMetricGroup.addGroup("physicalStorage");
-        physicalStorageMetricGroup.gauge(
-                MetricNames.BUCKET_PHYSICAL_STORAGE_LOCAL_LOG_SIZE, this::logSize);
-
         MetricGroup metricGroup = bucketMetricGroup.addGroup("log");
         metricGroup.gauge(
                 MetricNames.LOG_NUM_SEGMENTS, () -> localLog.getSegments().numberOfSegments());

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -435,6 +435,10 @@ public final class LogTablet {
 
     /** Register metrics for this log tablet in the metric group. */
     public void registerMetrics(BucketMetricGroup bucketMetricGroup) {
+        MetricGroup physicalStorageMetricGroup = bucketMetricGroup.addGroup("physicalStorage");
+        physicalStorageMetricGroup.gauge(
+                MetricNames.BUCKET_PHYSICAL_STORAGE_LOCAL_LOG_SIZE, this::logSize);
+
         MetricGroup metricGroup = bucketMetricGroup.addGroup("log");
         metricGroup.gauge(
                 MetricNames.LOG_NUM_SEGMENTS, () -> localLog.getSegments().numberOfSegments());

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -294,6 +294,11 @@ public final class Replica {
         isrShrinks = serverMetrics.isrShrinks();
         failedIsrUpdates = serverMetrics.failedIsrUpdates();
 
+        // physical storage metrics.
+        MetricGroup physicalStorageMetrics = bucketMetricGroup.addGroup("physicalStorage");
+        physicalStorageMetrics.gauge(
+                MetricNames.BUCKET_PHYSICAL_STORAGE_LOCAL_LOG_SIZE, logTablet::logSize);
+
         // logical storage metrics.
         MetricGroup logicalStorageMetrics = bucketMetricGroup.addGroup("logicalStorage");
         logicalStorageMetrics.gauge(

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
@@ -201,6 +201,63 @@ final class ReplicaTest extends ReplicaTestBase {
     }
 
     @Test
+    void testBucketPhysicalStorageLocalLogSizeIncludesFollower() throws Exception {
+        TableBucket tableBucket = new TableBucket(DATA1_TABLE_ID, 1);
+        Replica logReplica = makeLogReplica(DATA1_PHYSICAL_TABLE_PATH, tableBucket);
+        makeLogReplicaAsLeader(logReplica);
+        logReplica.appendRecordsToLeader(genMemoryLogRecordsByObject(DATA1), 0);
+
+        Gauge<Long> localLogSizeGauge = getBucketLocalLogSizeGauge(logReplica);
+        long localLogSize = logReplica.getLogTablet().logSize();
+        assertThat(localLogSize).isPositive();
+        assertThat(localLogSizeGauge.getValue()).isEqualTo(localLogSize);
+
+        int followerLeaderEpoch = INITIAL_LEADER_EPOCH + 1;
+        int newLeaderId = TABLET_SERVER_ID + 1;
+        List<Integer> replicas = Arrays.asList(TABLET_SERVER_ID, newLeaderId);
+        logReplica.makeFollower(
+                new NotifyLeaderAndIsrData(
+                        DATA1_PHYSICAL_TABLE_PATH,
+                        tableBucket,
+                        replicas,
+                        new LeaderAndIsr(
+                                newLeaderId,
+                                followerLeaderEpoch,
+                                replicas,
+                                Collections.emptyList(),
+                                INITIAL_COORDINATOR_EPOCH,
+                                followerLeaderEpoch)));
+
+        assertThat(logReplica.isLeader()).isFalse();
+        assertThat(localLogSizeGauge.getValue()).isEqualTo(localLogSize);
+    }
+
+    @Test
+    void testPhysicalStorageLocalLogSizeIsScopedPerBucket() throws Exception {
+        TableBucket firstTableBucket = new TableBucket(DATA1_TABLE_ID, 1);
+        TableBucket secondTableBucket = new TableBucket(DATA1_TABLE_ID, 2);
+        Replica firstReplica = makeLogReplica(DATA1_PHYSICAL_TABLE_PATH, firstTableBucket);
+        Replica secondReplica = makeLogReplica(DATA1_PHYSICAL_TABLE_PATH, secondTableBucket);
+        makeLeaderReplica(firstReplica, DATA1_TABLE_PATH, firstTableBucket, INITIAL_LEADER_EPOCH);
+        makeLeaderReplica(secondReplica, DATA1_TABLE_PATH, secondTableBucket, INITIAL_LEADER_EPOCH);
+
+        firstReplica.appendRecordsToLeader(genMemoryLogRecordsByObject(DATA1), 0);
+
+        Gauge<Long> firstBucketGauge = getBucketLocalLogSizeGauge(firstReplica);
+        Gauge<Long> secondBucketGauge = getBucketLocalLogSizeGauge(secondReplica);
+        assertThat(firstBucketGauge.getValue())
+                .isEqualTo(firstReplica.getLogTablet().logSize())
+                .isGreaterThan(secondBucketGauge.getValue());
+        assertThat(secondBucketGauge.getValue()).isEqualTo(secondReplica.getLogTablet().logSize());
+        assertThat(firstReplica.bucketMetrics().getAllVariables())
+                .containsEntry("partition", "")
+                .containsEntry("bucket", "1");
+        assertThat(secondReplica.bucketMetrics().getAllVariables())
+                .containsEntry("partition", "")
+                .containsEntry("bucket", "2");
+    }
+
+    @Test
     void testAppendRecordsWithOutOfOrderBatchSequence() throws Exception {
         Replica logReplica =
                 makeLogReplica(DATA1_PHYSICAL_TABLE_PATH, new TableBucket(DATA1_TABLE_ID, 1));
@@ -902,6 +959,16 @@ final class ReplicaTest extends ReplicaTestBase {
                 (Gauge<Long>)
                         ((AbstractMetricGroup) lakeTieringMetricGroup).getMetrics().get(metricName);
         return gauge.getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Gauge<Long> getBucketLocalLogSizeGauge(Replica replica) {
+        MetricGroup physicalStorageMetricGroup =
+                replica.bucketMetrics().addGroup("physicalStorage");
+        return (Gauge<Long>)
+                ((AbstractMetricGroup) physicalStorageMetricGroup)
+                        .getMetrics()
+                        .get(MetricNames.BUCKET_PHYSICAL_STORAGE_LOCAL_LOG_SIZE);
     }
 
     private void makeLogReplicaAsLeader(Replica replica) throws Exception {

--- a/website/docs/maintenance/observability/monitor-metrics.md
+++ b/website/docs/maintenance/observability/monitor-metrics.md
@@ -767,7 +767,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </thead>
   <tbody>
     <tr>
-      <th rowspan="31"><strong>tabletserver</strong></th>
+      <th rowspan="33"><strong>tabletserver</strong></th>
       <td rowspan="20">table</td>
       <td>messagesInPerSecond</td>
       <td>The number of messages written per second to this table.</td>
@@ -919,6 +919,12 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
      <tr>
       <td>size</td>
       <td>The number of bytes written per second to this table.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>table_bucket_physicalStorage</td>
+      <td>localLogSize</td>
+      <td>The physical size, in bytes, of all local log segments for this table bucket on this TabletServer. The metric is reported for both leader and follower replicas and includes the partition and bucket variables. Sum it by partition or table, and across TabletServers, to obtain the corresponding local log footprint including replication.</td>
       <td>Gauge</td>
     </tr>
      <tr>


### PR DESCRIPTION
AI-Model: gpt-5.6-sol
AI-Contributed/Feature: 15/15
AI-Contributed/UT: 67/67

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #3840 

<!-- What is the purpose of the change -->

Introduce a bucket-level gauge:

- Scope/Infix: `table_bucket_physicalStorage`
- Metric: `localLogSize`
- Unit: bytes
- Variables: `database`, `table`, `partition`, and `bucket`

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
