### PR TITLE
[rust][client][server][gateway] Relax partial update nullability rule

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/Upsert.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/Upsert.java
@@ -47,9 +47,9 @@ public interface Upsert {
      * remove the entire row is rejected when a specified column other than primary key is NOT NULL,
      * since it cannot be set to null.
      *
-     * <p>The specified columns must contain all columns of primary key, and all columns omitted
-     * from the specified columns should be nullable, since they are set to null when the row
-     * doesn't exist. Specified columns may be declared NOT NULL.
+     * <p>Note: The specified columns must contain all columns of primary key, and all columns
+     * omitted from the specified columns should be nullable, since they are set to null when the
+     * row doesn't exist. Specified columns may be declared NOT NULL.
      *
      * @param targetColumns the column indexes to partial update
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/Upsert.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/Upsert.java
@@ -49,7 +49,9 @@ public interface Upsert {
      *
      * <p>Note: The specified columns must contain all columns of primary key, and all columns
      * omitted from the specified columns should be nullable, since they are set to null when the
-     * row doesn't exist. Specified columns may be declared NOT NULL.
+     * row doesn't exist. Specified columns may be declared NOT NULL, except on a table with an auto
+     * increment column, where a specified column other than primary key must be nullable, since the
+     * auto increment column is always set and a partial delete could therefore never succeed.
      *
      * @param targetColumns the column indexes to partial update
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/Upsert.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/Upsert.java
@@ -43,10 +43,12 @@ public interface Upsert {
      *
      * <p>For delete operations, the entire row will not be removed immediately, but only the
      * specified columns except primary key will be set to null. The entire row will be removed when
-     * all columns except primary key are null after a delete operation.
+     * all columns except primary key are null after a delete operation. Such a delete is rejected
+     * when a specified column other than primary key is NOT NULL, since it cannot be set to null.
      *
      * <p>Note: The specified columns must contain all columns of primary key, and all columns
-     * except primary key should be nullable.
+     * omitted from the specified columns should be nullable, since they are set to null when the
+     * row doesn't exist. Specified columns may be declared NOT NULL.
      *
      * @param targetColumns the column indexes to partial update
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/Upsert.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/Upsert.java
@@ -43,12 +43,13 @@ public interface Upsert {
      *
      * <p>For delete operations, the entire row will not be removed immediately, but only the
      * specified columns except primary key will be set to null. The entire row will be removed when
-     * all columns except primary key are null after a delete operation. Such a delete is rejected
-     * when a specified column other than primary key is NOT NULL, since it cannot be set to null.
+     * all columns except primary key are null after a delete operation. A delete that does not
+     * remove the entire row is rejected when a specified column other than primary key is NOT NULL,
+     * since it cannot be set to null.
      *
-     * <p>Note: The specified columns must contain all columns of primary key, and all columns
-     * omitted from the specified columns should be nullable, since they are set to null when the
-     * row doesn't exist. Specified columns may be declared NOT NULL.
+     * <p>The specified columns must contain all columns of primary key, and all columns omitted
+     * from the specified columns should be nullable, since they are set to null when the row
+     * doesn't exist. Specified columns may be declared NOT NULL.
      *
      * @param targetColumns the column indexes to partial update
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
@@ -54,11 +54,11 @@ public class UpsertWrite {
      * row will be removed when all columns except primary key are null after a {@link
      * UpsertWriter#delete(InternalRow)} operation.
      *
-     * <p>Note: The specified columns must contain all columns of the primary key, and all columns
-     * omitted from the specified columns should be nullable, since they are set to null when the
-     * row doesn't exist. A {@link UpsertWriter#delete(InternalRow)} operation that does not remove
-     * the entire row also requires the specified columns except primary key to be nullable, since
-     * it sets them to null. Removing the entire row sets no column to null and is always allowed.
+     * <p>The specified columns must contain all columns of the primary key, and all columns omitted
+     * from the specified columns should be nullable, since they are set to null when the row
+     * doesn't exist. A {@link UpsertWriter#delete(InternalRow)} operation that does not remove the
+     * entire row also requires the specified columns except primary key to be nullable, since it
+     * sets them to null. Removing the entire row sets no column to null and is always allowed.
      *
      * @param targetColumns the columns to partial update,
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
@@ -59,6 +59,9 @@ public class UpsertWrite {
      * row doesn't exist. A {@link UpsertWriter#delete(InternalRow)} operation that does not remove
      * the entire row also requires the specified columns except primary key to be nullable, since
      * it sets them to null. Removing the entire row sets no column to null and is always allowed.
+     * On a table with an auto increment column the entire row is never removed, since the auto
+     * increment column is always set, so a specified column other than primary key must be nullable
+     * there.
      *
      * @param targetColumns the columns to partial update,
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
@@ -57,9 +57,8 @@ public class UpsertWrite {
      * <p>Note: The specified columns must contain all columns of the primary key, and all columns
      * omitted from the specified columns should be nullable, since they are set to null when the
      * row doesn't exist. A {@link UpsertWriter#delete(InternalRow)} operation that does not remove
-     * the entire row additionally requires the specified columns except primary key to be nullable,
-     * since it sets them to null. Removing the entire row sets no column to null, so it stays
-     * allowed whatever the nullability of the specified columns.
+     * the entire row also requires the specified columns except primary key to be nullable, since
+     * it sets them to null. Removing the entire row sets no column to null and is always allowed.
      *
      * @param targetColumns the columns to partial update,
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
@@ -54,8 +54,10 @@ public class UpsertWrite {
      * row will be removed when all columns except primary key are null after a {@link
      * UpsertWriter#delete(InternalRow)} operation.
      *
-     * <p>Note: The specified columns must be a contains all columns of primary key, and all columns
-     * except primary key should be nullable.
+     * <p>Note: The specified columns must contain all columns of the primary key, and all columns
+     * omitted from the specified columns should be nullable, since they are set to null when the
+     * row doesn't exist. A {@link UpsertWriter#delete(InternalRow)} operation additionally requires
+     * the specified columns except primary key to be nullable, since it sets them to null.
      *
      * @param targetColumns the columns to partial update,
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
@@ -54,8 +54,12 @@ public class UpsertWrite {
      * row will be removed when all columns except primary key are null after a {@link
      * UpsertWriter#delete(InternalRow)} operation.
      *
-     * <p>Note: The specified columns must be a contains all columns of primary key, and all columns
-     * except primary key should be nullable.
+     * <p>Note: The specified columns must contain all columns of the primary key, and all columns
+     * omitted from the specified columns should be nullable, since they are set to null when the
+     * row doesn't exist. A {@link UpsertWriter#delete(InternalRow)} operation that does not remove
+     * the entire row additionally requires the specified columns except primary key to be nullable,
+     * since it sets them to null. Removing the entire row sets no column to null, so it stays
+     * allowed whatever the nullability of the specified columns.
      *
      * @param targetColumns the columns to partial update,
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWrite.java
@@ -54,11 +54,11 @@ public class UpsertWrite {
      * row will be removed when all columns except primary key are null after a {@link
      * UpsertWriter#delete(InternalRow)} operation.
      *
-     * <p>The specified columns must contain all columns of the primary key, and all columns omitted
-     * from the specified columns should be nullable, since they are set to null when the row
-     * doesn't exist. A {@link UpsertWriter#delete(InternalRow)} operation that does not remove the
-     * entire row also requires the specified columns except primary key to be nullable, since it
-     * sets them to null. Removing the entire row sets no column to null and is always allowed.
+     * <p>Note: The specified columns must contain all columns of the primary key, and all columns
+     * omitted from the specified columns should be nullable, since they are set to null when the
+     * row doesn't exist. A {@link UpsertWriter#delete(InternalRow)} operation that does not remove
+     * the entire row also requires the specified columns except primary key to be nullable, since
+     * it sets them to null. Removing the entire row sets no column to null and is always allowed.
      *
      * @param targetColumns the columns to partial update,
      */

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
@@ -126,7 +126,6 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
             targetColumnsSet.set(targetColumnIndex);
         }
 
-        BitSet pkColumnSet = new BitSet();
         // check the target columns contains the primary key
         for (String key : primaryKeys) {
             int pkIndex = rowType.getFieldIndex(key);
@@ -136,7 +135,6 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
                                 "The target write columns %s must contain the primary key columns %s.",
                                 rowType.project(targetColumns).getFieldNames(), primaryKeys));
             }
-            pkColumnSet.set(pkIndex);
         }
 
         BitSet autoIncrementColumnSet = new BitSet();
@@ -152,17 +150,21 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
             autoIncrementColumnSet.set(autoIncrementColumnIndex);
         }
 
-        // check the columns not in targetColumns should be nullable
+        // an omitted column is written as null, so it must be nullable. auto increment columns
+        // are always omitted and only get their value on the server.
         for (int i = 0; i < rowType.getFieldCount(); i++) {
-            // column not in primary key and not in auto increment column
-            if (!pkColumnSet.get(i) && !autoIncrementColumnSet.get(i)) {
-                // the column should be nullable
-                if (!rowType.getTypeAt(i).isNullable()) {
+            if (!targetColumnsSet.get(i) && !rowType.getTypeAt(i).isNullable()) {
+                String columnName = rowType.getFieldNames().get(i);
+                if (autoIncrementColumnSet.get(i)) {
                     throw new IllegalArgumentException(
                             String.format(
-                                    "Partial Update requires all columns except primary key to be nullable, but column %s is NOT NULL.",
-                                    rowType.getFieldNames().get(i)));
+                                    "Partial Update requires the auto increment column %s to be nullable, since it is always omitted from the target columns and assigned by the server.",
+                                    columnName));
                 }
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Partial Update requires all columns omitted from the target columns to be nullable, but omitted column %s is NOT NULL.",
+                                columnName));
             }
         }
     }

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
@@ -155,13 +155,9 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
             autoIncrementColumnSet.set(autoIncrementColumnIndex);
         }
 
-        // The aggregation merge engine returns the new row unchanged on the first write instead of
-        // null filling the omitted columns, so it keeps requiring every column except the primary
-        // key to be nullable. The server enforces the same rule when it builds the merger, and
-        // checking it here keeps the rejection at writer creation instead of at the first write.
-        // OVERWRITE is exempt, since it bypasses the configured merge engine on the server and
-        // merges with the default merger, which null fills the omitted columns like any other
-        // partial update.
+        // the aggregation merge engine does not null fill omitted columns on the first write, so
+        // it keeps requiring every column except the primary key to be nullable, like the server.
+        // OVERWRITE is exempt, since the server merges it with the default merger instead.
         if (mergeEngineType == MergeEngineType.AGGREGATION && mergeMode != MergeMode.OVERWRITE) {
             for (int i = 0; i < rowType.getFieldCount(); i++) {
                 if (!primaryKeys.contains(rowType.getFieldNames().get(i))

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
@@ -219,6 +219,21 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
                                 columnName));
             }
         }
+
+        // the auto increment column is always set, so a partial delete could never collapse
+        // the row and would always fail on a NOT NULL non-primary-key target column.
+        if (!autoIncrementColumnSet.isEmpty()) {
+            for (int i = 0; i < rowType.getFieldCount(); i++) {
+                if (targetColumnsSet.get(i)
+                        && !primaryKeys.contains(rowType.getFieldNames().get(i))
+                        && !rowType.getTypeAt(i).isNullable()) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Partial Update on a table with an auto increment column requires all target columns except the primary key to be nullable, but target column %s is NOT NULL, since the auto increment column is always set and a partial delete could therefore never succeed.",
+                                    rowType.getFieldNames().get(i)));
+                }
+            }
+        }
     }
 
     /**

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
@@ -274,9 +274,9 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
 
     /**
      * Rejects a null in a NOT NULL target column. Runs before any field getter or encoding, which
-     * would fail with a bare NullPointerException. Slightly stricter than the server when the
-     * target columns cover every schema column, since the server then skips the PartialUpdater, but
-     * such a row is not reachable through the public API.
+     * would fail with a bare NullPointerException. When the target columns cover every schema
+     * column the server skips the PartialUpdater and this check is the only guard, and the encoders
+     * would reject the null anyway, so it never changes which rows are accepted.
      */
     private void checkNotNullTargetColumns(InternalRow row) {
         for (int index : notNullTargetColumns) {

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
@@ -36,6 +36,7 @@ import org.apache.fluss.types.RowType;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -57,6 +58,9 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
 
     /** The merge mode for this writer. This controls how the server handles data merging. */
     private final MergeMode mergeMode;
+
+    /** Indexes of the NOT NULL target columns, empty when there is nothing to check. */
+    private final int[] notNullTargetColumns;
 
     UpsertWriterImpl(
             TablePath tablePath,
@@ -105,6 +109,21 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
 
         this.tableInfo = tableInfo;
         this.mergeMode = mergeMode;
+        this.notNullTargetColumns = findNotNullTargetColumns(rowType, partialUpdateColumns);
+    }
+
+    private static int[] findNotNullTargetColumns(RowType rowType, @Nullable int[] targetColumns) {
+        if (targetColumns == null) {
+            return new int[0];
+        }
+        int[] indexes = new int[targetColumns.length];
+        int count = 0;
+        for (int targetColumn : targetColumns) {
+            if (!rowType.getTypeAt(targetColumn).isNullable()) {
+                indexes[count++] = targetColumn;
+            }
+        }
+        return Arrays.copyOf(indexes, count);
     }
 
     private static void sanityCheck(
@@ -155,9 +174,22 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
             autoIncrementColumnSet.set(autoIncrementColumnIndex);
         }
 
-        // the aggregation merge engine does not null fill omitted columns on the first write, so
-        // it keeps requiring every column except the primary key to be nullable, like the server.
-        // OVERWRITE is exempt, since the server merges it with the default merger instead.
+        // the first_row and versioned mergers reject partial update outright on the server, at
+        // the first write, so fail at writer creation instead. OVERWRITE is exempt, since the
+        // server merges it with the default merger.
+        if (mergeMode != MergeMode.OVERWRITE) {
+            if (mergeEngineType == MergeEngineType.FIRST_ROW) {
+                throw new IllegalArgumentException(
+                        "Partial update is not supported for the first_row merge engine.");
+            } else if (mergeEngineType == MergeEngineType.VERSIONED) {
+                throw new IllegalArgumentException(
+                        "Partial update is not supported for the versioned merge engine.");
+            }
+        }
+
+        // the aggregation merge engine does not fill omitted columns with null on the first
+        // write, so it keeps requiring every column except the primary key to be nullable, like
+        // the server. OVERWRITE is exempt, since the server merges it with the default merger.
         if (mergeEngineType == MergeEngineType.AGGREGATION && mergeMode != MergeMode.OVERWRITE) {
             for (int i = 0; i < rowType.getFieldCount(); i++) {
                 if (!primaryKeys.contains(rowType.getFieldNames().get(i))
@@ -198,6 +230,7 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
     @Override
     public CompletableFuture<UpsertResult> upsert(InternalRow row) {
         checkFieldCount(row);
+        checkNotNullTargetColumns(row);
         byte[] key = primaryKeyEncoder.encodeKey(row);
         byte[] bucketKey =
                 bucketKeyEncoder == primaryKeyEncoder ? key : bucketKeyEncoder.encodeKey(row);
@@ -237,6 +270,23 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
                         targetColumns,
                         mergeMode);
         return sendWithResult(record, DeleteResult::new);
+    }
+
+    /**
+     * Rejects a null in a NOT NULL target column. Runs before any field getter or encoding, which
+     * would fail with a bare NullPointerException. Slightly stricter than the server when the
+     * target columns cover every schema column, since the server then skips the PartialUpdater, but
+     * such a row is not reachable through the public API.
+     */
+    private void checkNotNullTargetColumns(InternalRow row) {
+        for (int index : notNullTargetColumns) {
+            if (row.isNullAt(index)) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Target column %s is NOT NULL but the written row has no value for it.",
+                                tableInfo.getRowType().getFieldNames().get(index)));
+            }
+        }
     }
 
     private BinaryRow encodeRow(InternalRow row) {

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/writer/UpsertWriterImpl.java
@@ -21,6 +21,7 @@ import org.apache.fluss.client.write.WriteFormat;
 import org.apache.fluss.client.write.WriteRecord;
 import org.apache.fluss.client.write.WriterClient;
 import org.apache.fluss.metadata.KvFormat;
+import org.apache.fluss.metadata.MergeEngineType;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.BinaryRow;
@@ -77,7 +78,9 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
                 rowType,
                 tableInfo.getPrimaryKeys(),
                 tableInfo.getSchema().getAutoIncrementColumnNames(),
-                partialUpdateColumns);
+                partialUpdateColumns,
+                tableInfo.getTableConfig().getMergeEngineType().orElse(null),
+                mergeMode);
 
         this.targetColumns = partialUpdateColumns;
         // encode primary key using physical primary key
@@ -108,7 +111,9 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
             RowType rowType,
             List<String> primaryKeys,
             List<String> autoIncrementColumnNames,
-            @Nullable int[] targetColumns) {
+            @Nullable int[] targetColumns,
+            @Nullable MergeEngineType mergeEngineType,
+            MergeMode mergeMode) {
         // skip check when target columns is null
         if (targetColumns == null) {
             if (!autoIncrementColumnNames.isEmpty()) {
@@ -126,7 +131,6 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
             targetColumnsSet.set(targetColumnIndex);
         }
 
-        BitSet pkColumnSet = new BitSet();
         // check the target columns contains the primary key
         for (String key : primaryKeys) {
             int pkIndex = rowType.getFieldIndex(key);
@@ -136,7 +140,6 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
                                 "The target write columns %s must contain the primary key columns %s.",
                                 rowType.project(targetColumns).getFieldNames(), primaryKeys));
             }
-            pkColumnSet.set(pkIndex);
         }
 
         BitSet autoIncrementColumnSet = new BitSet();
@@ -152,17 +155,40 @@ class UpsertWriterImpl extends AbstractTableWriter implements UpsertWriter {
             autoIncrementColumnSet.set(autoIncrementColumnIndex);
         }
 
-        // check the columns not in targetColumns should be nullable
-        for (int i = 0; i < rowType.getFieldCount(); i++) {
-            // column not in primary key and not in auto increment column
-            if (!pkColumnSet.get(i) && !autoIncrementColumnSet.get(i)) {
-                // the column should be nullable
-                if (!rowType.getTypeAt(i).isNullable()) {
+        // The aggregation merge engine returns the new row unchanged on the first write instead of
+        // null filling the omitted columns, so it keeps requiring every column except the primary
+        // key to be nullable. The server enforces the same rule when it builds the merger, and
+        // checking it here keeps the rejection at writer creation instead of at the first write.
+        // OVERWRITE is exempt, since it bypasses the configured merge engine on the server and
+        // merges with the default merger, which null fills the omitted columns like any other
+        // partial update.
+        if (mergeEngineType == MergeEngineType.AGGREGATION && mergeMode != MergeMode.OVERWRITE) {
+            for (int i = 0; i < rowType.getFieldCount(); i++) {
+                if (!primaryKeys.contains(rowType.getFieldNames().get(i))
+                        && !rowType.getTypeAt(i).isNullable()) {
                     throw new IllegalArgumentException(
                             String.format(
-                                    "Partial Update requires all columns except primary key to be nullable, but column %s is NOT NULL.",
+                                    "Partial aggregate requires all columns except primary key to be nullable, but column %s is NOT NULL.",
                                     rowType.getFieldNames().get(i)));
                 }
+            }
+        }
+
+        // an omitted column is written as null, so it must be nullable. auto increment columns
+        // are always omitted and only get their value on the server.
+        for (int i = 0; i < rowType.getFieldCount(); i++) {
+            if (!targetColumnsSet.get(i) && !rowType.getTypeAt(i).isNullable()) {
+                String columnName = rowType.getFieldNames().get(i);
+                if (autoIncrementColumnSet.get(i)) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Partial Update requires the auto increment column %s to be nullable, since it is always omitted from the target columns and assigned by the server.",
+                                    columnName));
+                }
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Partial Update requires all columns omitted from the target columns to be nullable, but omitted column %s is NOT NULL.",
+                                columnName));
             }
         }
     }

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/FlussTableITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/FlussTableITCase.java
@@ -1007,6 +1007,15 @@ class FlussTableITCase extends ClientToServerITCaseBase {
                     .cause()
                     .isInstanceOf(InvalidTargetColumnException.class)
                     .hasMessageContaining("but target column c is NOT NULL.");
+
+            // the rejected delete leaves the stored row untouched
+            assertThat(lookupRow(lookuper, rowKey))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "bbb", 200L}));
+
+            // and the writer still works after the rejection
+            upsertWriter.upsert(row(1, null, 300L)).get();
+            assertThat(lookupRow(lookuper, rowKey))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "bbb", 300L}));
         }
     }
 
@@ -1069,6 +1078,52 @@ class FlussTableITCase extends ClientToServerITCaseBase {
             assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "c").createWriter())
                     .hasMessage(
                             "Explicitly specifying values for the auto increment column c is not allowed.");
+        }
+
+        // a NOT NULL auto increment column is creatable but rejects any partial update, since
+        // the always omitted auto increment column would have to be written as null first
+        schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.INT())
+                        .column("c", new BigIntType(false))
+                        .primaryKey("a")
+                        .enableAutoIncrement("c")
+                        .build();
+        tableDescriptor = TableDescriptor.builder().schema(schema).distributedBy(3, "a").build();
+        TablePath notNullAutoIncrementPath =
+                TablePath.of("test_db_1", "test_not_null_auto_increment_column_upsert");
+        createTable(notNullAutoIncrementPath, tableDescriptor, true);
+        try (Table table = conn.getTable(notNullAutoIncrementPath)) {
+            assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "b").createWriter())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage(
+                            "Partial Update requires the auto increment column c to be nullable, "
+                                    + "since it is always omitted from the target columns and assigned by the server.");
+        }
+
+        // an auto increment table rejects a NOT NULL non-primary-key target column, since the
+        // always set auto increment column would make every partial delete fail
+        schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", new BigIntType(false))
+                        .column("c", DataTypes.BIGINT())
+                        .primaryKey("a")
+                        .enableAutoIncrement("c")
+                        .build();
+        tableDescriptor = TableDescriptor.builder().schema(schema).distributedBy(3, "a").build();
+        TablePath notNullTargetAutoIncrementPath =
+                TablePath.of("test_db_1", "test_not_null_target_auto_increment_column_upsert");
+        createTable(notNullTargetAutoIncrementPath, tableDescriptor, true);
+        try (Table table = conn.getTable(notNullTargetAutoIncrementPath)) {
+            assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "b").createWriter())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage(
+                            "Partial Update on a table with an auto increment column requires all target columns "
+                                    + "except the primary key to be nullable, but target column b is NOT NULL, "
+                                    + "since the auto increment column is always set and a partial delete could "
+                                    + "therefore never succeed.");
         }
     }
 

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/FlussTableITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/FlussTableITCase.java
@@ -34,8 +34,10 @@ import org.apache.fluss.client.table.writer.UpsertWriter;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.MemorySize;
+import org.apache.fluss.exception.InvalidTargetColumnException;
 import org.apache.fluss.fs.FsPath;
 import org.apache.fluss.fs.TestFileSystem;
+import org.apache.fluss.metadata.AggFunctions;
 import org.apache.fluss.metadata.DataLakeFormat;
 import org.apache.fluss.metadata.KvFormat;
 import org.apache.fluss.metadata.LogFormat;
@@ -53,6 +55,7 @@ import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.row.ProjectedRow;
 import org.apache.fluss.row.encode.KvValueLayout;
 import org.apache.fluss.row.indexed.IndexedRow;
+import org.apache.fluss.rpc.protocol.MergeMode;
 import org.apache.fluss.types.BigIntType;
 import org.apache.fluss.types.DataTypes;
 import org.apache.fluss.types.RowType;
@@ -91,6 +94,7 @@ import static org.apache.fluss.testutils.DataTestUtils.keyRow;
 import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.apache.fluss.testutils.InternalRowAssert.assertThatRow;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT case for {@link FlussTable}. */
@@ -960,6 +964,45 @@ class FlussTableITCase extends ClientToServerITCaseBase {
     }
 
     @Test
+    void testPartialPutWithNotNullTargetColumn() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.STRING())
+                        .column("c", new BigIntType(false))
+                        .primaryKey("a")
+                        .build();
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder().schema(schema).distributedBy(3, "a").build();
+        createTable(DATA1_TABLE_PATH_PK, tableDescriptor, true);
+
+        try (Table table = conn.getTable(DATA1_TABLE_PATH_PK)) {
+            // seed a full row so that column b, outside the target columns, is not null
+            table.newUpsert().createWriter().upsert(row(1, "bbb", 1L)).get();
+
+            UpsertWriter upsertWriter = table.newUpsert().partialUpdate("a", "c").createWriter();
+            upsertWriter.upsert(row(1, null, 100L)).get();
+
+            Lookuper lookuper = table.newLookup().createLookuper();
+            GenericRow rowKey = row(1);
+            assertThat(lookupRow(lookuper, rowKey))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "bbb", 100L}));
+
+            // updating the same target columns again keeps column b untouched
+            upsertWriter.upsert(row(1, null, 200L)).get();
+            assertThat(lookupRow(lookuper, rowKey))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "bbb", 200L}));
+
+            // a partial delete would null out the NOT NULL column c, and only the server can
+            // tell, since it depends on the stored row
+            assertThatThrownBy(() -> upsertWriter.delete(row(1, null, 200L)).get())
+                    .cause()
+                    .isInstanceOf(InvalidTargetColumnException.class)
+                    .hasMessageContaining("but target column c is NOT NULL.");
+        }
+    }
+
+    @Test
     void testInvalidPartialUpdate() throws Exception {
         Schema schema =
                 Schema.newBuilder()
@@ -979,13 +1022,15 @@ class FlussTableITCase extends ClientToServerITCaseBase {
                     .hasMessage(
                             "The target write columns [b] must contain the primary key columns [a].");
 
-            // the column not in the primary key is nullable, should throw exception
+            // the column omitted from the target columns is NOT NULL, should throw exception
             assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "b").createWriter())
                     .hasMessage(
-                            "Partial Update requires all columns except primary key to be nullable, but column c is NOT NULL.");
-            assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "c").createWriter())
-                    .hasMessage(
-                            "Partial Update requires all columns except primary key to be nullable, but column c is NOT NULL.");
+                            "Partial Update requires all columns omitted from the target columns to be nullable, "
+                                    + "but omitted column c is NOT NULL.");
+            // column c is NOT NULL but listed in the target columns, so it is always provided by
+            // the writer and should be accepted
+            assertThatCode(() -> table.newUpsert().partialUpdate("a", "c").createWriter())
+                    .doesNotThrowAnyException();
             assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "d").createWriter())
                     .hasMessage(
                             "Can not find target column: d for table test_db_1.test_pk_table_1.");
@@ -1016,6 +1061,51 @@ class FlussTableITCase extends ClientToServerITCaseBase {
             assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "c").createWriter())
                     .hasMessage(
                             "Explicitly specifying values for the auto increment column c is not allowed.");
+        }
+    }
+
+    @Test
+    void testPartialUpdateOnAggregationTable() throws Exception {
+        // the aggregation merge engine returns the new row unchanged on the first write, so it
+        // keeps requiring every column except the primary key to be nullable, even a column listed
+        // in the target columns
+        Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.BIGINT(), AggFunctions.SUM())
+                        .column("c", new BigIntType(false), AggFunctions.SUM())
+                        .primaryKey("a")
+                        .build();
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ConfigOptions.TABLE_MERGE_ENGINE.key(), "aggregation");
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder()
+                        .schema(schema)
+                        .distributedBy(3, "a")
+                        .properties(properties)
+                        .build();
+        TablePath tablePath = TablePath.of("test_db_1", "test_aggregation_partial_update");
+        createTable(tablePath, tableDescriptor, true);
+
+        try (Table table = conn.getTable(tablePath)) {
+            // the writer is rejected at creation, so the failure does not wait for the first write
+            assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "c").createWriter())
+                    .hasMessage(
+                            "Partial aggregate requires all columns except primary key to be nullable, "
+                                    + "but column c is NOT NULL.");
+
+            // OVERWRITE bypasses the configured merge engine on the server, which merges with the
+            // default merger instead, so the aggregation requirement does not apply to it
+            UpsertWriter overwriteWriter =
+                    table.newUpsert()
+                            .mergeMode(MergeMode.OVERWRITE)
+                            .partialUpdate("a", "c")
+                            .createWriter();
+            overwriteWriter.upsert(row(1, null, 100L)).get();
+
+            Lookuper lookuper = table.newLookup().createLookuper();
+            assertThat(lookupRow(lookuper, row(1)))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, null, 100L}));
         }
     }
 

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/FlussTableITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/FlussTableITCase.java
@@ -34,6 +34,7 @@ import org.apache.fluss.client.table.writer.UpsertWriter;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.MemorySize;
+import org.apache.fluss.exception.InvalidTargetColumnException;
 import org.apache.fluss.fs.FsPath;
 import org.apache.fluss.fs.TestFileSystem;
 import org.apache.fluss.metadata.DataLakeFormat;
@@ -90,6 +91,7 @@ import static org.apache.fluss.testutils.DataTestUtils.keyRow;
 import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.apache.fluss.testutils.InternalRowAssert.assertThatRow;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT case for {@link FlussTable}. */
@@ -956,6 +958,45 @@ class FlussTableITCase extends ClientToServerITCaseBase {
     }
 
     @Test
+    void testPartialPutWithNotNullTargetColumn() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.STRING())
+                        .column("c", new BigIntType(false))
+                        .primaryKey("a")
+                        .build();
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder().schema(schema).distributedBy(3, "a").build();
+        createTable(DATA1_TABLE_PATH_PK, tableDescriptor, true);
+
+        try (Table table = conn.getTable(DATA1_TABLE_PATH_PK)) {
+            // seed a full row so that column b, outside the target columns, is not null
+            table.newUpsert().createWriter().upsert(row(1, "bbb", 1L)).get();
+
+            UpsertWriter upsertWriter = table.newUpsert().partialUpdate("a", "c").createWriter();
+            upsertWriter.upsert(row(1, null, 100L)).get();
+
+            Lookuper lookuper = table.newLookup().createLookuper();
+            GenericRow rowKey = row(1);
+            assertThat(lookupRow(lookuper, rowKey))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "bbb", 100L}));
+
+            // updating the same target columns again keeps column b untouched
+            upsertWriter.upsert(row(1, null, 200L)).get();
+            assertThat(lookupRow(lookuper, rowKey))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "bbb", 200L}));
+
+            // a partial delete would null out the NOT NULL column c, and only the server can
+            // tell, since it depends on the stored row
+            assertThatThrownBy(() -> upsertWriter.delete(row(1, null, 200L)).get())
+                    .cause()
+                    .isInstanceOf(InvalidTargetColumnException.class)
+                    .hasMessageContaining("but target column c is NOT NULL.");
+        }
+    }
+
+    @Test
     void testInvalidPartialUpdate() throws Exception {
         Schema schema =
                 Schema.newBuilder()
@@ -975,13 +1016,15 @@ class FlussTableITCase extends ClientToServerITCaseBase {
                     .hasMessage(
                             "The target write columns [b] must contain the primary key columns [a].");
 
-            // the column not in the primary key is nullable, should throw exception
+            // the column omitted from the target columns is NOT NULL, should throw exception
             assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "b").createWriter())
                     .hasMessage(
-                            "Partial Update requires all columns except primary key to be nullable, but column c is NOT NULL.");
-            assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "c").createWriter())
-                    .hasMessage(
-                            "Partial Update requires all columns except primary key to be nullable, but column c is NOT NULL.");
+                            "Partial Update requires all columns omitted from the target columns to be nullable, "
+                                    + "but omitted column c is NOT NULL.");
+            // column c is NOT NULL but listed in the target columns, so it is always provided by
+            // the writer and should be accepted
+            assertThatCode(() -> table.newUpsert().partialUpdate("a", "c").createWriter())
+                    .doesNotThrowAnyException();
             assertThatThrownBy(() -> table.newUpsert().partialUpdate("a", "d").createWriter())
                     .hasMessage(
                             "Can not find target column: d for table test_db_1.test_pk_table_1.");

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/FlussTableITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/FlussTableITCase.java
@@ -993,6 +993,14 @@ class FlussTableITCase extends ClientToServerITCaseBase {
             assertThat(lookupRow(lookuper, rowKey))
                     .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "bbb", 200L}));
 
+            // a null in the NOT NULL target column c is rejected before anything is sent
+            assertThatThrownBy(() -> upsertWriter.upsert(row(1, null, null)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage(
+                            "Target column c is NOT NULL but the written row has no value for it.");
+            assertThat(lookupRow(lookuper, rowKey))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "bbb", 200L}));
+
             // a partial delete would null out the NOT NULL column c, and only the server can
             // tell, since it depends on the stored row
             assertThatThrownBy(() -> upsertWriter.delete(row(1, null, 200L)).get())
@@ -1106,6 +1114,78 @@ class FlussTableITCase extends ClientToServerITCaseBase {
             Lookuper lookuper = table.newLookup().createLookuper();
             assertThat(lookupRow(lookuper, row(1)))
                     .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, null, 100L}));
+        }
+    }
+
+    @Test
+    void testPartialUpdateOnFirstRowAndVersionedTable() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.STRING())
+                        .column("c", DataTypes.BIGINT())
+                        .primaryKey("a")
+                        .build();
+
+        Map<String, String> firstRowProperties = new HashMap<>();
+        firstRowProperties.put(ConfigOptions.TABLE_MERGE_ENGINE.key(), "first_row");
+        TableDescriptor firstRowDescriptor =
+                TableDescriptor.builder()
+                        .schema(schema)
+                        .distributedBy(3, "a")
+                        .properties(firstRowProperties)
+                        .build();
+        TablePath firstRowPath = TablePath.of("test_db_1", "test_first_row_partial_update");
+        createTable(firstRowPath, firstRowDescriptor, true);
+
+        Map<String, String> versionedProperties = new HashMap<>();
+        versionedProperties.put(ConfigOptions.TABLE_MERGE_ENGINE.key(), "versioned");
+        versionedProperties.put(ConfigOptions.TABLE_MERGE_ENGINE_VERSION_COLUMN.key(), "c");
+        TableDescriptor versionedDescriptor =
+                TableDescriptor.builder()
+                        .schema(schema)
+                        .distributedBy(3, "a")
+                        .properties(versionedProperties)
+                        .build();
+        TablePath versionedPath = TablePath.of("test_db_1", "test_versioned_partial_update");
+        createTable(versionedPath, versionedDescriptor, true);
+
+        try (Table firstRowTable = conn.getTable(firstRowPath);
+                Table versionedTable = conn.getTable(versionedPath)) {
+            // both mergers reject partial update on the server at the first write, so the
+            // client rejects the writer at creation instead
+            assertThatThrownBy(
+                            () -> firstRowTable.newUpsert().partialUpdate("a", "b").createWriter())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Partial update is not supported for the first_row merge engine.");
+            assertThatThrownBy(
+                            () -> versionedTable.newUpsert().partialUpdate("a", "b").createWriter())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Partial update is not supported for the versioned merge engine.");
+
+            // OVERWRITE bypasses the configured merge engine on the server, which merges with
+            // the default merger instead, so partial update behaves as on an ordinary table
+            UpsertWriter firstRowOverwriteWriter =
+                    firstRowTable
+                            .newUpsert()
+                            .mergeMode(MergeMode.OVERWRITE)
+                            .partialUpdate("a", "b")
+                            .createWriter();
+            firstRowOverwriteWriter.upsert(row(1, "x", null)).get();
+            Lookuper firstRowLookuper = firstRowTable.newLookup().createLookuper();
+            assertThat(lookupRow(firstRowLookuper, row(1)))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "x", null}));
+
+            UpsertWriter versionedOverwriteWriter =
+                    versionedTable
+                            .newUpsert()
+                            .mergeMode(MergeMode.OVERWRITE)
+                            .partialUpdate("a", "b")
+                            .createWriter();
+            versionedOverwriteWriter.upsert(row(1, "y", null)).get();
+            Lookuper versionedLookuper = versionedTable.newLookup().createLookuper();
+            assertThat(lookupRow(versionedLookuper, row(1)))
+                    .isEqualTo(compactedRow(schema.getRowType(), new Object[] {1, "y", null}));
         }
     }
 

--- a/fluss-gateway/openapi.yaml
+++ b/fluss-gateway/openapi.yaml
@@ -986,7 +986,10 @@ components:
             in every upsert row. Missing or explicit-null nullable targets are written as null, and
             untargeted columns are preserved. Deletes require only primary-key values and clear the
             targeted non-key columns, so Fluss rejects a delete that would null a NOT NULL target
-            column. The row is removed when all non-key columns become null.
+            column. The row is removed when all non-key columns become null. On a table with an
+            auto-increment column a NOT NULL target column outside the primary key is rejected
+            outright, because the auto-increment column is always set and the row can never be
+            removed, so such a delete could never succeed.
           items:
             type: string
           minItems: 1

--- a/fluss-gateway/openapi.yaml
+++ b/fluss-gateway/openapi.yaml
@@ -981,11 +981,12 @@ components:
           description: |-
             Columns targeted by every entry in this batch. KV tables only.
 
-            Every primary-key column must be included, and every non-primary-key,
-            non-auto-increment column in the table must be nullable. Missing or explicit-null nullable
-            targets are written as null; untargeted columns are preserved. Deletes require only
-            primary-key values and clear the targeted non-key columns; the row is removed when all
-            non-key columns become null.
+            Every primary-key column must be included, and every column omitted from the target
+            columns must be nullable. A NOT NULL target column must be present with a non-null value
+            in every upsert row. Missing or explicit-null nullable targets are written as null, and
+            untargeted columns are preserved. Deletes require only primary-key values and clear the
+            targeted non-key columns, so Fluss rejects a delete that would null a NOT NULL target
+            column. The row is removed when all non-key columns become null.
           items:
             type: string
           minItems: 1

--- a/fluss-gateway/src/protocol/rest/records.rs
+++ b/fluss-gateway/src/protocol/rest/records.rs
@@ -314,6 +314,26 @@ fn sparse_targets(
             ));
         }
     }
+    // the auto-increment column is always set, so a partial delete could never collapse the
+    // row and would always fail on a NOT NULL non-primary-key target column.
+    if !auto_increment.is_empty() {
+        for field in fields {
+            if selected.contains(field.name())
+                && !table
+                    .get_primary_keys()
+                    .iter()
+                    .any(|key| key.as_str() == field.name())
+                && !field.data_type().is_nullable()
+            {
+                return Err(RowDecodeError::schema_mismatch(
+                    GatewayError::invalid_argument(format!(
+                        "a partial update on a table with an auto-increment column requires every target column except the primary key to be nullable, but target column `{}` is NOT NULL, since the auto-increment column is always set and a partial delete could never succeed",
+                        field.name()
+                    )),
+                ));
+            }
+        }
+    }
     Ok(Some(columns.to_vec()))
 }
 
@@ -407,7 +427,10 @@ pub struct WriteBody<T> {
     /// in every upsert row. Missing or explicit-null nullable targets are written as null, and
     /// untargeted columns are preserved. Deletes require only primary-key values and clear the
     /// targeted non-key columns, so Fluss rejects a delete that would null a NOT NULL target
-    /// column. The row is removed when all non-key columns become null.
+    /// column. The row is removed when all non-key columns become null. On a table with an
+    /// auto-increment column a NOT NULL target column outside the primary key is rejected
+    /// outright, because the auto-increment column is always set and the row can never be
+    /// removed, so such a delete could never succeed.
     #[serde(default)]
     #[schema(min_items = 1)]
     pub partial_update_columns: Option<Vec<String>>,
@@ -832,6 +855,87 @@ mod tests {
         assert_eq!(
             sparse_targets(&auto_increment_table_info(true), Some(&["id".to_string()])).unwrap(),
             Some(vec!["id".to_string()])
+        );
+    }
+
+    /// A KV table with an auto-increment column `seq` and a NOT NULL non-key column `name`.
+    fn auto_increment_table_with_not_null_column() -> TableInfo {
+        let schema = Schema::builder()
+            .column(
+                "id",
+                DataType::Int(fluss::metadata::IntType::with_nullable(false)),
+            )
+            .column("seq", DataType::BigInt(fluss::metadata::BigIntType::new()))
+            .column(
+                "name",
+                DataType::String(fluss::metadata::StringType::with_nullable(false)),
+            )
+            .primary_key(["id"])
+            .enable_auto_increment("seq")
+            .unwrap()
+            .build()
+            .unwrap();
+        let descriptor = TableDescriptor::builder()
+            .schema(schema)
+            .distributed_by(Some(1), Vec::new())
+            .build()
+            .unwrap();
+        TableInfo::of(TablePath::new("fluss", "counters"), 1, 1, descriptor, 0, 0)
+    }
+
+    /// The auto-increment column is always set, so a partial delete could never collapse the
+    /// row and would always fail on a NOT NULL non-key target column.
+    #[test]
+    fn auto_increment_table_rejects_not_null_target_column() {
+        let table = auto_increment_table_with_not_null_column();
+
+        let error =
+            sparse_targets(&table, Some(&["id".to_string(), "name".to_string()])).unwrap_err();
+        assert!(
+            error.message().contains(
+                "a partial update on a table with an auto-increment column requires every \
+                 target column except the primary key to be nullable, but target column \
+                 `name` is NOT NULL, since the auto-increment column is always set and a \
+                 partial delete could never succeed"
+            ),
+            "got {}",
+            error.message()
+        );
+
+        // the same targets are fine once the auto-increment column is gone
+        let targets = vec!["id".to_string(), "name".to_string()];
+        assert_eq!(
+            sparse_targets(&strict_table_info("strict"), Some(&targets)).unwrap(),
+            Some(targets)
+        );
+    }
+
+    /// Preflight validates the target columns before it looks at any operation, so a delete
+    /// only batch is now rejected too, where it used to decode the primary key and let the
+    /// server judge it per row.
+    #[test]
+    fn auto_increment_table_rejects_a_delete_only_batch_at_preflight() {
+        let table = auto_increment_table_with_not_null_column();
+        let decoder = SchemaDecoder::new(table.row_type().clone()).unwrap();
+        let entries = vec![PreparedEntry {
+            id: "d1".to_string(),
+            operation: Operation::Delete,
+            row_json: br#"{"id":7}"#.to_vec(),
+        }];
+
+        let error = preflight(
+            table,
+            &decoder,
+            &entries,
+            Some(&["id".to_string(), "name".to_string()]),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .message()
+                .contains("but target column `name` is NOT NULL"),
+            "got {}",
+            error.message()
         );
     }
 

--- a/fluss-gateway/src/protocol/rest/records.rs
+++ b/fluss-gateway/src/protocol/rest/records.rs
@@ -291,19 +291,24 @@ fn sparse_targets(
             ));
         }
     }
+    // A listed target column may be NOT NULL. The sparse decoder requires it to be present
+    // with a non-null value in every upsert row.
     for field in fields {
-        if table
-            .get_primary_keys()
-            .iter()
-            .any(|key| key == field.name())
-            || auto_increment.iter().any(|name| name == field.name())
-        {
+        if selected.contains(field.name()) {
             continue;
         }
         if !field.data_type().is_nullable() {
+            if auto_increment.iter().any(|name| name == field.name()) {
+                return Err(RowDecodeError::schema_mismatch(
+                    GatewayError::invalid_argument(format!(
+                        "a partial update requires the auto-increment column `{}` to be nullable, since it is always omitted from the target columns and assigned by the server",
+                        field.name()
+                    )),
+                ));
+            }
             return Err(RowDecodeError::schema_mismatch(
                 GatewayError::invalid_argument(format!(
-                    "a partial update requires every non-primary-key, non-auto-increment column to be nullable, but column `{}` is NOT NULL",
+                    "a partial update requires every column omitted from the target columns to be nullable, but omitted column `{}` is NOT NULL",
                     field.name()
                 )),
             ));
@@ -397,11 +402,12 @@ fn ensure_json_acceptable(headers: &axum::http::HeaderMap) -> GatewayResult<()> 
 pub struct WriteBody<T> {
     /// Columns targeted by every entry in this batch. KV tables only.
     ///
-    /// Every primary-key column must be included, and every non-primary-key,
-    /// non-auto-increment column in the table must be nullable. Missing or explicit-null nullable
-    /// targets are written as null; untargeted columns are preserved. Deletes require only
-    /// primary-key values and clear the targeted non-key columns; the row is removed when all
-    /// non-key columns become null.
+    /// Every primary-key column must be included, and every column omitted from the target
+    /// columns must be nullable. A NOT NULL target column must be present with a non-null value
+    /// in every upsert row. Missing or explicit-null nullable targets are written as null, and
+    /// untargeted columns are preserved. Deletes require only primary-key values and clear the
+    /// targeted non-key columns, so Fluss rejects a delete that would null a NOT NULL target
+    /// column. The row is removed when all non-key columns become null.
     #[serde(default)]
     #[schema(min_items = 1)]
     pub partial_update_columns: Option<Vec<String>>,
@@ -743,8 +749,8 @@ mod tests {
         assert!(sparse_targets(&table, None).unwrap().is_none());
     }
 
-    #[test]
-    fn partial_updates_require_nullable_non_key_columns() {
+    /// A KV table whose non-key column `name` is NOT NULL, legal as a partial-update target.
+    fn strict_table_info(table: &str) -> TableInfo {
         let schema = Schema::builder()
             .column(
                 "id",
@@ -762,11 +768,94 @@ mod tests {
             .distributed_by(Some(1), Vec::new())
             .build()
             .unwrap();
-        let table = TableInfo::of(TablePath::new("fluss", "strict"), 1, 1, descriptor, 0, 0);
+        TableInfo::of(TablePath::new("fluss", table), 1, 1, descriptor, 0, 0)
+    }
 
-        let error =
-            sparse_targets(&table, Some(&["id".to_string(), "name".to_string()])).unwrap_err();
-        assert!(error.message().contains("column `name` is NOT NULL"));
+    #[test]
+    fn partial_updates_require_omitted_columns_to_be_nullable() {
+        let table = strict_table_info("strict");
+
+        let targets = vec!["id".to_string(), "name".to_string()];
+        assert_eq!(
+            sparse_targets(&table, Some(&targets)).unwrap(),
+            Some(targets)
+        );
+
+        let error = sparse_targets(&table, Some(&["id".to_string()])).unwrap_err();
+        assert!(
+            error
+                .message()
+                .contains("omitted column `name` is NOT NULL"),
+            "got {}",
+            error.message()
+        );
+    }
+
+    /// A KV table with one auto-increment column `seq` of the given nullability.
+    fn auto_increment_table_info(seq_nullable: bool) -> TableInfo {
+        let schema = Schema::builder()
+            .column(
+                "id",
+                DataType::Int(fluss::metadata::IntType::with_nullable(false)),
+            )
+            .column(
+                "seq",
+                DataType::BigInt(fluss::metadata::BigIntType::with_nullable(seq_nullable)),
+            )
+            .column("name", DataType::String(fluss::metadata::StringType::new()))
+            .primary_key(["id"])
+            .enable_auto_increment("seq")
+            .unwrap()
+            .build()
+            .unwrap();
+        let descriptor = TableDescriptor::builder()
+            .schema(schema)
+            .distributed_by(Some(1), Vec::new())
+            .build()
+            .unwrap();
+        TableInfo::of(TablePath::new("fluss", "counters"), 1, 1, descriptor, 0, 0)
+    }
+
+    #[test]
+    fn omitted_auto_increment_columns_follow_the_nullable_rule_with_a_dedicated_message() {
+        let error = sparse_targets(&auto_increment_table_info(false), Some(&["id".to_string()]))
+            .unwrap_err();
+        assert!(
+            error.message().contains(
+                "requires the auto-increment column `seq` to be nullable, since it is always \
+                 omitted from the target columns and assigned by the server"
+            ),
+            "got {}",
+            error.message()
+        );
+
+        assert_eq!(
+            sparse_targets(&auto_increment_table_info(true), Some(&["id".to_string()])).unwrap(),
+            Some(vec!["id".to_string()])
+        );
+    }
+
+    /// A delete decodes only the primary key, so a NOT NULL non-key target column is fine at
+    /// preflight and the server judges it per row against the stored data.
+    #[test]
+    fn a_delete_entry_is_accepted_under_a_not_null_target_column() {
+        let table = strict_table_info("strict");
+        let targets = vec!["id".to_string(), "name".to_string()];
+        assert_eq!(
+            sparse_targets(&table, Some(&targets)).unwrap(),
+            Some(targets)
+        );
+
+        let decoder = SchemaDecoder::new(table.row_type().clone()).unwrap();
+        assert!(
+            decoder
+                .decode_row(
+                    "entry `d1`",
+                    br#"{"id":7}"#,
+                    RowShape::Sparse(table.get_primary_keys()),
+                )
+                .is_ok()
+        );
     }
 
     async fn post(app: &axum::Router, path: &str, body: &str) -> (StatusCode, serde_json::Value) {
@@ -1150,5 +1239,58 @@ mod tests {
             recorded[0].as_deref(),
             Some(&["id".to_string(), "name".to_string()][..])
         );
+    }
+
+    /// A NOT NULL target column is legal, but every upsert row must then carry a non-null value
+    /// for it. A row that omits it or sends null is rejected with 400 before submission, the
+    /// endpoint's contract for validation failures.
+    #[tokio::test]
+    async fn a_not_null_target_column_is_accepted_and_enforced_per_row() {
+        let backend = Arc::new(
+            FakeFlussBackend::with_catalog(&[("fluss", &["strict"])])
+                .with_table(strict_table_info("strict")),
+        );
+        let app = app(Arc::clone(&backend));
+        let path = "/v1/clusters/default/databases/fluss/tables/strict/records";
+
+        for (body, expected_in_message) in [
+            (
+                r#"{"partial_update_columns":["id","name"],
+                    "entries":[{"id":"e1","upsert":{"id":1,"name":"ada"}},
+                               {"id":"e2","upsert":{"id":2}}]}"#,
+                "entry `e2`: column `name` is required and was not provided",
+            ),
+            (
+                r#"{"partial_update_columns":["id","name"],
+                    "entries":[{"id":"e1","upsert":{"id":1,"name":"ada"}},
+                               {"id":"e2","upsert":{"id":2,"name":null}}]}"#,
+                "entry `e2`: column `name` must not be null",
+            ),
+            (
+                r#"{"partial_update_columns":["id"],
+                    "entries":[{"id":"e1","upsert":{"id":1}}]}"#,
+                "omitted column `name` is NOT NULL",
+            ),
+        ] {
+            let (status, response) = post(&app, path, body).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+            let message = response["error"]["message"].as_str().unwrap();
+            assert!(
+                message.contains(expected_in_message),
+                "body {body} gave message {message}"
+            );
+        }
+        assert!(backend.writes().is_empty());
+
+        let (status, response) = post(
+            &app,
+            path,
+            r#"{"partial_update_columns":["id","name"],
+                "entries":[{"id":"e1","upsert":{"id":1,"name":"ada"}}]}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(response["success_count"], 1);
+        assert_eq!(backend.writes().len(), 1);
     }
 }

--- a/fluss-rust/crates/fluss/src/client/table/upsert.rs
+++ b/fluss-rust/crates/fluss/src/client/table/upsert.rs
@@ -268,7 +268,7 @@ impl UpsertWriterFactory {
             }
         }
 
-        // an omitted column is written as NULL, so it must be nullable. auto increment columns
+        // an omitted column is written as null, so it must be nullable. auto increment columns
         // are always omitted and only get their value on the server.
         for (i, field) in row_type.fields().iter().enumerate() {
             if !target_column_set[i] && !field.data_type.is_nullable() {

--- a/fluss-rust/crates/fluss/src/client/table/upsert.rs
+++ b/fluss-rust/crates/fluss/src/client/table/upsert.rs
@@ -289,6 +289,24 @@ impl UpsertWriterFactory {
             }
         }
 
+        // the auto increment column is always set, so a partial delete could never collapse
+        // the row and would always fail on a NOT NULL non-primary-key target column.
+        if auto_increment_column_set.any() {
+            for (i, field) in row_type.fields().iter().enumerate() {
+                if target_column_set[i]
+                    && !primary_keys.iter().any(|key| key.as_str() == field.name())
+                    && !field.data_type.is_nullable()
+                {
+                    return Err(IllegalArgument {
+                        message: format!(
+                            "Partial Update on a table with an auto increment column requires all target columns except the primary key to be nullable, but target column {} is NOT NULL, since the auto increment column is always set and a partial delete could therefore never succeed.",
+                            field.name()
+                        ),
+                    });
+                }
+            }
+        }
+
         Ok(())
     }
 }
@@ -608,6 +626,36 @@ mod tests {
             &auto_increment_col_names,
             &target_columns,
         );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn auto_increment_table_rejects_not_null_target_column() {
+        // the auto increment column is always set, so a partial delete could never collapse
+        // the row and would always fail on the NOT NULL target column
+        let row_type = RowType::new(vec![
+            DataField::new("id", DataTypes::int().as_non_nullable(), None),
+            DataField::new("name", DataTypes::string().as_non_nullable(), None),
+            DataField::new("seq", DataTypes::bigint(), None),
+        ]);
+        let primary_keys = vec!["id".to_string()];
+        let auto_increment_col_names = vec!["seq".to_string()];
+        let target_columns = Some(Arc::new(vec![0usize, 1]));
+
+        let result = UpsertWriterFactory::sanity_check(
+            &row_type,
+            &primary_keys,
+            &auto_increment_col_names,
+            &target_columns,
+        );
+
+        assert!(result.unwrap_err().to_string().contains(
+            "Partial Update on a table with an auto increment column requires all target columns except the primary key to be nullable, but target column name is NOT NULL, since the auto increment column is always set and a partial delete could therefore never succeed."
+        ));
+
+        // the same target columns without an auto increment column are fine
+        let result =
+            UpsertWriterFactory::sanity_check(&row_type, &primary_keys, &vec![], &target_columns);
         assert!(result.is_ok());
     }
 }

--- a/fluss-rust/crates/fluss/src/client/table/upsert.rs
+++ b/fluss-rust/crates/fluss/src/client/table/upsert.rs
@@ -225,8 +225,6 @@ impl UpsertWriterFactory {
             target_column_set.set(target_index, true);
         }
 
-        let mut pk_column_set = bitvec![0; field_count];
-
         // check the target columns contains the primary key
         for primary_key in primary_keys {
             let pk_index = row_type.get_field_index(primary_key.as_str());
@@ -241,7 +239,6 @@ impl UpsertWriterFactory {
                             ),
                         });
                     }
-                    pk_column_set.set(pk_index, true);
                 }
                 None => {
                     return Err(IllegalArgument {
@@ -267,24 +264,28 @@ impl UpsertWriterFactory {
                         ),
                     });
                 }
-
                 auto_increment_column_set.set(index, true);
             }
         }
 
-        // check the columns not in targetColumns should be nullable
-        for i in 0..field_count {
-            // column not in primary key and not in auto increment column
-            if !pk_column_set[i] && !auto_increment_column_set[i] {
-                // the column should be nullable
-                if !row_type.fields().get(i).unwrap().data_type.is_nullable() {
+        // an omitted column is written as NULL, so it must be nullable. auto increment columns
+        // are always omitted and only get their value on the server.
+        for (i, field) in row_type.fields().iter().enumerate() {
+            if !target_column_set[i] && !field.data_type.is_nullable() {
+                if auto_increment_column_set[i] {
                     return Err(IllegalArgument {
                         message: format!(
-                            "Partial Update requires all columns except primary key to be nullable, but column {} is NOT NULL.",
-                            row_type.fields().get(i).unwrap().name()
+                            "Partial Update requires the auto increment column {} to be nullable, since it is always omitted from the target columns and assigned by the server.",
+                            field.name()
                         ),
                     });
                 }
+                return Err(IllegalArgument {
+                    message: format!(
+                        "Partial Update requires all columns omitted from the target columns to be nullable, but omitted column {} is NOT NULL.",
+                        field.name()
+                    ),
+                });
             }
         }
 
@@ -534,8 +535,80 @@ mod tests {
         );
 
         assert!(result.unwrap_err().to_string().contains(
-            "Partial Update requires all columns except primary key to be nullable, but column required_field is NOT NULL."
+            "Partial Update requires all columns omitted from the target columns to be nullable, but omitted column required_field is NOT NULL."
         ));
+    }
+
+    #[test]
+    fn not_null_column_in_target_columns_is_accepted() {
+        let row_type = RowType::new(vec![
+            DataField::new("id", DataTypes::int().as_non_nullable(), None),
+            DataField::new(
+                "required_field",
+                DataTypes::string().as_non_nullable(),
+                None,
+            ),
+            DataField::new("optional_field", DataTypes::int(), None),
+        ]);
+        let primary_keys = vec!["id".to_string()];
+        let auto_increment_col_names = vec![];
+
+        // `required_field` is NOT NULL but listed as a target column, so it is always written
+        let target_columns = Some(Arc::new(vec![0usize, 1]));
+        let result = UpsertWriterFactory::sanity_check(
+            &row_type,
+            &primary_keys,
+            &auto_increment_col_names,
+            &target_columns,
+        );
+        assert!(result.is_ok());
+
+        // Listing every column is equally valid.
+        let target_columns = Some(Arc::new(vec![0usize, 1, 2]));
+        let result = UpsertWriterFactory::sanity_check(
+            &row_type,
+            &primary_keys,
+            &auto_increment_col_names,
+            &target_columns,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn omitted_not_null_auto_increment_column_is_rejected() {
+        let row_type = RowType::new(vec![
+            DataField::new("id", DataTypes::int().as_non_nullable(), None),
+            DataField::new("name", DataTypes::string(), None),
+            DataField::new("seq", DataTypes::bigint().as_non_nullable(), None),
+        ]);
+        let primary_keys = vec!["id".to_string()];
+        let auto_increment_col_names = vec!["seq".to_string()];
+        let target_columns = Some(Arc::new(vec![0usize, 1]));
+
+        let result = UpsertWriterFactory::sanity_check(
+            &row_type,
+            &primary_keys,
+            &auto_increment_col_names,
+            &target_columns,
+        );
+
+        assert!(result.unwrap_err().to_string().contains(
+            "Partial Update requires the auto increment column seq to be nullable, since it is always omitted from the target columns and assigned by the server."
+        ));
+
+        // The same table with a nullable auto increment column is fine.
+        let row_type = RowType::new(vec![
+            DataField::new("id", DataTypes::int().as_non_nullable(), None),
+            DataField::new("name", DataTypes::string(), None),
+            DataField::new("seq", DataTypes::bigint(), None),
+        ]);
+        let result = UpsertWriterFactory::sanity_check(
+            &row_type,
+            &primary_keys,
+            &auto_increment_col_names,
+            &target_columns,
+        );
+        assert!(result.is_ok());
     }
 }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/partialupdate/PartialUpdater.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/partialupdate/PartialUpdater.java
@@ -44,6 +44,14 @@ public class PartialUpdater {
     private final boolean updatePrimaryKeyOnly;
     private final DataType[] fieldDataTypes;
 
+    /** The target columns that are NOT NULL, checked by {@link #updateRow}. */
+    private final BitSet notNullTargetCols = new BitSet();
+
+    /** The same columns without the primary key, checked by {@link #deleteRow}. */
+    private final BitSet notNullNonPkTargetCols = new BitSet();
+
+    private final String[] fieldNames;
+
     public PartialUpdater(KvFormat kvFormat, short schemaId, Schema schema, int[] targetColumns) {
         this.targetSchemaId = schemaId;
         for (int targetColumn : targetColumns) {
@@ -54,6 +62,15 @@ public class PartialUpdater {
         }
         this.fieldDataTypes = schema.getRowType().getChildren().toArray(new DataType[0]);
         sanityCheck(schema, targetColumns);
+        this.fieldNames = schema.getRowType().getFieldNames().toArray(new String[0]);
+        for (int i = 0; i < fieldDataTypes.length; i++) {
+            if (partialUpdateCols.get(i) && !fieldDataTypes[i].isNullable()) {
+                notNullTargetCols.set(i);
+                if (!primaryKeyCols.get(i)) {
+                    notNullNonPkTargetCols.set(i);
+                }
+            }
+        }
 
         // getter for the fields in row
         flussFieldGetters = new InternalRow.FieldGetter[fieldDataTypes.length];
@@ -65,7 +82,6 @@ public class PartialUpdater {
     }
 
     private void sanityCheck(Schema schema, int[] targetColumns) {
-        BitSet pkColumnSet = new BitSet();
         // check the target columns contains the primary key
         for (int pkIndex : schema.getPrimaryKeyIndexes()) {
             if (!partialUpdateCols.get(pkIndex)) {
@@ -75,19 +91,28 @@ public class PartialUpdater {
                                 schema.getColumnNames(targetColumns),
                                 schema.getColumnNames(schema.getPrimaryKeyIndexes())));
             }
-            pkColumnSet.set(pkIndex);
         }
 
-        // check the columns not in targetColumns should be nullable
+        BitSet autoIncrementCols = new BitSet();
+        for (String name : schema.getAutoIncrementColumnNames()) {
+            autoIncrementCols.set(schema.getRowType().getFieldIndex(name));
+        }
+
+        // an omitted column is written as null, so it must be nullable. auto increment columns
+        // are always omitted and only get their value after the merge.
         for (int i = 0; i < fieldDataTypes.length; i++) {
-            // the columns not in primary key should be nullable
-            if (!pkColumnSet.get(i)) {
-                if (!fieldDataTypes[i].isNullable()) {
+            if (!partialUpdateCols.get(i) && !fieldDataTypes[i].isNullable()) {
+                String columnName = schema.getRowType().getFieldNames().get(i);
+                if (autoIncrementCols.get(i)) {
                     throw new InvalidTargetColumnException(
                             String.format(
-                                    "Partial Update requires all columns except primary key to be nullable, but column %s is NOT NULL.",
-                                    schema.getRowType().getFieldNames().get(i)));
+                                    "Partial Update requires the auto increment column %s to be nullable, since it is always omitted from the target columns and assigned by the server.",
+                                    columnName));
                 }
+                throw new InvalidTargetColumnException(
+                        String.format(
+                                "Partial Update requires all columns omitted from the target columns to be nullable, but omitted column %s is NOT NULL.",
+                                columnName));
             }
         }
     }
@@ -106,6 +131,8 @@ public class PartialUpdater {
             // only primary key columns are updated, return the old value directly
             return oldValue;
         }
+
+        checkNotNullTargetCols(partialValue);
 
         rowEncoder.startNewRow();
         // write each field
@@ -127,6 +154,23 @@ public class PartialUpdater {
     }
 
     /**
+     * Rejects a null in a non-nullable slot, which would desynchronise the encoded row. Runs before
+     * any field getter, since a getter deserialises the whole row and would fail first.
+     */
+    private void checkNotNullTargetCols(BinaryValue partialValue) {
+        for (int i = notNullTargetCols.nextSetBit(0);
+                i >= 0;
+                i = notNullTargetCols.nextSetBit(i + 1)) {
+            if (partialValue.row.isNullAt(i)) {
+                throw new InvalidTargetColumnException(
+                        String.format(
+                                "Target column %s is NOT NULL but the written row has no value for it.",
+                                fieldNames[i]));
+            }
+        }
+    }
+
+    /**
      * Partial delete the given {@code value}. If all the fields except for {@link
      * #partialUpdateCols} in {@code value.row} are null, return null. Otherwise, update all the
      * {@link #partialUpdateCols} in the {@code value.row} except for the primary key columns to
@@ -134,11 +178,20 @@ public class PartialUpdater {
      *
      * @param value the value to be deleted
      * @return the value after partial deleted
+     * @throws InvalidTargetColumnException if a non-primary-key target column is NOT NULL, since it
+     *     would have to be set to null
      */
     public @Nullable BinaryValue deleteRow(BinaryValue value) {
         if (isFieldsNull(value.row, partialUpdateCols)) {
+            // the whole row is removed, so no column is set to null
             return null;
         } else {
+            if (!notNullNonPkTargetCols.isEmpty()) {
+                throw new InvalidTargetColumnException(
+                        String.format(
+                                "Partial Delete sets the target columns to null, so it requires all target columns except primary key to be nullable, but target column %s is NOT NULL.",
+                                fieldNames[notNullNonPkTargetCols.nextSetBit(0)]));
+            }
             rowEncoder.startNewRow();
             // write each field
             for (int i = 0; i < fieldDataTypes.length; i++) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/partialupdate/PartialUpdater.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/partialupdate/PartialUpdater.java
@@ -154,8 +154,8 @@ public class PartialUpdater {
     }
 
     /**
-     * Rejects a null in a non-nullable slot, which would desynchronise the encoded row. Runs before
-     * any field getter, since a getter deserialises the whole row and would fail first.
+     * Rejects a null in a non-nullable slot, which would corrupt the encoded row. Runs before any
+     * field getter, since a getter deserializes the whole row and would fail first.
      */
     private void checkNotNullTargetCols(BinaryValue partialValue) {
         for (int i = notNullTargetCols.nextSetBit(0);

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/partialupdate/PartialUpdater.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/partialupdate/PartialUpdater.java
@@ -61,7 +61,6 @@ public class PartialUpdater {
             primaryKeyCols.set(pkIndex);
         }
         this.fieldDataTypes = schema.getRowType().getChildren().toArray(new DataType[0]);
-        sanityCheck(schema, targetColumns);
         this.fieldNames = schema.getRowType().getFieldNames().toArray(new String[0]);
         for (int i = 0; i < fieldDataTypes.length; i++) {
             if (partialUpdateCols.get(i) && !fieldDataTypes[i].isNullable()) {
@@ -71,6 +70,7 @@ public class PartialUpdater {
                 }
             }
         }
+        sanityCheck(schema, targetColumns);
 
         // getter for the fields in row
         flussFieldGetters = new InternalRow.FieldGetter[fieldDataTypes.length];
@@ -114,6 +114,15 @@ public class PartialUpdater {
                                 "Partial Update requires all columns omitted from the target columns to be nullable, but omitted column %s is NOT NULL.",
                                 columnName));
             }
+        }
+
+        // the auto increment column is always set, so a partial delete could never collapse
+        // the row and would always fail on a NOT NULL non-primary-key target column.
+        if (!autoIncrementCols.isEmpty() && !notNullNonPkTargetCols.isEmpty()) {
+            throw new InvalidTargetColumnException(
+                    String.format(
+                            "Partial Update on a table with an auto increment column requires all target columns except the primary key to be nullable, but target column %s is NOT NULL, since the auto increment column is always set and a partial delete could therefore never succeed.",
+                            fieldNames[notNullNonPkTargetCols.nextSetBit(0)]));
         }
     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
@@ -703,6 +703,69 @@ class KvTabletTest {
     }
 
     @Test
+    void testIgnoreDeleteBehaviorSkipsPartialDeleteRejection() throws Exception {
+        final Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.STRING())
+                        .column("c", new StringType(false))
+                        .primaryKey("a")
+                        .build();
+        Map<String, String> config = new HashMap<>();
+        config.put("table.delete.behavior", "ignore");
+        initLogTabletAndKvTablet(schema, config);
+        KvRecordTestUtils.KvRecordFactory recordFactory =
+                KvRecordTestUtils.KvRecordFactory.of(schema.getRowType());
+        kvTablet.putAsLeader(
+                kvRecordBatchFactory.ofRecords(
+                        Collections.singletonList(
+                                recordFactory.ofRecord(
+                                        "k1".getBytes(), new Object[] {1, "bbb", "str"}))),
+                null);
+
+        // the delete is dropped before the partial delete runs, so the NOT NULL target column c
+        // is never nulled and the row survives untouched
+        KvRecordBatch deleteBatch =
+                kvRecordBatchFactory.ofRecords(
+                        Collections.singletonList(recordFactory.ofRecord("k1".getBytes(), null)));
+        assertThatCode(() -> kvTablet.putAsLeader(deleteBatch, new int[] {0, 2}))
+                .doesNotThrowAnyException();
+        assertThat(kvTablet.getKvPreWriteBuffer().get(Key.of("k1".getBytes()))).isNotNull();
+    }
+
+    @Test
+    void testIgnoreDeleteBehaviorStillRejectsAutoIncrementNotNullTargetColumn() throws Exception {
+        final Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", new StringType(false))
+                        .column("c", DataTypes.BIGINT())
+                        .primaryKey("a")
+                        .enableAutoIncrement("c")
+                        .build();
+        Map<String, String> config = new HashMap<>();
+        config.put("table.delete.behavior", "ignore");
+        initLogTabletAndKvTablet(schema, config);
+        KvRecordTestUtils.KvRecordFactory recordFactory =
+                KvRecordTestUtils.KvRecordFactory.of(schema.getRowType());
+        KvRecordBatch kvRecordBatch =
+                kvRecordBatchFactory.ofRecords(
+                        Collections.singletonList(
+                                recordFactory.ofRecord(
+                                        "k1".getBytes(), new Object[] {1, "b", 1L})));
+
+        // the rejection happens when the target columns are configured, so it fires even though
+        // no delete could ever reach the partial delete path on this table
+        assertThatThrownBy(() -> kvTablet.putAsLeader(kvRecordBatch, new int[] {0, 1}))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage(
+                        "Partial Update on a table with an auto increment column requires all target columns "
+                                + "except the primary key to be nullable, but target column b is NOT NULL, "
+                                + "since the auto increment column is always set and a partial delete could "
+                                + "therefore never succeed.");
+    }
+
+    @Test
     void testPartialUpdateAndDelete() throws Exception {
         initLogTabletAndKvTablet(DATA2_SCHEMA, new HashMap<>());
         RowType rowType = DATA2_SCHEMA.getRowType();

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
@@ -648,14 +648,45 @@ class KvTabletTest {
                         Collections.singletonList(
                                 data2kvRecordFactory.ofRecord(
                                         "k1".getBytes(), new Object[] {1, null, "str"})));
+        // column c is omitted from the target columns, so it would be written as null
         assertThatThrownBy(() -> kvTablet.putAsLeader(kvRecordBatch, new int[] {0, 1}))
                 .isInstanceOf(InvalidTargetColumnException.class)
                 .hasMessage(
-                        "Partial Update requires all columns except primary key to be nullable, but column c is NOT NULL.");
-        assertThatThrownBy(() -> kvTablet.putAsLeader(kvRecordBatch, new int[] {0, 2}))
+                        "Partial Update requires all columns omitted from the target columns to be nullable, "
+                                + "but omitted column c is NOT NULL.");
+        // column c is listed in the target columns, so it is always provided by the writer
+        assertThatCode(() -> kvTablet.putAsLeader(kvRecordBatch, new int[] {0, 2}))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testPartialDeleteWithNotNullTargetColumn() throws Exception {
+        final Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.STRING())
+                        .column("c", new StringType(false))
+                        .primaryKey("a")
+                        .build();
+        initLogTabletAndKvTablet(schema, new HashMap<>());
+        KvRecordTestUtils.KvRecordFactory recordFactory =
+                KvRecordTestUtils.KvRecordFactory.of(schema.getRowType());
+        // seed a full row so the delete really has to null out column c
+        kvTablet.putAsLeader(
+                kvRecordBatchFactory.ofRecords(
+                        Collections.singletonList(
+                                recordFactory.ofRecord(
+                                        "k1".getBytes(), new Object[] {1, "bbb", "str"}))),
+                null);
+
+        KvRecordBatch deleteBatch =
+                kvRecordBatchFactory.ofRecords(
+                        Collections.singletonList(recordFactory.ofRecord("k1".getBytes(), null)));
+        assertThatThrownBy(() -> kvTablet.putAsLeader(deleteBatch, new int[] {0, 2}))
                 .isInstanceOf(InvalidTargetColumnException.class)
                 .hasMessage(
-                        "Partial Update requires all columns except primary key to be nullable, but column c is NOT NULL.");
+                        "Partial Delete sets the target columns to null, so it requires all target columns "
+                                + "except primary key to be nullable, but target column c is NOT NULL.");
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
@@ -320,14 +320,45 @@ class KvTabletTest {
                         Collections.singletonList(
                                 data2kvRecordFactory.ofRecord(
                                         "k1".getBytes(), new Object[] {1, null, "str"})));
+        // column c is omitted from the target columns, so it would be written as null
         assertThatThrownBy(() -> kvTablet.putAsLeader(kvRecordBatch, new int[] {0, 1}))
                 .isInstanceOf(InvalidTargetColumnException.class)
                 .hasMessage(
-                        "Partial Update requires all columns except primary key to be nullable, but column c is NOT NULL.");
-        assertThatThrownBy(() -> kvTablet.putAsLeader(kvRecordBatch, new int[] {0, 2}))
+                        "Partial Update requires all columns omitted from the target columns to be nullable, "
+                                + "but omitted column c is NOT NULL.");
+        // column c is listed in the target columns, so it is always provided by the writer
+        assertThatCode(() -> kvTablet.putAsLeader(kvRecordBatch, new int[] {0, 2}))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testPartialDeleteWithNotNullTargetColumn() throws Exception {
+        final Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.STRING())
+                        .column("c", new StringType(false))
+                        .primaryKey("a")
+                        .build();
+        initLogTabletAndKvTablet(schema, new HashMap<>());
+        KvRecordTestUtils.KvRecordFactory recordFactory =
+                KvRecordTestUtils.KvRecordFactory.of(schema.getRowType());
+        // seed a full row so the delete really has to null out column c
+        kvTablet.putAsLeader(
+                kvRecordBatchFactory.ofRecords(
+                        Collections.singletonList(
+                                recordFactory.ofRecord(
+                                        "k1".getBytes(), new Object[] {1, "bbb", "str"}))),
+                null);
+
+        KvRecordBatch deleteBatch =
+                kvRecordBatchFactory.ofRecords(
+                        Collections.singletonList(recordFactory.ofRecord("k1".getBytes(), null)));
+        assertThatThrownBy(() -> kvTablet.putAsLeader(deleteBatch, new int[] {0, 2}))
                 .isInstanceOf(InvalidTargetColumnException.class)
                 .hasMessage(
-                        "Partial Update requires all columns except primary key to be nullable, but column c is NOT NULL.");
+                        "Partial Delete sets the target columns to null, so it requires all target columns "
+                                + "except primary key to be nullable, but target column c is NOT NULL.");
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
@@ -687,6 +687,19 @@ class KvTabletTest {
                 .hasMessage(
                         "Partial Delete sets the target columns to null, so it requires all target columns "
                                 + "except primary key to be nullable, but target column c is NOT NULL.");
+
+        // b is already null for k2, so the delete removes the whole row and nulls no column
+        kvTablet.putAsLeader(
+                kvRecordBatchFactory.ofRecords(
+                        Collections.singletonList(
+                                recordFactory.ofRecord(
+                                        "k2".getBytes(), new Object[] {2, null, "str"}))),
+                null);
+        KvRecordBatch wholeRowDeleteBatch =
+                kvRecordBatchFactory.ofRecords(
+                        Collections.singletonList(recordFactory.ofRecord("k2".getBytes(), null)));
+        assertThatCode(() -> kvTablet.putAsLeader(wholeRowDeleteBatch, new int[] {0, 2}))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/partialupdate/PartialUpdaterTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/partialupdate/PartialUpdaterTest.java
@@ -21,8 +21,8 @@ import org.apache.fluss.exception.InvalidTargetColumnException;
 import org.apache.fluss.metadata.KvFormat;
 import org.apache.fluss.metadata.Schema;
 import org.apache.fluss.record.BinaryValue;
-import org.apache.fluss.row.compacted.CompactedRow;
-import org.apache.fluss.row.compacted.CompactedRowDeserializer;
+import org.apache.fluss.row.BinaryRow;
+import org.apache.fluss.row.decode.RowDecoder;
 import org.apache.fluss.types.BigIntType;
 import org.apache.fluss.types.DataType;
 import org.apache.fluss.types.DataTypes;
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.apache.fluss.testutils.DataTestUtils.compactedRow;
+import static org.apache.fluss.testutils.DataTestUtils.indexedRow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -146,13 +147,17 @@ class PartialUpdaterTest {
 
         BinaryValue merged =
                 partialUpdater.updateRow(
-                        binaryValue(SCHEMA, 1, "old", "oldC"), row(1, null, "newC"));
+                        binaryValue(kvFormat, SCHEMA, 1, "old", "oldC"),
+                        row(kvFormat, 1, null, "newC"));
         assertThat(merged.row.getString(1).toString()).isEqualTo("old");
         assertThat(merged.row.getString(2).toString()).isEqualTo("newC");
 
         // a null in a non-nullable slot has to be caught rather than encoded. the row is typed
         // with SCHEMA as the server types it, so the guard has to fire before any deserialization
-        assertThatThrownBy(() -> partialUpdater.updateRow(null, asServerTypedRow(1, "b", null)))
+        assertThatThrownBy(
+                        () ->
+                                partialUpdater.updateRow(
+                                        null, asServerTypedRow(kvFormat, 1, "b", null)))
                 .isInstanceOf(InvalidTargetColumnException.class)
                 .hasMessage("Target column c is NOT NULL but the written row has no value for it.");
     }
@@ -163,14 +168,15 @@ class PartialUpdaterTest {
         PartialUpdater partialUpdater =
                 new PartialUpdater(kvFormat, SCHEMA_ID, SCHEMA, new int[] {0, 2});
 
-        assertThatThrownBy(() -> partialUpdater.deleteRow(binaryValue(SCHEMA, 1, "b", "c")))
+        assertThatThrownBy(
+                        () -> partialUpdater.deleteRow(binaryValue(kvFormat, SCHEMA, 1, "b", "c")))
                 .isInstanceOf(InvalidTargetColumnException.class)
                 .hasMessage(
                         "Partial Delete sets the target columns to null, so it requires all target columns "
                                 + "except primary key to be nullable, but target column c is NOT NULL.");
 
         // b is already null, so the row is removed outright and nothing is nulled
-        assertThat(partialUpdater.deleteRow(binaryValue(SCHEMA, 1, null, "c"))).isNull();
+        assertThat(partialUpdater.deleteRow(binaryValue(kvFormat, SCHEMA, 1, null, "c"))).isNull();
     }
 
     @ParameterizedTest
@@ -179,7 +185,8 @@ class PartialUpdaterTest {
         PartialUpdater partialUpdater =
                 new PartialUpdater(kvFormat, SCHEMA_ID, NULLABLE_SCHEMA, new int[] {0, 2});
 
-        BinaryValue deleted = partialUpdater.deleteRow(binaryValue(NULLABLE_SCHEMA, 1, "b", "c"));
+        BinaryValue deleted =
+                partialUpdater.deleteRow(binaryValue(kvFormat, NULLABLE_SCHEMA, 1, "b", "c"));
 
         assertThat(deleted).isNotNull();
         assertThat(deleted.row.getString(1).toString()).isEqualTo("b");
@@ -201,26 +208,34 @@ class PartialUpdaterTest {
     }
 
     /** A row of {@link #NULLABLE_SCHEMA}, usable as the partial value for any of the schemas. */
-    private static BinaryValue row(int a, String b, String c) {
-        return binaryValue(NULLABLE_SCHEMA, a, b, c);
+    private static BinaryValue row(KvFormat kvFormat, int a, String b, String c) {
+        return binaryValue(kvFormat, NULLABLE_SCHEMA, a, b, c);
     }
 
     /**
      * The same bytes as {@link #row}, but typed with {@link #SCHEMA} the way the server types an
-     * incoming record. Reading any field of it deserializes the whole row and fails on the null
-     * that {@code c} is not allowed to hold.
+     * incoming record. Both formats size the null-bit header from the field count alone, and the
+     * guard reads only that header, so the null in {@code c} reaches the guard.
      */
-    private static BinaryValue asServerTypedRow(int a, String b, String c) {
-        CompactedRow encoded = compactedRow(NULLABLE_SCHEMA.getRowType(), new Object[] {a, b, c});
+    private static BinaryValue asServerTypedRow(KvFormat kvFormat, int a, String b, String c) {
+        BinaryRow encoded = encodeRow(kvFormat, NULLABLE_SCHEMA, a, b, c);
         byte[] bytes = new byte[encoded.getSizeInBytes()];
         encoded.copyTo(bytes, 0);
         DataType[] types = SCHEMA.getRowType().getChildren().toArray(new DataType[0]);
-        return new BinaryValue(
-                SCHEMA_ID, CompactedRow.from(types, bytes, new CompactedRowDeserializer(types)));
+        return new BinaryValue(SCHEMA_ID, RowDecoder.create(kvFormat, types).decode(bytes));
     }
 
-    private static BinaryValue binaryValue(Schema schema, int a, String b, String c) {
-        return new BinaryValue(
-                SCHEMA_ID, compactedRow(schema.getRowType(), new Object[] {a, b, c}));
+    private static BinaryValue binaryValue(
+            KvFormat kvFormat, Schema schema, int a, String b, String c) {
+        return new BinaryValue(SCHEMA_ID, encodeRow(kvFormat, schema, a, b, c));
+    }
+
+    /** Builds the row in the concrete type of the kv format, as the server read path does. */
+    private static BinaryRow encodeRow(
+            KvFormat kvFormat, Schema schema, int a, String b, String c) {
+        Object[] values = new Object[] {a, b, c};
+        return kvFormat == KvFormat.INDEXED
+                ? indexedRow(schema.getRowType(), values)
+                : compactedRow(schema.getRowType(), values);
     }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/partialupdate/PartialUpdaterTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/partialupdate/PartialUpdaterTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.kv.partialupdate;
+
+import org.apache.fluss.exception.InvalidTargetColumnException;
+import org.apache.fluss.metadata.KvFormat;
+import org.apache.fluss.metadata.Schema;
+import org.apache.fluss.record.BinaryValue;
+import org.apache.fluss.row.compacted.CompactedRow;
+import org.apache.fluss.row.compacted.CompactedRowDeserializer;
+import org.apache.fluss.types.BigIntType;
+import org.apache.fluss.types.DataType;
+import org.apache.fluss.types.DataTypes;
+import org.apache.fluss.types.StringType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.apache.fluss.testutils.DataTestUtils.compactedRow;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link PartialUpdater} target column validation. */
+class PartialUpdaterTest {
+
+    private static final short SCHEMA_ID = 1;
+
+    private static final String OMITTED_NOT_NULL_MESSAGE =
+            "Partial Update requires all columns omitted from the target columns to be nullable, "
+                    + "but omitted column c is NOT NULL.";
+
+    /** {@code a INT NOT NULL} (primary key), {@code b STRING}, {@code c STRING NOT NULL}. */
+    private static final Schema SCHEMA =
+            Schema.newBuilder()
+                    .column("a", DataTypes.INT())
+                    .column("b", DataTypes.STRING())
+                    .column("c", new StringType(false))
+                    .primaryKey("a")
+                    .build();
+
+    /** {@code (a, b)} primary key, {@code c STRING NOT NULL}, {@code d STRING}. */
+    private static final Schema COMPOSITE_PK_SCHEMA =
+            Schema.newBuilder()
+                    .column("a", DataTypes.INT())
+                    .column("b", DataTypes.STRING())
+                    .column("c", new StringType(false))
+                    .column("d", DataTypes.STRING())
+                    .primaryKey("a", "b")
+                    .build();
+
+    /** Same shape as {@link #SCHEMA} but with a nullable {@code c}. */
+    private static final Schema NULLABLE_SCHEMA =
+            Schema.newBuilder()
+                    .column("a", DataTypes.INT())
+                    .column("b", DataTypes.STRING())
+                    .column("c", DataTypes.STRING())
+                    .primaryKey("a")
+                    .build();
+
+    @ParameterizedTest
+    @EnumSource(KvFormat.class)
+    void testNullabilityIsRequiredOnlyForOmittedColumns(KvFormat kvFormat) {
+        // c is NOT NULL, so it is accepted as a target column and rejected when omitted
+        assertThatCode(() -> new PartialUpdater(kvFormat, SCHEMA_ID, SCHEMA, new int[] {0, 2}))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> new PartialUpdater(kvFormat, SCHEMA_ID, SCHEMA, new int[] {0, 1, 2}))
+                .doesNotThrowAnyException();
+        assertThatThrownBy(() -> new PartialUpdater(kvFormat, SCHEMA_ID, SCHEMA, new int[] {0, 1}))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage(OMITTED_NOT_NULL_MESSAGE);
+
+        // every column of a composite primary key is NOT NULL and always a target column
+        assertThatCode(
+                        () ->
+                                new PartialUpdater(
+                                        kvFormat,
+                                        SCHEMA_ID,
+                                        COMPOSITE_PK_SCHEMA,
+                                        new int[] {0, 1, 2}))
+                .doesNotThrowAnyException();
+        assertThatThrownBy(
+                        () ->
+                                new PartialUpdater(
+                                        kvFormat,
+                                        SCHEMA_ID,
+                                        COMPOSITE_PK_SCHEMA,
+                                        new int[] {0, 1, 3}))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage(OMITTED_NOT_NULL_MESSAGE);
+    }
+
+    @Test
+    void testTargetColumnsMustContainPrimaryKey() {
+        assertThatThrownBy(() -> createPartialUpdater(SCHEMA, new int[] {1, 2}))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage(
+                        "The target write columns [b, c] must contain the primary key columns [a].");
+        assertThatThrownBy(() -> createPartialUpdater(COMPOSITE_PK_SCHEMA, new int[] {0, 2, 3}))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage(
+                        "The target write columns [a, c, d] must contain the primary key columns [a, b].");
+    }
+
+    @Test
+    void testAutoIncrementColumnMustBeNullable() {
+        // an auto increment column is always omitted and only gets its value after the merge,
+        // so updateRow writes null into it first
+        assertThatThrownBy(
+                        () ->
+                                createPartialUpdater(
+                                        autoIncrementSchema(new BigIntType(false)),
+                                        new int[] {0, 1}))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage(
+                        "Partial Update requires the auto increment column c to be nullable, "
+                                + "since it is always omitted from the target columns and assigned by the server.");
+        assertThatCode(
+                        () ->
+                                createPartialUpdater(
+                                        autoIncrementSchema(DataTypes.BIGINT()), new int[] {0, 1}))
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @EnumSource(KvFormat.class)
+    void testUpdateRowKeepsOmittedColumnsAndRejectsNullInNotNullTargetColumn(KvFormat kvFormat) {
+        PartialUpdater partialUpdater =
+                new PartialUpdater(kvFormat, SCHEMA_ID, SCHEMA, new int[] {0, 2});
+
+        BinaryValue merged =
+                partialUpdater.updateRow(
+                        binaryValue(SCHEMA, 1, "old", "oldC"), row(1, null, "newC"));
+        assertThat(merged.row.getString(1).toString()).isEqualTo("old");
+        assertThat(merged.row.getString(2).toString()).isEqualTo("newC");
+
+        // a null in a non-nullable slot has to be caught rather than encoded. the row is typed
+        // with SCHEMA as the server types it, so the guard has to fire before any deserialization
+        assertThatThrownBy(() -> partialUpdater.updateRow(null, asServerTypedRow(1, "b", null)))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage("Target column c is NOT NULL but the written row has no value for it.");
+    }
+
+    @ParameterizedTest
+    @EnumSource(KvFormat.class)
+    void testDeleteRowRejectsNotNullTargetColumnUnlessWholeRowIsRemoved(KvFormat kvFormat) {
+        PartialUpdater partialUpdater =
+                new PartialUpdater(kvFormat, SCHEMA_ID, SCHEMA, new int[] {0, 2});
+
+        assertThatThrownBy(() -> partialUpdater.deleteRow(binaryValue(SCHEMA, 1, "b", "c")))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage(
+                        "Partial Delete sets the target columns to null, so it requires all target columns "
+                                + "except primary key to be nullable, but target column c is NOT NULL.");
+
+        // b is already null, so the row is removed outright and nothing is nulled
+        assertThat(partialUpdater.deleteRow(binaryValue(SCHEMA, 1, null, "c"))).isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(KvFormat.class)
+    void testDeleteRowSetsNullableTargetColumnsToNull(KvFormat kvFormat) {
+        PartialUpdater partialUpdater =
+                new PartialUpdater(kvFormat, SCHEMA_ID, NULLABLE_SCHEMA, new int[] {0, 2});
+
+        BinaryValue deleted = partialUpdater.deleteRow(binaryValue(NULLABLE_SCHEMA, 1, "b", "c"));
+
+        assertThat(deleted).isNotNull();
+        assertThat(deleted.row.getString(1).toString()).isEqualTo("b");
+        assertThat(deleted.row.isNullAt(2)).isTrue();
+    }
+
+    private static PartialUpdater createPartialUpdater(Schema schema, int[] targetColumns) {
+        return new PartialUpdater(KvFormat.COMPACTED, SCHEMA_ID, schema, targetColumns);
+    }
+
+    private static Schema autoIncrementSchema(DataType autoIncrementType) {
+        return Schema.newBuilder()
+                .column("a", DataTypes.INT())
+                .column("b", DataTypes.STRING())
+                .column("c", autoIncrementType)
+                .primaryKey("a")
+                .enableAutoIncrement("c")
+                .build();
+    }
+
+    /** A row of {@link #NULLABLE_SCHEMA}, usable as the partial value for any of the schemas. */
+    private static BinaryValue row(int a, String b, String c) {
+        return binaryValue(NULLABLE_SCHEMA, a, b, c);
+    }
+
+    /**
+     * The same bytes as {@link #row}, but typed with {@link #SCHEMA} the way the server types an
+     * incoming record. Reading any field of it deserialises the whole row and fails on the null
+     * that {@code c} is not allowed to hold.
+     */
+    private static BinaryValue asServerTypedRow(int a, String b, String c) {
+        CompactedRow encoded = compactedRow(NULLABLE_SCHEMA.getRowType(), new Object[] {a, b, c});
+        byte[] bytes = new byte[encoded.getSizeInBytes()];
+        encoded.copyTo(bytes, 0);
+        DataType[] types = SCHEMA.getRowType().getChildren().toArray(new DataType[0]);
+        return new BinaryValue(
+                SCHEMA_ID, CompactedRow.from(types, bytes, new CompactedRowDeserializer(types)));
+    }
+
+    private static BinaryValue binaryValue(Schema schema, int a, String b, String c) {
+        return new BinaryValue(
+                SCHEMA_ID, compactedRow(schema.getRowType(), new Object[] {a, b, c}));
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/partialupdate/PartialUpdaterTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/partialupdate/PartialUpdaterTest.java
@@ -139,6 +139,46 @@ class PartialUpdaterTest {
                 .doesNotThrowAnyException();
     }
 
+    @Test
+    void testAutoIncrementTableRejectsNotNullTargetColumn() {
+        // the auto increment column is always set, so a partial delete can never collapse the
+        // row and would always fail on the NOT NULL target column b
+        Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", new BigIntType(false))
+                        .column("c", DataTypes.BIGINT())
+                        .primaryKey("a")
+                        .enableAutoIncrement("c")
+                        .build();
+        assertThatThrownBy(() -> createPartialUpdater(schema, new int[] {0, 1}))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage(
+                        "Partial Update on a table with an auto increment column requires all target columns "
+                                + "except the primary key to be nullable, but target column b is NOT NULL, "
+                                + "since the auto increment column is always set and a partial delete could "
+                                + "therefore never succeed.");
+    }
+
+    @Test
+    void testNotNullAutoIncrementColumnIsReportedBeforeTheNotNullTargetColumn() {
+        // both rules apply here, and the auto increment column's own nullability is the more
+        // basic defect, so it has to be the one reported
+        Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", new BigIntType(false))
+                        .column("c", new BigIntType(false))
+                        .primaryKey("a")
+                        .enableAutoIncrement("c")
+                        .build();
+        assertThatThrownBy(() -> createPartialUpdater(schema, new int[] {0, 1}))
+                .isInstanceOf(InvalidTargetColumnException.class)
+                .hasMessage(
+                        "Partial Update requires the auto increment column c to be nullable, "
+                                + "since it is always omitted from the target columns and assigned by the server.");
+    }
+
     @ParameterizedTest
     @EnumSource(KvFormat.class)
     void testUpdateRowKeepsOmittedColumnsAndRejectsNullInNotNullTargetColumn(KvFormat kvFormat) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/partialupdate/PartialUpdaterTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/partialupdate/PartialUpdaterTest.java
@@ -207,7 +207,7 @@ class PartialUpdaterTest {
 
     /**
      * The same bytes as {@link #row}, but typed with {@link #SCHEMA} the way the server types an
-     * incoming record. Reading any field of it deserialises the whole row and fails on the null
+     * incoming record. Reading any field of it deserializes the whole row and fails on the null
      * that {@code c} is not allowed to hold.
      */
     private static BinaryValue asServerTypedRow(int a, String b, String c) {

--- a/website/docs/table-design/table-types/pk-table.md
+++ b/website/docs/table-design/table-types/pk-table.md
@@ -74,6 +74,21 @@ follows:
 | 1 | 2.0 | t1 |
 | 2 | 3.0 | t2 |
 
+### Nullability requirements
+
+A column left out of the written columns is set to `null` when the row does not exist yet, so every column outside the
+written columns must be nullable. Columns that are written are always supplied by the writer, so they may be declared
+`NOT NULL`. An auto increment column is always left out of the written columns and only receives its value on the
+server, so it must be nullable as well.
+
+Partial delete has a stricter requirement. It sets the written columns other than the primary key to `null`, so it is
+rejected when one of them is `NOT NULL`, unless every column outside the written columns is already `null`, in which
+case the whole row is removed instead.
+
+Tables using the `aggregation` merge engine keep the stricter rule for partial update as well: every column other than
+the primary key must be nullable, including the written ones. The write is rejected by the server rather than when the
+writer is created.
+
 ## Merge Engines
 
 The **Merge Engine** in Fluss is a core component designed to efficiently handle and consolidate data updates for Primary Key Tables.

--- a/website/docs/table-design/table-types/pk-table.md
+++ b/website/docs/table-design/table-types/pk-table.md
@@ -85,6 +85,27 @@ Partial delete has a stricter requirement. It sets the target columns other than
 rejected when one of them is `NOT NULL`, unless every column outside the target columns is already `null`, in which
 case the whole row is removed instead.
 
+In practice this means that deletes are not available by default when the target columns include a `NOT NULL` column
+outside the primary key. Every partial delete on such a table is rejected, except in the rare case where every column
+outside the target columns is already `null` and the row collapses into a whole-row removal.
+
+If you do not need deletes on such a table, set the table property `table.delete.behavior` to `ignore` to drop delete
+requests silently, or to `disable` to fail them with a `DeletionDisabledException`. Both settings take effect before
+the partial delete is attempted, so the rejection above no longer occurs. See the
+[storage options](/engine-flink/options.md#storage-options) for details.
+
+When writing with a streaming Flink sink, note that `sink.ignore-delete` defaults to `false`, so the job fails on the
+first `-U` or `-D` record it receives and keeps restarting. Set `sink.ignore-delete` to `true` (see the
+[write options](/engine-flink/options.md#write-options)) to drop those records on the client side, or set
+`table.delete.behavior` to `ignore` to drop them on the server side. Setting it to `disable` does not help here,
+because the job still fails on the delete, only with a different error.
+
+Tables with an auto increment column are stricter. On such a table, a `NOT NULL` target column outside the primary key
+is not allowed at all and is rejected before any data is written, when the writer is created or on the first write
+request. Because the rejection does not depend on a delete being processed, the `table.delete.behavior` workaround
+does not apply here. Note that a Flink sink creates its writer once the job is running, so such a job fails after it
+has been submitted rather than when the statement is planned.
+
 Tables using the `aggregation` merge engine keep the stricter rule for partial update as well, so every column other
 than the primary key must be nullable, including the target columns.
 

--- a/website/docs/table-design/table-types/pk-table.md
+++ b/website/docs/table-design/table-types/pk-table.md
@@ -85,8 +85,8 @@ Partial delete has a stricter requirement. It sets the target columns other than
 rejected when one of them is `NOT NULL`, unless every column outside the target columns is already `null`, in which
 case the whole row is removed instead.
 
-Tables using the `aggregation` merge engine keep the stricter rule for partial update as well: every column other than
-the primary key must be nullable, including the target columns.
+Tables using the `aggregation` merge engine keep the stricter rule for partial update as well, so every column other
+than the primary key must be nullable, including the target columns.
 
 ## Merge Engines
 

--- a/website/docs/table-design/table-types/pk-table.md
+++ b/website/docs/table-design/table-types/pk-table.md
@@ -74,6 +74,20 @@ follows:
 | 1 | 2.0 | t1 |
 | 2 | 3.0 | t2 |
 
+### Nullability requirements
+
+A column left out of the written columns is set to `null` when the row does not exist yet, so every column outside the
+written columns must be nullable. Columns that are written are always supplied by the writer, so they may be declared
+`NOT NULL`. An auto increment column is always left out of the written columns and only receives its value on the
+server, so it must be nullable as well.
+
+Partial delete has a stricter requirement. It sets the written columns other than the primary key to `null`, so it is
+rejected when one of them is `NOT NULL`, unless every column outside the written columns is already `null`, in which
+case the whole row is removed instead.
+
+Tables using the `aggregation` merge engine keep the stricter rule for partial update as well: every column other than
+the primary key must be nullable, including the written ones. The writer is rejected when it is created.
+
 ## Merge Engines
 
 The **Merge Engine** in Fluss is a core component designed to efficiently handle and consolidate data updates for Primary Key Tables.

--- a/website/docs/table-design/table-types/pk-table.md
+++ b/website/docs/table-design/table-types/pk-table.md
@@ -76,17 +76,17 @@ follows:
 
 ### Nullability requirements
 
-A column left out of the written columns is set to `null` when the row does not exist yet, so every column outside the
-written columns must be nullable. Columns that are written are always supplied by the writer, so they may be declared
-`NOT NULL`. An auto increment column is always left out of the written columns and only receives its value on the
+A column omitted from the target columns (the columns being written) is set to `null` when the row does not exist yet,
+so every omitted column must be nullable. A target column is always supplied by the writer, so it may be declared
+`NOT NULL`. An auto increment column is always omitted from the target columns and only receives its value on the
 server, so it must be nullable as well.
 
-Partial delete has a stricter requirement. It sets the written columns other than the primary key to `null`, so it is
-rejected when one of them is `NOT NULL`, unless every column outside the written columns is already `null`, in which
+Partial delete has a stricter requirement. It sets the target columns other than the primary key to `null`, so it is
+rejected when one of them is `NOT NULL`, unless every column outside the target columns is already `null`, in which
 case the whole row is removed instead.
 
 Tables using the `aggregation` merge engine keep the stricter rule for partial update as well: every column other than
-the primary key must be nullable, including the written ones. The writer is rejected when it is created.
+the primary key must be nullable, including the target columns.
 
 ## Merge Engines
 


### PR DESCRIPTION

## Summary

Partial update validation required every non-primary-key column of a primary key table to be nullable, including
columns explicitly listed in the target columns. A listed column is supplied by the writer on every request, so the
requirement rejected valid schemas. The loop's own comment described the intended behavior ("check the columns not in
targetColumns"), but the loop never consulted the target column set.

The check is duplicated across four layers that validate independently, and all four carried the defect:

| Layer | Location |
|---|---|
| Rust client | `fluss-rust/.../client/table/upsert.rs`, `UpsertWriterFactory::sanity_check` |
| Java client | `fluss-client/.../writer/UpsertWriterImpl.java`, `sanityCheck` |
| Server | `fluss-server/.../kv/partialupdate/PartialUpdater.java`, `sanityCheck` |
| REST gateway | `fluss-gateway/src/protocol/rest/records.rs`, `sparse_targets` |

The reported symptom cannot be resolved in the Rust client alone. A client-only fix permits writer construction and
defers the same rejection to the server at first write, so all four layers change together.

## Resulting validation rules

| Column | Requirement | Rationale |
|---|---|---|
| Omitted from target columns | Must be nullable | `updateRow` writes null into it when the row does not yet exist |
| Listed in target columns | May be `NOT NULL` | The writer supplies a value on every request |
| Auto increment | Must be nullable | Always omitted, and assigned its value only after the merge |
| Non-primary-key target column, under partial delete | Must be nullable | `deleteRow` sets it to null unless the whole row is removed |

## Divergence from the fix proposed in the issue

The issue proposes retaining the auto-increment exemption
(`!target_column_set[i] && !pk_column_set[i] && !auto_increment_column_set[i]`) and this PR removes it. Removing the
exemption is the correct direction because of ordering on the write path. `PartialUpdater.updateRow` null-fills
omitted columns before `AutoIncrementUpdater` assigns a value (`KvWriteProcessor.processUpsert` to `applyInsert` to
`updateAutoIncrementColumns`). Relaxing the server instead would allow a `NOT NULL` auto increment column to reach
`BinaryWriter.createNotNullValueWriter` holding null, producing an NPE surfaced to the client as
`UnknownServerException`.

## Runtime guards

The previous rule guaranteed that a row reaching `PartialUpdater` cannot carry null in a non-nullable slot. Relaxing
it needs guards, because the decode path is not defensive: `InternalRow.createFieldGetter` and `CompactedRowReader`
omit the `isNullAt` branch for non-nullable types, and CompactedRow is a sequential variable-length encoding, so a
null bit in a non-nullable slot corrupts every later field (IndexedRow, whose reader honors the null bit per column,
corrupts only that column).

- `updateRow` rejects a null value supplied for a `NOT NULL` target column, primary key columns included. The check
  runs before any field getter, because the first getter deserializes the whole row with the non-null-checking
  readers and would fail first with an error dependent on the bytes that follow. `isNullAt` reads only the null-bit
  header, so the check itself never deserializes.
- `deleteRow` rejects partial delete when a non-primary-key target column is `NOT NULL`. The guard is placed after
  the `isFieldsNull` short circuit, so whole-row removal, which nulls nothing, remains legal. The guard is server
  side only, since legality depends on the stored row, and a client-side equivalent would be stricter and would make
  a server-supported operation unreachable.
- The Java client runs the same null check per row before encoding, with the server's message, since the encoder
  would otherwise fail with a bare `NullPointerException` before the request is sent.
- The gateway requires a non-null value for every `NOT NULL` target column in each upsert entry of a sparse batch,
  using the decoder's existing per-row required-column enforcement. Delete entries carry only primary key values, so
  the server judges them against the stored row.

One path stays outside the server guards: target columns covering every schema column short circuit in
`DefaultRowMerger.configureTargetColumns` and never build a `PartialUpdater`. The exposure equals a plain full-row
upsert, the Java client guard covers the case client side, and the encoders reject a null before anything is stored.

## Merge engines

The `first_row` and `versioned` mergers reject partial update outright, and the `aggregation` merger does not fill
omitted columns with null on the first write, so aggregation tables keep requiring every column except the primary key to
be nullable. The Java client now checks all three at writer creation with the server's wording. Before, `first_row`
and `versioned` failed at the first write as `UnknownServerException`, and aggregation was rejected at creation with
the generic message.
`MergeMode.OVERWRITE` is exempt, because `KvWriteProcessor` merges an overwrite with the default merger rather than
the configured merge engine.

The Rust client reads no merge engine configuration today. The table config is available at writer creation, but the
guard is not part of this PR, to keep the Rust diff small. A Rust user on such a table still sees the rejection at
the first write. The Rust client also has no per-row check for a null in a `NOT NULL` target column. Such a write fails
in the encoder with a type error before it is sent, so nothing bad reaches the server. The gateway performs no merge
engine check either, so a REST partial update on such a table is rejected by the backend writer rather than at
preflight.

## Error message

Changed from:

```
Partial Update requires all columns except primary key to be nullable, but column %s is NOT NULL.
```

to:

```
Partial Update requires all columns omitted from the target columns to be nullable, but omitted column %s is NOT NULL.
```

A `NOT NULL` auto increment column gets a dedicated message, because the user cannot follow the generic advice of
listing the column, targeting an auto increment column is itself rejected:

```
Partial Update requires the auto increment column %s to be nullable, since it is always omitted from the target columns and assigned by the server.
```

The gateway keeps its own message style and now reports the omitted column the same way, including the dedicated
auto increment message.

## Flink

A Flink sink writing a partial update (a column subset in the SQL INSERT, or partial update columns on
`FlussSinkBuilder`) with a `NOT NULL` target column initializes and writes, and the first retract record is rejected
by the server's delete guard, which is not retriable. Insert-only pipelines are unaffected. The sink does not check this at plan time, so the rejection surfaces when the first delete arrives.

## Compatibility

No wire format, storage format, or public API signature changes. The change relaxes validation, so previously
accepted writes remain accepted. Three cases move their failure from the first write to writer creation: partial
update on `first_row` and `versioned` tables, and a `NOT NULL` auto increment column. The rejection message for
aggregation tables changes from `Partial Update requires...` to `Partial aggregate requires...`.

Fixes #3849

🤖 AI-assisted changes - reviewed by human developer
