### PR TITLE
[CI] Wait for table metadata in authorization test

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -420,6 +420,10 @@ public class FlussAuthorizationITCase {
         // 6. getLatestLakeSnapshot
         // 7. listOffsets
 
+        TableInfo tableInfo = rootAdmin.getTableInfo(DATA1_TABLE_PATH_PK).get();
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(
+                new TableBucket(tableInfo.getTableId(), 0));
+
         // first check call these methods without authorization.
         assertThat(guestAdmin.listTables(DATA1_TABLE_PATH_PK.getDatabaseName()).get())
                 .isEqualTo(Collections.emptyList());

--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -152,6 +152,9 @@ public class FlussAuthorizationITCase {
                         DATA1_TABLE_PATH_PK.getDatabaseName(), DatabaseDescriptor.EMPTY, true)
                 .get();
         rootAdmin.createTable(DATA1_TABLE_PATH_PK, DATA1_TABLE_DESCRIPTOR_PK, true).get();
+        TableInfo tableInfo = rootAdmin.getTableInfo(DATA1_TABLE_PATH_PK).get();
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(
+                new TableBucket(tableInfo.getTableId(), 0));
     }
 
     @AfterEach
@@ -420,10 +423,6 @@ public class FlussAuthorizationITCase {
         // 6. getLatestLakeSnapshot
         // 7. listOffsets
 
-        TableInfo tableInfo = rootAdmin.getTableInfo(DATA1_TABLE_PATH_PK).get();
-        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(
-                new TableBucket(tableInfo.getTableId(), 0));
-
         // first check call these methods without authorization.
         assertThat(guestAdmin.listTables(DATA1_TABLE_PATH_PK.getDatabaseName()).get())
                 .isEqualTo(Collections.emptyList());
@@ -503,8 +502,6 @@ public class FlussAuthorizationITCase {
 
         GetKvSnapshotMetadataRequest request = new GetKvSnapshotMetadataRequest();
         request.setTableId(tableId).setBucketId(0).setSnapshotId(0);
-        // Make sure all tabletServer has ready replica and ready metadata for the table.
-        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(new TableBucket(tableId, 0));
 
         // call getKvSnapshotMetadata without authorization.
         assertNoTableDescribeAuth(() -> readOnlyGateway.getKvSnapshotMetadata(request).get());


### PR DESCRIPTION
<!--
Generated-by: Codex following https://github.com/apache/fluss/blob/main/AGENTS.md
-->

### Purpose

Linked issue: close #3747

`FlussAuthorizationITCase.testDescribeTableOperation` can call `listOffsets` after the bucket replica is online but before the TabletServer metadata cache contains the table ID. The authorization check then fails with `UnknownTableOrBucketException` instead of exercising the intended ACL behavior.

### Brief change log

- Establish bucket 0 replica and TabletServer metadata readiness after creating the default table in the shared test setup.
- Remove duplicate readiness waits from the affected tests.

### Tests

- `./mvnw -pl fluss-client -am -Dtest=FlussAuthorizationITCase -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

### API and Format

No API or storage format changes.

### Documentation

No documentation changes.
