### PR TITLE
[docs] Rename Streamhouse to Lakestream and add Hudi

### DIFF
--- a/website/docs/streaming-lakehouse/overview.mdx
+++ b/website/docs/streaming-lakehouse/overview.mdx
@@ -34,7 +34,7 @@ The data in the Fluss cluster, stored in streaming Arrow format, is optimized fo
 The data in the Fluss cluster serves as a real-time data layer, retaining days of data with sub-second-level freshness. In contrast, the data in the Lakehouse serves as a historical data layer, retaining months of data with minute-level freshness.
 
 <ThemedImage
-    alt="Streamhouse"
+    alt="Lakestream"
     light="streamhouse_light.png"
     dark="streamhouse.png"
 />

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1028,7 +1028,7 @@
 
 /* Architecture section has no lead paragraph between the H2 and the diagram,
    so we collapse the header's bottom spacing and the title's own bottom
-   margin to put the SVG directly under "Unlocking the Streamhouse Architecture". */
+   margin to put the SVG directly under "Unlocking the Lakestream Architecture". */
 .archSection .sectionHeader,
 .archSection .archTitle {
     margin-bottom: 0;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -120,7 +120,7 @@ function HeroDiagram() {
     //   04 · QUERY ENGINES (bottom) — Flink, Spark, Trino, StarRocks, DuckDB, Ray
     //
     // The hot tier tiers down to a Lakehouse cold tier (Paimon · Iceberg ·
-    // Lance) via a Tiering Service. ViewBox is 1200 × 640 (15:8) to give the
+    // Hudi · Lance) via a Tiering Service. ViewBox is 1200 × 640 (15:8) to give the
     // four columns enough breathing room without crowding labels.
     return (
         <svg
@@ -134,7 +134,8 @@ function HeroDiagram() {
                 IoT/clickstreams) feed the Fluss hot tier in the centre,
                 which is composed of a Coordinator Server and a row of
                 Tablet Servers. Data continuously tiers down to a Lakehouse
-                cold tier (Apache Paimon, Apache Iceberg, Lance) via a
+                cold tier (Apache Paimon, Apache Iceberg, Apache Hudi,
+                Lance) via a
                 Tiering Service. Read patterns on the right include
                 streaming reads, batch reads, lookup joins, and a union
                 read that merges hot and cold. Query engines along the
@@ -355,17 +356,18 @@ function HeroDiagram() {
 
                 {[
                     {x: 312, label: 'Apache Paimon',  highlight: false},
-                    {x: 482, label: 'Apache Iceberg', highlight: true },
-                    {x: 652, label: 'Lance',          highlight: false},
+                    {x: 438, label: 'Apache Iceberg', highlight: true },
+                    {x: 564, label: 'Apache Hudi',    highlight: false},
+                    {x: 690, label: 'Lance',          highlight: false},
                 ].map((l, i) => (
                     <g key={i}>
-                        <rect x={l.x} y="438" width="156" height="46" rx="8"
+                        <rect x={l.x} y="438" width="118" height="46" rx="8"
                               fill={l.highlight ? '#194670' : '#0A1745'}
                               stroke={l.highlight
                                   ? 'rgba(38,109,149,0.7)'
                                   : 'rgba(122,175,203,0.4)'}
                               strokeWidth="1" />
-                        <text x={l.x + 78} y="466" textAnchor="middle"
+                        <text x={l.x + 59} y="466" textAnchor="middle"
                               fill="#E6ECFA" fontSize="12" fontWeight="700">
                             {l.label}
                         </text>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -355,17 +355,15 @@ function HeroDiagram() {
                 </text>
 
                 {[
-                    {x: 312, label: 'Apache Paimon',  highlight: false},
-                    {x: 438, label: 'Apache Iceberg', highlight: true },
-                    {x: 564, label: 'Apache Hudi',    highlight: false},
-                    {x: 690, label: 'Lance',          highlight: false},
+                    {x: 312, label: 'Apache Paimon'},
+                    {x: 438, label: 'Apache Iceberg'},
+                    {x: 564, label: 'Apache Hudi'},
+                    {x: 690, label: 'Lance'},
                 ].map((l, i) => (
                     <g key={i}>
                         <rect x={l.x} y="438" width="118" height="46" rx="8"
-                              fill={l.highlight ? '#194670' : '#0A1745'}
-                              stroke={l.highlight
-                                  ? 'rgba(38,109,149,0.7)'
-                                  : 'rgba(122,175,203,0.4)'}
+                              fill="#0A1745"
+                              stroke="rgba(122,175,203,0.4)"
                               strokeWidth="1" />
                         <text x={l.x + 59} y="466" textAnchor="middle"
                               fill="#E6ECFA" fontSize="12" fontWeight="700">

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -615,7 +615,7 @@ function ArchitectureSection() {
                 <div className={clsx(styles.sectionHeader, styles.sectionHeaderCenter)}>
                     <span className={styles.eyebrow}>Architecture</span>
                     <h2 className={clsx(styles.sectionTitle, styles.archTitle)}>
-                        Unlocking the Streamhouse Architecture
+                        Unlocking the Lakestream Architecture
                     </h2>
                 </div>
                 <div className={styles.archDiagram}>
@@ -660,7 +660,7 @@ function SystemsTaxSection() {
             sub: 'Sub-millisecond key/value serving',
         },
         {
-            label: 'Streamhouse',
+            label: 'Lakestream',
             sub: 'Real-time data layer for Lakehouse architecture',
         },
         {


### PR DESCRIPTION
## Summary

- Rename the Streamhouse branding to Lakestream on the website homepage
- Add Apache Hudi to the Lakehouse cold tier in the Lakestream architecture diagram
- Update the documentation image alt text and the related CSS comment for consistency


Homepage architecture:

<img width="3024" height="1660" alt="image" src="https://github.com/user-attachments/assets/a4b1dd74-3a43-4638-a173-8ccfc8016e03" />


## Motivation

Use the new Lakestream name consistently across user-facing website and documentation content, and reflect Apache Hudi support introduced in this version.

## Test Plan

- `git diff --check`
- Confirmed `rg -n "Streamhouse" website` returns no remaining user-facing matches
- Confirmed the architecture diagram and its accessibility description include Apache Hudi

🤖 AI-assisted changes - reviewed by human developer


