### PR TITLE
[server] remove multi-key partitions from cache correctly

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/AutoPartitionManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/AutoPartitionManager.java
@@ -354,21 +354,10 @@ public class AutoPartitionManager implements AutoCloseable {
                 lock,
                 () -> {
                     if (autoPartitionTables.containsKey(tableId)) {
-                        TableInfo tableInfo = autoPartitionTables.get(tableId);
-                        TreeMap<String, Set<String>> partitionMap = partitionsByTable.get(tableId);
-                        if (tableInfo.getPartitionKeys().size() > 1) {
-                            String autoPartitionValue =
-                                    extractAutoPartitionValue(tableInfo, partitionName);
-                            Set<String> partitionSet = partitionMap.get(autoPartitionValue);
-                            if (partitionSet != null) {
-                                partitionSet.remove(partitionName);
-                                if (partitionSet.isEmpty()) {
-                                    partitionMap.remove(autoPartitionValue);
-                                }
-                            }
-                        } else {
-                            partitionMap.remove(partitionName);
-                        }
+                        removePartitionFromPartitionsByTable(
+                                autoPartitionTables.get(tableId),
+                                partitionsByTable.get(tableId),
+                                partitionName);
                     }
                 });
     }
@@ -410,6 +399,24 @@ public class AutoPartitionManager implements AutoCloseable {
             partitionSet.add(partitionName);
         } else {
             partitionMap.put(partitionName, null);
+        }
+    }
+
+    private void removePartitionFromPartitionsByTable(
+            TableInfo tableInfo,
+            NavigableMap<String, Set<String>> partitionMap,
+            String partitionName) {
+        if (tableInfo.getPartitionKeys().size() > 1) {
+            String autoPartitionValue = extractAutoPartitionValue(tableInfo, partitionName);
+            Set<String> partitionSet = partitionMap.get(autoPartitionValue);
+            if (partitionSet != null) {
+                partitionSet.remove(partitionName);
+                if (partitionSet.isEmpty()) {
+                    partitionMap.remove(autoPartitionValue);
+                }
+            }
+        } else {
+            partitionMap.remove(partitionName);
         }
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/AutoPartitionManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/AutoPartitionManager.java
@@ -354,7 +354,21 @@ public class AutoPartitionManager implements AutoCloseable {
                 lock,
                 () -> {
                     if (autoPartitionTables.containsKey(tableId)) {
-                        partitionsByTable.get(tableId).remove(partitionName);
+                        TableInfo tableInfo = autoPartitionTables.get(tableId);
+                        TreeMap<String, Set<String>> partitionMap = partitionsByTable.get(tableId);
+                        if (tableInfo.getPartitionKeys().size() > 1) {
+                            String autoPartitionValue =
+                                    extractAutoPartitionValue(tableInfo, partitionName);
+                            Set<String> partitionSet = partitionMap.get(autoPartitionValue);
+                            if (partitionSet != null) {
+                                partitionSet.remove(partitionName);
+                                if (partitionSet.isEmpty()) {
+                                    partitionMap.remove(autoPartitionValue);
+                                }
+                            }
+                        } else {
+                            partitionMap.remove(partitionName);
+                        }
                     }
                 });
     }
@@ -671,6 +685,30 @@ public class AutoPartitionManager implements AutoCloseable {
     @Nullable
     protected Integer getAutoCreateDayDelayMinutes(long tableId) {
         return autoCreateDayPartitionDelayMinutes.get(tableId);
+    }
+
+    /** Returns a snapshot of the cached partitions for the specified table. */
+    @VisibleForTesting
+    @Nullable
+    protected Map<String, Set<String>> getPartitionsByTable(long tableId) {
+        return inLock(
+                lock,
+                () -> {
+                    TreeMap<String, Set<String>> partitionMap = partitionsByTable.get(tableId);
+                    if (partitionMap == null) {
+                        return null;
+                    }
+
+                    Map<String, Set<String>> snapshot = new TreeMap<>();
+                    partitionMap.forEach(
+                            (partitionTime, partitionSet) ->
+                                    snapshot.put(
+                                            partitionTime,
+                                            partitionSet == null
+                                                    ? null
+                                                    : new HashSet<>(partitionSet)));
+                    return snapshot;
+                });
     }
 
     @Override

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/AutoPartitionManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/AutoPartitionManagerTest.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -677,8 +678,9 @@ class AutoPartitionManagerTest {
         assertThat(partitions.keySet()).contains("20250420", "20250421", "20250422");
     }
 
-    @Test
-    void testRemovePartitionFromMultiplePartitionKeysTable() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = {2, -1})
+    void testRemovePartitionFromMultiplePartitionKeysTable(int numRetention) throws Exception {
         ManuallyTriggeredScheduledExecutorService periodicExecutor =
                 new ManuallyTriggeredScheduledExecutorService();
         AutoPartitionManager autoPartitionManager =
@@ -691,7 +693,7 @@ class AutoPartitionManagerTest {
                         new ManualClock(0L),
                         periodicExecutor);
 
-        TableInfo table = createPartitionedTable(2, 0, AutoPartitionTimeUnit.DAY, true);
+        TableInfo table = createPartitionedTable(numRetention, 0, AutoPartitionTimeUnit.DAY, true);
         long tableId = table.getTableId();
         autoPartitionManager.addAutoPartitionTable(table, false);
         autoPartitionManager.addPartition(tableId, "20250419$A");

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/AutoPartitionManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/AutoPartitionManagerTest.java
@@ -677,6 +677,41 @@ class AutoPartitionManagerTest {
         assertThat(partitions.keySet()).contains("20250420", "20250421", "20250422");
     }
 
+    @Test
+    void testRemovePartitionFromMultiplePartitionKeysTable() throws Exception {
+        ManuallyTriggeredScheduledExecutorService periodicExecutor =
+                new ManuallyTriggeredScheduledExecutorService();
+        AutoPartitionManager autoPartitionManager =
+                new AutoPartitionManager(
+                        new TestingServerMetadataCache(3),
+                        metadataManager,
+                        remoteDirDynamicLoader,
+                        new Configuration(),
+                        disabledCapacityController(),
+                        new ManualClock(0L),
+                        periodicExecutor);
+
+        TableInfo table = createPartitionedTable(2, 0, AutoPartitionTimeUnit.DAY, true);
+        long tableId = table.getTableId();
+        autoPartitionManager.addAutoPartitionTable(table, false);
+        autoPartitionManager.addPartition(tableId, "20250419$A");
+        autoPartitionManager.addPartition(tableId, "20250419$B");
+
+        assertThat(autoPartitionManager.getPartitionsByTable(tableId))
+                .containsEntry(
+                        "20250419", new HashSet<>(Arrays.asList("20250419$A", "20250419$B")));
+
+        autoPartitionManager.removePartition(tableId, "20250419$A");
+
+        assertThat(autoPartitionManager.getPartitionsByTable(tableId))
+                .containsEntry("20250419", new HashSet<>(Arrays.asList("20250419$B")));
+
+        autoPartitionManager.removePartition(tableId, "20250419$B");
+
+        assertThat(autoPartitionManager.getPartitionsByTable(tableId))
+                .doesNotContainKey("20250419");
+    }
+
     /**
      * Test if AutoPartitionManager.createPartition applies maxBucketLimit per partition while
      * adding new partition automatically.

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/AutoPartitionManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/AutoPartitionManagerTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -678,9 +677,8 @@ class AutoPartitionManagerTest {
         assertThat(partitions.keySet()).contains("20250420", "20250421", "20250422");
     }
 
-    @ParameterizedTest
-    @ValueSource(ints = {2, -1})
-    void testRemovePartitionFromMultiplePartitionKeysTable(int numRetention) throws Exception {
+    @Test
+    void testRemovePartitionFromMultiplePartitionKeysTable() throws Exception {
         ManuallyTriggeredScheduledExecutorService periodicExecutor =
                 new ManuallyTriggeredScheduledExecutorService();
         AutoPartitionManager autoPartitionManager =
@@ -693,7 +691,7 @@ class AutoPartitionManagerTest {
                         new ManualClock(0L),
                         periodicExecutor);
 
-        TableInfo table = createPartitionedTable(numRetention, 0, AutoPartitionTimeUnit.DAY, true);
+        TableInfo table = createPartitionedTable(2, 0, AutoPartitionTimeUnit.DAY, true);
         long tableId = table.getTableId();
         autoPartitionManager.addAutoPartitionTable(table, false);
         autoPartitionManager.addPartition(tableId, "20250419$A");


### PR DESCRIPTION
### Purpose

Fix incorrect Auto Partition cache removal for tables with multiple partition keys.

### Brief change log

- Fixed partition removal from the nested cache structure.
- Removed empty time-based cache entries.
- Added a regression test for multi-key partition removal.
- Resolved the test file merge conflict while preserving existing coverage.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
