### PR TITLE
[test] Add multi-version compatibility test selection

### DIFF
--- a/.github/workflows/stage.sh
+++ b/.github/workflows/stage.sh
@@ -29,6 +29,7 @@ SPARK_LAKE_TEST_TAG="org.apache.fluss.spark.lake.SparkLakeTest"
 
 MODULES_FLINK1="\
 fluss-flink/fluss-flink-1.20,\
+fluss-flink/fluss-flink-1.19,\
 fluss-flink/fluss-flink-1.18\
 "
 
@@ -37,9 +38,6 @@ fluss-flink,\
 fluss-flink/fluss-flink-common,\
 fluss-flink/fluss-flink-2.2\
 "
-
-# Skip Flink 1.19 to reduce PR CI time; consider covering it in a daily CI run.
-MODULES_EXCLUDED_FROM_TEST="fluss-flink/fluss-flink-1.19"
 
 MODULES_COMMON_SPARK="\
 fluss-spark,\
@@ -72,10 +70,9 @@ function get_test_modules_for_stage() {
     local modules_lake=$MODULES_LAKE
     local negated_flink1=\!${MODULES_FLINK1//,/,\!}
     local negated_flink2=\!${MODULES_FLINK2//,/,\!}
-    local negated_excluded=\!${MODULES_EXCLUDED_FROM_TEST//,/,\!}
     local negated_spark=\!${MODULES_COMMON_SPARK//,/,\!}
     local negated_lake=\!${MODULES_LAKE//,/,\!}
-    local modules_core="$negated_flink1,$negated_flink2,$negated_excluded,$negated_spark,$negated_lake"
+    local modules_core="$negated_flink1,$negated_flink2,$negated_spark,$negated_lake"
 
     case ${stage} in
         (${STAGE_CORE})

--- a/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/adapter/Flink118CatalogTableAdapterTest.java
+++ b/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/adapter/Flink118CatalogTableAdapterTest.java
@@ -22,15 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Test for {@link CatalogTableAdapter}. */
-public class FlinkCatalogTableTest {
+/** Test for {@link CatalogTableAdapter} in flink 1.18. */
+public class Flink118CatalogTableAdapterTest extends FlinkCatalogTableAdapterTest {
 
     @Test
     public void testIsMaterializedTable() {
-        assertThat(
-                        CatalogTableAdapter.isMaterializedTable(
-                                CatalogBaseTable.TableKind.MATERIALIZED_TABLE))
-                .isEqualTo(true);
         assertThat(CatalogTableAdapter.isMaterializedTable(CatalogBaseTable.TableKind.VIEW))
                 .isEqualTo(false);
         assertThat(CatalogTableAdapter.isMaterializedTable(CatalogBaseTable.TableKind.TABLE))

--- a/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/procedure/Flink118ProcedureITCase.java
+++ b/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/procedure/Flink118ProcedureITCase.java
@@ -17,6 +17,8 @@
 
 package org.apache.fluss.flink.procedure;
 
+import org.apache.fluss.testutils.common.MultiVersionTest;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,6 +30,7 @@ public class Flink118ProcedureITCase extends FlinkProcedureITCase {
     void testIndexArgument() throws Exception {}
 
     @Test
+    @MultiVersionTest
     void testLackParams() {
         assertThatThrownBy(
                         () ->

--- a/fluss-flink/fluss-flink-1.18/src/test/resources/junit-platform.properties
+++ b/fluss-flink/fluss-flink-1.18/src/test/resources/junit-platform.properties
@@ -16,4 +16,5 @@
 # limitations under the License.
 #
 
-org.apache.fluss.testutils.common.TestLoggerExtension
+junit.jupiter.extensions.autodetection.enabled=true
+fluss.tests.multiversion.enabled=true

--- a/fluss-flink/fluss-flink-1.19/src/test/java/org/apache/fluss/flink/adapter/Flink119CatalogTableAdapterTest.java
+++ b/fluss-flink/fluss-flink-1.19/src/test/java/org/apache/fluss/flink/adapter/Flink119CatalogTableAdapterTest.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Test for {@link CatalogTableAdapter} in flink 1.18. */
-public class Flink118CatalogTableTest extends FlinkCatalogTableTest {
+/** Test for {@link CatalogTableAdapter} in flink 1.19. */
+public class Flink119CatalogTableAdapterTest extends FlinkCatalogTableAdapterTest {
 
     @Test
     public void testIsMaterializedTable() {

--- a/fluss-flink/fluss-flink-1.19/src/test/resources/junit-platform.properties
+++ b/fluss-flink/fluss-flink-1.19/src/test/resources/junit-platform.properties
@@ -16,4 +16,5 @@
 # limitations under the License.
 #
 
-org.apache.fluss.testutils.common.TestLoggerExtension
+junit.jupiter.extensions.autodetection.enabled=true
+fluss.tests.multiversion.enabled=true

--- a/fluss-flink/fluss-flink-2.2/src/test/java/org/apache/fluss/flink/catalog/Flink22CatalogITCase.java
+++ b/fluss-flink/fluss-flink-2.2/src/test/java/org/apache/fluss/flink/catalog/Flink22CatalogITCase.java
@@ -17,6 +17,8 @@
 
 package org.apache.fluss.flink.catalog;
 
+import org.apache.fluss.testutils.common.MultiVersionTest;
+
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -29,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class Flink22CatalogITCase extends FlinkCatalogITCase {
 
     @Test
+    @MultiVersionTest
     void testGetTableWithIndex() throws Exception {
         String tableName = "table_with_pk_only";
         tEnv.executeSql(

--- a/fluss-flink/fluss-flink-2.2/src/test/java/org/apache/fluss/flink/catalog/Flink22TableFactoryTest.java
+++ b/fluss-flink/fluss-flink-2.2/src/test/java/org/apache/fluss/flink/catalog/Flink22TableFactoryTest.java
@@ -17,31 +17,11 @@
 
 package org.apache.fluss.flink.catalog;
 
-import org.apache.flink.table.api.Schema;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.runtime.connector.source.LookupRuntimeProviderContext;
 
-import java.util.List;
-import java.util.Map;
-
 /** Test for {@link FlinkTableFactory} in Flink 2.2. */
 public class Flink22TableFactoryTest extends FlinkTableFactoryTest {
-
-    @Override
-    protected CatalogTable createCatalogTable(
-            Schema schema,
-            String comment,
-            List<String> partitionKeys,
-            Map<String, String> options) {
-        return CatalogTable.newBuilder()
-                .schema(schema)
-                .comment(comment)
-                .partitionKeys(partitionKeys)
-                .options(options)
-                .build();
-    }
-
     @Override
     protected LookupTableSource.LookupContext createLookupContext(int[][] lookupKeys) {
         return new LookupRuntimeProviderContext(lookupKeys, false);

--- a/fluss-flink/fluss-flink-2.2/src/test/java/org/apache/fluss/flink/catalog/Flink22TableFactoryTest.java
+++ b/fluss-flink/fluss-flink-2.2/src/test/java/org/apache/fluss/flink/catalog/Flink22TableFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.catalog;
+
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.runtime.connector.source.LookupRuntimeProviderContext;
+
+import java.util.List;
+import java.util.Map;
+
+/** Test for {@link FlinkTableFactory} in Flink 2.2. */
+public class Flink22TableFactoryTest extends FlinkTableFactoryTest {
+
+    @Override
+    protected CatalogTable createCatalogTable(
+            Schema schema,
+            String comment,
+            List<String> partitionKeys,
+            Map<String, String> options) {
+        return CatalogTable.newBuilder()
+                .schema(schema)
+                .comment(comment)
+                .partitionKeys(partitionKeys)
+                .options(options)
+                .build();
+    }
+
+    @Override
+    protected LookupTableSource.LookupContext createLookupContext(int[][] lookupKeys) {
+        return new LookupRuntimeProviderContext(lookupKeys, false);
+    }
+}

--- a/fluss-flink/fluss-flink-2.2/src/test/java/org/apache/fluss/flink/source/Flink22DeltaJoinITCase.java
+++ b/fluss-flink/fluss-flink-2.2/src/test/java/org/apache/fluss/flink/source/Flink22DeltaJoinITCase.java
@@ -22,6 +22,7 @@ import org.apache.fluss.flink.utils.FlinkTestBase;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.shaded.guava32.com.google.common.collect.ImmutableMap;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -53,6 +54,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT case for Delta Join optimization in Flink 2.2. */
+@MultiVersionTest
 public class Flink22DeltaJoinITCase extends FlinkTestBase {
 
     private static final String CATALOG_NAME = "test_catalog";

--- a/fluss-flink/fluss-flink-2.2/src/test/resources/junit-platform.properties
+++ b/fluss-flink/fluss-flink-2.2/src/test/resources/junit-platform.properties
@@ -16,4 +16,5 @@
 # limitations under the License.
 #
 
-org.apache.fluss.testutils.common.TestLoggerExtension
+junit.jupiter.extensions.autodetection.enabled=true
+fluss.tests.multiversion.enabled=true

--- a/fluss-flink/fluss-flink-common/README.md
+++ b/fluss-flink/fluss-flink-common/README.md
@@ -1,0 +1,218 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# Flink Multi-Version Tests
+
+The Flink connector shares most test implementations from `fluss-flink-common` and runs them
+through version-specific test classes in `fluss-flink-${flink.version}` modules. To keep CI time
+under control, Flink 1.20 is the default test version and runs the complete test suite. Other Flink
+versions run only tests marked with `@MultiVersionTest`.
+
+This mechanism applies to every JUnit test in a filtered version module, including both `*ITCase`
+classes and regular unit test classes.
+
+## Execution Model
+
+| Flink module | Tests that run |
+| --- | --- |
+| `fluss-flink-1.20` | All tests |
+| `fluss-flink-1.18` | Only tests marked with `@MultiVersionTest` |
+| `fluss-flink-1.19` | Only tests marked with `@MultiVersionTest` |
+| `fluss-flink-2.2` | Only tests marked with `@MultiVersionTest` |
+
+The non-default modules enable JUnit extension auto-detection and multi-version filtering in their
+`src/test/resources/junit-platform.properties` files:
+
+```properties
+junit.jupiter.extensions.autodetection.enabled=true
+fluss.tests.multiversion.enabled=true
+```
+
+[`MultiVersionTestCondition`](../../fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/MultiVersionTestCondition.java)
+disables an unmarked test before its test lifecycle starts. A class with no selected methods is
+disabled as a whole. Flink 1.20 does not contain this configuration, so the condition leaves all
+of its tests enabled.
+
+## Marking a Multi-Version Test
+
+Add `@MultiVersionTest` to the smallest test scope that exercises a Flink compatibility boundary.
+For example, annotate one representative method when the other methods in the class only verify
+version-independent Fluss behavior:
+
+```java
+import org.apache.fluss.testutils.common.MultiVersionTest;
+
+import org.junit.jupiter.api.Test;
+
+class FlinkCatalogITCase {
+
+    @Test
+    @MultiVersionTest
+    void testCreateTable() throws Exception {
+        // Test a representative catalog operation against every supported Flink version.
+    }
+
+    @Test
+    void testVersionIndependentBehavior() throws Exception {
+        // Runs only with Flink 1.20.
+    }
+}
+```
+
+The annotation is inherited from shared test methods, so the version-specific subclasses do not
+need to repeat it.
+
+Annotate the class only when every test method in the class must run against every supported Flink
+version:
+
+```java
+@MultiVersionTest
+class FlinkAdapterTest {
+
+    @Test
+    void testFirstCompatibilityPath() {}
+
+    @Test
+    void testSecondCompatibilityPath() {}
+}
+```
+
+Class-level annotations are also inherited by version-specific subclasses. Use them sparingly,
+because every current and future test method added to the class becomes a multi-version test.
+
+Good candidates for multi-version coverage include:
+
+- Flink APIs whose signatures or behavior differ between supported versions.
+- Planner, catalog, connector, serialization, or runtime integration points that have caused a
+  version-specific regression.
+- A small representative end-to-end path that verifies an important compatibility contract.
+
+Do not mark every method just because its test class has version-specific subclasses. Functional
+variants that exercise the same compatibility path should normally run only with Flink 1.20.
+
+## Adding a Shared Test
+
+Shared integration tests normally live in `fluss-flink-common/src/test/java`. Version modules use
+small subclasses to bind the shared test to their Flink dependencies:
+
+```java
+// fluss-flink-common/src/test/java/.../FlinkExampleITCase.java
+abstract class FlinkExampleITCase {
+
+    @Test
+    void testDefaultBehavior() {
+        // Runs only with Flink 1.20 because it is not marked.
+    }
+
+    @Test
+    @MultiVersionTest
+    void testCompatibilityBoundary() {
+        // Runs with every supported Flink version.
+    }
+}
+```
+
+```java
+// fluss-flink-1.20/src/test/java/.../Flink120ExampleITCase.java
+public class Flink120ExampleITCase extends FlinkExampleITCase {}
+```
+
+Create equivalent thin subclasses in each supported version module when the shared test compiles
+and is relevant there. In filtered modules, an unmarked inherited method is discovered but
+disabled. A marked inherited method is selected automatically.
+
+When adding a new method to an existing shared class:
+
+1. Add the test to the shared class in `fluss-flink-common`.
+2. Decide whether it covers a distinct Flink compatibility boundary.
+3. Leave it unmarked for default-version-only coverage, or add method-level `@MultiVersionTest`
+   for all-version coverage.
+4. Prefer one representative multi-version method over multiple equivalent variants.
+5. Run the complete Flink 1.20 suite and the filtered suites before submitting the change.
+
+## Adding a Version-Specific Test
+
+Put behavior that exists only in one Flink version in that version's test subclass or test class.
+Tests in a non-default module still need `@MultiVersionTest`; otherwise the module-level condition
+will disable them:
+
+```java
+public class Flink118ProcedureITCase extends FlinkProcedureITCase {
+
+    @Test
+    @MultiVersionTest
+    void testFlink118SpecificSignature() {
+        // The method exists only in this module, so it runs only with Flink 1.18.
+    }
+}
+```
+
+Although the annotation says “multi-version”, in this case it means that the method participates
+in the compatibility-test selection. It cannot run in another version module because the method
+is declared only in the Flink 1.18 module.
+
+## Running the Tests
+
+Run the complete default-version suite:
+
+```bash
+./mvnw verify -pl fluss-flink/fluss-flink-1.20 -am
+```
+
+Run all filtered compatibility suites:
+
+```bash
+./mvnw verify \
+  -pl fluss-flink/fluss-flink-1.18,fluss-flink/fluss-flink-1.19,fluss-flink/fluss-flink-2.2 \
+  -am
+```
+
+### IntelliJ IDEA
+
+Run the version-specific subclass from the corresponding version module. For example, run
+`Flink118CatalogITCase` to reproduce the Flink 1.18 selection or `Flink120CatalogITCase` to run the
+complete catalog test class. IntelliJ loads the module's `junit-platform.properties` from its test
+classpath, so no additional VM options are required.
+
+Avoid running the shared base class directly when checking version-specific behavior: that uses the
+`fluss-flink-common` classpath instead of the target version module and does not reproduce the CI
+selection.
+
+## Adding a New Flink Version
+
+When introducing another `fluss-flink-${flink.version}` module:
+
+1. Add thin version-specific subclasses for the shared tests that the new version supports.
+2. If it is not the default version, add `src/test/resources/junit-platform.properties` with the
+   two filtering properties shown above.
+3. Do not add the filtering properties to the default version module; it must run the complete
+   suite.
+4. Run the default suite and the new module to confirm that unmarked tests run only in the default
+   module and marked tests run in both.
+5. If the default version changes, move the full-suite responsibility by removing the properties
+   from the new default module and adding them to the previous default module.
+
+## Review Checklist
+
+- Does this test exercise a Flink-version compatibility boundary rather than only Fluss behavior?
+- Is method-level `@MultiVersionTest` sufficient, or does every method really need class-level
+  selection?
+- Does each required version module have a subclass that discovers the shared test?
+- Are version-specific tests in filtered modules explicitly marked?
+- Does Flink 1.20 still run the complete suite?
+- Do IntelliJ and Maven both run the version-specific subclass with the expected selection?

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/action/orphan/OrphanFilesCleanITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/action/orphan/OrphanFilesCleanITCase.java
@@ -40,6 +40,7 @@ import org.apache.fluss.server.zk.data.BucketSnapshot;
 import org.apache.fluss.server.zk.data.RemoteLogManifestHandle;
 import org.apache.fluss.server.zk.data.ZkData.BucketSnapshotsZNode;
 import org.apache.fluss.server.zk.data.ZkData.PartitionZNode;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.types.DataTypes;
 import org.apache.fluss.utils.FlussPaths;
 
@@ -163,6 +164,7 @@ abstract class OrphanFilesCleanITCase extends AbstractTestBase {
     private static final Duration OLD_ENOUGH = Duration.ofDays(2);
 
     @Test
+    @MultiVersionTest
     void mixedOrphanAndActiveFilesInSameBucket() throws Exception {
         String dbName = newDatabaseName("mixed");
         TablePath tablePath = createLogTable(dbName, "mixed_bucket");

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/adapter/FlinkCatalogTableAdapterTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/adapter/FlinkCatalogTableAdapterTest.java
@@ -17,16 +17,23 @@
 
 package org.apache.fluss.flink.adapter;
 
+import org.apache.fluss.testutils.common.MultiVersionTest;
+
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Test for {@link CatalogTableAdapter} in flink 1.19. */
-public class Flink119CatalogTableTest extends FlinkCatalogTableTest {
+/** Test for {@link CatalogTableAdapter}. */
+@MultiVersionTest
+public class FlinkCatalogTableAdapterTest {
 
     @Test
     public void testIsMaterializedTable() {
+        assertThat(
+                        CatalogTableAdapter.isMaterializedTable(
+                                CatalogBaseTable.TableKind.MATERIALIZED_TABLE))
+                .isEqualTo(true);
         assertThat(CatalogTableAdapter.isMaterializedTable(CatalogBaseTable.TableKind.VIEW))
                 .isEqualTo(false);
         assertThat(CatalogTableAdapter.isMaterializedTable(CatalogBaseTable.TableKind.TABLE))

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/adapter/FlinkMultipleParameterToolTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/adapter/FlinkMultipleParameterToolTest.java
@@ -17,11 +17,14 @@
 
 package org.apache.fluss.flink.adapter;
 
+import org.apache.fluss.testutils.common.MultiVersionTest;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link MultipleParameterToolAdapter}. */
+@MultiVersionTest
 abstract class FlinkMultipleParameterToolTest {
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogFactoryTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogFactoryTest.java
@@ -19,6 +19,7 @@ package org.apache.fluss.flink.catalog;
 
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.flink.FlinkConnectorOptions;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link FlinkCatalogFactory}. */
+@MultiVersionTest
 abstract class FlinkCatalogFactoryTest {
 
     static final String CATALOG_NAME = "my_catalog";

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -33,6 +33,7 @@ import org.apache.fluss.metadata.DataLakeFormat;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -159,6 +160,7 @@ abstract class FlinkCatalogITCase {
     }
 
     @Test
+    @MultiVersionTest
     void testCreateTable() throws Exception {
         // create a table will all supported data types
         tEnv.executeSql(

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkCatalogTest.java
@@ -26,6 +26,7 @@ import org.apache.fluss.flink.adapter.ResolvedCatalogMaterializedTableAdapter;
 import org.apache.fluss.flink.lake.LakeFlinkCatalog;
 import org.apache.fluss.flink.utils.FlinkConversionsTest;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.utils.ExceptionUtils;
 
 import org.apache.flink.table.api.DataTypes;
@@ -225,6 +226,7 @@ class FlinkCatalogTest {
     }
 
     @Test
+    @MultiVersionTest
     void testCreateTable() throws Exception {
         Map<String, String> options = new HashMap<>();
         assertThatThrownBy(() -> catalog.getTable(tableInDefaultDb))

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.fluss.flink.sink.FlinkTableSink;
 import org.apache.fluss.flink.source.FlinkTableSource;
 import org.apache.fluss.flink.source.lookup.FlinkAsyncLookupFunction;
 import org.apache.fluss.flink.source.lookup.FlinkLookupFunction;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
@@ -68,6 +69,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link FlinkTableFactory}. */
+@MultiVersionTest
 abstract class FlinkTableFactoryTest {
 
     public static final ObjectIdentifier OBJECT_IDENTIFIER =

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
@@ -19,6 +19,8 @@ package org.apache.fluss.flink.catalog;
 
 import org.apache.fluss.flink.FlinkConnectorOptions;
 import org.apache.fluss.flink.sink.FlinkTableSink;
+import org.apache.fluss.flink.source.BinlogFlinkTableSource;
+import org.apache.fluss.flink.source.ChangelogFlinkTableSource;
 import org.apache.fluss.flink.source.FlinkTableSource;
 import org.apache.fluss.flink.source.lookup.FlinkAsyncLookupFunction;
 import org.apache.fluss.flink.source.lookup.FlinkLookupFunction;
@@ -165,7 +167,7 @@ abstract class FlinkTableFactoryTest {
         tableSource = (FlinkTableSource) createTableSource(schema, properties);
         int[][] lookupKey = {{0}, {2}};
         LookupTableSource.LookupRuntimeProvider lookupProvider =
-                tableSource.getLookupRuntimeProvider(new LookupRuntimeProviderContext(lookupKey));
+                tableSource.getLookupRuntimeProvider(createLookupContext(lookupKey));
         assertThat(lookupProvider instanceof AsyncLookupFunctionProvider).isTrue();
         AsyncLookupFunction asyncLookupFunction =
                 ((AsyncLookupFunctionProvider) lookupProvider).createAsyncLookupFunction();
@@ -174,8 +176,7 @@ abstract class FlinkTableFactoryTest {
         // test sync
         properties.put(FlinkConnectorOptions.LOOKUP_ASYNC.key(), "false");
         tableSource = (FlinkTableSource) createTableSource(schema, properties);
-        lookupProvider =
-                tableSource.getLookupRuntimeProvider(new LookupRuntimeProviderContext(lookupKey));
+        lookupProvider = tableSource.getLookupRuntimeProvider(createLookupContext(lookupKey));
         assertThat(lookupProvider instanceof LookupFunctionProvider).isTrue();
         LookupFunction lookupFunction =
                 ((LookupFunctionProvider) lookupProvider).createLookupFunction();
@@ -217,6 +218,29 @@ abstract class FlinkTableFactoryTest {
                                         configuration))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("$binlog virtual tables only support streaming mode.");
+    }
+
+    @Test
+    void testVirtualLogTableSources() {
+        Map<String, String> properties = getBasicOptions();
+
+        DynamicTableSource changelogSource =
+                createTableSource(
+                        CHANGELOG_TABLE_IDENTIFIER,
+                        createChangelogSchema(),
+                        properties,
+                        Collections.emptyMap(),
+                        new Configuration());
+        assertThat(changelogSource).isInstanceOf(ChangelogFlinkTableSource.class);
+
+        DynamicTableSource binlogSource =
+                createTableSource(
+                        BINLOG_TABLE_IDENTIFIER,
+                        createBinlogSchema(),
+                        properties,
+                        Collections.emptyMap(),
+                        new Configuration());
+        assertThat(binlogSource).isInstanceOf(BinlogFlinkTableSource.class);
     }
 
     @Test
@@ -266,6 +290,19 @@ abstract class FlinkTableFactoryTest {
                 null);
     }
 
+    private ResolvedSchema createChangelogSchema() {
+        return new ResolvedSchema(
+                Arrays.asList(
+                        Column.physical("_change_type", DataTypes.STRING().notNull()),
+                        Column.physical("_log_offset", DataTypes.BIGINT().notNull()),
+                        Column.physical("_commit_timestamp", DataTypes.TIMESTAMP_LTZ(3).notNull()),
+                        Column.physical("first", DataTypes.STRING().notNull()),
+                        Column.physical("second", DataTypes.INT()),
+                        Column.physical("third", DataTypes.STRING().notNull())),
+                Collections.emptyList(),
+                null);
+    }
+
     private static Map<String, String> getBasicOptions() {
         Map<String, String> options = new HashMap<>();
         options.put("connector", "fluss");
@@ -279,12 +316,12 @@ abstract class FlinkTableFactoryTest {
         return basicOptions;
     }
 
-    private static DynamicTableSource createTableSource(
+    private DynamicTableSource createTableSource(
             ResolvedSchema schema, Map<String, String> options) {
         return createTableSource(schema, options, Collections.emptyMap());
     }
 
-    private static DynamicTableSource createTableSource(
+    private DynamicTableSource createTableSource(
             ResolvedSchema schema,
             Map<String, String> options,
             Map<String, String> enrichmentOptions) {
@@ -292,7 +329,7 @@ abstract class FlinkTableFactoryTest {
                 OBJECT_IDENTIFIER, schema, options, enrichmentOptions, new Configuration());
     }
 
-    private static DynamicTableSource createTableSource(
+    private DynamicTableSource createTableSource(
             ObjectIdentifier objectIdentifier,
             ResolvedSchema schema,
             Map<String, String> options,
@@ -303,7 +340,7 @@ abstract class FlinkTableFactoryTest {
                 new FactoryUtil.DefaultDynamicTableContext(
                         objectIdentifier,
                         new ResolvedCatalogTable(
-                                CatalogTable.of(
+                                createCatalogTable(
                                         Schema.newBuilder().fromResolvedSchema(schema).build(),
                                         "mock source",
                                         schema.getPrimaryKey()
@@ -318,15 +355,14 @@ abstract class FlinkTableFactoryTest {
         return tableFactory.createDynamicTableSource(context);
     }
 
-    private static DynamicTableSink createTableSink(
-            ResolvedSchema schema, Map<String, String> options) {
+    private DynamicTableSink createTableSink(ResolvedSchema schema, Map<String, String> options) {
 
         FlinkTableFactory tableFactory = createFlinkTableFactory();
         FactoryUtil.DefaultDynamicTableContext context =
                 new FactoryUtil.DefaultDynamicTableContext(
                         OBJECT_IDENTIFIER,
                         new ResolvedCatalogTable(
-                                CatalogTable.of(
+                                createCatalogTable(
                                         Schema.newBuilder().fromResolvedSchema(schema).build(),
                                         "mock sink",
                                         Collections.emptyList(),
@@ -337,6 +373,20 @@ abstract class FlinkTableFactoryTest {
                         Thread.currentThread().getContextClassLoader(),
                         false);
         return tableFactory.createDynamicTableSink(context);
+    }
+
+    /** Creates a catalog table using the API available in the tested Flink version. */
+    protected CatalogTable createCatalogTable(
+            Schema schema,
+            String comment,
+            List<String> partitionKeys,
+            Map<String, String> options) {
+        return CatalogTable.of(schema, comment, partitionKeys, options);
+    }
+
+    /** Creates a lookup context using the API available in the tested Flink version. */
+    protected LookupTableSource.LookupContext createLookupContext(int[][] lookupKeys) {
+        return new LookupRuntimeProviderContext(lookupKeys);
     }
 
     public static FlinkTableFactory createFlinkTableFactory() {

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
@@ -18,6 +18,7 @@
 package org.apache.fluss.flink.catalog;
 
 import org.apache.fluss.flink.FlinkConnectorOptions;
+import org.apache.fluss.flink.adapter.CatalogTableAdapter;
 import org.apache.fluss.flink.sink.FlinkTableSink;
 import org.apache.fluss.flink.source.BinlogFlinkTableSource;
 import org.apache.fluss.flink.source.ChangelogFlinkTableSource;
@@ -32,7 +33,6 @@ import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.CommonCatalogOptions;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -340,7 +340,7 @@ abstract class FlinkTableFactoryTest {
                 new FactoryUtil.DefaultDynamicTableContext(
                         objectIdentifier,
                         new ResolvedCatalogTable(
-                                createCatalogTable(
+                                CatalogTableAdapter.toCatalogTable(
                                         Schema.newBuilder().fromResolvedSchema(schema).build(),
                                         "mock source",
                                         schema.getPrimaryKey()
@@ -362,7 +362,7 @@ abstract class FlinkTableFactoryTest {
                 new FactoryUtil.DefaultDynamicTableContext(
                         OBJECT_IDENTIFIER,
                         new ResolvedCatalogTable(
-                                createCatalogTable(
+                                CatalogTableAdapter.toCatalogTable(
                                         Schema.newBuilder().fromResolvedSchema(schema).build(),
                                         "mock sink",
                                         Collections.emptyList(),
@@ -373,15 +373,6 @@ abstract class FlinkTableFactoryTest {
                         Thread.currentThread().getContextClassLoader(),
                         false);
         return tableFactory.createDynamicTableSink(context);
-    }
-
-    /** Creates a catalog table using the API available in the tested Flink version. */
-    protected CatalogTable createCatalogTable(
-            Schema schema,
-            String comment,
-            List<String> partitionKeys,
-            Map<String, String> options) {
-        return CatalogTable.of(schema, comment, partitionKeys, options);
     }
 
     /** Creates a lookup context using the API available in the tested Flink version. */

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/MaterializedTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/MaterializedTableITCase.java
@@ -20,6 +20,7 @@ package org.apache.fluss.flink.catalog;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.rest.RestClusterClient;
@@ -164,6 +165,7 @@ public abstract class MaterializedTableITCase {
     }
 
     @Test
+    @MultiVersionTest
     void testCreateMaterializedTableInContinuousMode() throws Exception {
         String materializedTableDDL =
                 "CREATE MATERIALIZED TABLE shop_detail\n"

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/metrics/FlinkMetricsITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/metrics/FlinkMetricsITCase.java
@@ -27,6 +27,7 @@ import org.apache.fluss.metadata.TableDescriptor;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.metrics.MetricNames;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.types.DataTypes;
 
 import org.apache.flink.api.common.JobID;
@@ -149,6 +150,7 @@ abstract class FlinkMetricsITCase {
     }
 
     @Test
+    @MultiVersionTest
     void testMetricsReport() throws Exception {
         TableDescriptor tableDescriptor =
                 TableDescriptor.builder()

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/procedure/FlinkProcedureITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/procedure/FlinkProcedureITCase.java
@@ -174,6 +174,7 @@ public abstract class FlinkProcedureITCase {
                 .hasMessageContaining("No match found for function signature generate_n");
     }
 
+    @MultiVersionTest
     @Test
     void testIndexArgument() throws Exception {
         tEnv.executeSql(

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/procedure/FlinkProcedureITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/procedure/FlinkProcedureITCase.java
@@ -34,6 +34,7 @@ import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
 import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.data.ServerTags;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
@@ -129,6 +130,7 @@ public abstract class FlinkProcedureITCase {
     }
 
     @Test
+    @MultiVersionTest
     void testShowProcedures() throws Exception {
         try (CloseableIterator<Row> showProceduresIterator =
                 tEnv.executeSql("show procedures").collect()) {

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/security/acl/FlinkAuthorizationITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/security/acl/FlinkAuthorizationITCase.java
@@ -32,6 +32,7 @@ import org.apache.fluss.security.acl.PermissionType;
 import org.apache.fluss.security.acl.Resource;
 import org.apache.fluss.security.auth.sasl.jaas.LoginManager;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.utils.ParentResourceBlockingClassLoader;
 import org.apache.fluss.utils.TemporaryClassLoaderContext;
 
@@ -133,6 +134,7 @@ abstract class FlinkAuthorizationITCase extends AbstractTestBase {
     }
 
     @Test
+    @MultiVersionTest
     void testShowDatabases() throws Exception {
         assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show databases").collect()))
                 .isEmpty();

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/FlinkComplexTypeITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/FlinkComplexTypeITCase.java
@@ -23,6 +23,7 @@ import org.apache.fluss.client.table.Table;
 import org.apache.fluss.exception.InvalidTableException;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -105,6 +106,7 @@ abstract class FlinkComplexTypeITCase extends AbstractTestBase {
     }
 
     @Test
+    @MultiVersionTest
     void testComplexTypesInLogTable() throws Exception {
         tEnv.executeSql(
                 "create table complex_log_test ("

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/FlinkTableSinkITCase.java
@@ -530,6 +530,7 @@ abstract class FlinkTableSinkITCase extends AbstractTestBase {
     }
 
     @Test
+    @MultiVersionTest
     void testPartialUpsert() throws Exception {
         tEnv.executeSql(
                 "create table sink_test (a int not null primary key not enforced, b bigint, c string) with('bucket.num' = '3')");

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/FlinkTableSinkITCase.java
@@ -29,6 +29,7 @@ import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.utils.types.Tuple2;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
@@ -139,6 +140,7 @@ abstract class FlinkTableSinkITCase extends AbstractTestBase {
     }
 
     @ParameterizedTest
+    @MultiVersionTest
     @ValueSource(booleans = {true, false})
     void testAppendLog(boolean compressed) throws Exception {
         String compressedProperties =

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/UndoRecoveryITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/UndoRecoveryITCase.java
@@ -30,6 +30,7 @@ import org.apache.fluss.flink.sink.testutils.FailingCountingSource;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -193,6 +194,7 @@ abstract class UndoRecoveryITCase {
      * checkpoint are undone during recovery)
      */
     @Test
+    @MultiVersionTest
     void testCheckpointFailoverRecovery() throws Exception {
         String tableName = "undo_checkpoint_failover_" + System.currentTimeMillis();
         TablePath tablePath = TablePath.of(DEFAULT_DB, tableName);

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/BinlogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/BinlogVirtualTableITCase.java
@@ -27,6 +27,7 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.utils.clock.ManualClock;
 
 import org.apache.flink.api.common.JobID;
@@ -183,6 +184,7 @@ abstract class BinlogVirtualTableITCase {
     }
 
     @Test
+    @MultiVersionTest
     public void testDescribeBinlogTable() throws Exception {
         // Create a table with various data types to test complex schema
         tEnv.executeSql(

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
@@ -27,6 +27,7 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.utils.clock.ManualClock;
 
 import org.apache.flink.api.common.JobID;
@@ -175,6 +176,7 @@ abstract class ChangelogVirtualTableITCase {
     }
 
     @Test
+    @MultiVersionTest
     public void testDescribeChangelogTable() throws Exception {
         // Create a table with various data types to test complex schema
         tEnv.executeSql(

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceBatchITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceBatchITCase.java
@@ -26,6 +26,7 @@ import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.row.BinaryString;
 import org.apache.fluss.row.GenericArray;
 import org.apache.fluss.row.GenericMap;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -96,6 +97,7 @@ abstract class FlinkTableSourceBatchITCase extends FlinkTestBase {
     }
 
     @Test
+    @MultiVersionTest
     void testScanSingleRowFilter() throws Exception {
         String tableName = prepareSourceTable(new String[] {"name", "id"}, null);
         String query = String.format("SELECT * FROM %s WHERE id = 1 AND name = 'name1'", tableName);

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFailOverITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFailOverITCase.java
@@ -25,6 +25,7 @@ import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
 import org.apache.fluss.server.zk.ZooKeeperClient;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.utils.types.Tuple2;
 
 import org.apache.flink.configuration.CheckpointingOptions;
@@ -130,6 +131,7 @@ abstract class FlinkTableSourceFailOverITCase {
     }
 
     @Test
+    @MultiVersionTest
     void testRestore() throws Exception {
         TablePath tablePath = TablePath.of("fluss", "test_recreate_table");
         Tuple2<String, CloseableIterator<Row>> savepointPathAndResults =

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceITCase.java
@@ -30,6 +30,7 @@ import org.apache.fluss.row.GenericRow;
 import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
 import org.apache.fluss.server.zk.ZooKeeperClient;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.utils.clock.ManualClock;
 
 import org.apache.commons.lang3.RandomUtils;
@@ -144,6 +145,7 @@ abstract class FlinkTableSourceITCase extends AbstractTestBase {
     }
 
     @Test
+    @MultiVersionTest
     public void testCreateTableLike() throws Exception {
         tEnv.executeSql(
                         "CREATE TEMPORARY TABLE Orders (\n"

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringITCase.java
@@ -30,6 +30,7 @@ import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.server.log.FetchIsolation;
 import org.apache.fluss.server.log.LogTablet;
 import org.apache.fluss.server.replica.Replica;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 import org.apache.fluss.types.DataTypes;
 import org.apache.fluss.utils.ExceptionUtils;
 
@@ -74,6 +75,7 @@ abstract class TieringITCase extends FlinkTieringTestBase {
     }
 
     @Test
+    @MultiVersionTest
     void testTieringReachMaxDuration() throws Exception {
         TablePath logTablePath = TablePath.of("fluss", "logtable");
         createTable(logTablePath, false);

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/committer/TieringCommitOperatorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/committer/TieringCommitOperatorTest.java
@@ -29,6 +29,7 @@ import org.apache.fluss.flink.utils.FlinkTestBase;
 import org.apache.fluss.lake.committer.CommittedLakeSnapshot;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.testutils.common.MultiVersionTest;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -62,6 +63,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** UT for {@link TieringCommitOperator}. */
+@MultiVersionTest
 class TieringCommitOperatorTest extends FlinkTestBase {
 
     private TieringCommitOperator<TestingWriteResult, TestingCommittable> committerOperator;

--- a/fluss-spark/pom.xml
+++ b/fluss-spark/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>3.1.0</version>
+            <version>${scalatest.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/fluss-test-utils/pom.xml
+++ b/fluss-test-utils/pom.xml
@@ -41,5 +41,13 @@
             <artifactId>assertj-core</artifactId>
             <scope>compile</scope>
         </dependency>
+
+        <!-- Used only to make MultiVersionTest a tag understood by ScalaTest. -->
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>${scalatest.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/MultiVersionTest.java
+++ b/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/MultiVersionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.testutils.common;
+
+import org.junit.jupiter.api.Tag;
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a test that should run against every supported version of an external system.
+ *
+ * <p>The annotation is recognized as the same tag by JUnit 5 and ScalaTest. It may be placed on a
+ * test method or a test class. Tests without this annotation should run only against the default
+ * version of the external system. JUnit modules for non-default versions enable {@link
+ * MultiVersionTestCondition} through configuration; ScalaTest function-style tests should use
+ * {@link MultiVersionTestTag#INSTANCE} instead.
+ */
+@Tag(MultiVersionTest.TAG)
+@TagAnnotation
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface MultiVersionTest {
+
+    /** Tag used by test runner configurations to select multi-version tests. */
+    String TAG = "org.apache.fluss.testutils.common.MultiVersionTest";
+}

--- a/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/MultiVersionTestCondition.java
+++ b/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/MultiVersionTestCondition.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.testutils.common;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.annotation.Testable;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import java.lang.reflect.Method;
+
+/**
+ * Filters JUnit tests not marked with {@link MultiVersionTest} in a non-default version module.
+ *
+ * <p>The filter can be enabled for a module with {@value #ENABLE_PROPERTY}, or for an individual
+ * test class with {@link RunMultiVersionTestsOnly}.
+ */
+public final class MultiVersionTestCondition implements ExecutionCondition {
+
+    /** JUnit configuration parameter that enables multi-version filtering for a test module. */
+    public static final String ENABLE_PROPERTY = "fluss.tests.multiversion.enabled";
+
+    private static final ConditionEvaluationResult ENABLED =
+            ConditionEvaluationResult.enabled("Multi-version filtering is not enabled");
+
+    private static final ConditionEvaluationResult ENABLED_CLASS =
+            ConditionEvaluationResult.enabled("Class contains selected multi-version tests");
+
+    private static final ConditionEvaluationResult ENABLED_MULTI_VERSION =
+            ConditionEvaluationResult.enabled("Test is marked as multi-version");
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (!context.getTestClass().isPresent()) {
+            return ENABLED;
+        }
+
+        Class<?> testClass = context.getRequiredTestClass();
+        if (!isFilteringEnabled(context, testClass)) {
+            return ENABLED;
+        }
+
+        if (!context.getTestMethod().isPresent()) {
+            return hasSelectedTests(testClass)
+                    ? ENABLED_CLASS
+                    : ConditionEvaluationResult.disabled("Class has no multi-version tests");
+        }
+
+        Method testMethod = context.getRequiredTestMethod();
+        if (context.getTags().contains(MultiVersionTest.TAG)) {
+            return ENABLED_MULTI_VERSION;
+        }
+
+        return ConditionEvaluationResult.disabled(
+                String.format(
+                        "Test '%s' is not marked with @MultiVersionTest", testMethod.getName()));
+    }
+
+    private static boolean isFilteringEnabled(ExtensionContext context, Class<?> testClass) {
+        boolean enabledByConfiguration =
+                context.getConfigurationParameter(ENABLE_PROPERTY)
+                        .map(Boolean::parseBoolean)
+                        .orElse(false);
+        return enabledByConfiguration
+                || AnnotationSupport.isAnnotated(testClass, RunMultiVersionTestsOnly.class);
+    }
+
+    private static boolean hasSelectedTests(Class<?> testClass) {
+        if (AnnotationSupport.isAnnotated(testClass, MultiVersionTest.class)) {
+            return true;
+        }
+
+        Class<?> currentClass = testClass;
+        while (currentClass != null && currentClass != Object.class) {
+            for (Method method : currentClass.getDeclaredMethods()) {
+                if (AnnotationSupport.isAnnotated(method, Testable.class)
+                        && AnnotationSupport.isAnnotated(method, MultiVersionTest.class)) {
+                    return true;
+                }
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+        return false;
+    }
+}

--- a/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/MultiVersionTestCondition.java
+++ b/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/MultiVersionTestCondition.java
@@ -17,6 +17,7 @@
 
 package org.apache.fluss.testutils.common;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -24,6 +25,8 @@ import org.junit.platform.commons.annotation.Testable;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Filters JUnit tests not marked with {@link MultiVersionTest} in a non-default version module.
@@ -81,17 +84,30 @@ public final class MultiVersionTestCondition implements ExecutionCondition {
                 || AnnotationSupport.isAnnotated(testClass, RunMultiVersionTestsOnly.class);
     }
 
-    private static boolean hasSelectedTests(Class<?> testClass) {
-        if (AnnotationSupport.isAnnotated(testClass, MultiVersionTest.class)) {
-            return true;
-        }
+    static boolean hasSelectedTests(Class<?> testClass) {
+        return hasSelectedTests(testClass, new HashSet<>());
+    }
 
+    private static boolean hasSelectedTests(Class<?> testClass, Set<Class<?>> inspectedClasses) {
         Class<?> currentClass = testClass;
         while (currentClass != null && currentClass != Object.class) {
-            for (Method method : currentClass.getDeclaredMethods()) {
-                if (AnnotationSupport.isAnnotated(method, Testable.class)
-                        && AnnotationSupport.isAnnotated(method, MultiVersionTest.class)) {
+            if (inspectedClasses.add(currentClass)) {
+                if (AnnotationSupport.isAnnotated(currentClass, MultiVersionTest.class)) {
                     return true;
+                }
+
+                for (Method method : currentClass.getDeclaredMethods()) {
+                    if (AnnotationSupport.isAnnotated(method, Testable.class)
+                            && AnnotationSupport.isAnnotated(method, MultiVersionTest.class)) {
+                        return true;
+                    }
+                }
+
+                for (Class<?> nestedClass : currentClass.getDeclaredClasses()) {
+                    if (AnnotationSupport.isAnnotated(nestedClass, Nested.class)
+                            && hasSelectedTests(nestedClass, inspectedClasses)) {
+                        return true;
+                    }
                 }
             }
             currentClass = currentClass.getSuperclass();

--- a/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/MultiVersionTestTag.java
+++ b/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/MultiVersionTestTag.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.testutils.common;
+
+import org.scalatest.Tag;
+
+/** ScalaTest tag equivalent of {@link MultiVersionTest} for function-style tests. */
+public final class MultiVersionTestTag {
+
+    /** Shared tag instance for ScalaTest test registration. */
+    public static final Tag INSTANCE = new Tag(MultiVersionTest.TAG);
+
+    private MultiVersionTestTag() {}
+}

--- a/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/RunMultiVersionTestsOnly.java
+++ b/fluss-test-utils/src/main/java/org/apache/fluss/testutils/common/RunMultiVersionTestsOnly.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.testutils.common;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Enables {@link MultiVersionTestCondition} for an individual JUnit test class. */
+@ExtendWith(MultiVersionTestCondition.class)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RunMultiVersionTestsOnly {}

--- a/fluss-test-utils/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/fluss-test-utils/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-org.apache.fluss.testutils.common.TestLoggerExtension
+org.apache.fluss.testutils.common.MultiVersionTestCondition

--- a/fluss-test-utils/src/test/java/org/apache/fluss/testutils/common/MultiVersionTestConditionTest.java
+++ b/fluss-test-utils/src/test/java/org/apache/fluss/testutils/common/MultiVersionTestConditionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.testutils.common;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link MultiVersionTestCondition}. */
+@RunMultiVersionTestsOnly
+class MultiVersionTestConditionTest extends MultiVersionTestConditionTestBase {
+
+    @Test
+    @MultiVersionTest
+    void testMarkedDeclaredMethodRuns() {}
+
+    @Test
+    void testUnmarkedDeclaredMethodDoesNotRun() {
+        throw new AssertionError("Unmarked declared test should have been disabled");
+    }
+}
+
+abstract class MultiVersionTestConditionTestBase {
+
+    @Test
+    @MultiVersionTest
+    void testMarkedInheritedMethodRuns() {}
+
+    @Test
+    void testUnmarkedInheritedMethodDoesNotRun() {
+        throw new AssertionError("Unmarked inherited test should have been disabled");
+    }
+}
+
+@RunMultiVersionTestsOnly
+class OnlyUnmarkedInheritedMultiVersionTestConditionTest
+        extends OnlyUnmarkedInheritedMultiVersionTestConditionTestBase {}
+
+abstract class OnlyUnmarkedInheritedMultiVersionTestConditionTestBase {
+
+    @Test
+    void testUnmarkedInheritedMethodDoesNotStartClass() {
+        throw new AssertionError("Class without selected tests should have been disabled");
+    }
+}

--- a/fluss-test-utils/src/test/java/org/apache/fluss/testutils/common/MultiVersionTestConditionTest.java
+++ b/fluss-test-utils/src/test/java/org/apache/fluss/testutils/common/MultiVersionTestConditionTest.java
@@ -17,7 +17,11 @@
 
 package org.apache.fluss.testutils.common;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link MultiVersionTestCondition}. */
 @RunMultiVersionTestsOnly
@@ -28,8 +32,51 @@ class MultiVersionTestConditionTest extends MultiVersionTestConditionTestBase {
     void testMarkedDeclaredMethodRuns() {}
 
     @Test
+    @MultiVersionTest
+    void testSelectedNestedTestsAreDetected() {
+        assertThat(MultiVersionTestCondition.hasSelectedTests(OnlyMarkedNestedMethodTest.class))
+                .isTrue();
+        assertThat(MultiVersionTestCondition.hasSelectedTests(OnlyMarkedNestedClassTest.class))
+                .isTrue();
+        assertThat(MultiVersionTestCondition.hasSelectedTests(OnlyUnmarkedNestedTest.class))
+                .isFalse();
+    }
+
+    @Test
     void testUnmarkedDeclaredMethodDoesNotRun() {
         throw new AssertionError("Unmarked declared test should have been disabled");
+    }
+
+    private static class OnlyMarkedNestedMethodTest {
+
+        @Nested
+        class NestedTests {
+
+            @Test
+            @MultiVersionTest
+            void testMarkedNestedMethod() {}
+        }
+    }
+
+    private static class OnlyMarkedNestedClassTest {
+
+        @Nested
+        @MultiVersionTest
+        class NestedTests {
+
+            @Test
+            void testNestedClassMethod() {}
+        }
+    }
+
+    private static class OnlyUnmarkedNestedTest {
+
+        @Nested
+        class NestedTests {
+
+            @Test
+            void testUnmarkedNestedMethod() {}
+        }
     }
 }
 
@@ -47,7 +94,13 @@ abstract class MultiVersionTestConditionTestBase {
 
 @RunMultiVersionTestsOnly
 class OnlyUnmarkedInheritedMultiVersionTestConditionTest
-        extends OnlyUnmarkedInheritedMultiVersionTestConditionTestBase {}
+        extends OnlyUnmarkedInheritedMultiVersionTestConditionTestBase {
+
+    @BeforeAll
+    static void failIfClassLifecycleStarts() {
+        throw new AssertionError("Class without selected tests should have been disabled");
+    }
+}
 
 abstract class OnlyUnmarkedInheritedMultiVersionTestConditionTestBase {
 

--- a/fluss-test-utils/src/test/java/org/apache/fluss/testutils/common/MultiVersionTestTest.java
+++ b/fluss-test-utils/src/test/java/org/apache/fluss/testutils/common/MultiVersionTestTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.testutils.common;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.scalatest.TagAnnotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link MultiVersionTest}. */
+class MultiVersionTestTest {
+
+    @Test
+    void testSupportedTestFrameworkTags() {
+        assertThat(MultiVersionTest.class.getAnnotation(Tag.class).value())
+                .isEqualTo(MultiVersionTest.TAG);
+        assertThat(MultiVersionTest.class).hasAnnotation(TagAnnotation.class);
+        assertThat(MultiVersionTestTag.INSTANCE.name()).isEqualTo(MultiVersionTest.TAG);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>${scala212.version}</scala.version>
         <spark.version>3.5.7</spark.version>
+        <scalatest.version>3.1.0</scalatest.version>
 
         <fluss.hadoop.version>3.4.0</fluss.hadoop.version>
         <frocksdb.version>6.20.3-ververica-2.0</frocksdb.version>


### PR DESCRIPTION
## Summary

- introduce a shared `@MultiVersionTest` marker for JUnit 5 and ScalaTest
- run the complete Flink test suite on 1.20 while selecting only marked tests on 1.18, 1.19, and 2.2
- auto-discover the JUnit execution condition so Maven and IntelliJ IDEA use the same filtering semantics
- skip an ITCase class lifecycle when it contains no selected multi-version tests
- restore Flink 1.19 to the CI stage now that its compatibility suite is filtered

Closes #3912

## Test Plan

- `./mvnw -pl fluss-test-utils -Dfluss.reuseForks=true clean test`
- `./mvnw -pl fluss-test-utils,fluss-flink/fluss-flink-common,fluss-flink/fluss-flink-1.18,fluss-flink/fluss-flink-1.19,fluss-flink/fluss-flink-1.20,fluss-flink/fluss-flink-2.2 -DskipTests -Dfluss.reuseForks=true test-compile`
- `git diff --check`


## Before and After

The table below compares the theoretical number of test methods that would run if every Flink version executed its complete inherited test suite with the number selected after introducing `@MultiVersionTest`.

| Flink version | Test classes | Before filtering | Currently selected | Skipped | Reduction | Execution strategy |
|---|---:|---:|---:|---:|---:|---|
| 1.18 | 18 (13 ITCase / 5 UnitTest) | 197 | 33 | 164 | 83.2% | Multi-version tests only |
| 1.19 | 19 (14 ITCase / 5 UnitTest) | 210 | 33 | 177 | 84.3% | Multi-version tests only |
| 1.20 | 18 (15 ITCase / 3 UnitTest) | 205 | 205 | 0 | 0% | Complete test suite |
| 2.2 | 19 (16 ITCase / 3 UnitTest) | 241 | 44 | 197 | 81.7% | Multi-version tests only |
| **Total** | **74** | **853** | **315** | **538** | **63.1%** | — |

The new mechanism reduces the theoretical number of multi-version test-method executions by **63.1%**, from **853** to **315**, while keeping Flink 1.20 as the complete regression baseline.

- Flink 1.20 runs the complete test suite.
- Flink 1.18, 1.19, and 2.2 run only tests marked with `@MultiVersionTest`, either directly on the test method or inherited from a class-level annotation.
- Every version-specific wrapper class now contains at least one selected test; no wrapper class is skipped entirely.
- Compatibility-sensitive tests can be added incrementally without requiring every inherited test to run against every Flink version.

> **Note:** Before this change, Flink 1.19 was excluded from CI entirely. Therefore, “Before filtering” represents the theoretical full-suite count for every supported Flink version and is intended to measure the effect of the filtering mechanism itself.
>
> Counts are based on distinct test methods. Individual invocations generated by parameterized tests are not expanded.

🤖 AI-assisted changes - reviewed by human developer