### PR TITLE
[flink] Complete bounded log splits after filtered batches

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/reader/FlinkSourceSplitReader.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/reader/FlinkSourceSplitReader.java
@@ -468,6 +468,11 @@ public class FlinkSourceSplitReader implements SplitReader<RecordAndPos, SourceS
             splitIdByTableBucket.put(scanBucket, splitId);
             tableScanBuckets.add(scanBucket);
             List<ScanRecord> bucketScanRecords = scanRecords.records(scanBucket);
+            Long consumedUpToOffset = scanRecords.consumedUpToOffset(scanBucket);
+            if (consumedUpToOffset != null && consumedUpToOffset >= stoppingOffset) {
+                stoppingOffsets.put(scanBucket, stoppingOffset);
+                finishedSplits.add(splitId);
+            }
             if (!bucketScanRecords.isEmpty()) {
                 final ScanRecord lastRecord = bucketScanRecords.get(bucketScanRecords.size() - 1);
                 // We keep the maximum message timestamp in the fetch for calculating lags

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceBatchITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceBatchITCase.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
 import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertResultsIgnoreOrder;
+import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.collectRowsUntilEndWithTimeout;
 import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.collectRowsWithTimeout;
 import static org.apache.fluss.server.testutils.FlussClusterExtension.BUILTIN_DATABASE;
 import static org.apache.fluss.testutils.DataTestUtils.row;
@@ -347,6 +348,32 @@ abstract class FlinkTableSourceBatchITCase extends FlinkTestBase {
                             "+I[5, address5, name5]");
         }
         assertResultsIgnoreOrder(collected, expected, true);
+    }
+
+    @Test
+    void testFilteredLogTableBatchScanCompletesWhenNoRecordsMatch() throws Exception {
+        String tableName = String.format("test_filtered_log_table_%s", RandomUtils.nextInt());
+        tEnv.executeSql(
+                String.format(
+                        "create table %s (id int, name varchar) with ("
+                                + "'bucket.num' = '1', "
+                                + "'table.statistics.columns' = 'id')",
+                        tableName));
+
+        TablePath tablePath = TablePath.of(databaseName, tableName);
+        try (Table table = conn.getTable(tablePath)) {
+            AppendWriter appendWriter = table.newAppend().createWriter();
+            for (int i = 1; i <= 5; i++) {
+                appendWriter.append(row(i, "name" + i));
+            }
+            appendWriter.flush();
+        }
+
+        String query = String.format("SELECT * FROM %s WHERE id > 100", tableName);
+        assertThat(tEnv.explainSql(query)).contains("filter=[>(id, 100)]");
+
+        CloseableIterator<Row> collected = tEnv.executeSql(query).collect();
+        assertThat(collectRowsUntilEndWithTimeout(collected)).isEmpty();
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/testutils/FlinkRowAssertionsUtils.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/testutils/FlinkRowAssertionsUtils.java
@@ -119,6 +119,35 @@ public class FlinkRowAssertionsUtils {
         return actual;
     }
 
+    /**
+     * Collects all rows and fails if the Flink result iterator does not finish within one minute.
+     */
+    public static List<String> collectRowsUntilEndWithTimeout(CloseableIterator<Row> iterator) {
+        CompletableFuture<List<String>> future =
+                CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                return collectBatchRows(iterator);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        },
+                        EXECUTOR);
+        try {
+            return future.get(1, TimeUnit.MINUTES);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            try {
+                iterator.close();
+            } catch (Exception ignored) {
+                // The timeout is the test failure we need to report.
+            }
+            throw new AssertionError("Flink job did not finish within one minute.", e);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to collect Flink job results.", e.getCause());
+        }
+    }
+
     protected static List<String> collectRowsWithTimeout(
             CloseableIterator<Row> iterator,
             int expectedCount,


### PR DESCRIPTION
### Purpose

Linked issue: close #3872

Flink bounded Log Table batch scans can fail to finish when statistics filtering materializes no records even though the scanner has consumed the split through its stopping offset.

### Brief change log

- Use scanner consumed progress to mark bounded log splits finished when a poll contains no materialized records.
- Keep the existing last-record offset fallback for results without consumed progress.
- Add a single-bucket statistics-filtered batch regression test.

### Tests

- `FlinkSourceSplitReaderTest`: 7/7 passed.
- `Flink120TableSourceBatchITCase#testFilteredLogTableBatchScanCompletesWhenNoRecordsMatch`: 1/1 passed.
- Spotless and Checkstyle checks passed for the affected modules.

### API and Format

No API or storage format changes.

### Documentation

No documentation changes required.

### Generative AI disclosure

- [ ] No generative AI tools used
- [x] Yes (OpenAI Codex)