### PR TITLE
[server] Support group-based ACL authorization

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/ServerAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/ServerAuthenticator.java
@@ -23,6 +23,8 @@ import org.apache.fluss.security.acl.FlussPrincipal;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Authenticator for server side.
@@ -95,6 +97,11 @@ public interface ServerAuthenticator extends Closeable {
      * complete).
      */
     FlussPrincipal createPrincipal();
+
+    /** Creates additional principals associated with the authenticated identity. */
+    default Collection<FlussPrincipal> createAdditionalPrincipals() {
+        return Collections.emptyList();
+    }
 
     /** Close the authenticator. */
     default void close() throws IOException {}

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/ServerAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/ServerAuthenticator.java
@@ -23,6 +23,8 @@ import org.apache.fluss.security.acl.FlussPrincipal;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Authenticator for server side.
@@ -95,6 +97,18 @@ public interface ServerAuthenticator extends Closeable {
      * complete).
      */
     FlussPrincipal createPrincipal();
+
+    /**
+     * Creates additional principals (such as groups or roles) associated with the authenticated
+     * identity. These principals are evaluated during ACL matching but are not considered for
+     * superuser checks.
+     *
+     * <p>Implementations must return a non-null list with no {@code null} elements; return an empty
+     * list when there are none.
+     */
+    default List<FlussPrincipal> createAdditionalPrincipals() {
+        return Collections.emptyList();
+    }
 
     /** Close the authenticator. */
     default void close() throws IOException {}

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/FlussRequest.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/FlussRequest.java
@@ -28,6 +28,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
@@ -45,6 +49,7 @@ public final class FlussRequest implements RpcRequest {
     private final String listenerName;
     private final boolean isInternal;
     private final FlussPrincipal principal;
+    private final List<FlussPrincipal> additionalPrincipals;
     private final InetAddress address;
     private final CompletableFuture<ApiMessage> responseFuture;
 
@@ -66,6 +71,35 @@ public final class FlussRequest implements RpcRequest {
             FlussPrincipal principal,
             InetAddress address,
             CompletableFuture<ApiMessage> responseFuture) {
+        this(
+                apiKey,
+                apiVersion,
+                requestId,
+                apiMethod,
+                message,
+                buffer,
+                listenerName,
+                isInternal,
+                principal,
+                Collections.emptyList(),
+                address,
+                responseFuture);
+    }
+
+    /** Creates a request with the primary and additional authenticated principals. */
+    public FlussRequest(
+            short apiKey,
+            short apiVersion,
+            int requestId,
+            ApiMethod apiMethod,
+            ApiMessage message,
+            ByteBuf buffer,
+            String listenerName,
+            boolean isInternal,
+            FlussPrincipal principal,
+            Collection<FlussPrincipal> additionalPrincipals,
+            InetAddress address,
+            CompletableFuture<ApiMessage> responseFuture) {
         this.apiKey = apiKey;
         this.apiVersion = apiVersion;
         this.requestId = requestId;
@@ -75,6 +109,8 @@ public final class FlussRequest implements RpcRequest {
         this.responseFuture = responseFuture;
         this.isInternal = isInternal;
         this.principal = principal;
+        this.additionalPrincipals =
+                Collections.unmodifiableList(new ArrayList<>(additionalPrincipals));
         this.address = address;
         this.listenerName = listenerName;
         this.startTimeMs = System.currentTimeMillis();
@@ -161,6 +197,10 @@ public final class FlussRequest implements RpcRequest {
 
     public FlussPrincipal getPrincipal() {
         return principal;
+    }
+
+    public Collection<FlussPrincipal> getAdditionalPrincipals() {
+        return additionalPrincipals;
     }
 
     public boolean isInternal() {

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/FlussRequest.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/FlussRequest.java
@@ -28,6 +28,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
@@ -45,6 +48,7 @@ public final class FlussRequest implements RpcRequest {
     private final String listenerName;
     private final boolean isInternal;
     private final FlussPrincipal principal;
+    private final List<FlussPrincipal> additionalPrincipals;
     private final InetAddress address;
     private final CompletableFuture<ApiMessage> responseFuture;
 
@@ -66,6 +70,35 @@ public final class FlussRequest implements RpcRequest {
             FlussPrincipal principal,
             InetAddress address,
             CompletableFuture<ApiMessage> responseFuture) {
+        this(
+                apiKey,
+                apiVersion,
+                requestId,
+                apiMethod,
+                message,
+                buffer,
+                listenerName,
+                isInternal,
+                principal,
+                Collections.emptyList(),
+                address,
+                responseFuture);
+    }
+
+    /** Creates a request with the primary and additional authenticated principals. */
+    public FlussRequest(
+            short apiKey,
+            short apiVersion,
+            int requestId,
+            ApiMethod apiMethod,
+            ApiMessage message,
+            ByteBuf buffer,
+            String listenerName,
+            boolean isInternal,
+            FlussPrincipal principal,
+            List<FlussPrincipal> additionalPrincipals,
+            InetAddress address,
+            CompletableFuture<ApiMessage> responseFuture) {
         this.apiKey = apiKey;
         this.apiVersion = apiVersion;
         this.requestId = requestId;
@@ -75,6 +108,8 @@ public final class FlussRequest implements RpcRequest {
         this.responseFuture = responseFuture;
         this.isInternal = isInternal;
         this.principal = principal;
+        this.additionalPrincipals =
+                Collections.unmodifiableList(new ArrayList<>(additionalPrincipals));
         this.address = address;
         this.listenerName = listenerName;
         this.startTimeMs = System.currentTimeMillis();
@@ -161,6 +196,10 @@ public final class FlussRequest implements RpcRequest {
 
     public FlussPrincipal getPrincipal() {
         return principal;
+    }
+
+    public List<FlussPrincipal> getAdditionalPrincipals() {
+        return additionalPrincipals;
     }
 
     public boolean isInternal() {

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/FlussRequestHandler.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/FlussRequestHandler.java
@@ -62,7 +62,8 @@ public class FlussRequestHandler implements RequestHandler<FlussRequest> {
                             request.getListenerName(),
                             request.isInternal(),
                             request.getAddress(),
-                            request.getPrincipal()));
+                            request.getPrincipal(),
+                            request.getAdditionalPrincipals()));
             // check if the coordinator server is the current leader if the API is a coordinator
             // TODO: we should only check coordinator APIs instead of all APIs
             if (isCoordinator && api.getApiKey() != ApiKeys.API_VERSIONS) {

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/NettyServerHandler.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/NettyServerHandler.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -130,6 +131,9 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
                             listenerName,
                             isInternal,
                             authenticator.isCompleted() ? authenticator.createPrincipal() : null,
+                            authenticator.isCompleted()
+                                    ? authenticator.createAdditionalPrincipals()
+                                    : Collections.emptyList(),
                             ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress(),
                             future);
 

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/Session.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/Session.java
@@ -21,6 +21,9 @@ import org.apache.fluss.security.acl.FlussPrincipal;
 
 import java.io.Serializable;
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /** The connection session of a request. */
 public class Session implements Serializable {
@@ -29,6 +32,7 @@ public class Session implements Serializable {
     private final boolean isInternal;
     private final InetAddress inetAddress;
     private final FlussPrincipal principal;
+    private final List<FlussPrincipal> additionalPrincipals;
 
     public Session(
             short apiVersion,
@@ -36,11 +40,24 @@ public class Session implements Serializable {
             boolean isInternal,
             InetAddress inetAddress,
             FlussPrincipal principal) {
+        this(apiVersion, listenerName, isInternal, inetAddress, principal, Collections.emptyList());
+    }
+
+    /** Creates a session with the primary and additional authenticated principals. */
+    public Session(
+            short apiVersion,
+            String listenerName,
+            boolean isInternal,
+            InetAddress inetAddress,
+            FlussPrincipal principal,
+            List<FlussPrincipal> additionalPrincipals) {
         this.apiVersion = apiVersion;
         this.listenerName = listenerName;
         this.isInternal = isInternal;
         this.inetAddress = inetAddress;
         this.principal = principal;
+        this.additionalPrincipals =
+                Collections.unmodifiableList(new ArrayList<>(additionalPrincipals));
     }
 
     public short getApiVersion() {
@@ -57,6 +74,11 @@ public class Session implements Serializable {
 
     public FlussPrincipal getPrincipal() {
         return principal;
+    }
+
+    /** Returns additional principals associated with the authenticated identity. */
+    public List<FlussPrincipal> getAdditionalPrincipals() {
+        return additionalPrincipals;
     }
 
     public boolean isInternal() {

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/Session.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/Session.java
@@ -21,6 +21,10 @@ import org.apache.fluss.security.acl.FlussPrincipal;
 
 import java.io.Serializable;
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /** The connection session of a request. */
 public class Session implements Serializable {
@@ -29,6 +33,7 @@ public class Session implements Serializable {
     private final boolean isInternal;
     private final InetAddress inetAddress;
     private final FlussPrincipal principal;
+    private final List<FlussPrincipal> additionalPrincipals;
 
     public Session(
             short apiVersion,
@@ -36,11 +41,24 @@ public class Session implements Serializable {
             boolean isInternal,
             InetAddress inetAddress,
             FlussPrincipal principal) {
+        this(apiVersion, listenerName, isInternal, inetAddress, principal, Collections.emptyList());
+    }
+
+    /** Creates a session with the primary and additional authenticated principals. */
+    public Session(
+            short apiVersion,
+            String listenerName,
+            boolean isInternal,
+            InetAddress inetAddress,
+            FlussPrincipal principal,
+            Collection<FlussPrincipal> additionalPrincipals) {
         this.apiVersion = apiVersion;
         this.listenerName = listenerName;
         this.isInternal = isInternal;
         this.inetAddress = inetAddress;
         this.principal = principal;
+        this.additionalPrincipals =
+                Collections.unmodifiableList(new ArrayList<>(additionalPrincipals));
     }
 
     public short getApiVersion() {
@@ -57,6 +75,11 @@ public class Session implements Serializable {
 
     public FlussPrincipal getPrincipal() {
         return principal;
+    }
+
+    /** Returns additional principals associated with the authenticated identity. */
+    public List<FlussPrincipal> getAdditionalPrincipals() {
+        return additionalPrincipals;
     }
 
     public boolean isInternal() {

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/authenticate/AuthenticationTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/authenticate/AuthenticationTest.java
@@ -32,7 +32,9 @@ import org.apache.fluss.rpc.metrics.TestingClientMetricGroup;
 import org.apache.fluss.rpc.netty.client.NettyClient;
 import org.apache.fluss.rpc.netty.server.NettyServer;
 import org.apache.fluss.rpc.netty.server.RequestsMetrics;
+import org.apache.fluss.rpc.netty.server.Session;
 import org.apache.fluss.rpc.protocol.ApiKeys;
+import org.apache.fluss.security.acl.FlussPrincipal;
 import org.apache.fluss.utils.NetUtils;
 
 import org.junit.jupiter.api.AfterEach;
@@ -52,6 +54,7 @@ public class AuthenticationTest {
     private NettyServer nettyServer;
     private ServerNode usernamePasswordServerNode;
     private ServerNode mutualAuthServerNode;
+    private TestingAuthenticateGatewayService service;
 
     @BeforeEach
     public void setup() throws Exception {
@@ -106,6 +109,11 @@ public class AuthenticationTest {
         try (NettyClient nettyClient =
                 new NettyClient(clientConfig, TestingClientMetricGroup.newInstance())) {
             verifyGetTableNamesList(nettyClient, mutualAuthServerNode);
+            assertThat(service.getLastSession().getPrincipal()).isEqualTo(FlussPrincipal.ANONYMOUS);
+            assertThat(service.getLastSession().getAdditionalPrincipals())
+                    .containsExactly(
+                            new FlussPrincipal("data-engineers", "Group"),
+                            new FlussPrincipal("table-reader", "Role"));
         }
 
         // test invalid challenge from server
@@ -248,7 +256,7 @@ public class AuthenticationTest {
         // 3 worker threads is enough for this test
         configuration.setString(ConfigOptions.NETTY_SERVER_NUM_WORKER_THREADS.key(), "3");
         MetricGroup metricGroup = NOPMetricsGroup.newInstance();
-        TestingAuthenticateGatewayService service = new TestingAuthenticateGatewayService();
+        service = new TestingAuthenticateGatewayService();
         try (NetUtils.Port availablePort1 = getAvailablePort();
                 NetUtils.Port availablePort2 = getAvailablePort()) {
             this.nettyServer =
@@ -277,10 +285,17 @@ public class AuthenticationTest {
      * authentication.
      */
     public static class TestingAuthenticateGatewayService extends TestingTabletGatewayService {
+        private volatile Session lastSession;
+
         @Override
         public CompletableFuture<ListTablesResponse> listTables(ListTablesRequest request) {
+            lastSession = currentSession();
             return CompletableFuture.completedFuture(
                     new ListTablesResponse().addAllTableNames(Collections.singleton("test-table")));
+        }
+
+        Session getLastSession() {
+            return lastSession;
         }
     }
 }

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/authenticate/MutualAuthenticationPlugin.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/authenticate/MutualAuthenticationPlugin.java
@@ -27,6 +27,8 @@ import org.apache.fluss.security.auth.ClientAuthenticator;
 import org.apache.fluss.security.auth.ServerAuthenticationPlugin;
 import org.apache.fluss.security.auth.ServerAuthenticator;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.fluss.config.ConfigBuilder.key;
@@ -192,6 +194,13 @@ public class MutualAuthenticationPlugin
         @Override
         public FlussPrincipal createPrincipal() {
             return FlussPrincipal.ANONYMOUS;
+        }
+
+        @Override
+        public List<FlussPrincipal> createAdditionalPrincipals() {
+            return Arrays.asList(
+                    new FlussPrincipal("data-engineers", "Group"),
+                    new FlussPrincipal("table-reader", "Role"));
         }
 
         @Override

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/authenticate/MutualAuthenticationPlugin.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/authenticate/MutualAuthenticationPlugin.java
@@ -27,6 +27,8 @@ import org.apache.fluss.security.auth.ClientAuthenticator;
 import org.apache.fluss.security.auth.ServerAuthenticationPlugin;
 import org.apache.fluss.security.auth.ServerAuthenticator;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.fluss.config.ConfigBuilder.key;
@@ -192,6 +194,13 @@ public class MutualAuthenticationPlugin
         @Override
         public FlussPrincipal createPrincipal() {
             return FlussPrincipal.ANONYMOUS;
+        }
+
+        @Override
+        public Collection<FlussPrincipal> createAdditionalPrincipals() {
+            return Arrays.asList(
+                    new FlussPrincipal("data-engineers", "Group"),
+                    new FlussPrincipal("table-reader", "Role"));
         }
 
         @Override

--- a/fluss-server/src/main/java/org/apache/fluss/server/authorizer/DefaultAuthorizer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/authorizer/DefaultAuthorizer.java
@@ -174,6 +174,7 @@ public class DefaultAuthorizer extends AbstractAuthorizer implements FatalErrorH
                 || aclsAllowAccess(
                         action.getResource(),
                         principal,
+                        session.getAdditionalPrincipals(),
                         action.getOperation(),
                         session.getInetAddress().getHostAddress());
     }
@@ -481,9 +482,28 @@ public class DefaultAuthorizer extends AbstractAuthorizer implements FatalErrorH
     @VisibleForTesting
     public boolean aclsAllowAccess(
             Resource resource, FlussPrincipal principal, OperationType operation, String host) {
+        return aclsAllowAccess(resource, principal, Collections.emptyList(), operation, host);
+    }
+
+    private boolean aclsAllowAccess(
+            Resource resource,
+            FlussPrincipal principal,
+            Collection<FlussPrincipal> additionalPrincipals,
+            OperationType operation,
+            String host) {
         Set<AccessControlEntry> accessControlEntries = matchingAcls(resource);
         return isEmptyAclAndAuthorized(resource, accessControlEntries)
-                || allowAclExists(resource, principal, operation, host, accessControlEntries);
+                || allowAclExists(resource, principal, operation, host, accessControlEntries)
+                || additionalPrincipals.stream()
+                        .filter(Objects::nonNull)
+                        .anyMatch(
+                                additionalPrincipal ->
+                                        allowAclExists(
+                                                resource,
+                                                additionalPrincipal,
+                                                operation,
+                                                host,
+                                                accessControlEntries));
     }
 
     private boolean isEmptyAclAndAuthorized(Resource resource, Collection acls) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/authorizer/DefaultAuthorizer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/authorizer/DefaultAuthorizer.java
@@ -174,6 +174,7 @@ public class DefaultAuthorizer extends AbstractAuthorizer implements FatalErrorH
                 || aclsAllowAccess(
                         action.getResource(),
                         principal,
+                        session.getAdditionalPrincipals(),
                         action.getOperation(),
                         session.getInetAddress().getHostAddress());
     }
@@ -481,9 +482,27 @@ public class DefaultAuthorizer extends AbstractAuthorizer implements FatalErrorH
     @VisibleForTesting
     public boolean aclsAllowAccess(
             Resource resource, FlussPrincipal principal, OperationType operation, String host) {
+        return aclsAllowAccess(resource, principal, Collections.emptyList(), operation, host);
+    }
+
+    private boolean aclsAllowAccess(
+            Resource resource,
+            FlussPrincipal principal,
+            List<FlussPrincipal> additionalPrincipals,
+            OperationType operation,
+            String host) {
         Set<AccessControlEntry> accessControlEntries = matchingAcls(resource);
         return isEmptyAclAndAuthorized(resource, accessControlEntries)
-                || allowAclExists(resource, principal, operation, host, accessControlEntries);
+                || allowAclExists(resource, principal, operation, host, accessControlEntries)
+                || additionalPrincipals.stream()
+                        .anyMatch(
+                                additionalPrincipal ->
+                                        allowAclExists(
+                                                resource,
+                                                additionalPrincipal,
+                                                operation,
+                                                host,
+                                                accessControlEntries));
     }
 
     private boolean isEmptyAclAndAuthorized(Resource resource, Collection acls) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/authorizer/DefaultAuthorizerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/authorizer/DefaultAuthorizerTest.java
@@ -206,6 +206,48 @@ public class DefaultAuthorizerTest {
     }
 
     @Test
+    void testAuthorizationWithAdditionalPrincipals() throws Exception {
+        Resource resource = Resource.table("database1", "table1");
+        FlussPrincipal matchingGroup = new FlussPrincipal("data-engineers", "GROUP");
+        Session session =
+                createSession(
+                        "USER",
+                        "alice",
+                        "192.168.1.1",
+                        Arrays.asList(
+                                null, new FlussPrincipal("fluss-readers", "GROUP"), matchingGroup));
+
+        authorizer.addAcls(
+                createRootUserSession(),
+                Collections.singletonList(
+                        new AclBinding(
+                                resource,
+                                new AccessControlEntry(
+                                        matchingGroup,
+                                        "192.168.1.1",
+                                        READ,
+                                        PermissionType.ALLOW))));
+
+        assertThat(authorizer.isAuthorized(session, READ, resource)).isTrue();
+    }
+
+    @Test
+    void testAdditionalPrincipalDoesNotGrantSuperUser() throws Exception {
+        Resource resource = Resource.database("database1");
+        Session session =
+                createSession(
+                        "USER",
+                        "alice",
+                        "192.168.1.1",
+                        Collections.singletonList(new FlussPrincipal(ROOT_USER, "USER")));
+        authorizer.addAcls(
+                createRootUserSession(),
+                Collections.singletonList(createAclBinding(resource, "another-user", "*", READ)));
+
+        assertThat(authorizer.isAuthorized(session, READ, resource)).isFalse();
+    }
+
+    @Test
     void testAclModificationRequiresAllPermission() throws Exception {
         Resource resource = Resource.database("database1");
         Session alterSession = createSession("alter-user", "192.168.1.1");
@@ -748,12 +790,22 @@ public class DefaultAuthorizerTest {
     }
 
     private Session createSession(String userType, String username, String host) throws Exception {
+        return createSession(userType, username, host, Collections.emptyList());
+    }
+
+    private Session createSession(
+            String userType,
+            String username,
+            String host,
+            Collection<FlussPrincipal> additionalPrincipals)
+            throws Exception {
         return new Session(
                 (byte) 1,
                 "FLUSS",
                 false,
                 InetAddress.getByName(host),
-                new FlussPrincipal(username, userType));
+                new FlussPrincipal(username, userType),
+                additionalPrincipals);
     }
 
     private AclBinding createAclBinding(

--- a/fluss-server/src/test/java/org/apache/fluss/server/authorizer/DefaultAuthorizerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/authorizer/DefaultAuthorizerTest.java
@@ -206,6 +206,47 @@ public class DefaultAuthorizerTest {
     }
 
     @Test
+    void testAuthorizationWithAdditionalPrincipals() throws Exception {
+        Resource resource = Resource.table("database1", "table1");
+        FlussPrincipal matchingGroup = new FlussPrincipal("data-engineers", "GROUP");
+        Session session =
+                createSession(
+                        "USER",
+                        "alice",
+                        "192.168.1.1",
+                        Arrays.asList(new FlussPrincipal("fluss-readers", "GROUP"), matchingGroup));
+
+        authorizer.addAcls(
+                createRootUserSession(),
+                Collections.singletonList(
+                        new AclBinding(
+                                resource,
+                                new AccessControlEntry(
+                                        matchingGroup,
+                                        "192.168.1.1",
+                                        READ,
+                                        PermissionType.ALLOW))));
+
+        assertThat(authorizer.isAuthorized(session, READ, resource)).isTrue();
+    }
+
+    @Test
+    void testAdditionalPrincipalDoesNotGrantSuperUser() throws Exception {
+        Resource resource = Resource.database("database1");
+        Session session =
+                createSession(
+                        "USER",
+                        "alice",
+                        "192.168.1.1",
+                        Collections.singletonList(new FlussPrincipal(ROOT_USER, "USER")));
+        authorizer.addAcls(
+                createRootUserSession(),
+                Collections.singletonList(createAclBinding(resource, "another-user", "*", READ)));
+
+        assertThat(authorizer.isAuthorized(session, READ, resource)).isFalse();
+    }
+
+    @Test
     void testAclModificationRequiresAllPermission() throws Exception {
         Resource resource = Resource.database("database1");
         Session alterSession = createSession("alter-user", "192.168.1.1");
@@ -748,12 +789,22 @@ public class DefaultAuthorizerTest {
     }
 
     private Session createSession(String userType, String username, String host) throws Exception {
+        return createSession(userType, username, host, Collections.emptyList());
+    }
+
+    private Session createSession(
+            String userType,
+            String username,
+            String host,
+            List<FlussPrincipal> additionalPrincipals)
+            throws Exception {
         return new Session(
                 (byte) 1,
                 "FLUSS",
                 false,
                 InetAddress.getByName(host),
-                new FlussPrincipal(username, userType));
+                new FlussPrincipal(username, userType),
+                additionalPrincipals);
     }
 
     private AclBinding createAclBinding(

--- a/website/docs/security/authorization.md
+++ b/website/docs/security/authorization.md
@@ -66,7 +66,7 @@ Fluss implements a permission inheritance model, where certain operations imply 
 The FlussPrincipal is a core concept in the Fluss security architecture. It represents the identity of an authenticated entity (such as a user or service) and serves as the central bridge between authentication and authorization. Once a client successfully authenticates via a supported mechanism (e.g., SASL/PLAIN, Kerberos), a FlussPrincipal is created to represent that client's identity.
 This principal is then used throughout the system for access control decisions, linking who the user is with what they are allowed to do.
 
-The principal type indicates the category of the principal (e. g., "User", "Group", "Role"), while the name identifies the specific entity within that category. By default, the simple authorizer uses "User" as the principal type, but custom authorizers can extend this to support role-based or group-based access control lists (ACLs).
+The principal type indicates the category of the principal (e. g., "User", "Group", "Role"), while the name identifies the specific entity within that category. An authenticated session has one primary principal and may have additional principals such as groups or roles. The default authorizer evaluates ACLs against the primary and additional principals, while superuser checks use only the primary principal.
 Example usage:
 * `new FlussPrincipal("admin", "User")` – A standard user principal.
 * `new FlussPrincipal("admins", "Group")` – A group-based principal for authorization.

--- a/website/docs/security/overview.md
+++ b/website/docs/security/overview.md
@@ -77,9 +77,9 @@ For example:
 * User `guest` might only be allowed to consume messages from a specific table.
 
 ### Fluss Principal – The Bridge Between Authentication and Authorization
-Once a client successfully authenticates, Fluss creates a **Fluss Principal**, which represents the authenticated identity. This  **Fluss Principal** is used throughout the system during authorization checks.
+Once a client successfully authenticates, Fluss creates a primary **Fluss Principal**, which represents the authenticated identity. Authentication may also provide additional principals such as groups or roles.
 
-The principal type indicates the category of the principal (e.g., "User", "Group", "Role"), while the name identifies the specific entity within that category. By default, the simple authorizer uses "User" as the principal type, but custom authorizers can extend this to support role-based or group-based access control lists (ACLs).
+The principal type indicates the category of the principal (e.g., "User", "Group", "Role"), while the name identifies the specific entity within that category. The default authorizer evaluates ACLs against the primary and additional principals, while superuser checks use only the primary principal.
 Example usage:
 * `new FlussPrincipal("admin", "User")` – A standard user principal.
 * `new FlussPrincipal("admins", "Group")` – A group-based principal for authorization.


### PR DESCRIPTION
<!-- Generated-by: Codex following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md) -->

### Purpose

Linked issue: close #3829

Allow authentication mechanisms to attach group and role principals to an authenticated session so ACL authorization can evaluate both the primary and additional principals.

### Brief change log

- Allow authenticators to optionally provide additional principals; existing implementations continue to return none by default.
- Propagate additional principals through `FlussRequest` and `Session`.
- Evaluate regular ACLs against the primary and additional principals while keeping superuser checks limited to the primary principal.
- Update the security documentation for primary and additional principal semantics.

### Tests

- `AuthenticationTest`
- `DefaultAuthorizerTest`

### API and Format

This adds a default method to `ServerAuthenticator`. It does not change the RPC wire format or storage format.

### Documentation

Updated the authorization and security overview documentation.