### PR TITLE
[FLUSS-3553][build] Fix shaded Jackson classes leaking into uber-jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -913,6 +913,17 @@
                                     'META-INF/versions/11/META-INF/maven/'.
                                      -->
                                 <exclude>**/META-INF/maven/?*/?*/**</exclude>
+                                <!-- Exclude unshaded Multi-Release Jar (MRJ) entries from
+                                     fluss-shaded-jackson. The shade relocation only handles
+                                     base-path classes; MRJ entries under META-INF/versions/*/
+                                     remain at their original com.fasterxml.jackson path and
+                                     leak into the uber-jar, shadowing downstream apps' own
+                                     jackson-core (e.g. NoSuchMethodError: JsonToken._updateToken
+                                     added in 2.16 but leaked 2.15.x wins class-load race).
+                                     The base FastDoubleParser implementation (at the relocated
+                                     path) is sufficient for all Java versions; the MRJ entries
+                                     are only performance optimizations. -->
+                                <exclude>META-INF/versions/**/com/fasterxml/**</exclude>
                             </excludes>
                         </filter>
                     </filters>


### PR DESCRIPTION
## Summary

`fluss-shaded-jackson` contains unshaded Multi-Release JAR (MRJ) entries under
`META-INF/versions/*/com/fasterxml/jackson/core/io/doubleparser/` (and sibling
parser dirs). The Maven Shade Plugin only relocates base-path classes, not MRJ
entries. These leak into uber-jars (`fluss-client`, `fluss-flink-*`) and can
shadow downstream apps' jackson-core 2.16+, causing `NoSuchMethodError:
JsonToken._updateToken`.

## Root Cause

The shade plugin's relocation (`<relocation>`) only transforms classes at their
base path (`com/fasterxml/jackson/...`). Multi-Release JAR entries stored under
`META-INF/versions/<java-version>/com/fasterxml/jackson/...` are **not** relocated
and remain at their original package path. When these entries are packaged into
uber-jars, they can win the class-loading race against the consumer's own
jackson-core dependency.

## Fix

Add `<exclude>META-INF/versions/**/com/fasterxml/**</exclude>` to the root
`pom.xml` global shade filter (`<artifact>*</artifact>`). This cascades to ALL
modules via `combine.children="append"`.

The base `FastDoubleParser` implementation (at the relocated path) is sufficient
for all Java versions; the MRJ entries are only performance optimizations for
specific JDK versions.

## Test Plan

- Before fix: 5 uber-jars (fluss-client + fluss-flink-1.18/1.19/1.20/2.2/tiering)
  contain unshaded jackson MRJ entries
- After fix: 0 unshaded jackson entries in all 5 uber-jars
- `./mvnw -pl fluss-common test` passes (267 tests, 0 failures)
- `./mvnw spotless:check` passes
- `git diff --check` clean

## Files Changed

- `pom.xml` (+11 lines: 1 exclude rule in global shade filter)

🤖 AI-assisted changes - reviewed by human developer

Closes #3553