### PR TITLE
[flink] Validate database existence when resolving catalog functions in FlinkCatalog

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -802,11 +802,17 @@ public class FlinkCatalog extends AbstractCatalog {
     @Override
     public List<String> listFunctions(String dbName)
             throws DatabaseNotExistException, CatalogException {
+        if (!databaseExists(dbName)) {
+            throw new DatabaseNotExistException(getName(), dbName);
+        }
         return new ArrayList<>(BUILTIN_BITMAP_FUNCTIONS.keySet());
     }
 
     @Override
     public boolean functionExists(ObjectPath objectPath) throws CatalogException {
+        if (!databaseExists(objectPath.getDatabaseName())) {
+            return false;
+        }
         return BUILTIN_BITMAP_FUNCTIONS.containsKey(
                 objectPath.getObjectName().toLowerCase(Locale.ROOT));
     }
@@ -814,6 +820,9 @@ public class FlinkCatalog extends AbstractCatalog {
     @Override
     public CatalogFunction getFunction(ObjectPath functionPath)
             throws FunctionNotExistException, CatalogException {
+        if (!databaseExists(functionPath.getDatabaseName())) {
+            throw new FunctionNotExistException(getName(), functionPath);
+        }
         String className =
                 BUILTIN_BITMAP_FUNCTIONS.get(functionPath.getObjectName().toLowerCase(Locale.ROOT));
         if (className == null) {

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -811,7 +811,10 @@ public class FlinkCatalog extends AbstractCatalog {
     @Override
     public boolean functionExists(ObjectPath objectPath) throws CatalogException {
         if (!databaseExists(objectPath.getDatabaseName())) {
-            return false;
+            throw new CatalogException(
+                    String.format(
+                            "Database %s does not exist in catalog %s.",
+                            objectPath.getDatabaseName(), getName()));
         }
         return BUILTIN_BITMAP_FUNCTIONS.containsKey(
                 objectPath.getObjectName().toLowerCase(Locale.ROOT));
@@ -821,7 +824,10 @@ public class FlinkCatalog extends AbstractCatalog {
     public CatalogFunction getFunction(ObjectPath functionPath)
             throws FunctionNotExistException, CatalogException {
         if (!databaseExists(functionPath.getDatabaseName())) {
-            throw new FunctionNotExistException(getName(), functionPath);
+            throw new CatalogException(
+                    String.format(
+                            "Database %s does not exist in catalog %s.",
+                            functionPath.getDatabaseName(), getName()));
         }
         String className =
                 BUILTIN_BITMAP_FUNCTIONS.get(functionPath.getObjectName().toLowerCase(Locale.ROOT));

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -821,10 +821,7 @@ public class FlinkCatalog extends AbstractCatalog {
     public CatalogFunction getFunction(ObjectPath functionPath)
             throws FunctionNotExistException, CatalogException {
         if (!databaseExists(functionPath.getDatabaseName())) {
-            throw new CatalogException(
-                    String.format(
-                            "Database %s does not exist in catalog %s.",
-                            functionPath.getDatabaseName(), getName()));
+            throw new FunctionNotExistException(getName(), functionPath);
         }
         String className =
                 BUILTIN_BITMAP_FUNCTIONS.get(functionPath.getObjectName().toLowerCase(Locale.ROOT));

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -811,10 +811,7 @@ public class FlinkCatalog extends AbstractCatalog {
     @Override
     public boolean functionExists(ObjectPath objectPath) throws CatalogException {
         if (!databaseExists(objectPath.getDatabaseName())) {
-            throw new CatalogException(
-                    String.format(
-                            "Database %s does not exist in catalog %s.",
-                            objectPath.getDatabaseName(), getName()));
+            return false;
         }
         return BUILTIN_BITMAP_FUNCTIONS.containsKey(
                 objectPath.getObjectName().toLowerCase(Locale.ROOT));

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -1007,13 +1007,12 @@ abstract class FlinkCatalogITCase {
     @Test
     void testBitmapFunctionFailsForFullyQualifiedNonexistentDatabase() {
         assertThatThrownBy(
-                        () ->
-                                tEnv.executeSql(
-                                        "SELECT "
-                                                + CATALOG_NAME
-                                                + ".nonexistent_db.rb_build(ARRAY[1,2])"))
-                .cause()
-                .isInstanceOf(ValidationException.class);
+                () ->
+                        tEnv.executeSql(
+                                "SELECT "
+                                        + CATALOG_NAME
+                                        + ".nonexistent_db.rb_build(ARRAY[1,2])"))
+                .hasMessageContaining("No match found for function signature rb_build");
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -1007,11 +1007,11 @@ abstract class FlinkCatalogITCase {
     @Test
     void testBitmapFunctionFailsForFullyQualifiedNonexistentDatabase() {
         assertThatThrownBy(
-                () ->
-                        tEnv.executeSql(
-                                "SELECT "
-                                        + CATALOG_NAME
-                                        + ".nonexistent_db.rb_build(ARRAY[1,2])"))
+                        () ->
+                                tEnv.executeSql(
+                                        "SELECT "
+                                                + CATALOG_NAME
+                                                + ".nonexistent_db.rb_build(ARRAY[1,2])"))
                 .hasMessageContaining("No match found for function signature rb_build");
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -1012,7 +1012,7 @@ abstract class FlinkCatalogITCase {
                                         "SELECT "
                                                 + CATALOG_NAME
                                                 + ".nonexistent_db.rb_build(ARRAY[1,2])"))
-                .hasMessageContaining("nonexistent_db");
+                .hasMessageContaining("No match found for function signature");
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -1012,7 +1012,7 @@ abstract class FlinkCatalogITCase {
                                         "SELECT "
                                                 + CATALOG_NAME
                                                 + ".nonexistent_db.rb_build(ARRAY[1,2])"))
-                .hasMessageContaining("No match found for function signature rb_build");
+                .hasMessageContaining("nonexistent_db");
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -1005,6 +1005,18 @@ abstract class FlinkCatalogITCase {
     }
 
     @Test
+    void testBitmapFunctionFailsForFullyQualifiedNonexistentDatabase() {
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                        "SELECT "
+                                                + CATALOG_NAME
+                                                + ".nonexistent_db.rb_build(ARRAY[1,2])"))
+                .cause()
+                .isInstanceOf(ValidationException.class);
+    }
+
+    @Test
     void testCreateCatalogWithLakeProperties() throws Exception {
         Map<String, String> properties = new HashMap<>();
         properties.put("paimon.jdbc.password", "pass");

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
@@ -1221,4 +1221,37 @@ class FlinkCatalogTest {
         // verify unknown still returns false
         assertThat(catalog.functionExists(new ObjectPath(DEFAULT_DB, "unknown_fn"))).isFalse();
     }
+
+    @Test
+    void testBuiltinFunctionsRequireExistingDatabase() throws Exception {
+        String nonexistentDb = "nonexistent_db_for_functions";
+        assertThat(catalog.databaseExists(nonexistentDb)).isFalse();
+
+        // listFunctions on a nonexistent database throws
+        assertThatThrownBy(() -> catalog.listFunctions(nonexistentDb))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessage(
+                        "Database %s does not exist in Catalog %s.", nonexistentDb, CATALOG_NAME);
+
+        // functionExists on a nonexistent database returns false, not throw
+        ObjectPath qualifiedInNonexistentDb = new ObjectPath(nonexistentDb, "rb_build");
+        assertThat(catalog.functionExists(qualifiedInNonexistentDb)).isFalse();
+
+        // getFunction on a nonexistent database throws FunctionNotExistException
+        assertThatThrownBy(() -> catalog.getFunction(qualifiedInNonexistentDb))
+                .isInstanceOf(FunctionNotExistException.class);
+
+        // built-in functions still resolve from every existing database, not just DEFAULT_DB
+        String secondDb = "second_db_for_functions";
+        catalog.createDatabase(
+                secondDb, new CatalogDatabaseImpl(Collections.emptyMap(), null), true);
+        try {
+            assertThat(catalog.functionExists(new ObjectPath(secondDb, "rb_build"))).isTrue();
+            assertThat(catalog.getFunction(new ObjectPath(secondDb, "rb_build"))).isNotNull();
+            assertThat(catalog.listFunctions(secondDb))
+                    .contains("rb_build_agg", "rb_or_agg", "rb_and_agg", "rb_xor_agg");
+        } finally {
+            catalog.dropDatabase(secondDb, true, true);
+        }
+    }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
@@ -1237,10 +1237,9 @@ class FlinkCatalogTest {
         ObjectPath qualifiedInNonexistentDb = new ObjectPath(nonexistentDb, "rb_build");
         assertThat(catalog.functionExists(qualifiedInNonexistentDb)).isFalse();
 
-        // getFunction on a nonexistent database throws CatalogException with db-not-found message
+        // getFunction on a nonexistent database throws FunctionNotExistException
         assertThatThrownBy(() -> catalog.getFunction(qualifiedInNonexistentDb))
-                .isInstanceOf(CatalogException.class)
-                .hasMessageContaining("Database " + nonexistentDb + " does not exist");
+                .isInstanceOf(FunctionNotExistException.class);
 
         // built-in functions still resolve from every existing database, not just DEFAULT_DB
         String secondDb = "second_db_for_functions";

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
@@ -1233,12 +1233,9 @@ class FlinkCatalogTest {
                 .hasMessage(
                         "Database %s does not exist in Catalog %s.", nonexistentDb, CATALOG_NAME);
 
-        // functionExists on a nonexistent database throws CatalogException with db-not-found
-        // message
+        // functionExists on a nonexistent database returns false, not throw
         ObjectPath qualifiedInNonexistentDb = new ObjectPath(nonexistentDb, "rb_build");
-        assertThatThrownBy(() -> catalog.functionExists(qualifiedInNonexistentDb))
-                .isInstanceOf(CatalogException.class)
-                .hasMessageContaining("Database " + nonexistentDb + " does not exist");
+        assertThat(catalog.functionExists(qualifiedInNonexistentDb)).isFalse();
 
         // getFunction on a nonexistent database throws CatalogException with db-not-found message
         assertThatThrownBy(() -> catalog.getFunction(qualifiedInNonexistentDb))

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
@@ -1233,13 +1233,17 @@ class FlinkCatalogTest {
                 .hasMessage(
                         "Database %s does not exist in Catalog %s.", nonexistentDb, CATALOG_NAME);
 
-        // functionExists on a nonexistent database returns false, not throw
+        // functionExists on a nonexistent database throws CatalogException with db-not-found
+        // message
         ObjectPath qualifiedInNonexistentDb = new ObjectPath(nonexistentDb, "rb_build");
-        assertThat(catalog.functionExists(qualifiedInNonexistentDb)).isFalse();
+        assertThatThrownBy(() -> catalog.functionExists(qualifiedInNonexistentDb))
+                .isInstanceOf(CatalogException.class)
+                .hasMessageContaining("Database " + nonexistentDb + " does not exist");
 
-        // getFunction on a nonexistent database throws FunctionNotExistException
+        // getFunction on a nonexistent database throws CatalogException with db-not-found message
         assertThatThrownBy(() -> catalog.getFunction(qualifiedInNonexistentDb))
-                .isInstanceOf(FunctionNotExistException.class);
+                .isInstanceOf(CatalogException.class)
+                .hasMessageContaining("Database " + nonexistentDb + " does not exist");
 
         // built-in functions still resolve from every existing database, not just DEFAULT_DB
         String secondDb = "second_db_for_functions";


### PR DESCRIPTION
### Purpose

Linked issue: close #3901

`FlinkCatalog#listFunctions`, `#functionExists`, and `#getFunction` resolved the built-in RoaringBitmap SQL functions (introduced in FIP-37) purely by function name, ignoring the database component of the request entirely. As a result, a fully qualified reference to a built-in function resolved successfully even when its database did not exist, e.g.:

```sql
SELECT fluss_catalog.nonexistent_db.rb_build(ARRAY[1, 2]);
```

This broke the database-scoped semantics Flink catalogs are expected to guarantee, and made it impossible to rely on the database component of `<catalog>.<database>.<function>` identifying an existing database.

### Brief change log

- `FlinkCatalog.java`:
  - `listFunctions(String dbName)` now throws `DatabaseNotExistException` if `dbName` does not exist, before returning the built-in bitmap function names.
  - `functionExists(ObjectPath)` now returns `false` if the object path's database does not exist, before checking the built-in function map.
  - `getFunction(ObjectPath)` now throws `FunctionNotExistException` if the object path's database does not exist, before resolving the function class.
  - All three reuse the existing `databaseExists(String)` (already backed by  `admin.databaseExists()`), so no new dependency or RPC path was introduced.
  - Built-in functions still resolve unqualified from any existing database — only the database-existence gate is new; no scoping to a specific database was added.

### Tests

- Verified locally:
  - `./mvnw test -pl fluss-flink/fluss-flink-common -Dtest="FlinkCatalogTest"` — BUILD SUCCESS
  - `./mvnw verify -pl fluss-flink/fluss-flink-common -Dit.test="Flink118CatalogITCase,Flink119CatalogITCase,Flink120CatalogITCase,Flink22CatalogITCase,RbFunctionsCatalogITCase"` — BUILD SUCCESS

### API and Format

no new public API is introduced.

### Documentation

No user-facing documentation changes needed 