### PR TITLE
[lake/tiering][follow] Allow overriding tiering remote-first read preference

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/LakeTieringJobBuilder.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/LakeTieringJobBuilder.java
@@ -34,8 +34,10 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SCANNER_LOG_READ_PREFERENCE;
 import static org.apache.fluss.flink.tiering.source.TieringSource.TIERING_SOURCE_TRANSFORMATION_UID;
 import static org.apache.fluss.flink.tiering.source.TieringSourceOptions.POLL_TIERING_TABLE_INTERVAL;
+import static org.apache.fluss.rpc.protocol.FetchLogReadPreference.REMOTE_FIRST;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
 /** The builder to build Flink lake tiering job. */
@@ -81,6 +83,12 @@ public class LakeTieringJobBuilder {
         LakeStorage lakeStorage = checkNotNull(lakeStoragePlugin).createLakeStorage(dataLakeConfig);
 
         LakeTieringFactory lakeTieringFactory = lakeStorage.createLakeTieringFactory();
+
+        // tiering prefers remote-first fetch to offload reads from tablet servers,
+        // unless users explicitly configure the read preference
+        if (!flussConfig.contains(CLIENT_SCANNER_LOG_READ_PREFERENCE)) {
+            flussConfig.set(CLIENT_SCANNER_LOG_READ_PREFERENCE, REMOTE_FIRST);
+        }
 
         // build tiering source
         TieringSource.Builder<?> tieringSourceBuilder =

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSource.java
@@ -45,11 +45,9 @@ import org.apache.flink.streaming.api.graph.StreamGraphHasherV2;
 import java.nio.charset.StandardCharsets;
 
 import static org.apache.fluss.config.ConfigOptions.CLIENT_SCANNER_IO_TMP_DIR;
-import static org.apache.fluss.config.ConfigOptions.CLIENT_SCANNER_LOG_READ_PREFERENCE;
 import static org.apache.fluss.flink.tiering.source.TieringSourceOptions.POLL_TIERING_TABLE_INTERVAL;
 import static org.apache.fluss.flink.utils.FlinkConnectorOptionsUtils.getClientScannerIoTmpDir;
 import static org.apache.fluss.flink.utils.FlinkConnectorOptionsUtils.getLakeTieringIoTmpDirs;
-import static org.apache.fluss.rpc.protocol.FetchLogReadPreference.REMOTE_FIRST;
 
 /**
  * The flink source implementation for tiering data from Fluss to downstream lake.
@@ -119,7 +117,6 @@ public class TieringSource<WriteResult>
         FutureCompletingBlockingQueue<RecordsWithSplitIds<TableBucketWriteResult<WriteResult>>>
                 elementsQueue = new FutureCompletingBlockingQueue<>();
         Configuration readerConf = new Configuration(flussConf);
-        readerConf.set(CLIENT_SCANNER_LOG_READ_PREFERENCE, REMOTE_FIRST);
         readerConf.set(
                 CLIENT_SCANNER_IO_TMP_DIR,
                 getClientScannerIoTmpDir(readerConf, sourceReaderContext.getConfiguration()));


### PR DESCRIPTION
This is a follow-up of #3606, which hardcodes the remote-first read preference in TieringSource#createReader so that an explicitly configured client.scanner.log.read-preference is silently overwritten.

Apply the remote-first default in LakeTieringJobBuilder#build only when the option is not explicitly configured, so users can fall back to local-first as an escape hatch. The tiering default behavior and the default of regular Flink source jobs are not changed.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
