### PR TITLE
[rust] Fix log append rejecting NOT NULL columns

### DIFF
--- a/fluss-rust/crates/fluss/src/record/arrow.rs
+++ b/fluss-rust/crates/fluss/src/record/arrow.rs
@@ -590,15 +590,15 @@ fn estimate_arrow_ipc_overhead(
 ) -> Result<usize> {
     use arrow::array::new_null_array;
 
-    // Create a 1-row batch of nulls. Null arrays have minimal, predictable
-    // data: no validity bitmap, no variable-length data, just fixed-width
-    // zero buffers. This lets us compute raw data size exactly.
-    let null_arrays: Vec<ArrayRef> = schema
-        .fields()
-        .iter()
-        .map(|field| new_null_array(field.data_type(), 1))
-        .collect();
-    let batch = RecordBatch::try_new(schema.clone(), null_arrays)?;
+    let fields = schema.fields();
+    let mut probe_fields = Vec::with_capacity(fields.len());
+    let mut null_arrays: Vec<ArrayRef> = Vec::with_capacity(fields.len());
+    for f in fields {
+        null_arrays.push(new_null_array(f.data_type(), 1));
+        probe_fields.push(f.as_ref().clone().with_nullable(true));
+    }
+    let probe_schema: SchemaRef = Arc::new(arrow_schema::Schema::new(probe_fields));
+    let batch = RecordBatch::try_new(probe_schema.clone(), null_arrays)?;
 
     // Sum the raw buffer sizes — this is what buffer_size() would report.
     let raw_data: usize = batch
@@ -621,7 +621,7 @@ fn estimate_arrow_ipc_overhead(
     let mut buf = vec![];
     let write_option =
         IpcWriteOptions::try_with_compression(IpcWriteOptions::default(), compression);
-    let mut writer = StreamWriter::try_new_with_options(&mut buf, schema, write_option?)?;
+    let mut writer = StreamWriter::try_new_with_options(&mut buf, &probe_schema, write_option?)?;
     let header_len = writer.get_ref().len();
     writer.write(&batch)?;
     let total_len = writer.get_ref().len();
@@ -1901,6 +1901,83 @@ mod tests {
     use crate::metadata::{DataField, DataTypes, PhysicalTablePath, RowType, TablePath};
     use crate::row::{DataGetters, GenericRow};
     use crate::test_utils::build_table_info;
+
+    #[test]
+    fn nonnullable_append_builder_roundtrips_for_both_append_modes() {
+        let row_type = RowType::new(vec![DataField::new(
+            "id",
+            DataTypes::bigint().as_non_nullable(),
+            None,
+        )]);
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let table_info = Arc::new(build_table_info(table_path.clone(), 1, 1));
+        let physical_table_path = Arc::new(PhysicalTablePath::of(Arc::new(table_path)));
+
+        for to_append_record_batch in [false, true] {
+            let mut builder = MemoryLogRecordsArrowBuilder::new(
+                1,
+                &row_type,
+                to_append_record_batch,
+                ArrowCompressionInfo {
+                    compression_type: ArrowCompressionType::None,
+                    compression_level: DEFAULT_NON_ZSTD_COMPRESSION_LEVEL,
+                },
+                usize::MAX,
+                Arc::new(ArrowCompressionRatioEstimator::default()),
+            )
+            .expect("NOT NULL builder should construct");
+
+            if to_append_record_batch {
+                let batch_schema = Arc::new(arrow_schema::Schema::new(vec![Field::new(
+                    "id",
+                    arrow_schema::DataType::Int64,
+                    false,
+                )]));
+                let batch = RecordBatch::try_new(
+                    batch_schema,
+                    vec![Arc::new(arrow::array::Int64Array::from(vec![1_i64, 2_i64]))
+                        as arrow::array::ArrayRef],
+                )
+                .expect("non-nullable record batch");
+                let record = WriteRecord::for_append_record_batch(
+                    Arc::clone(&table_info),
+                    physical_table_path.clone(),
+                    1,
+                    batch,
+                );
+                builder
+                    .append(&record)
+                    .expect("append batch should succeed");
+            } else {
+                let mut r1 = GenericRow::new(1);
+                r1.set_field(0, 1_i64);
+                let mut r2 = GenericRow::new(1);
+                r2.set_field(0, 2_i64);
+                builder
+                    .append(&WriteRecord::for_append(
+                        Arc::clone(&table_info),
+                        physical_table_path.clone(),
+                        1,
+                        &r1,
+                    ))
+                    .expect("append row 1 should succeed");
+                builder
+                    .append(&WriteRecord::for_append(
+                        Arc::clone(&table_info),
+                        physical_table_path.clone(),
+                        1,
+                        &r2,
+                    ))
+                    .expect("append row 2 should succeed");
+            }
+
+            assert_eq!(builder.records_count(), 2);
+            let bytes = builder
+                .build()
+                .expect("build should succeed for NOT NULL column");
+            assert!(!bytes.is_empty());
+        }
+    }
 
     fn single_int_read_context() -> (ReadContext, SchemaRef) {
         let row_type = Arc::new(RowType::new(vec![DataField::new(

--- a/fluss-rust/crates/fluss/tests/integration/log_table.rs
+++ b/fluss-rust/crates/fluss/tests/integration/log_table.rs
@@ -56,6 +56,7 @@ mod table_test {
                 Schema::builder()
                     .column("c1", DataTypes::int())
                     .column("c2", DataTypes::string())
+                    .column("c3", DataTypes::bigint().as_non_nullable())
                     .build()
                     .expect("Failed to build schema"),
             )
@@ -76,17 +77,25 @@ mod table_test {
             .create_writer()
             .expect("Failed to create writer");
 
-        let batch1 =
-            record_batch!(("c1", Int32, [1, 2, 3]), ("c2", Utf8, ["a1", "a2", "a3"])).unwrap();
+        let batch1 = record_batch!(
+            ("c1", Int32, [1, 2, 3]),
+            ("c2", Utf8, ["a1", "a2", "a3"]),
+            ("c3", Int64, [10, 20, 30])
+        )
+        .unwrap();
         append_writer
             .append_arrow_batch(batch1)
-            .expect("Failed to append batch");
+            .expect("Failed to append batch with mixed nullability");
 
-        let batch2 =
-            record_batch!(("c1", Int32, [4, 5, 6]), ("c2", Utf8, ["a4", "a5", "a6"])).unwrap();
+        let batch2 = record_batch!(
+            ("c1", Int32, [4, 5, 6]),
+            ("c2", Utf8, ["a4", "a5", "a6"]),
+            ("c3", Int64, [40, 50, 60])
+        )
+        .unwrap();
         append_writer
             .append_arrow_batch(batch2)
-            .expect("Failed to append batch");
+            .expect("Failed to append batch with mixed nullability");
 
         // Flush to ensure all writes are acknowledged
         append_writer.flush().await.expect("Failed to flush");
@@ -124,6 +133,7 @@ mod table_test {
                         (
                             row.get_int(0).unwrap(),
                             row.get_string(1).unwrap().to_string(),
+                            row.get_long(2).unwrap(),
                         )
                     })
                     .collect()
@@ -135,13 +145,13 @@ mod table_test {
 
         // Sort and verify record contents
         collected.sort();
-        let expected: Vec<(i32, String)> = vec![
-            (1, "a1".to_string()),
-            (2, "a2".to_string()),
-            (3, "a3".to_string()),
-            (4, "a4".to_string()),
-            (5, "a5".to_string()),
-            (6, "a6".to_string()),
+        let expected: Vec<(i32, String, i64)> = vec![
+            (1, "a1".to_string(), 10),
+            (2, "a2".to_string(), 20),
+            (3, "a3".to_string(), 30),
+            (4, "a4".to_string(), 40),
+            (5, "a5".to_string(), 50),
+            (6, "a6".to_string(), 60),
         ];
         assert_eq!(collected, expected);
 
@@ -2194,6 +2204,7 @@ mod table_test {
                 Schema::builder()
                     .column("c1", DataTypes::int())
                     .column("c2", DataTypes::string())
+                    .column("c3", DataTypes::bigint().as_non_nullable())
                     .build()
                     .expect("schema"),
             )
@@ -2212,10 +2223,13 @@ mod table_test {
 
         let row_count: i32 = 30;
         for id in 1..=row_count {
-            let mut row = GenericRow::new(2);
+            let mut row = GenericRow::new(3);
             row.set_field(0, id);
             row.set_field(1, "x");
-            writer.append(&row).expect("append row");
+            row.set_field(2, id as i64 * 10);
+            writer
+                .append(&row)
+                .expect("append row with mixed nullability");
         }
         writer.flush().await.expect("flush");
 


### PR DESCRIPTION

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3897

<!-- What is the purpose of the change -->

### Brief change log

- Build the probe from a nullability-relaxed schema clone (nullability is schema-message metadata, excluded from the measured overhead). 
- Adds a regression test.

### Tests

- Adds a regression test.

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
