### PR TITLE
[common] Add standard principal type constants

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/security/acl/FlussPrincipal.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/acl/FlussPrincipal.java
@@ -41,7 +41,11 @@ import java.util.Objects;
  */
 @PublicEvolving
 public class FlussPrincipal implements Principal {
-    public static final FlussPrincipal ANONYMOUS = new FlussPrincipal("ANONYMOUS", "User");
+    public static final String USER_TYPE = "User";
+    public static final String GROUP_TYPE = "Group";
+    public static final String ROLE_TYPE = "Role";
+
+    public static final FlussPrincipal ANONYMOUS = new FlussPrincipal("ANONYMOUS", USER_TYPE);
     /** The wildcard principal, which represents all principals. */
     public static final FlussPrincipal WILD_CARD_PRINCIPAL = new FlussPrincipal("*", "*");
 

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslServerAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslServerAuthenticator.java
@@ -148,6 +148,6 @@ public class SaslServerAuthenticator implements ServerAuthenticator {
 
     @Override
     public FlussPrincipal createPrincipal() {
-        return new FlussPrincipal(saslServer.getAuthorizationID(), "User");
+        return new FlussPrincipal(saslServer.getAuthorizationID(), FlussPrincipal.USER_TYPE);
     }
 }


### PR DESCRIPTION
<!-- Generated-by: Codex following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md) -->

### Purpose

Related to #3829.

Provide canonical names for the standard User, Group, and Role principal types while preserving the string-based extensibility of `FlussPrincipal`.

### Brief change log

- Add `USER_TYPE`, `GROUP_TYPE`, and `ROLE_TYPE` constants to `FlussPrincipal`.
- Use `USER_TYPE` when creating the anonymous principal and authenticated SASL user principals.
- Keep the existing String constructor so custom principal types remain supported.

### Tests

- `./mvnw -pl fluss-common -DskipITs verify`
  - 1,732 unit tests passed.
  - 186 integration tests passed.
  - Checkstyle and Spotless passed.

### API and Format

This adds public constants to `FlussPrincipal`. It does not change existing constructors, ACL matching semantics, configuration, RPC wire format, or storage format.

### Documentation

No documentation changes are required.