### PR TITLE
[server] Balance replicas and leaders within each table

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/RebalanceITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/RebalanceITCase.java
@@ -210,6 +210,73 @@ public class RebalanceITCase {
     }
 
     @Test
+    void testRebalanceFullGoalChainBalancesEachTable() throws Exception {
+        String dbName = "db-table-goal-chain";
+        admin.createDatabase(dbName, DatabaseDescriptor.EMPTY, false).get();
+        admin.addServerTag(Collections.singletonList(3), ServerTag.PERMANENT_OFFLINE).get();
+        long[] tableIds = new long[2];
+        for (int i = 0; i < tableIds.length; i++) {
+            tableIds[i] =
+                    createTable(
+                            new TablePath(dbName, "table-goal-chain-" + i), DATA1_TABLE_DESCRIPTOR);
+            FLUSS_CLUSTER_EXTENSION.waitUntilTableReady(tableIds[i]);
+        }
+        admin.removeServerTag(Collections.singletonList(3), ServerTag.PERMANENT_OFFLINE).get();
+
+        String rebalanceId =
+                admin.rebalance(
+                                Arrays.asList(
+                                        GoalType.RACK_AWARE,
+                                        GoalType.TABLE_REPLICA_DISTRIBUTION,
+                                        GoalType.REPLICA_DISTRIBUTION,
+                                        GoalType.TABLE_LEADER_DISTRIBUTION,
+                                        GoalType.LEADER_DISTRIBUTION))
+                        .get();
+        retry(
+                Duration.ofMinutes(2),
+                () -> {
+                    Optional<RebalanceProgress> progress = admin.listRebalanceProgress(null).get();
+                    assertThat(progress).isPresent();
+                    assertThat(progress.get().rebalanceId()).isEqualTo(rebalanceId);
+                    assertThat(progress.get().status()).isEqualTo(RebalanceStatus.COMPLETED);
+                    for (long tableId : tableIds) {
+                        for (int serverId = 0; serverId < 4; serverId++) {
+                            ReplicaManager replicaManager =
+                                    FLUSS_CLUSTER_EXTENSION
+                                            .getTabletServerById(serverId)
+                                            .getReplicaManager();
+                            long replicas =
+                                    replicaManager
+                                            .onlineReplicas()
+                                            .filter(
+                                                    replica ->
+                                                            replica.getTableBucket().getTableId()
+                                                                    == tableId)
+                                            .count();
+                            long leaders =
+                                    replicaManager
+                                            .onlineReplicas()
+                                            .filter(
+                                                    replica ->
+                                                            replica.getTableBucket().getTableId()
+                                                                            == tableId
+                                                                    && replica.isLeader())
+                                            .count();
+                            // Each table has 3 buckets with replication factor 3 over 4 alive
+                            // servers, so the per-table balance windows are [2, 3] replicas and
+                            // [0, 1] leaders. The replica window is asserted exactly: the offline
+                            // tag is removed before the rebalance, so no evacuation happens and
+                            // the replica placement is deterministic. The leader window keeps one
+                            // extra unit of tolerance because a leader is occasionally left
+                            // unmigrated, tracked at https://github.com/apache/fluss/issues/2405.
+                            assertThat(replicas).isBetween(2L, 3L);
+                            assertThat(leaders).isBetween(0L, 2L);
+                        }
+                    }
+                });
+    }
+
+    @Test
     void testListRebalanceProgress() throws Exception {
         String dbName = "db-rebalance-list";
         admin.createDatabase(dbName, DatabaseDescriptor.EMPTY, false).get();

--- a/fluss-common/src/main/java/org/apache/fluss/cluster/rebalance/GoalType.java
+++ b/fluss-common/src/main/java/org/apache/fluss/cluster/rebalance/GoalType.java
@@ -44,7 +44,13 @@ public enum GoalType {
      * Goal to generate replica movement tasks to ensure that the number of replicas on each
      * tabletServer is near balanced and the replicas are distributed across racks.
      */
-    RACK_AWARE(2);
+    RACK_AWARE(2),
+
+    /** Goal to balance replica counts independently for each table. */
+    TABLE_REPLICA_DISTRIBUTION(3),
+
+    /** Goal to balance leader replica counts independently for each table. */
+    TABLE_LEADER_DISTRIBUTION(4);
 
     public final int value;
 
@@ -59,6 +65,10 @@ public enum GoalType {
             return LEADER_DISTRIBUTION;
         } else if (value == RACK_AWARE.value) {
             return RACK_AWARE;
+        } else if (value == TABLE_REPLICA_DISTRIBUTION.value) {
+            return TABLE_REPLICA_DISTRIBUTION;
+        } else if (value == TABLE_LEADER_DISTRIBUTION.value) {
+            return TABLE_LEADER_DISTRIBUTION;
         } else {
             throw new IllegalArgumentException(
                     String.format(

--- a/fluss-common/src/test/java/org/apache/fluss/cluster/rebalance/GoalTypeTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/cluster/rebalance/GoalTypeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.cluster.rebalance;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link GoalType}. */
+public class GoalTypeTest {
+
+    @Test
+    void testValueOfIntForAllGoalTypes() {
+        assertThat(GoalType.valueOf(0)).isEqualTo(GoalType.REPLICA_DISTRIBUTION);
+        assertThat(GoalType.valueOf(1)).isEqualTo(GoalType.LEADER_DISTRIBUTION);
+        assertThat(GoalType.valueOf(2)).isEqualTo(GoalType.RACK_AWARE);
+        assertThat(GoalType.valueOf(3)).isEqualTo(GoalType.TABLE_REPLICA_DISTRIBUTION);
+        assertThat(GoalType.valueOf(4)).isEqualTo(GoalType.TABLE_LEADER_DISTRIBUTION);
+
+        for (GoalType goalType : GoalType.values()) {
+            assertThat(GoalType.valueOf(goalType.value)).isEqualTo(goalType);
+        }
+    }
+
+    @Test
+    void testFromNameForAllGoalTypes() {
+        for (GoalType goalType : GoalType.values()) {
+            assertThat(GoalType.fromName(goalType.name().toLowerCase())).isEqualTo(goalType);
+        }
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/procedure/RebalanceProcedure.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/procedure/RebalanceProcedure.java
@@ -26,7 +26,9 @@ import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Procedure to trigger rebalance.
@@ -41,6 +43,8 @@ import java.util.List;
  * CALL sys.rebalance('REPLICA_DISTRIBUTION');
  * -- Trigger rebalance with REPLICA_DISTRIBUTION and LEADER_DISTRIBUTION goals
  * CALL sys.rebalance('REPLICA_DISTRIBUTION,LEADER_DISTRIBUTION');
+ * -- Trigger rebalance with the recommended table-aware goal order
+ * CALL sys.rebalance('RACK_AWARE,TABLE_REPLICA_DISTRIBUTION,REPLICA_DISTRIBUTION,TABLE_LEADER_DISTRIBUTION,LEADER_DISTRIBUTION');
  * </pre>
  */
 public class RebalanceProcedure extends ProcedureBase {
@@ -57,19 +61,26 @@ public class RebalanceProcedure extends ProcedureBase {
         return new String[] {rebalanceId};
     }
 
+    private static final String VALID_GOALS =
+            Arrays.stream(GoalType.values()).map(Enum::name).collect(Collectors.joining(", "));
+
     private static List<GoalType> validateAndGetPriorityGoals(String priorityGoals) {
         if (priorityGoals == null || priorityGoals.trim().isEmpty()) {
             throw new IllegalArgumentException(
-                    "priority goals cannot be null or empty. You can specify one goal as 'REPLICA_DISTRIBUTION' or "
-                            + "specify multi goals as 'REPLICA_DISTRIBUTION,LEADER_DISTRIBUTION' (split by ',')");
+                    "priority goals cannot be null or empty. Valid goals are "
+                            + VALID_GOALS
+                            + ". You can specify one goal or specify multiple goals in priority "
+                            + "order (split by ',').");
         }
 
         priorityGoals = priorityGoals.trim();
         String[] splitGoals = priorityGoals.split(",");
         if (splitGoals.length == 0) {
             throw new IllegalArgumentException(
-                    "priority goals cannot be empty. You can specify one goal as 'REPLICA_DISTRIBUTION' "
-                            + "or specify multi goals as 'REPLICA_DISTRIBUTION,LEADER_DISTRIBUTION' (split by ',')");
+                    "priority goals cannot be empty. Valid goals are "
+                            + VALID_GOALS
+                            + ". You can specify one goal or specify multiple goals in priority "
+                            + "order (split by ',').");
         }
         List<GoalType> goalTypes = new ArrayList<>();
         for (String goal : splitGoals) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/GoalUtils.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/GoalUtils.java
@@ -39,6 +39,10 @@ public class GoalUtils {
                 return new LeaderReplicaDistributionGoal();
             case RACK_AWARE:
                 return new RackAwareGoal();
+            case TABLE_REPLICA_DISTRIBUTION:
+                return new TableReplicaDistributionGoal();
+            case TABLE_LEADER_DISTRIBUTION:
+                return new TableLeaderReplicaDistributionGoal();
             default:
                 throw new IllegalArgumentException("Unsupported goal type " + goalType);
         }

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/LeaderReplicaDistributionGoal.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/LeaderReplicaDistributionGoal.java
@@ -216,7 +216,8 @@ public class LeaderReplicaDistributionGoal extends ReplicaDistributionAbstractGo
         SortedSet<ServerModel> candidateServers;
         candidateServers =
                 new TreeSet<>(
-                        Comparator.comparingInt(ServerModel::numLeaderReplicas)
+                        Comparator.comparingInt(
+                                        (ServerModel candidate) -> candidate.numLeaderReplicas())
                                 .thenComparingInt(ServerModel::id));
         candidateServers.addAll(
                 cluster.aliveServers().stream()

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/ReplicaDistributionGoal.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/ReplicaDistributionGoal.java
@@ -167,7 +167,7 @@ public class ReplicaDistributionGoal extends ReplicaDistributionAbstractGoal {
             ServerModel server, ClusterModel cluster, Set<Goal> optimizedGoals) {
         SortedSet<ServerModel> candidateServers =
                 new TreeSet<>(
-                        Comparator.comparingInt(ServerModel::numReplicas)
+                        Comparator.comparingInt((ServerModel candidate) -> candidate.numReplicas())
                                 .thenComparingInt(ServerModel::id));
 
         candidateServers.addAll(

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/TableDistributionAbstractGoal.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/TableDistributionAbstractGoal.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator.rebalance.goal;
+
+import org.apache.fluss.exception.RebalanceFailureException;
+import org.apache.fluss.server.coordinator.rebalance.RebalancingAction;
+import org.apache.fluss.server.coordinator.rebalance.model.ClusterModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ServerModel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.fluss.server.coordinator.rebalance.ActionAcceptance.ACCEPT;
+import static org.apache.fluss.server.coordinator.rebalance.goal.GoalUtils.aliveServers;
+
+/** An abstract base for goals that distribute replicas independently for each table. */
+public abstract class TableDistributionAbstractGoal extends AbstractGoal {
+    private static final Logger LOG = LoggerFactory.getLogger(TableDistributionAbstractGoal.class);
+    private static final double BALANCE_MARGIN = 0.9;
+    private static final double REBALANCE_THRESHOLD = 1.10d;
+
+    protected final Set<Long> tablesAboveRebalanceUpperLimit;
+    protected final Set<Long> tablesBelowRebalanceLowerLimit;
+    protected final Map<Long, Integer> rebalanceUpperLimitByTable;
+    protected final Map<Long, Integer> rebalanceLowerLimitByTable;
+    protected Set<Integer> aliveServers;
+
+    protected TableDistributionAbstractGoal() {
+        tablesAboveRebalanceUpperLimit = new HashSet<>();
+        tablesBelowRebalanceLowerLimit = new HashSet<>();
+        rebalanceUpperLimitByTable = new HashMap<>();
+        rebalanceLowerLimitByTable = new HashMap<>();
+    }
+
+    @Override
+    protected void initGoalState(ClusterModel clusterModel) throws RebalanceFailureException {
+        aliveServers = aliveServers(clusterModel);
+        if (aliveServers.isEmpty()) {
+            throw new RebalanceFailureException(
+                    String.format(
+                            "[%s] All alive tabletServers are excluded from replica moves.",
+                            name()));
+        }
+        rebalanceUpperLimitByTable.clear();
+        rebalanceLowerLimitByTable.clear();
+        Map<Long, Integer> numInterestedReplicasByTable =
+                numInterestedReplicasByTable(clusterModel);
+        for (Long tableId : clusterModel.tables()) {
+            double average =
+                    numInterestedReplicasByTable.getOrDefault(tableId, 0)
+                            / (double) aliveServers.size();
+            rebalanceUpperLimitByTable.put(tableId, rebalanceUpperLimit(average));
+            rebalanceLowerLimitByTable.put(tableId, rebalanceLowerLimit(average));
+        }
+    }
+
+    @Override
+    protected boolean selfSatisfied(ClusterModel clusterModel, RebalancingAction action) {
+        return actionAcceptance(action, clusterModel) == ACCEPT;
+    }
+
+    @Override
+    protected void updateGoalState(ClusterModel clusterModel) {
+        if (!tablesAboveRebalanceUpperLimit.isEmpty()) {
+            LOG.debug(
+                    "Tables {} remain above their rebalance upper limits after {}.",
+                    tablesAboveRebalanceUpperLimit,
+                    name());
+            tablesAboveRebalanceUpperLimit.clear();
+            succeeded = false;
+        }
+        if (!tablesBelowRebalanceLowerLimit.isEmpty()) {
+            LOG.debug(
+                    "Tables {} remain below their rebalance lower limits after {}.",
+                    tablesBelowRebalanceLowerLimit,
+                    name());
+            tablesBelowRebalanceLowerLimit.clear();
+            succeeded = false;
+        }
+        finish();
+    }
+
+    protected int upperLimit(long tableId, ServerModel server) {
+        return server.isOfflineTagged() ? 0 : rebalanceUpperLimitByTable.get(tableId);
+    }
+
+    protected int lowerLimit(long tableId, ServerModel server) {
+        return server.isOfflineTagged() ? 0 : rebalanceLowerLimitByTable.get(tableId);
+    }
+
+    protected boolean isAlive(ServerModel server) {
+        return aliveServers.contains(server.id());
+    }
+
+    private int rebalanceUpperLimit(double average) {
+        return (int) Math.ceil(average * (1 + adjustedRebalancePercentage()));
+    }
+
+    private int rebalanceLowerLimit(double average) {
+        return (int) Math.floor(average * Math.max(0, 1 - adjustedRebalancePercentage()));
+    }
+
+    private double adjustedRebalancePercentage() {
+        return (REBALANCE_THRESHOLD - 1) * BALANCE_MARGIN;
+    }
+
+    /**
+     * Returns the number of replicas relevant to this goal for every table of the cluster, keyed by
+     * table id. The counts of all tables are retrieved at once so that computing the balance limits
+     * does not rescan the buckets of the cluster once per table.
+     */
+    abstract Map<Long, Integer> numInterestedReplicasByTable(ClusterModel clusterModel);
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/TableLeaderReplicaDistributionGoal.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/TableLeaderReplicaDistributionGoal.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator.rebalance.goal;
+
+import org.apache.fluss.exception.RebalanceFailureException;
+import org.apache.fluss.server.coordinator.rebalance.ActionAcceptance;
+import org.apache.fluss.server.coordinator.rebalance.ActionType;
+import org.apache.fluss.server.coordinator.rebalance.RebalancingAction;
+import org.apache.fluss.server.coordinator.rebalance.model.BucketModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ClusterModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ClusterModelStats;
+import org.apache.fluss.server.coordinator.rebalance.model.ReplicaModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ServerModel;
+import org.apache.fluss.utils.MathUtils;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.apache.fluss.server.coordinator.rebalance.ActionAcceptance.ACCEPT;
+import static org.apache.fluss.server.coordinator.rebalance.ActionAcceptance.REPLICA_REJECT;
+import static org.apache.fluss.utils.MathUtils.EPSILON;
+import static org.apache.fluss.utils.Preconditions.checkNotNull;
+
+/** Soft goal to distribute leader replicas of every table across tablet servers. */
+public class TableLeaderReplicaDistributionGoal extends TableDistributionAbstractGoal {
+
+    @Override
+    public ActionAcceptance actionAcceptance(RebalancingAction action, ClusterModel clusterModel) {
+        ServerModel sourceServer = clusterModel.server(action.getSourceServerId());
+        ServerModel destinationServer = clusterModel.server(action.getDestinationServerId());
+        checkNotNull(
+                sourceServer, "Source server " + action.getSourceServerId() + " is not found.");
+        checkNotNull(
+                destinationServer,
+                "Destination server " + action.getDestinationServerId() + " is not found.");
+        ReplicaModel sourceReplica = sourceServer.replica(action.getTableBucket());
+        checkNotNull(sourceReplica, "Source replica " + action.getTableBucket() + " is not found.");
+        if (action.getActionType() == ActionType.REPLICA_MOVEMENT && !sourceReplica.isLeader()) {
+            return ACCEPT;
+        }
+        if (action.getActionType() != ActionType.LEADERSHIP_MOVEMENT
+                && action.getActionType() != ActionType.REPLICA_MOVEMENT) {
+            throw new IllegalArgumentException("Unsupported action type " + action.getActionType());
+        }
+        long tableId = action.getTableBucket().getTableId();
+        return destinationServer.numLeaderReplicas(tableId) + 1
+                                <= upperLimit(tableId, destinationServer)
+                        && (!isAlive(sourceServer)
+                                || sourceServer.numLeaderReplicas(tableId) - 1
+                                        >= lowerLimit(tableId, sourceServer))
+                ? ACCEPT
+                : REPLICA_REJECT;
+    }
+
+    @Override
+    protected void rebalanceForServer(
+            ServerModel server, ClusterModel clusterModel, Set<Goal> optimizedGoals)
+            throws RebalanceFailureException {
+        for (Long tableId : clusterModel.tables()) {
+            int numLeaders = server.numLeaderReplicas(tableId);
+            if (numLeaders > upperLimit(tableId, server) || server.isOfflineTagged()) {
+                boolean leadershipNotMoved =
+                        rebalanceByMovingLeadershipOut(
+                                server, tableId, clusterModel, optimizedGoals);
+                boolean leadersNotMoved =
+                        leadershipNotMoved
+                                && rebalanceByMovingLeaderReplicasOut(
+                                        server, tableId, clusterModel, optimizedGoals);
+                if (leadersNotMoved) {
+                    tablesAboveRebalanceUpperLimit.add(tableId);
+                }
+            } else if (isAlive(server) && numLeaders < lowerLimit(tableId, server)) {
+                boolean leadershipNotMoved =
+                        rebalanceByMovingLeadershipIn(
+                                server, tableId, clusterModel, optimizedGoals);
+                boolean leadersNotMoved =
+                        leadershipNotMoved
+                                && rebalanceByMovingLeaderReplicasIn(
+                                        server, tableId, clusterModel, optimizedGoals);
+                if (leadersNotMoved) {
+                    tablesBelowRebalanceLowerLimit.add(tableId);
+                }
+            }
+        }
+    }
+
+    @Override
+    public ClusterModelStatsComparator clusterModelStatsComparator() {
+        return new TableLeaderReplicaDistributionStatsComparator();
+    }
+
+    @Override
+    Map<Long, Integer> numInterestedReplicasByTable(ClusterModel clusterModel) {
+        return clusterModel.numLeaderReplicasByTable();
+    }
+
+    private boolean rebalanceByMovingLeadershipOut(
+            ServerModel sourceServer,
+            long tableId,
+            ClusterModel clusterModel,
+            Set<Goal> optimizedGoals) {
+        for (ReplicaModel leader : sourceServer.leaderReplicas(tableId)) {
+            BucketModel bucket = clusterModel.bucket(leader.tableBucket());
+            checkNotNull(bucket, "Bucket " + leader.tableBucket() + " is not found.");
+            Set<ServerModel> candidates = new HashSet<>(bucket.followerServers());
+            ServerModel destination =
+                    maybeApplyBalancingAction(
+                            clusterModel,
+                            leader,
+                            candidates,
+                            ActionType.LEADERSHIP_MOVEMENT,
+                            optimizedGoals);
+            if (destination != null
+                    && sourceServer.numLeaderReplicas(tableId)
+                            <= upperLimit(tableId, sourceServer)) {
+                return false;
+            }
+        }
+        return sourceServer.numLeaderReplicas(tableId) > upperLimit(tableId, sourceServer);
+    }
+
+    private boolean rebalanceByMovingLeadershipIn(
+            ServerModel destinationServer,
+            long tableId,
+            ClusterModel clusterModel,
+            Set<Goal> optimizedGoals) {
+        List<ServerModel> candidate = Collections.singletonList(destinationServer);
+        for (ReplicaModel replica : destinationServer.replicas(tableId)) {
+            if (replica.isLeader()) {
+                continue;
+            }
+            BucketModel bucket = clusterModel.bucket(replica.tableBucket());
+            checkNotNull(bucket, "Bucket " + replica.tableBucket() + " is not found.");
+            ServerModel destination =
+                    maybeApplyBalancingAction(
+                            clusterModel,
+                            bucket.leader(),
+                            candidate,
+                            ActionType.LEADERSHIP_MOVEMENT,
+                            optimizedGoals);
+            if (destination != null
+                    && destinationServer.numLeaderReplicas(tableId)
+                            >= lowerLimit(tableId, destinationServer)) {
+                return false;
+            }
+        }
+        return destinationServer.numLeaderReplicas(tableId)
+                < lowerLimit(tableId, destinationServer);
+    }
+
+    private boolean rebalanceByMovingLeaderReplicasOut(
+            ServerModel sourceServer,
+            long tableId,
+            ClusterModel clusterModel,
+            Set<Goal> optimizedGoals) {
+        SortedSet<ServerModel> candidates =
+                new TreeSet<>(
+                        Comparator.comparingInt(
+                                        (ServerModel server) -> server.numLeaderReplicas(tableId))
+                                .thenComparingInt(ServerModel::id));
+        for (ServerModel server : clusterModel.aliveServers()) {
+            if (server.numLeaderReplicas(tableId) < upperLimit(tableId, server)) {
+                candidates.add(server);
+            }
+        }
+        for (ReplicaModel leader : sourceServer.leaderReplicas(tableId)) {
+            ServerModel destination =
+                    maybeApplyBalancingAction(
+                            clusterModel,
+                            leader,
+                            candidates,
+                            ActionType.REPLICA_MOVEMENT,
+                            optimizedGoals);
+            if (destination != null) {
+                if (sourceServer.numLeaderReplicas(tableId) <= upperLimit(tableId, sourceServer)) {
+                    return false;
+                }
+                candidates.remove(destination);
+                if (destination.numLeaderReplicas(tableId) < upperLimit(tableId, destination)) {
+                    candidates.add(destination);
+                }
+            }
+        }
+        return sourceServer.numLeaderReplicas(tableId) > upperLimit(tableId, sourceServer);
+    }
+
+    private boolean rebalanceByMovingLeaderReplicasIn(
+            ServerModel destinationServer,
+            long tableId,
+            ClusterModel clusterModel,
+            Set<Goal> optimizedGoals) {
+        PriorityQueue<ServerModel> sources =
+                new PriorityQueue<>(
+                        Comparator.comparingInt(
+                                        (ServerModel server) -> server.numLeaderReplicas(tableId))
+                                .reversed()
+                                .thenComparingInt(ServerModel::id));
+        for (ServerModel sourceServer : clusterModel.servers()) {
+            if (sourceServer.numLeaderReplicas(tableId) > lowerLimit(tableId, sourceServer)
+                    || !isAlive(sourceServer)) {
+                sources.add(sourceServer);
+            }
+        }
+        List<ServerModel> candidate = Collections.singletonList(destinationServer);
+        while (!sources.isEmpty()) {
+            ServerModel sourceServer = sources.poll();
+            for (ReplicaModel leader : sourceServer.leaderReplicas(tableId)) {
+                ServerModel destination =
+                        maybeApplyBalancingAction(
+                                clusterModel,
+                                leader,
+                                candidate,
+                                ActionType.REPLICA_MOVEMENT,
+                                optimizedGoals);
+                if (destination != null) {
+                    if (destinationServer.numLeaderReplicas(tableId)
+                            >= lowerLimit(tableId, destinationServer)) {
+                        return false;
+                    }
+                    if (!sources.isEmpty()
+                            && sourceServer.numLeaderReplicas(tableId)
+                                    < sources.peek().numLeaderReplicas(tableId)) {
+                        sources.add(sourceServer);
+                        break;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Detects per-table regressions of the leader replica distribution.
+     *
+     * <p>This comparator is a regression detector rather than a general purpose total order: it
+     * returns a negative value as soon as the standard deviation of any table got worse, and zero
+     * otherwise. It never reports a preference for the post-optimization stats, because "preferred"
+     * is not well defined when one table improves while another one stays equal. The only caller,
+     * {@code AbstractGoal#optimize}, checks the negative branch alone.
+     */
+    private class TableLeaderReplicaDistributionStatsComparator
+            implements ClusterModelStatsComparator {
+        private String reasonForLastNegativeResult;
+
+        @Override
+        public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
+            for (Map.Entry<Long, Double> entry : stats1.leaderReplicaStdDevByTable().entrySet()) {
+                long tableId = entry.getKey();
+                double postOptimizationStdDev = entry.getValue();
+                double preOptimizationStdDev = stats2.leaderReplicaStdDevByTable().get(tableId);
+                if (MathUtils.compare(preOptimizationStdDev, postOptimizationStdDev, EPSILON) < 0) {
+                    reasonForLastNegativeResult =
+                            String.format(
+                                    "Violated %s for table %s. [Std Deviation of Leader Replica "
+                                            + "Distribution] post-optimization:%.3f pre-optimization:%.3f",
+                                    name(), tableId, postOptimizationStdDev, preOptimizationStdDev);
+                    return -1;
+                }
+            }
+            return 0;
+        }
+
+        @Override
+        public String explainLastComparison() {
+            return reasonForLastNegativeResult;
+        }
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/TableReplicaDistributionGoal.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/goal/TableReplicaDistributionGoal.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator.rebalance.goal;
+
+import org.apache.fluss.exception.RebalanceFailureException;
+import org.apache.fluss.server.coordinator.rebalance.ActionAcceptance;
+import org.apache.fluss.server.coordinator.rebalance.ActionType;
+import org.apache.fluss.server.coordinator.rebalance.RebalancingAction;
+import org.apache.fluss.server.coordinator.rebalance.model.ClusterModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ClusterModelStats;
+import org.apache.fluss.server.coordinator.rebalance.model.ReplicaModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ServerModel;
+import org.apache.fluss.utils.MathUtils;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.apache.fluss.server.coordinator.rebalance.ActionAcceptance.ACCEPT;
+import static org.apache.fluss.server.coordinator.rebalance.ActionAcceptance.REPLICA_REJECT;
+import static org.apache.fluss.utils.MathUtils.EPSILON;
+import static org.apache.fluss.utils.Preconditions.checkNotNull;
+
+/** Soft goal to distribute replicas of every table across tablet servers. */
+public class TableReplicaDistributionGoal extends TableDistributionAbstractGoal {
+
+    @Override
+    public ActionAcceptance actionAcceptance(RebalancingAction action, ClusterModel clusterModel) {
+        if (action.getActionType() == ActionType.LEADERSHIP_MOVEMENT) {
+            return ACCEPT;
+        }
+        if (action.getActionType() != ActionType.REPLICA_MOVEMENT) {
+            throw new IllegalArgumentException("Unsupported action type " + action.getActionType());
+        }
+        ServerModel sourceServer = clusterModel.server(action.getSourceServerId());
+        ServerModel destinationServer = clusterModel.server(action.getDestinationServerId());
+        checkNotNull(
+                sourceServer, "Source server " + action.getSourceServerId() + " is not found.");
+        checkNotNull(
+                destinationServer,
+                "Destination server " + action.getDestinationServerId() + " is not found.");
+        long tableId = action.getTableBucket().getTableId();
+        return destinationServer.numReplicas(tableId) + 1 <= upperLimit(tableId, destinationServer)
+                        && (!isAlive(sourceServer)
+                                || sourceServer.numReplicas(tableId) - 1
+                                        >= lowerLimit(tableId, sourceServer))
+                ? ACCEPT
+                : REPLICA_REJECT;
+    }
+
+    @Override
+    protected void rebalanceForServer(
+            ServerModel server, ClusterModel clusterModel, Set<Goal> optimizedGoals)
+            throws RebalanceFailureException {
+        for (Long tableId : clusterModel.tables()) {
+            int replicaCount = server.numReplicas(tableId);
+            if (replicaCount > upperLimit(tableId, server) || server.isOfflineTagged()) {
+                if (rebalanceByMovingReplicasOut(server, tableId, clusterModel, optimizedGoals)) {
+                    tablesAboveRebalanceUpperLimit.add(tableId);
+                }
+            } else if (isAlive(server) && replicaCount < lowerLimit(tableId, server)) {
+                if (rebalanceByMovingReplicasIn(server, tableId, clusterModel, optimizedGoals)) {
+                    tablesBelowRebalanceLowerLimit.add(tableId);
+                }
+            }
+        }
+    }
+
+    @Override
+    public ClusterModelStatsComparator clusterModelStatsComparator() {
+        return new TableReplicaDistributionStatsComparator();
+    }
+
+    @Override
+    Map<Long, Integer> numInterestedReplicasByTable(ClusterModel clusterModel) {
+        return clusterModel.numReplicasByTable();
+    }
+
+    private boolean rebalanceByMovingReplicasOut(
+            ServerModel sourceServer,
+            long tableId,
+            ClusterModel clusterModel,
+            Set<Goal> optimizedGoals) {
+        SortedSet<ServerModel> candidates =
+                new TreeSet<>(
+                        Comparator.comparingInt((ServerModel server) -> server.numReplicas(tableId))
+                                .thenComparingInt(ServerModel::numReplicas)
+                                .thenComparingInt(ServerModel::id));
+        for (ServerModel server : clusterModel.aliveServers()) {
+            if (server.numReplicas(tableId) < upperLimit(tableId, server)) {
+                candidates.add(server);
+            }
+        }
+        for (ReplicaModel replica : sourceServer.replicas(tableId)) {
+            ServerModel destination =
+                    maybeApplyBalancingAction(
+                            clusterModel,
+                            replica,
+                            candidates,
+                            ActionType.REPLICA_MOVEMENT,
+                            optimizedGoals);
+            if (destination != null) {
+                if (sourceServer.numReplicas(tableId) <= upperLimit(tableId, sourceServer)) {
+                    return false;
+                }
+                candidates.remove(destination);
+                if (destination.numReplicas(tableId) < upperLimit(tableId, destination)) {
+                    candidates.add(destination);
+                }
+            }
+        }
+        return sourceServer.numReplicas(tableId) > upperLimit(tableId, sourceServer);
+    }
+
+    private boolean rebalanceByMovingReplicasIn(
+            ServerModel destinationServer,
+            long tableId,
+            ClusterModel clusterModel,
+            Set<Goal> optimizedGoals) {
+        PriorityQueue<ServerModel> sources =
+                new PriorityQueue<>(
+                        Comparator.comparingInt((ServerModel server) -> server.numReplicas(tableId))
+                                .reversed()
+                                .thenComparingInt(ServerModel::id));
+        for (ServerModel sourceServer : clusterModel.servers()) {
+            if (sourceServer.numReplicas(tableId) > lowerLimit(tableId, sourceServer)
+                    || !isAlive(sourceServer)) {
+                sources.add(sourceServer);
+            }
+        }
+        List<ServerModel> candidate = Collections.singletonList(destinationServer);
+        while (!sources.isEmpty()) {
+            ServerModel sourceServer = sources.poll();
+            for (ReplicaModel replica : sourceServer.replicas(tableId)) {
+                ServerModel destination =
+                        maybeApplyBalancingAction(
+                                clusterModel,
+                                replica,
+                                candidate,
+                                ActionType.REPLICA_MOVEMENT,
+                                optimizedGoals);
+                if (destination != null) {
+                    if (destinationServer.numReplicas(tableId)
+                            >= lowerLimit(tableId, destinationServer)) {
+                        return false;
+                    }
+                    if (!sources.isEmpty()
+                            && sourceServer.numReplicas(tableId)
+                                    < sources.peek().numReplicas(tableId)) {
+                        sources.add(sourceServer);
+                        break;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Detects per-table regressions of the replica distribution.
+     *
+     * <p>This comparator is a regression detector rather than a general purpose total order: it
+     * returns a negative value as soon as the standard deviation of any table got worse, and zero
+     * otherwise. It never reports a preference for the post-optimization stats, because "preferred"
+     * is not well defined when one table improves while another one stays equal. The only caller,
+     * {@code AbstractGoal#optimize}, checks the negative branch alone.
+     */
+    private class TableReplicaDistributionStatsComparator implements ClusterModelStatsComparator {
+        private String reasonForLastNegativeResult;
+
+        @Override
+        public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
+            for (Map.Entry<Long, Double> entry : stats1.replicaStdDevByTable().entrySet()) {
+                long tableId = entry.getKey();
+                double postOptimizationStdDev = entry.getValue();
+                double preOptimizationStdDev = stats2.replicaStdDevByTable().get(tableId);
+                if (MathUtils.compare(preOptimizationStdDev, postOptimizationStdDev, EPSILON) < 0) {
+                    reasonForLastNegativeResult =
+                            String.format(
+                                    "Violated %s for table %s. [Std Deviation of Replica Distribution] "
+                                            + "post-optimization:%.3f pre-optimization:%.3f",
+                                    name(), tableId, postOptimizationStdDev, preOptimizationStdDev);
+                    return -1;
+                }
+            }
+            return 0;
+        }
+
+        @Override
+        public String explainLastComparison() {
+            return reasonForLastNegativeResult;
+        }
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/model/ClusterModel.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/model/ClusterModel.java
@@ -132,6 +132,22 @@ public class ClusterModel {
     }
 
     /**
+     * Returns the number of replicas of every table in the cluster, keyed by table id and
+     * aggregated over all partitions of a partitioned table.
+     *
+     * <p>The whole map is built in a single pass over the buckets, so that callers that need the
+     * counts of many tables do not rescan the buckets once per table.
+     */
+    public Map<Long, Integer> numReplicasByTable() {
+        Map<Long, Integer> numReplicasByTable = new HashMap<>();
+        for (Map.Entry<TableBucket, BucketModel> entry : bucketsByTableBucket.entrySet()) {
+            numReplicasByTable.merge(
+                    entry.getKey().getTableId(), entry.getValue().replicas().size(), Integer::sum);
+        }
+        return numReplicasByTable;
+    }
+
+    /**
      * @return All the leader replicas in the cluster.
      */
     public Set<ReplicaModel> leaderReplicas() {
@@ -151,6 +167,23 @@ public class ClusterModel {
             numLeaderReplicas += bucket.leader() != null ? 1 : 0;
         }
         return numLeaderReplicas;
+    }
+
+    /**
+     * Returns the number of leader replicas of every table in the cluster, keyed by table id and
+     * aggregated over all partitions of a partitioned table.
+     *
+     * <p>The whole map is built in a single pass over the buckets, see {@link
+     * #numReplicasByTable()}.
+     */
+    public Map<Long, Integer> numLeaderReplicasByTable() {
+        Map<Long, Integer> numLeaderReplicasByTable = new HashMap<>();
+        for (Map.Entry<TableBucket, BucketModel> entry : bucketsByTableBucket.entrySet()) {
+            if (entry.getValue().leader() != null) {
+                numLeaderReplicasByTable.merge(entry.getKey().getTableId(), 1, Integer::sum);
+            }
+        }
+        return numLeaderReplicasByTable;
     }
 
     public SortedMap<Long, List<BucketModel>> getBucketsByTable() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/model/ClusterModelStats.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/model/ClusterModelStats.java
@@ -30,13 +30,16 @@ import java.util.function.Function;
 public class ClusterModelStats {
     private final Map<StatisticType, Number> replicaStats;
     private final Map<StatisticType, Number> leaderReplicaStats;
+    private final Map<Long, Double> replicaStdDevByTable;
+    private final Map<Long, Double> leaderReplicaStdDevByTable;
     private int numServers;
     private int numReplicasInCluster;
 
     public ClusterModelStats() {
         replicaStats = new HashMap<>();
         leaderReplicaStats = new HashMap<>();
-
+        replicaStdDevByTable = new HashMap<>();
+        leaderReplicaStdDevByTable = new HashMap<>();
         numServers = 0;
         numReplicasInCluster = 0;
     }
@@ -47,6 +50,7 @@ public class ClusterModelStats {
         this.numServers = servers.size();
         numForReplicas(clusterModel, servers, aliveServers);
         numForLeaderReplicas(servers, aliveServers);
+        populateTableStdDev(clusterModel, aliveServers);
         return this;
     }
 
@@ -64,6 +68,100 @@ public class ClusterModelStats {
             SortedSet<ServerModel> servers, Set<ServerModel> aliveServers) {
         populateReplicaStats(
                 ServerModel::numLeaderReplicas, leaderReplicaStats, servers, aliveServers);
+    }
+
+    /**
+     * Generate the per-table standard deviation of replica and leader replica counts over alive
+     * servers.
+     *
+     * <p>Mirrors {@link #populateReplicaStats}: the average of a table divides the count over all
+     * servers by the number of alive servers, while the variance only covers alive servers. The
+     * accumulation is sparse, it only walks the tables that a server actually hosts, and adds
+     * {@code average^2} once for every alive server that hosts no replica of the table.
+     */
+    private void populateTableStdDev(ClusterModel clusterModel, Set<ServerModel> aliveServers) {
+        int numAliveServers = aliveServers.size();
+        Map<Long, Double> replicaAverages =
+                averages(clusterModel.numReplicasByTable(), numAliveServers);
+        Map<Long, Double> leaderAverages =
+                averages(clusterModel.numLeaderReplicasByTable(), numAliveServers);
+        Map<Long, Double> replicaSquaredDeviations = new HashMap<>();
+        Map<Long, Double> leaderSquaredDeviations = new HashMap<>();
+        Map<Long, Integer> replicaHostingServers = new HashMap<>();
+        Map<Long, Integer> leaderHostingServers = new HashMap<>();
+
+        for (ServerModel server : aliveServers) {
+            for (Long tableId : server.tables()) {
+                accumulate(
+                        replicaSquaredDeviations,
+                        replicaHostingServers,
+                        tableId,
+                        server.numReplicas(tableId),
+                        replicaAverages.getOrDefault(tableId, 0.0));
+                accumulate(
+                        leaderSquaredDeviations,
+                        leaderHostingServers,
+                        tableId,
+                        server.numLeaderReplicas(tableId),
+                        leaderAverages.getOrDefault(tableId, 0.0));
+            }
+        }
+
+        for (Long tableId : clusterModel.tables()) {
+            replicaStdDevByTable.put(
+                    tableId,
+                    stdDev(
+                            replicaSquaredDeviations,
+                            replicaHostingServers,
+                            tableId,
+                            replicaAverages.getOrDefault(tableId, 0.0),
+                            numAliveServers));
+            leaderReplicaStdDevByTable.put(
+                    tableId,
+                    stdDev(
+                            leaderSquaredDeviations,
+                            leaderHostingServers,
+                            tableId,
+                            leaderAverages.getOrDefault(tableId, 0.0),
+                            numAliveServers));
+        }
+    }
+
+    private static Map<Long, Double> averages(
+            Map<Long, Integer> countByTable, int numAliveServers) {
+        Map<Long, Double> averages = new HashMap<>();
+        for (Map.Entry<Long, Integer> entry : countByTable.entrySet()) {
+            averages.put(entry.getKey(), ((double) entry.getValue()) / numAliveServers);
+        }
+        return averages;
+    }
+
+    private static void accumulate(
+            Map<Long, Double> squaredDeviations,
+            Map<Long, Integer> hostingServers,
+            long tableId,
+            int count,
+            double average) {
+        if (count == 0) {
+            // A server without any replica of the table is covered by the average^2 term below.
+            return;
+        }
+        squaredDeviations.merge(tableId, Math.pow(count - average, 2), Double::sum);
+        hostingServers.merge(tableId, 1, Integer::sum);
+    }
+
+    private static double stdDev(
+            Map<Long, Double> squaredDeviations,
+            Map<Long, Integer> hostingServers,
+            long tableId,
+            double average,
+            int numAliveServers) {
+        double squaredDeviation = squaredDeviations.getOrDefault(tableId, 0.0);
+        int hosting = hostingServers.getOrDefault(tableId, 0);
+        double variance =
+                (squaredDeviation + (numAliveServers - hosting) * Math.pow(average, 2))
+                        / numAliveServers;
+        return Math.sqrt(variance);
     }
 
     private void populateReplicaStats(
@@ -109,6 +207,16 @@ public class ClusterModelStats {
 
     public Map<StatisticType, Number> leaderReplicaStats() {
         return Collections.unmodifiableMap(leaderReplicaStats);
+    }
+
+    /** Returns the standard deviation of replica counts for each table. */
+    public Map<Long, Double> replicaStdDevByTable() {
+        return Collections.unmodifiableMap(replicaStdDevByTable);
+    }
+
+    /** Returns the standard deviation of leader replica counts for each table. */
+    public Map<Long, Double> leaderReplicaStdDevByTable() {
+        return Collections.unmodifiableMap(leaderReplicaStdDevByTable);
     }
 
     @VisibleForTesting

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/model/ServerModel.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/model/ServerModel.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.fluss.utils.Preconditions.checkState;
+
 /** A class that holds the information of the tabletServer for rebalance. */
 public class ServerModel implements Comparable<ServerModel> {
 
@@ -41,6 +43,12 @@ public class ServerModel implements Comparable<ServerModel> {
     /** A map for tracking (tableId, partitionId) -> (BucketId -> replica) for partitioned table. */
     private final Map<TablePartition, Map<Integer, ReplicaModel>> tablePartitionReplicas;
 
+    /** A map for tracking all replicas of each table, including all partitions. */
+    private final Map<Long, Set<ReplicaModel>> replicasByTable;
+
+    /** A map for tracking the number of leaders of each table. */
+    private final Map<Long, Integer> numLeaderReplicasByTable;
+
     private int numLeaderReplicas = 0;
 
     public ServerModel(int serverId, String rack, boolean isOfflineTagged) {
@@ -50,6 +58,8 @@ public class ServerModel implements Comparable<ServerModel> {
         this.replicas = new HashSet<>();
         this.tableReplicas = new HashMap<>();
         this.tablePartitionReplicas = new HashMap<>();
+        this.replicasByTable = new HashMap<>();
+        this.numLeaderReplicasByTable = new HashMap<>();
     }
 
     public int id() {
@@ -68,60 +78,89 @@ public class ServerModel implements Comparable<ServerModel> {
         return new HashSet<>(replicas);
     }
 
+    /** Returns replicas of the given table on this server, across all partitions. */
+    public Set<ReplicaModel> replicas(long tableId) {
+        Set<ReplicaModel> replicasOfTable = replicasByTable.get(tableId);
+        return replicasOfTable == null ? new HashSet<>() : new HashSet<>(replicasOfTable);
+    }
+
     public int numReplicas() {
         return replicas.size();
+    }
+
+    /** Returns the number of replicas of the given table on this server. */
+    public int numReplicas(long tableId) {
+        Set<ReplicaModel> replicasOfTable = replicasByTable.get(tableId);
+        return replicasOfTable == null ? 0 : replicasOfTable.size();
     }
 
     public Set<ReplicaModel> leaderReplicas() {
         return replicas.stream().filter(ReplicaModel::isLeader).collect(Collectors.toSet());
     }
 
+    /** Returns leaders of the given table on this server, across all partitions. */
+    public Set<ReplicaModel> leaderReplicas(long tableId) {
+        return replicas(tableId).stream()
+                .filter(ReplicaModel::isLeader)
+                .collect(Collectors.toSet());
+    }
+
     public int numLeaderReplicas() {
         return numLeaderReplicas;
     }
 
+    /** Returns the number of leader replicas of the given table on this server. */
+    public int numLeaderReplicas(long tableId) {
+        Integer numLeaders = numLeaderReplicasByTable.get(tableId);
+        return numLeaders == null ? 0 : numLeaders;
+    }
+
     public Set<Long> tables() {
-        Set<Long> tables = new HashSet<>(tableReplicas.keySet());
-        tablePartitionReplicas.keySet().forEach(t -> tables.add(t.getTableId()));
-        return tables;
+        return new HashSet<>(replicasByTable.keySet());
     }
 
     public void makeFollower(TableBucket tableBucket) {
         ReplicaModel replica = replica(tableBucket);
-        if (replica != null) {
-            if (replica.isLeader()) {
-                numLeaderReplicas--;
-            }
+        if (replica != null && replica.isLeader()) {
+            numLeaderReplicas--;
+            decrementLeaderReplica(tableBucket.getTableId());
             replica.makeFollower();
         }
     }
 
     public void makeLeader(TableBucket tableBucket) {
         ReplicaModel replica = replica(tableBucket);
-        if (replica != null) {
-            if (!replica.isLeader()) {
-                numLeaderReplicas++;
-            }
+        if (replica != null && !replica.isLeader()) {
+            numLeaderReplicas++;
+            incrementLeaderReplica(tableBucket.getTableId());
             replica.makeLeader();
         }
     }
 
     public void putReplica(TableBucket tableBucket, ReplicaModel replica) {
+        checkState(
+                replica(tableBucket) == null,
+                "Replica of bucket %s already exists on server %s.",
+                tableBucket,
+                serverId);
         replicas.add(replica);
+        replica.setServer(this);
+        long tableId = tableBucket.getTableId();
+        replicasByTable.computeIfAbsent(tableId, k -> new HashSet<>()).add(replica);
         if (replica.isLeader()) {
             numLeaderReplicas++;
+            incrementLeaderReplica(tableId);
         }
 
-        replica.setServer(this);
         if (tableBucket.getPartitionId() != null) {
             TablePartition tablePartition =
-                    new TablePartition(tableBucket.getTableId(), tableBucket.getPartitionId());
+                    new TablePartition(tableId, tableBucket.getPartitionId());
             tablePartitionReplicas
                     .computeIfAbsent(tablePartition, k -> new HashMap<>())
                     .put(tableBucket.getBucket(), replica);
         } else {
             tableReplicas
-                    .computeIfAbsent(tableBucket.getTableId(), k -> new HashMap<>())
+                    .computeIfAbsent(tableId, k -> new HashMap<>())
                     .put(tableBucket.getBucket(), replica);
         }
     }
@@ -147,39 +186,52 @@ public class ServerModel implements Comparable<ServerModel> {
 
     public @Nullable ReplicaModel removeReplica(TableBucket tableBucket) {
         ReplicaModel removedReplica = replica(tableBucket);
-        if (removedReplica != null) {
-            if (removedReplica.isLeader()) {
-                numLeaderReplicas--;
-            }
-
-            replicas.remove(removedReplica);
-
-            if (tableBucket.getPartitionId() != null) {
-                TablePartition tablePartition =
-                        new TablePartition(tableBucket.getTableId(), tableBucket.getPartitionId());
-                Map<Integer, ReplicaModel> tablePartitionReplicas =
-                        this.tablePartitionReplicas.get(tablePartition);
-                if (tablePartitionReplicas != null) {
-                    tablePartitionReplicas.remove(tableBucket.getBucket());
-
-                    if (tablePartitionReplicas.isEmpty()) {
-                        this.tablePartitionReplicas.remove(tablePartition);
-                    }
-                }
-            } else {
-                Map<Integer, ReplicaModel> tableReplicas =
-                        this.tableReplicas.get(tableBucket.getTableId());
-                if (tableReplicas != null) {
-                    tableReplicas.remove(tableBucket.getBucket());
-
-                    if (tableReplicas.isEmpty()) {
-                        this.tableReplicas.remove(tableBucket.getTableId());
-                    }
-                }
-            }
+        if (removedReplica == null) {
+            return null;
         }
 
+        long tableId = tableBucket.getTableId();
+        if (removedReplica.isLeader()) {
+            numLeaderReplicas--;
+            decrementLeaderReplica(tableId);
+        }
+        replicas.remove(removedReplica);
+        Set<ReplicaModel> tableReplicaSet = replicasByTable.get(tableId);
+        tableReplicaSet.remove(removedReplica);
+        if (tableReplicaSet.isEmpty()) {
+            replicasByTable.remove(tableId);
+        }
+
+        if (tableBucket.getPartitionId() != null) {
+            TablePartition tablePartition =
+                    new TablePartition(tableId, tableBucket.getPartitionId());
+            Map<Integer, ReplicaModel> partitionReplicas =
+                    tablePartitionReplicas.get(tablePartition);
+            partitionReplicas.remove(tableBucket.getBucket());
+            if (partitionReplicas.isEmpty()) {
+                tablePartitionReplicas.remove(tablePartition);
+            }
+        } else {
+            Map<Integer, ReplicaModel> nonPartitionedReplicas = tableReplicas.get(tableId);
+            nonPartitionedReplicas.remove(tableBucket.getBucket());
+            if (nonPartitionedReplicas.isEmpty()) {
+                tableReplicas.remove(tableId);
+            }
+        }
         return removedReplica;
+    }
+
+    private void incrementLeaderReplica(long tableId) {
+        numLeaderReplicasByTable.merge(tableId, 1, Integer::sum);
+    }
+
+    private void decrementLeaderReplica(long tableId) {
+        int numLeaders = numLeaderReplicasByTable.get(tableId) - 1;
+        if (numLeaders == 0) {
+            numLeaderReplicasByTable.remove(tableId);
+        } else {
+            numLeaderReplicasByTable.put(tableId, numLeaders);
+        }
     }
 
     @Override

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/RebalanceTestUtils.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/RebalanceTestUtils.java
@@ -17,18 +17,169 @@
 
 package org.apache.fluss.server.coordinator.rebalance;
 
+import org.apache.fluss.cluster.rebalance.RebalancePlanForBucket;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.server.coordinator.rebalance.goal.Goal;
+import org.apache.fluss.server.coordinator.rebalance.goal.LeaderReplicaDistributionGoal;
+import org.apache.fluss.server.coordinator.rebalance.goal.RackAwareGoal;
+import org.apache.fluss.server.coordinator.rebalance.goal.TableLeaderReplicaDistributionGoal;
+import org.apache.fluss.server.coordinator.rebalance.goal.TableReplicaDistributionGoal;
+import org.apache.fluss.server.coordinator.rebalance.model.BucketModel;
 import org.apache.fluss.server.coordinator.rebalance.model.ClusterModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ReplicaModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ServerModel;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-/** A util class for rebalance test. */
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Utilities shared by rebalance tests. */
 public class RebalanceTestUtils {
+    private static final double ADJUSTED_REBALANCE_PERCENTAGE = (1.10d - 1) * 0.9;
 
     public static void addBucket(
             ClusterModel clusterModel, TableBucket tb, List<Integer> replicas) {
         for (int i = 0; i < replicas.size(); i++) {
             clusterModel.createReplica(replicas.get(i), tb, i, i == 0);
         }
+    }
+
+    /** Captures the bucket-level state used to verify a rebalance result. */
+    public static Map<TableBucket, List<Integer>> captureReplicaDistribution(
+            ClusterModel clusterModel) {
+        Map<TableBucket, List<Integer>> distribution = new HashMap<>();
+        for (Map.Entry<TableBucket, List<Integer>> entry :
+                clusterModel.getReplicaDistribution().entrySet()) {
+            distribution.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+        }
+        return distribution;
+    }
+
+    /** Verifies bucket integrity and the contract of every emitted plan. */
+    public static void assertRebalanceInvariants(
+            Map<TableBucket, List<Integer>> originalDistribution,
+            ClusterModel clusterModel,
+            List<RebalancePlanForBucket> plans) {
+        Map<TableBucket, List<Integer>> finalDistribution = clusterModel.getReplicaDistribution();
+        assertThat(finalDistribution.keySet()).isEqualTo(originalDistribution.keySet());
+        for (Map.Entry<TableBucket, List<Integer>> entry : originalDistribution.entrySet()) {
+            TableBucket tableBucket = entry.getKey();
+            BucketModel bucket = clusterModel.bucket(tableBucket);
+            assertThat(bucket).isNotNull();
+            assertThat(bucket.replicas()).hasSize(entry.getValue().size());
+            Set<Integer> replicaIds = new HashSet<>();
+            int leaders = 0;
+            for (ReplicaModel replica : bucket.replicas()) {
+                assertThat(replicaIds.add(replica.server().id())).isTrue();
+                if (replica.isLeader()) {
+                    leaders++;
+                    assertThat(bucket.leader()).isSameAs(replica);
+                }
+            }
+            assertThat(leaders).isEqualTo(1);
+            assertThat(bucket.leader()).isNotNull();
+        }
+        for (RebalancePlanForBucket plan : plans) {
+            List<Integer> origin = plan.getOriginReplicas();
+            List<Integer> updated = plan.getNewReplicas();
+            assertThat(origin).hasSameSizeAs(updated);
+            assertThat(new HashSet<>(origin)).hasSize(origin.size());
+            assertThat(new HashSet<>(updated)).hasSize(updated.size());
+            assertThat(origin.get(0)).isEqualTo(plan.getOriginalLeader());
+            assertThat(updated.get(0)).isEqualTo(plan.getNewLeader());
+            for (Integer serverId : updated) {
+                assertThat(clusterModel.server(serverId).isOfflineTagged()).isFalse();
+            }
+            assertThat(origin).isNotEqualTo(updated);
+        }
+    }
+
+    /** Asserts that a completed goal is preserved and an incomplete one is not made worse. */
+    public static void assertGoalViolationNotRegressed(
+            Goal goal, int violationAfterGoal, ClusterModel clusterModel) {
+        int finalViolation = violation(goal, clusterModel);
+        if (violationAfterGoal == 0) {
+            assertThat(finalViolation).isZero();
+        } else {
+            assertThat(finalViolation).isLessThanOrEqualTo(violationAfterGoal);
+        }
+    }
+
+    /** Calculates the goal-scoped violation metric used by goal-combination tests. */
+    public static int violation(Goal goal, ClusterModel clusterModel) {
+        if (goal instanceof RackAwareGoal) {
+            int violations = 0;
+            for (TableBucket tableBucket : clusterModel.getReplicaDistribution().keySet()) {
+                Set<String> racks = new HashSet<>();
+                for (ReplicaModel replica : clusterModel.bucket(tableBucket).replicas()) {
+                    if (!racks.add(replica.server().rack())) {
+                        violations++;
+                        break;
+                    }
+                }
+            }
+            return violations;
+        }
+        boolean leaders =
+                goal instanceof LeaderReplicaDistributionGoal
+                        || goal instanceof TableLeaderReplicaDistributionGoal;
+        boolean tableScoped =
+                goal instanceof TableReplicaDistributionGoal
+                        || goal instanceof TableLeaderReplicaDistributionGoal;
+        int alive = clusterModel.aliveServers().size();
+        int violations = 0;
+        if (tableScoped) {
+            for (Long tableId : clusterModel.tables()) {
+                int total =
+                        leaders
+                                ? clusterModel.numLeaderReplicasByTable().get(tableId)
+                                : clusterModel.numReplicasByTable().get(tableId);
+                int lower = lowerLimit(total, alive);
+                int upper = upperLimit(total, alive);
+                for (ServerModel server : clusterModel.servers()) {
+                    int count =
+                            leaders
+                                    ? server.numLeaderReplicas(tableId)
+                                    : server.numReplicas(tableId);
+                    violations +=
+                            outsideWindow(
+                                    count,
+                                    server.isOfflineTagged() ? 0 : lower,
+                                    server.isOfflineTagged() ? 0 : upper);
+                }
+            }
+        } else {
+            int total = leaders ? clusterModel.numLeaderReplicas() : clusterModel.numReplicas();
+            int lower = lowerLimit(total, alive);
+            int upper = upperLimit(total, alive);
+            for (ServerModel server : clusterModel.servers()) {
+                int count = leaders ? server.numLeaderReplicas() : server.numReplicas();
+                violations +=
+                        outsideWindow(
+                                count,
+                                server.isOfflineTagged() ? 0 : lower,
+                                server.isOfflineTagged() ? 0 : upper);
+            }
+        }
+        return violations;
+    }
+
+    private static int lowerLimit(int total, int aliveServers) {
+        return (int)
+                Math.floor(((double) total / aliveServers) * (1 - ADJUSTED_REBALANCE_PERCENTAGE));
+    }
+
+    private static int upperLimit(int total, int aliveServers) {
+        return (int)
+                Math.ceil(((double) total / aliveServers) * (1 + ADJUSTED_REBALANCE_PERCENTAGE));
+    }
+
+    private static int outsideWindow(int count, int lower, int upper) {
+        return Math.max(lower - count, 0) + Math.max(count - upper, 0);
     }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/goal/GoalCombinationTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/goal/GoalCombinationTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator.rebalance.goal;
+
+import org.apache.fluss.cluster.rebalance.RebalancePlanForBucket;
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.server.coordinator.rebalance.model.ClusterModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ServerModel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.addBucket;
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.assertGoalViolationNotRegressed;
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.assertRebalanceInvariants;
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.captureReplicaDistribution;
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.violation;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests that goals preserve the guarantees of goals optimized before them. */
+public class GoalCombinationTest {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("goalChains")
+    void testGoalChainPreservesMeasuredGoalViolations(
+            String name, List<Goal> goals, boolean offline) {
+        ClusterModel plannedCluster = combinedFixture(offline);
+        Map<TableBucket, List<Integer>> plannedOriginal =
+                captureReplicaDistribution(plannedCluster);
+        List<RebalancePlanForBucket> plans =
+                new GoalOptimizer().doOptimizeOnce(plannedCluster, goals);
+        assertRebalanceInvariants(plannedOriginal, plannedCluster, plans);
+
+        ClusterModel cluster = combinedFixture(offline);
+        Map<TableBucket, List<Integer>> original = captureReplicaDistribution(cluster);
+        Set<Goal> optimized = new HashSet<>();
+        List<Integer> afterGoal = new ArrayList<>();
+        for (Goal goal : goals) {
+            goal.optimize(cluster, optimized);
+            optimized.add(goal);
+            afterGoal.add(violation(goal, cluster));
+        }
+        for (int i = 0; i < goals.size(); i++) {
+            assertGoalViolationNotRegressed(goals.get(i), afterGoal.get(i), cluster);
+        }
+        assertRebalanceInvariants(original, cluster, new ArrayList<RebalancePlanForBucket>());
+        if (offline) {
+            assertThat(cluster.server(4).numReplicas()).isZero();
+            assertThat(cluster.server(4).numLeaderReplicas()).isZero();
+        }
+    }
+
+    @Test
+    void testReplicaBeforeTableReplicaLeavesTableViolationWhileClusterWindowHolds() {
+        ClusterModel cluster = wrongOrderFixture();
+        Goal replica = new ReplicaDistributionGoal();
+        Goal tableReplica = new TableReplicaDistributionGoal();
+        Set<Goal> optimized = new HashSet<>();
+        replica.optimize(cluster, optimized);
+        optimized.add(replica);
+        tableReplica.optimize(cluster, optimized);
+
+        assertThat(violation(tableReplica, cluster)).isGreaterThan(0);
+        assertThat(violation(replica, cluster)).isZero();
+    }
+
+    @Test
+    void testRecommendedChainConvergesOnSecondRun() {
+        ClusterModel cluster = convergenceFixture();
+        List<Goal> goals = recommendedGoals();
+        GoalOptimizer optimizer = new GoalOptimizer();
+        optimizer.doOptimizeOnce(cluster, goals);
+        assertThat(optimizer.doOptimizeOnce(cluster, recommendedGoals())).isEmpty();
+    }
+
+    private static Stream<Arguments> goalChains() {
+        return Stream.of(
+                Arguments.of("recommended", recommendedGoals(), false),
+                Arguments.of(
+                        "table replica then table leader",
+                        Arrays.<Goal>asList(
+                                new TableReplicaDistributionGoal(),
+                                new TableLeaderReplicaDistributionGoal()),
+                        false),
+                Arguments.of(
+                        "table leader then leader",
+                        Arrays.<Goal>asList(
+                                new TableLeaderReplicaDistributionGoal(),
+                                new LeaderReplicaDistributionGoal()),
+                        false),
+                Arguments.of(
+                        "leader then table leader",
+                        Arrays.<Goal>asList(
+                                new LeaderReplicaDistributionGoal(),
+                                new TableLeaderReplicaDistributionGoal()),
+                        false),
+                Arguments.of(
+                        "rack then table leader",
+                        Arrays.<Goal>asList(
+                                new RackAwareGoal(), new TableLeaderReplicaDistributionGoal()),
+                        false),
+                Arguments.of(
+                        "rack then table replica",
+                        Arrays.<Goal>asList(
+                                new RackAwareGoal(), new TableReplicaDistributionGoal()),
+                        false),
+                Arguments.of(
+                        "table leader then table replica",
+                        Arrays.<Goal>asList(
+                                new TableLeaderReplicaDistributionGoal(),
+                                new TableReplicaDistributionGoal()),
+                        false),
+                Arguments.of(
+                        "replica then table replica",
+                        Arrays.<Goal>asList(
+                                new ReplicaDistributionGoal(), new TableReplicaDistributionGoal()),
+                        false),
+                Arguments.of("full chain with offline server", recommendedGoals(), true));
+    }
+
+    private static List<Goal> recommendedGoals() {
+        return Arrays.<Goal>asList(
+                new RackAwareGoal(),
+                new TableReplicaDistributionGoal(),
+                new ReplicaDistributionGoal(),
+                new TableLeaderReplicaDistributionGoal(),
+                new LeaderReplicaDistributionGoal());
+    }
+
+    private ClusterModel combinedFixture(boolean offline) {
+        SortedSet<ServerModel> servers = new TreeSet<>();
+        servers.add(new ServerModel(0, "rack0", false));
+        servers.add(new ServerModel(1, "rack1", false));
+        servers.add(new ServerModel(2, "rack2", false));
+        servers.add(new ServerModel(3, "rack3", false));
+        if (offline) {
+            servers.add(new ServerModel(4, "rack4", true));
+        }
+        ClusterModel cluster = new ClusterModel(servers);
+        for (int i = 0; i < 8; i++) {
+            addBucket(cluster, new TableBucket(1, i), Arrays.asList(0, 1));
+            addBucket(cluster, new TableBucket(2, i), Arrays.asList(2, 3));
+        }
+        for (int partition = 0; partition < 2; partition++) {
+            for (int bucket = 0; bucket < 4; bucket++) {
+                addBucket(
+                        cluster,
+                        new TableBucket(3, (long) partition, bucket),
+                        offline ? Arrays.asList(4, 2) : Arrays.asList(0, 2));
+            }
+        }
+        return cluster;
+    }
+
+    private ClusterModel wrongOrderFixture() {
+        SortedSet<ServerModel> servers = new TreeSet<>();
+        for (int i = 0; i < 4; i++) {
+            servers.add(new ServerModel(i, "rack" + i, false));
+        }
+        ClusterModel cluster = new ClusterModel(servers);
+        for (int i = 0; i < 8; i++) {
+            addBucket(cluster, new TableBucket(1, i), Arrays.asList(0));
+            addBucket(cluster, new TableBucket(2, i), Arrays.asList(1, 2, 3));
+        }
+        return cluster;
+    }
+
+    private ClusterModel convergenceFixture() {
+        SortedSet<ServerModel> servers = new TreeSet<>();
+        for (int i = 0; i < 4; i++) {
+            servers.add(new ServerModel(i, "rack" + i, false));
+        }
+        ClusterModel cluster = new ClusterModel(servers);
+        for (int i = 0; i < 8; i++) {
+            addBucket(cluster, new TableBucket(1, i), Arrays.asList(i % 2, 2 + i % 2));
+            addBucket(cluster, new TableBucket(2, i), Arrays.asList((i + 1) % 2, 2 + (i + 1) % 2));
+        }
+        return cluster;
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/goal/GoalOptimizerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/goal/GoalOptimizerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.fluss.server.coordinator.rebalance.goal;
 
+import org.apache.fluss.cluster.rebalance.GoalType;
 import org.apache.fluss.cluster.rebalance.RebalancePlanForBucket;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.server.coordinator.rebalance.model.ClusterModel;
@@ -27,11 +28,18 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.addBucket;
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.assertGoalViolationNotRegressed;
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.assertRebalanceInvariants;
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.captureReplicaDistribution;
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.violation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link GoalOptimizer}. */
@@ -66,8 +74,40 @@ public class GoalOptimizerTest {
         goals.add(new ReplicaDistributionGoal());
         goals.add(new LeaderReplicaDistributionGoal());
 
+        Map<TableBucket, List<Integer>> initialDistribution =
+                captureReplicaDistribution(clusterModel);
         List<RebalancePlanForBucket> plans = goalOptimizer.doOptimizeOnce(clusterModel, goals);
         assertThat(plans).isNotEmpty();
+        assertRebalanceInvariants(initialDistribution, clusterModel, plans);
+
+        // Replay the same chain goal by goal to measure, for every goal, that a violation solved by
+        // that goal is still solved once the whole chain has run.
+        ClusterModel replayed = new ClusterModel(freshServers());
+        for (int bucket = 0; bucket < 4; bucket++) {
+            addBucket(replayed, new TableBucket(bucket, 0), Arrays.asList(0, 1, 2));
+        }
+        List<Goal> replayedGoals =
+                Arrays.asList(new ReplicaDistributionGoal(), new LeaderReplicaDistributionGoal());
+        Set<Goal> optimized = new HashSet<>();
+        List<Integer> violationAfterGoal = new ArrayList<>();
+        for (Goal goal : replayedGoals) {
+            goal.optimize(replayed, optimized);
+            optimized.add(goal);
+            violationAfterGoal.add(violation(goal, replayed));
+        }
+        for (int i = 0; i < replayedGoals.size(); i++) {
+            assertGoalViolationNotRegressed(
+                    replayedGoals.get(i), violationAfterGoal.get(i), replayed);
+        }
+    }
+
+    private static SortedSet<ServerModel> freshServers() {
+        SortedSet<ServerModel> freshServers = new TreeSet<>();
+        freshServers.add(new ServerModel(0, "rack0", false));
+        freshServers.add(new ServerModel(1, "rack1", false));
+        freshServers.add(new ServerModel(2, "rack2", false));
+        freshServers.add(new ServerModel(3, "rack0", false));
+        return freshServers;
     }
 
     @Test
@@ -184,5 +224,13 @@ public class GoalOptimizerTest {
                                                 && plan.getNewReplicas().contains(0)
                                                 && !plan.getOriginReplicas().contains(0));
         assertThat(movesFrom1To0).isFalse();
+    }
+
+    @Test
+    void testGoalTypeFactoryForTableGoals() {
+        assertThat(GoalUtils.getGoalByType(GoalType.TABLE_REPLICA_DISTRIBUTION))
+                .isInstanceOf(TableReplicaDistributionGoal.class);
+        assertThat(GoalUtils.getGoalByType(GoalType.TABLE_LEADER_DISTRIBUTION))
+                .isInstanceOf(TableLeaderReplicaDistributionGoal.class);
     }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/goal/TableLeaderReplicaDistributionGoalTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/goal/TableLeaderReplicaDistributionGoalTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator.rebalance.goal;
+
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.server.coordinator.rebalance.ActionAcceptance;
+import org.apache.fluss.server.coordinator.rebalance.ActionType;
+import org.apache.fluss.server.coordinator.rebalance.RebalancingAction;
+import org.apache.fluss.server.coordinator.rebalance.model.ClusterModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ServerModel;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.addBucket;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TableLeaderReplicaDistributionGoal}. */
+public class TableLeaderReplicaDistributionGoalTest {
+
+    @Test
+    void testBalancesSkewedLeadersWithoutMovingReplicaSets() {
+        ClusterModel cluster = cluster(false);
+        for (int i = 0; i < 8; i++) {
+            addBucket(cluster, new TableBucket(1, i), Arrays.asList(0, 1, 2, 3));
+            addBucket(cluster, new TableBucket(2, i), Arrays.asList(1, 0, 2, 3));
+        }
+        Map<TableBucket, HashSet<Integer>> replicaSets = replicaSets(cluster);
+        Map<TableBucket, Integer> leaders = cluster.getLeaderDistribution();
+
+        new TableLeaderReplicaDistributionGoal().optimize(cluster, Collections.<Goal>emptySet());
+
+        for (ServerModel server : cluster.servers()) {
+            assertThat(server.numLeaderReplicas(1)).isBetween(1, 3);
+            assertThat(server.numLeaderReplicas(2)).isBetween(1, 3);
+        }
+        assertThat(replicaSets(cluster)).isEqualTo(replicaSets);
+        assertThat(cluster.getLeaderDistribution()).isNotEqualTo(leaders);
+    }
+
+    @Test
+    void testMovesLeaderReplicasToNewServerAndBalancesPartitions() {
+        ClusterModel cluster = cluster(false);
+        for (int partition = 0; partition < 2; partition++) {
+            for (int bucket = 0; bucket < 6; bucket++) {
+                addBucket(
+                        cluster, new TableBucket(1, (long) partition, bucket), Arrays.asList(0, 1));
+            }
+        }
+
+        new TableLeaderReplicaDistributionGoal().optimize(cluster, Collections.<Goal>emptySet());
+
+        assertThat(cluster.server(2).numLeaderReplicas(1)).isGreaterThan(0);
+        assertThat(cluster.server(3).numLeaderReplicas(1)).isGreaterThan(0);
+        for (ServerModel server : cluster.servers()) {
+            assertThat(server.numLeaderReplicas(1)).isBetween(2, 4);
+        }
+    }
+
+    @Test
+    void testEvacuatesOfflineLeader() {
+        ClusterModel cluster = cluster(true);
+        for (int i = 0; i < 6; i++) {
+            addBucket(cluster, new TableBucket(1, i), Arrays.asList(4, 0, 1));
+        }
+
+        new TableLeaderReplicaDistributionGoal().optimize(cluster, Collections.<Goal>emptySet());
+
+        assertThat(cluster.server(4).numLeaderReplicas()).isZero();
+    }
+
+    @Test
+    void testGracefullyDegradesWhenClusterLeaderGoalBlocksTableMoves() {
+        ClusterModel cluster = cluster(false);
+        for (int i = 0; i < 4; i++) {
+            addBucket(cluster, new TableBucket(1, i), Arrays.asList(0, 1, 2, 3));
+        }
+        for (int i = 0; i < 4; i++) {
+            addBucket(cluster, new TableBucket(2, i), Arrays.asList(1, 0));
+            addBucket(cluster, new TableBucket(3, i), Arrays.asList(2, 0));
+            addBucket(cluster, new TableBucket(4, i), Arrays.asList(3, 0));
+        }
+
+        LeaderReplicaDistributionGoal clusterLeaderGoal = new LeaderReplicaDistributionGoal();
+        clusterLeaderGoal.optimize(cluster, Collections.<Goal>emptySet());
+        TableLeaderReplicaDistributionGoal tableLeaderGoal =
+                new TableLeaderReplicaDistributionGoal();
+        tableLeaderGoal.optimize(cluster, Collections.<Goal>singleton(clusterLeaderGoal));
+
+        // A standalone table cannot have every alive server at its upper limit: the upper limit
+        // is derived from that table's average. Here the already-satisfied cluster leader window
+        // is the realistic constraint that blocks the remaining table-level leadership movement.
+        assertThat(cluster.server(0).numLeaderReplicas(1)).isGreaterThan(2);
+        assertThat(cluster.server(0).numLeaderReplicas()).isGreaterThanOrEqualTo(3);
+        for (ServerModel server : cluster.servers()) {
+            assertThat(server.numLeaderReplicas()).isBetween(3, 5);
+        }
+    }
+
+    @Test
+    void testLeaderAndFollowerReplicaMovementAcceptanceAtBoundaries() {
+        ClusterModel cluster = cluster(false);
+        TableBucket leaderBucket = new TableBucket(1, 0);
+        TableBucket followerBucket = new TableBucket(1, 1);
+        addBucket(cluster, leaderBucket, Arrays.asList(0, 1));
+        addBucket(cluster, followerBucket, Arrays.asList(1, 0));
+        TableLeaderReplicaDistributionGoal goal = new TableLeaderReplicaDistributionGoal();
+        goal.initGoalState(cluster);
+
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(
+                                        followerBucket, 0, 2, ActionType.REPLICA_MOVEMENT),
+                                cluster))
+                .isEqualTo(ActionAcceptance.ACCEPT);
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(
+                                        leaderBucket, 0, 2, ActionType.REPLICA_MOVEMENT),
+                                cluster))
+                .isEqualTo(ActionAcceptance.ACCEPT);
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(
+                                        leaderBucket, 0, 1, ActionType.REPLICA_MOVEMENT),
+                                cluster))
+                .isNotEqualTo(ActionAcceptance.ACCEPT);
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(
+                                        leaderBucket, 0, 1, ActionType.LEADERSHIP_MOVEMENT),
+                                cluster))
+                .isNotEqualTo(ActionAcceptance.ACCEPT);
+    }
+
+    @Test
+    void testRejectsLeadershipMoveOutOfServerAtLowerLimit() {
+        // 8 leaders of table 1 over 4 alive servers: avg 2, lower 1, upper 3. Server 3 leads
+        // exactly one bucket, so giving that leadership away would drop it below the lower limit.
+        ClusterModel cluster = cluster(false);
+        for (int bucket = 0; bucket < 3; bucket++) {
+            addBucket(cluster, new TableBucket(1, bucket), Arrays.asList(0, 1, 3));
+        }
+        for (int bucket = 3; bucket < 7; bucket++) {
+            addBucket(cluster, new TableBucket(1, bucket), Arrays.asList(1, 2, 0));
+        }
+        TableBucket boundaryBucket = new TableBucket(1, 7);
+        addBucket(cluster, boundaryBucket, Arrays.asList(3, 2, 0));
+        TableLeaderReplicaDistributionGoal goal = new TableLeaderReplicaDistributionGoal();
+        goal.initGoalState(cluster);
+
+        assertThat(cluster.server(3).numLeaderReplicas(1)).isEqualTo(1);
+        assertThat(cluster.server(2).numLeaderReplicas(1)).isEqualTo(0);
+        // Source at the lower limit is rejected for leadership movement ...
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(
+                                        boundaryBucket, 3, 2, ActionType.LEADERSHIP_MOVEMENT),
+                                cluster))
+                .isNotEqualTo(ActionAcceptance.ACCEPT);
+        // ... and for moving the leader replica itself.
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(
+                                        boundaryBucket, 3, 1, ActionType.REPLICA_MOVEMENT),
+                                cluster))
+                .isNotEqualTo(ActionAcceptance.ACCEPT);
+        // A source above the lower limit may still hand its leadership over.
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(
+                                        new TableBucket(1, 3),
+                                        1,
+                                        2,
+                                        ActionType.LEADERSHIP_MOVEMENT),
+                                cluster))
+                .isEqualTo(ActionAcceptance.ACCEPT);
+    }
+
+    private Map<TableBucket, HashSet<Integer>> replicaSets(ClusterModel cluster) {
+        Map<TableBucket, HashSet<Integer>> result = new HashMap<>();
+        for (Map.Entry<TableBucket, List<Integer>> entry :
+                cluster.getReplicaDistribution().entrySet()) {
+            result.put(entry.getKey(), new HashSet<>(entry.getValue()));
+        }
+        return result;
+    }
+
+    private ClusterModel cluster(boolean offlineServer) {
+        SortedSet<ServerModel> servers = new TreeSet<>();
+        servers.add(new ServerModel(0, "rack0", false));
+        servers.add(new ServerModel(1, "rack1", false));
+        servers.add(new ServerModel(2, "rack2", false));
+        servers.add(new ServerModel(3, "rack3", false));
+        if (offlineServer) {
+            servers.add(new ServerModel(4, "rack4", true));
+        }
+        return new ClusterModel(servers);
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/goal/TableReplicaDistributionGoalTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/goal/TableReplicaDistributionGoalTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator.rebalance.goal;
+
+import org.apache.fluss.cluster.rebalance.RebalancePlanForBucket;
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.server.coordinator.rebalance.ActionAcceptance;
+import org.apache.fluss.server.coordinator.rebalance.ActionType;
+import org.apache.fluss.server.coordinator.rebalance.RebalancingAction;
+import org.apache.fluss.server.coordinator.rebalance.model.ClusterModel;
+import org.apache.fluss.server.coordinator.rebalance.model.ServerModel;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.addBucket;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TableReplicaDistributionGoal}. */
+public class TableReplicaDistributionGoalTest {
+
+    @Test
+    void testBalancesSkewedTableWhileClusterIsBalanced() {
+        ClusterModel cluster = cluster(false);
+        for (int i = 0; i < 8; i++) {
+            addBucket(cluster, new TableBucket(1, i), Arrays.asList(0, 1));
+            addBucket(cluster, new TableBucket(2, i), Arrays.asList(2, 3));
+        }
+
+        new TableReplicaDistributionGoal().optimize(cluster, Collections.<Goal>emptySet());
+
+        for (ServerModel server : cluster.servers()) {
+            assertThat(server.numReplicas(1)).isBetween(3, 5);
+            assertThat(server.numReplicas(2)).isBetween(3, 5);
+        }
+    }
+
+    @Test
+    void testMovesReplicaToNewServerAndBalancesPartitionedTable() {
+        ClusterModel cluster = cluster(false);
+        for (int partition = 0; partition < 3; partition++) {
+            for (int bucket = 0; bucket < 4; bucket++) {
+                addBucket(
+                        cluster, new TableBucket(1, (long) partition, bucket), Arrays.asList(0, 1));
+            }
+        }
+
+        new TableReplicaDistributionGoal().optimize(cluster, Collections.<Goal>emptySet());
+
+        for (ServerModel server : cluster.servers()) {
+            assertThat(server.numReplicas(1)).isBetween(5, 7);
+        }
+        assertThat(cluster.server(2).numReplicas(1)).isGreaterThan(0);
+        assertThat(cluster.server(3).numReplicas(1)).isGreaterThan(0);
+    }
+
+    @Test
+    void testEvacuatesOfflineServer() {
+        ClusterModel cluster = cluster(true);
+        for (int i = 0; i < 6; i++) {
+            addBucket(cluster, new TableBucket(1, i), Arrays.asList(4, 0, 1));
+        }
+
+        new TableReplicaDistributionGoal().optimize(cluster, Collections.<Goal>emptySet());
+
+        assertThat(cluster.server(4).numReplicas()).isZero();
+        for (ServerModel server : cluster.aliveServers()) {
+            assertThat(server.numReplicas(1)).isLessThanOrEqualTo(5);
+        }
+    }
+
+    @Test
+    void testDegradesGracefullyWhenNoLegitDestinationExists() {
+        // A server can never be pushed above the upper limit of every alive server at once: if all
+        // of them held at least upper(t) replicas then avg(t) >= upper(t), which contradicts
+        // upper(t) = ceil(avg(t) * 1.09). Real "no headroom" therefore comes from placement, not
+        // from counts: here every bucket already has a replica on every server, so
+        // GoalUtils#legitMove rejects every destination and the offline server cannot be drained.
+        ClusterModel cluster = cluster(true);
+        for (int i = 0; i < 2; i++) {
+            addBucket(cluster, new TableBucket(1, i), Arrays.asList(4, 0, 1, 2, 3));
+        }
+
+        List<RebalancePlanForBucket> plans =
+                new GoalOptimizer()
+                        .doOptimizeOnce(
+                                cluster,
+                                Collections.<Goal>singletonList(
+                                        new TableReplicaDistributionGoal()));
+
+        // The goal is soft: it gives up instead of throwing, and leaves the placement untouched.
+        assertThat(plans).isEmpty();
+        assertThat(cluster.server(4).numReplicas(1)).isEqualTo(2);
+        for (ServerModel server : cluster.aliveServers()) {
+            assertThat(server.numReplicas(1)).isEqualTo(2);
+        }
+    }
+
+    @Test
+    void testRejectsMoveOutOfServerAtLowerLimit() {
+        // 8 replicas of table 1 over 4 alive servers: avg 2, lower 1, upper 3. Server 3 holds
+        // exactly one replica, so moving it out would drop the server below the lower limit.
+        ClusterModel cluster = cluster(false);
+        addBucket(cluster, new TableBucket(1, 0), Arrays.asList(0, 1, 2));
+        addBucket(cluster, new TableBucket(1, 1), Arrays.asList(0, 1, 2));
+        TableBucket boundaryBucket = new TableBucket(1, 2);
+        addBucket(cluster, boundaryBucket, Arrays.asList(3, 0));
+        TableReplicaDistributionGoal goal = new TableReplicaDistributionGoal();
+        goal.initGoalState(cluster);
+
+        assertThat(cluster.server(3).numReplicas(1)).isEqualTo(1);
+        // Source at the lower limit is rejected even though the destination has room.
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(
+                                        boundaryBucket, 3, 1, ActionType.REPLICA_MOVEMENT),
+                                cluster))
+                .isNotEqualTo(ActionAcceptance.ACCEPT);
+        // A source above the lower limit may move the same bucket to the same destination.
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(
+                                        new TableBucket(1, 0), 2, 3, ActionType.REPLICA_MOVEMENT),
+                                cluster))
+                .isEqualTo(ActionAcceptance.ACCEPT);
+    }
+
+    @Test
+    void testBoundaryAndSmallTableAcceptance() {
+        ClusterModel cluster = cluster(false);
+        TableBucket bucket = new TableBucket(1, 0);
+        addBucket(cluster, bucket, Arrays.asList(0, 1));
+        TableReplicaDistributionGoal goal = new TableReplicaDistributionGoal();
+        goal.initGoalState(cluster);
+
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(bucket, 0, 2, ActionType.LEADERSHIP_MOVEMENT),
+                                cluster))
+                .isEqualTo(ActionAcceptance.ACCEPT);
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(bucket, 0, 2, ActionType.REPLICA_MOVEMENT),
+                                cluster))
+                .isEqualTo(ActionAcceptance.ACCEPT);
+        assertThat(
+                        goal.actionAcceptance(
+                                new RebalancingAction(bucket, 0, 1, ActionType.REPLICA_MOVEMENT),
+                                cluster))
+                .isNotEqualTo(ActionAcceptance.ACCEPT);
+    }
+
+    private ClusterModel cluster(boolean offlineServer) {
+        SortedSet<ServerModel> servers = new TreeSet<>();
+        servers.add(new ServerModel(0, "rack0", false));
+        servers.add(new ServerModel(1, "rack1", false));
+        servers.add(new ServerModel(2, "rack2", false));
+        servers.add(new ServerModel(3, "rack3", false));
+        if (offlineServer) {
+            servers.add(new ServerModel(4, "rack4", true));
+        }
+        return new ClusterModel(servers);
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/model/ClusterModelStatsTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/model/ClusterModelStatsTest.java
@@ -109,4 +109,23 @@ public class ClusterModelStatsTest {
         assertThat(clusterModelStats.replicaStats().get(StatisticType.ST_DEV).doubleValue())
                 .isCloseTo(5.0, offset(0.001));
     }
+
+    @Test
+    void testPerTableStandardDeviationIncludesOfflineReplicasInAverage() {
+        SortedSet<ServerModel> servers = new TreeSet<>();
+        servers.add(new ServerModel(0, "rack0", false));
+        servers.add(new ServerModel(1, "rack1", false));
+        servers.add(new ServerModel(2, "rack2", true));
+        ClusterModel cluster = new ClusterModel(servers);
+        addBucket(cluster, new TableBucket(9, 0), Arrays.asList(0));
+        addBucket(cluster, new TableBucket(9, 1), Arrays.asList(0));
+        addBucket(cluster, new TableBucket(9, 2), Arrays.asList(2));
+
+        ClusterModelStats stats = cluster.getClusterStats();
+        // All three replicas contribute to avg=3/2, while only the two alive hosts contribute
+        // variance: sqrt(((2-1.5)^2 + (0-1.5)^2) / 2) = sqrt(1.25).
+        assertThat(stats.replicaStdDevByTable().get(9L)).isCloseTo(Math.sqrt(1.25), offset(0.001));
+        assertThat(stats.leaderReplicaStdDevByTable().get(9L))
+                .isCloseTo(Math.sqrt(1.25), offset(0.001));
+    }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/model/ServerModelTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/rebalance/model/ServerModelTest.java
@@ -21,7 +21,13 @@ import org.apache.fluss.metadata.TableBucket;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.apache.fluss.server.coordinator.rebalance.RebalanceTestUtils.addBucket;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link ServerModel}. */
 public class ServerModelTest {
@@ -75,6 +81,40 @@ public class ServerModelTest {
         assertThat(serverModel.replicas()).hasSize(5);
         assertThat(serverModel.numLeaderReplicas()).isEqualTo(2);
         assertThat(serverModel.tables()).containsExactly(1L, 3L);
+    }
+
+    @Test
+    void testPerTableIndexesTrackRelocationsAndDuplicateInsertions() {
+        SortedSet<ServerModel> servers = new TreeSet<>();
+        ServerModel server0 = new ServerModel(0, "rack0", false);
+        ServerModel server1 = new ServerModel(1, "rack1", false);
+        servers.add(server0);
+        servers.add(server1);
+        ClusterModel cluster = new ClusterModel(servers);
+        TableBucket p0 = new TableBucket(7, 0L, 0);
+        TableBucket p1 = new TableBucket(7, 1L, 0);
+        addBucket(cluster, p0, Arrays.asList(0));
+        addBucket(cluster, p1, Arrays.asList(0, 1));
+
+        assertThat(server0.numReplicas(7)).isEqualTo(2);
+        assertThat(server0.numLeaderReplicas(7)).isEqualTo(2);
+        assertThat(server0.replicas(7)).hasSize(2);
+        assertThat(server0.leaderReplicas(7)).hasSize(2);
+        cluster.relocateReplica(p0, 0, 1);
+        assertThat(server0.numReplicas(7)).isEqualTo(1);
+        assertThat(server1.numReplicas(7)).isEqualTo(2);
+        assertThat(server1.numLeaderReplicas(7)).isEqualTo(1);
+        cluster.relocateLeadership(p1, 0, 1);
+        assertThat(server0.numLeaderReplicas(7)).isZero();
+        assertThat(server1.numLeaderReplicas(7)).isEqualTo(2);
+        server0.removeReplica(p1);
+        assertThat(server0.replicas(7)).isEmpty();
+        assertThat(server0.tables()).doesNotContain(7L);
+
+        assertThatThrownBy(() -> server1.putReplica(p0, new ReplicaModel(p0, server1, true)))
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(server1.numReplicas(7)).isEqualTo(2);
+        assertThat(server1.numLeaderReplicas(7)).isEqualTo(2);
     }
 
     @Test

--- a/website/docs/engine-flink/procedures.md
+++ b/website/docs/engine-flink/procedures.md
@@ -443,9 +443,11 @@ CALL [catalog_name.]sys.rebalance(
 
 **Parameters:**
 
-- `priorityGoals` (required): The rebalance goals to achieve, specified as goal types. Can be a single goal (e.g., `'REPLICA_DISTRIBUTION'`) or multiple goals separated by commas (e.g., `'RACK_AWARE,REPLICA_DISTRIBUTION,LEADER_DISTRIBUTION'`). Valid goal types are:
+- `priorityGoals` (required): The rebalance goals to achieve, specified as goal types. Can be a single goal (e.g., `'TABLE_REPLICA_DISTRIBUTION'`) or multiple goals separated by commas (e.g., `'RACK_AWARE,TABLE_REPLICA_DISTRIBUTION,REPLICA_DISTRIBUTION,TABLE_LEADER_DISTRIBUTION,LEADER_DISTRIBUTION'`). Valid goal types are:
     - `'RACK_AWARE'`: Ensures replicas of the same bucket are distributed across different racks. This goal should be placed first when rack awareness is required to prevent non-rack-balanced assignments.
+    - `'TABLE_REPLICA_DISTRIBUTION'`: Ensures replicas of each table are near balanced across TabletServers.
     - `'REPLICA_DISTRIBUTION'`: Generates replica movement tasks to ensure the number of replicas on each TabletServer is near balanced.
+    - `'TABLE_LEADER_DISTRIBUTION'`: Ensures leaders of each table are near balanced across TabletServers.
     - `'LEADER_DISTRIBUTION'`: Generates leadership movement and leader replica movement tasks to ensure the number of leader replicas on each TabletServer is near balanced.
 
 **Returns:** An array with a single element containing the rebalance ID (e.g., `'rebalance-12345'`), which can be used to track or cancel the rebalance operation.
@@ -464,13 +466,13 @@ CALL [catalog_name.]sys.rebalance(
 USE fluss_catalog;
 
 -- Trigger rebalance with rack-aware goal (recommended for multi-rack deployments)
-CALL sys.rebalance('RACK_AWARE,REPLICA_DISTRIBUTION');
+CALL sys.rebalance('RACK_AWARE,TABLE_REPLICA_DISTRIBUTION,REPLICA_DISTRIBUTION');
 
 -- Trigger rebalance with replica distribution goal only
 CALL sys.rebalance('REPLICA_DISTRIBUTION');
 
 -- Trigger rebalance with multiple goals in priority order
-CALL sys.rebalance('RACK_AWARE,REPLICA_DISTRIBUTION,LEADER_DISTRIBUTION');
+CALL sys.rebalance('RACK_AWARE,TABLE_REPLICA_DISTRIBUTION,REPLICA_DISTRIBUTION,TABLE_LEADER_DISTRIBUTION,LEADER_DISTRIBUTION');
 ```
 
 ### list_rebalance

--- a/website/docs/maintenance/operations/rebalance.md
+++ b/website/docs/maintenance/operations/rebalance.md
@@ -62,7 +62,9 @@ System.out.println("Rebalance started with ID: " + rebalanceId);
 // Trigger rebalance with multiple goals in priority order
 List<GoalType> multipleGoals = Arrays.asList(
     GoalType.RACK_AWARE,
+    GoalType.TABLE_REPLICA_DISTRIBUTION,
     GoalType.REPLICA_DISTRIBUTION,
+    GoalType.TABLE_LEADER_DISTRIBUTION,
     GoalType.LEADER_DISTRIBUTION
 );
 String rebalanceId = admin.rebalance(multipleGoals).get();
@@ -70,11 +72,13 @@ String rebalanceId = admin.rebalance(multipleGoals).get();
 
 Available rebalance goals:
 - **RACK_AWARE**: Ensures replicas of the same bucket are distributed across different racks. This goal is essential for high availability in multi-rack deployments, as it prevents data loss when an entire rack fails.
+- **TABLE_REPLICA_DISTRIBUTION**: Ensures replicas of each table are near balanced across TabletServers. Use this before cluster-wide replica balancing for hot tables or after cluster expansion.
 - **REPLICA_DISTRIBUTION**: Ensures the number of replicas on each TabletServer is near balanced
+- **TABLE_LEADER_DISTRIBUTION**: Ensures leaders of each table are near balanced across TabletServers. It first transfers leadership between existing replicas and moves leader replicas only when necessary.
 - **LEADER_DISTRIBUTION**: Ensures the number of leader replicas on each TabletServer is near balanced
 
 :::tip Goal Priority
-Goals are processed in the order specified. When using `RACK_AWARE`, always place it first to ensure subsequent goals (like `REPLICA_DISTRIBUTION`) respect rack constraints. If `RACK_AWARE` is not the first goal, replica movements may violate rack awareness requirements.
+Goals are processed in the order specified. When using `RACK_AWARE`, always place it first to ensure subsequent goals respect rack constraints. For table-aware balancing, use `RACK_AWARE`, `TABLE_REPLICA_DISTRIBUTION`, `REPLICA_DISTRIBUTION`, `TABLE_LEADER_DISTRIBUTION`, then `LEADER_DISTRIBUTION`. If `RACK_AWARE` is not first, replica movements may violate rack awareness requirements.
 :::
 
 ### 3. Monitor Progress
@@ -167,7 +171,9 @@ public class RebalanceExample {
             System.out.println("Triggering rebalance...");
             List<GoalType> goals = Arrays.asList(
                 GoalType.RACK_AWARE,
+                GoalType.TABLE_REPLICA_DISTRIBUTION,
                 GoalType.REPLICA_DISTRIBUTION,
+                GoalType.TABLE_LEADER_DISTRIBUTION,
                 GoalType.LEADER_DISTRIBUTION
             );
             String rebalanceId = admin.rebalance(goals).get();
@@ -226,7 +232,7 @@ Example using Flink SQL:
 CALL sys.add_server_tag('0', 'PERMANENT_OFFLINE');
 
 -- Trigger rebalance with rack-aware goal (recommended)
-CALL sys.rebalance('RACK_AWARE,REPLICA_DISTRIBUTION,LEADER_DISTRIBUTION');
+CALL sys.rebalance('RACK_AWARE,TABLE_REPLICA_DISTRIBUTION,REPLICA_DISTRIBUTION,TABLE_LEADER_DISTRIBUTION,LEADER_DISTRIBUTION');
 
 -- Monitor progress
 CALL sys.list_rebalance();
@@ -242,22 +248,24 @@ CALL sys.cancel_rebalance();
 When your cluster is deployed across multiple racks for high availability, always place `RACK_AWARE` as the **first** goal in your rebalance request. This ensures that:
 
 1. The rebalance algorithm first satisfies rack distribution constraints
-2. Subsequent goals (like `REPLICA_DISTRIBUTION` and `LEADER_DISTRIBUTION`) only consider movements that maintain rack awareness
+2. Subsequent goals (like `TABLE_REPLICA_DISTRIBUTION`, `REPLICA_DISTRIBUTION`, `TABLE_LEADER_DISTRIBUTION` and `LEADER_DISTRIBUTION`) only consider movements that maintain rack awareness
 3. You won't end up with multiple replicas of the same bucket on the same rack
 
 **Recommended goal order for multi-rack deployments:**
 ```java
 List<GoalType> goals = Arrays.asList(
-    GoalType.RACK_AWARE,           // First: ensure rack distribution
-    GoalType.REPLICA_DISTRIBUTION, // Second: balance replica count
-    GoalType.LEADER_DISTRIBUTION   // Third: balance leader count
+    GoalType.RACK_AWARE,                 // First: ensure rack distribution
+    GoalType.TABLE_REPLICA_DISTRIBUTION, // Second: balance replica count of each table
+    GoalType.REPLICA_DISTRIBUTION,       // Third: balance replica count of the cluster
+    GoalType.TABLE_LEADER_DISTRIBUTION,  // Fourth: balance leader count of each table
+    GoalType.LEADER_DISTRIBUTION         // Fifth: balance leader count of the cluster
 );
 ```
 
 **Example using Flink SQL:**
 ```sql
 -- Correct: RACK_AWARE first ensures rack-balanced assignments
-CALL sys.rebalance('RACK_AWARE,REPLICA_DISTRIBUTION,LEADER_DISTRIBUTION');
+CALL sys.rebalance('RACK_AWARE,TABLE_REPLICA_DISTRIBUTION,REPLICA_DISTRIBUTION,TABLE_LEADER_DISTRIBUTION,LEADER_DISTRIBUTION');
 
 -- Incorrect: May produce non-rack-balanced assignments
 -- CALL sys.rebalance('REPLICA_DISTRIBUTION,RACK_AWARE');  -- Don't do this!


### PR DESCRIPTION
### Purpose

Linked issue: close #3871

The existing `REPLICA_DISTRIBUTION` and `LEADER_DISTRIBUTION` goals balance replica and leader counts across the whole cluster. As a result, a hot table can still be concentrated on a few TabletServers even when the cluster-wide counts are balanced, causing CPU and request-load hotspots.

This change adds complementary table-level goals so that replica placement and leadership are balanced independently for every table while preserving rack awareness and previously optimized goals.

### Brief change log

- Add `TABLE_REPLICA_DISTRIBUTION` and `TABLE_LEADER_DISTRIBUTION` as additive rebalance goal types.
- Track replicas and leaders by table in `ServerModel`, and expose per-table replica and leader distribution statistics in `ClusterModelStats`.
- Balance each table within its own lower and upper limits. Prefer leadership transfer between existing replicas, and move leader replicas only when leadership transfer cannot reach the table-level target.
- Reject a result when the replica or leader distribution of any individual table regresses, instead of allowing improvements in one table to hide regressions in another.
- Keep the existing cluster-level goals as complementary goals. The recommended order is `RACK_AWARE,TABLE_REPLICA_DISTRIBUTION,REPLICA_DISTRIBUTION,TABLE_LEADER_DISTRIBUTION,LEADER_DISTRIBUTION`.
- Update the Flink procedure and rebalance documentation.

### Tests

- Added unit tests for table replica and leader distribution, partitioned tables, offline servers, balance boundaries, goal ordering, convergence, idempotence, and stable numeric goal mappings.
- Added an end-to-end rebalance scenario covering the recommended five-goal chain.
- Ran 53 related tests on JDK 11: 53 passed, 0 failed.
- Ran Spotless and Checkstyle for `fluss-common`, `fluss-server`, `fluss-client`, and `fluss-flink-common`.
- `RebalanceITCase` compiles locally. Its execution is deferred to CI because the local sandbox does not permit the embedded ZooKeeper server to bind a socket.

### API and Format

- Adds the public goal types `TABLE_REPLICA_DISTRIBUTION(3)` and `TABLE_LEADER_DISTRIBUTION(4)`.
- No RPC schema change: rebalance goals continue to use the existing `repeated int32 goals` field.
- No storage format change.

### Documentation

- Document the new table-level goals and the recommended goal order in the Flink procedure and rebalance operation documentation.

### Generative AI disclosure

- [x] Yes — OpenAI GPT and Anthropic Claude were used for implementation assistance and cross-review.
