### PR TITLE
[server] Fix ISR shrink race during leader transition

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -2035,13 +2035,27 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 throw new InvalidUpdateVersionException(
                         "The request bucket epoch in adjust isr request is lower than current bucket epoch in coordinator.");
             } else {
-                if (!newLeaderAndIsr.isr().contains(newLeaderAndIsr.leader())) {
+                if (newLeaderAndIsr.leader() != currentLeaderAndIsr.leader()) {
+                    String errorMsg =
+                            String.format(
+                                    "Rejecting adjustIsr request for table bucket %s because request leader %s "
+                                            + "does not match current leader %s",
+                                    tableBucket,
+                                    newLeaderAndIsr.leader(),
+                                    currentLeaderAndIsr.leader());
+                    LOG.error(errorMsg);
+                    throw new FencedLeaderEpochException(errorMsg);
+                }
+
+                if (!newLeaderAndIsr.isr().contains(currentLeaderAndIsr.leader())) {
                     String errorMsg =
                             String.format(
                                     "Rejecting adjustIsr request for table bucket %s because leader %s "
                                             + "is not in the new ISR %s",
-                                    tableBucket, newLeaderAndIsr.leader(), newLeaderAndIsr.isr());
-                    LOG.info(errorMsg);
+                                    tableBucket,
+                                    currentLeaderAndIsr.leader(),
+                                    newLeaderAndIsr.isr());
+                    LOG.error(errorMsg);
                     throw new IneligibleReplicaException(errorMsg);
                 }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -2035,6 +2035,16 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 throw new InvalidUpdateVersionException(
                         "The request bucket epoch in adjust isr request is lower than current bucket epoch in coordinator.");
             } else {
+                if (!newLeaderAndIsr.isr().contains(newLeaderAndIsr.leader())) {
+                    String errorMsg =
+                            String.format(
+                                    "Rejecting adjustIsr request for table bucket %s because leader %s "
+                                            + "is not in the new ISR %s",
+                                    tableBucket, newLeaderAndIsr.leader(), newLeaderAndIsr.isr());
+                    LOG.info(errorMsg);
+                    throw new IneligibleReplicaException(errorMsg);
+                }
+
                 // Check if the new ISR are all ineligible replicas (doesn't contain any shutting
                 // down tabletServers).
                 Set<Integer> ineligibleReplicas = new HashSet<>(newLeaderAndIsr.isr());

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -1865,25 +1865,25 @@ public final class Replica {
      * <p>This function can be triggered when a replica's LEO has incremented.
      */
     private void maybeExpandISr(FollowerReplica followerReplica) {
-        IsrState currentIsrState = isrState;
         boolean needsIsrUpdate =
-                !currentIsrState.isInflight()
-                        && inReadLock(leaderIsrUpdateLock, () -> needsExpandIsr(followerReplica));
+                inReadLock(
+                        leaderIsrUpdateLock,
+                        () -> !isrState.isInflight() && needsExpandIsr(followerReplica));
 
         if (needsIsrUpdate) {
             Optional<IsrState.PendingExpandIsrState> adjustIsrUpdateOpt =
                     inWriteLock(
                             leaderIsrUpdateLock,
                             () -> {
+                                IsrState currentIsrState = isrState;
                                 // check if this replica needs to be added to the ISR.
-                                if (currentIsrState instanceof IsrState.CommittedIsrState) {
-                                    if (needsExpandIsr(followerReplica)) {
-                                        return Optional.of(
-                                                prepareIsrExpand(
-                                                        (IsrState.CommittedIsrState)
-                                                                currentIsrState,
-                                                        followerReplica.getFollowerId()));
-                                    }
+                                if (isLeader()
+                                        && currentIsrState instanceof IsrState.CommittedIsrState
+                                        && needsExpandIsr(followerReplica)) {
+                                    return Optional.of(
+                                            prepareIsrExpand(
+                                                    (IsrState.CommittedIsrState) currentIsrState,
+                                                    followerReplica.getFollowerId()));
                                 }
 
                                 return Optional.empty();
@@ -1949,7 +1949,7 @@ public final class Replica {
         // reflect the updated ISR even if there is a delay before we receive the confirmation.
         // Alternatively, if the update fails, no harm is done since the expanded ISR puts
         // a stricter requirement for advancement of the HW.
-        List<Integer> isrToSend = new ArrayList<>(isrState.isr());
+        List<Integer> isrToSend = new ArrayList<>(currentState.isr());
         isrToSend.add(newInSyncReplicaId);
 
         // TODO add server epoch to isr.

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -135,7 +135,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.IntSupplier;
 import java.util.function.Supplier;
@@ -191,7 +190,7 @@ public final class Replica {
     private final LogFormat logFormat;
     private final ArrowCompressionInfo arrowCompressionInfo;
     private final AtomicReference<Integer> leaderReplicaIdOpt = new AtomicReference<>();
-    private final ReadWriteLock leaderIsrUpdateLock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock leaderIsrUpdateLock = new ReentrantReadWriteLock();
     private final Clock clock;
     private final RemoteLogManager remoteLogManager;
 
@@ -2362,6 +2361,11 @@ public final class Replica {
     @VisibleForTesting
     public int getBucketEpoch() {
         return bucketEpoch;
+    }
+
+    @VisibleForTesting
+    ReentrantReadWriteLock getLeaderIsrUpdateLock() {
+        return leaderIsrUpdateLock;
     }
 
     @VisibleForTesting

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -1897,28 +1897,27 @@ public final class Replica {
     }
 
     void maybeShrinkIsr() {
-        IsrState currentIstState = isrState;
         boolean needsIsrUpdate =
-                !currentIstState.isInflight()
-                        && inReadLock(leaderIsrUpdateLock, this::needsShrinkIsr);
+                inReadLock(leaderIsrUpdateLock, () -> !isrState.isInflight() && needsShrinkIsr());
 
         if (needsIsrUpdate) {
             Optional<IsrState.PendingShrinkIsrState> adjustIsrUpdateOpt =
                     inWriteLock(
                             leaderIsrUpdateLock,
                             () -> {
-                                if (isLeader()) {
+                                IsrState currentIsrState = isrState;
+                                if (isLeader()
+                                        && currentIsrState instanceof IsrState.CommittedIsrState) {
                                     List<Integer> outOfSyncFollowerReplicas =
                                             getOutOfSyncFollowerReplicas(replicaMaxLagTime);
-                                    if (currentIstState instanceof IsrState.CommittedIsrState
-                                            && !outOfSyncFollowerReplicas.isEmpty()) {
+                                    if (!outOfSyncFollowerReplicas.isEmpty()) {
                                         List<Integer> newIsr =
-                                                new ArrayList<>(currentIstState.isr());
+                                                new ArrayList<>(currentIsrState.isr());
                                         newIsr.removeAll(outOfSyncFollowerReplicas);
                                         LOG.info(
                                                 "Shrink ISR From {} to {} for bucket {}. Leader: (high watermark: {}, "
                                                         + "end offset: {}, out of sync replicas: {})",
-                                                currentIstState.isr(),
+                                                currentIsrState.isr(),
                                                 newIsr,
                                                 tableBucket,
                                                 logTablet.getHighWatermark(),
@@ -1927,7 +1926,7 @@ public final class Replica {
                                         return Optional.of(
                                                 prepareIsrShrink(
                                                         (IsrState.CommittedIsrState)
-                                                                currentIstState,
+                                                                currentIsrState,
                                                         newIsr,
                                                         outOfSyncFollowerReplicas));
                                     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
@@ -1271,9 +1271,46 @@ class CoordinatorEventProcessorTest {
         assertThat(resultForBucketMap.keySet())
                 .containsAnyElementsOf(bucketLeaderAndIsrMap.keySet());
         assertThat(resultForBucketMap.values()).allMatch(AdjustIsrResultForBucket::succeeded);
+    }
 
+    @Test
+    void testProcessAdjustIsrRejectsRequestFromNonLeader() throws Exception {
         Map.Entry<TableBucket, LeaderAndIsr> entry =
-                fromCtx(ctx -> ctx.bucketLeaderAndIsr().entrySet().iterator().next());
+                createTableAndGetLeaderAndIsr("adjust_isr_from_non_leader");
+        TableBucket tableBucket = entry.getKey();
+        LeaderAndIsr currentLeaderAndIsr = entry.getValue();
+        int nonLeader =
+                currentLeaderAndIsr.isr().stream()
+                        .filter(replica -> replica != currentLeaderAndIsr.leader())
+                        .findFirst()
+                        .get();
+        LeaderAndIsr invalidLeaderAndIsr =
+                new LeaderAndIsr(
+                        nonLeader,
+                        currentLeaderAndIsr.leaderEpoch(),
+                        currentLeaderAndIsr.isr(),
+                        currentLeaderAndIsr.standbyReplicas(),
+                        currentLeaderAndIsr.coordinatorEpoch(),
+                        currentLeaderAndIsr.bucketEpoch());
+
+        AdjustIsrResultForBucket invalidResult = submitAdjustIsr(tableBucket, invalidLeaderAndIsr);
+
+        assertThat(invalidResult.getError().error())
+                .isEqualTo(Errors.FENCED_LEADER_EPOCH_EXCEPTION);
+        assertThat(invalidResult.getErrorMessage())
+                .contains(
+                        String.format(
+                                "request leader %s does not match current leader %s",
+                                nonLeader, currentLeaderAndIsr.leader()));
+        Optional<LeaderAndIsr> storedLeaderAndIsr =
+                fromCtx(ctx -> ctx.getBucketLeaderAndIsr(tableBucket));
+        assertThat(storedLeaderAndIsr).contains(currentLeaderAndIsr);
+    }
+
+    @Test
+    void testProcessAdjustIsrRejectsIsrWithoutCurrentLeader() throws Exception {
+        Map.Entry<TableBucket, LeaderAndIsr> entry =
+                createTableAndGetLeaderAndIsr("adjust_isr_without_current_leader");
         TableBucket tableBucket = entry.getKey();
         LeaderAndIsr currentLeaderAndIsr = entry.getValue();
         List<Integer> isrWithoutLeader =
@@ -1288,16 +1325,8 @@ class CoordinatorEventProcessorTest {
                         currentLeaderAndIsr.standbyReplicas(),
                         currentLeaderAndIsr.coordinatorEpoch(),
                         currentLeaderAndIsr.bucketEpoch());
-        CompletableFuture<AdjustIsrResponse> invalidResponse = new CompletableFuture<>();
-        eventProcessor
-                .getCoordinatorEventManager()
-                .put(
-                        new AdjustIsrReceivedEvent(
-                                Collections.singletonMap(tableBucket, invalidLeaderAndIsr),
-                                invalidResponse));
 
-        AdjustIsrResultForBucket invalidResult =
-                getAdjustIsrResponseData(invalidResponse.get()).get(tableBucket);
+        AdjustIsrResultForBucket invalidResult = submitAdjustIsr(tableBucket, invalidLeaderAndIsr);
         assertThat(invalidResult.getError().error()).isEqualTo(Errors.INELIGIBLE_REPLICA_EXCEPTION);
         assertThat(invalidResult.getErrorMessage())
                 .contains(
@@ -2530,6 +2559,47 @@ class CoordinatorEventProcessorTest {
         AccessContextEvent<T> event = new AccessContextEvent<>(retrieveFunction);
         eventProcessor.getCoordinatorEventManager().put(event);
         return event.getResultFuture().get(30, TimeUnit.SECONDS);
+    }
+
+    private Map.Entry<TableBucket, LeaderAndIsr> createTableAndGetLeaderAndIsr(String tableName)
+            throws Exception {
+        initCoordinatorChannel();
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        N_BUCKETS,
+                        REPLICATION_FACTOR,
+                        new TabletServerInfo[] {
+                            new TabletServerInfo(0, "rack0"),
+                            new TabletServerInfo(1, "rack1"),
+                            new TabletServerInfo(2, "rack2")
+                        });
+        long tableId =
+                metadataManager.createTable(
+                        TablePath.of(defaultDatabase, tableName),
+                        remoteDataDir,
+                        TEST_TABLE,
+                        tableAssignment,
+                        false);
+        verifyTableCreated(tableId, tableAssignment, N_BUCKETS, REPLICATION_FACTOR);
+
+        Map<TableBucket, LeaderAndIsr> bucketLeaderAndIsrMap =
+                new HashMap<>(
+                        waitValue(
+                                () -> fromCtx(ctx -> Optional.of(ctx.bucketLeaderAndIsr())),
+                                Duration.ofMinutes(1),
+                                "leader not elected"));
+        return bucketLeaderAndIsrMap.entrySet().iterator().next();
+    }
+
+    private AdjustIsrResultForBucket submitAdjustIsr(
+            TableBucket tableBucket, LeaderAndIsr newLeaderAndIsr) throws Exception {
+        CompletableFuture<AdjustIsrResponse> response = new CompletableFuture<>();
+        eventProcessor
+                .getCoordinatorEventManager()
+                .put(
+                        new AdjustIsrReceivedEvent(
+                                Collections.singletonMap(tableBucket, newLeaderAndIsr), response));
+        return getAdjustIsrResponseData(response.get()).get(tableBucket);
     }
 
     private long createTable(TablePath tablePath, TabletServerInfo[] servers) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessorTest.java
@@ -1271,6 +1271,41 @@ class CoordinatorEventProcessorTest {
         assertThat(resultForBucketMap.keySet())
                 .containsAnyElementsOf(bucketLeaderAndIsrMap.keySet());
         assertThat(resultForBucketMap.values()).allMatch(AdjustIsrResultForBucket::succeeded);
+
+        Map.Entry<TableBucket, LeaderAndIsr> entry =
+                fromCtx(ctx -> ctx.bucketLeaderAndIsr().entrySet().iterator().next());
+        TableBucket tableBucket = entry.getKey();
+        LeaderAndIsr currentLeaderAndIsr = entry.getValue();
+        List<Integer> isrWithoutLeader =
+                currentLeaderAndIsr.isr().stream()
+                        .filter(replica -> replica != currentLeaderAndIsr.leader())
+                        .collect(Collectors.toList());
+        LeaderAndIsr invalidLeaderAndIsr =
+                new LeaderAndIsr(
+                        currentLeaderAndIsr.leader(),
+                        currentLeaderAndIsr.leaderEpoch(),
+                        isrWithoutLeader,
+                        currentLeaderAndIsr.standbyReplicas(),
+                        currentLeaderAndIsr.coordinatorEpoch(),
+                        currentLeaderAndIsr.bucketEpoch());
+        CompletableFuture<AdjustIsrResponse> invalidResponse = new CompletableFuture<>();
+        eventProcessor
+                .getCoordinatorEventManager()
+                .put(
+                        new AdjustIsrReceivedEvent(
+                                Collections.singletonMap(tableBucket, invalidLeaderAndIsr),
+                                invalidResponse));
+
+        AdjustIsrResultForBucket invalidResult =
+                getAdjustIsrResponseData(invalidResponse.get()).get(tableBucket);
+        assertThat(invalidResult.getError().error()).isEqualTo(Errors.INELIGIBLE_REPLICA_EXCEPTION);
+        assertThat(invalidResult.getErrorMessage())
+                .contains(
+                        String.format(
+                                "leader %s is not in the new ISR", currentLeaderAndIsr.leader()));
+        Optional<LeaderAndIsr> storedLeaderAndIsr =
+                fromCtx(ctx -> ctx.getBucketLeaderAndIsr(tableBucket));
+        assertThat(storedLeaderAndIsr).contains(currentLeaderAndIsr);
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/AdjustIsrTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/AdjustIsrTest.java
@@ -30,14 +30,17 @@ import org.apache.fluss.server.zk.data.LeaderAndIsr;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.fluss.record.TestData.DATA1;
+import static org.apache.fluss.record.TestData.DATA1_PHYSICAL_TABLE_PATH;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_ID;
 import static org.apache.fluss.testutils.DataTestUtils.genMemoryLogRecordsByObject;
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
@@ -124,6 +127,72 @@ public class AdjustIsrTest extends ReplicaTestBase {
                 TimeUnit.MILLISECONDS);
         replica.maybeShrinkIsr();
         assertThat(replica.getIsr()).containsExactlyInAnyOrder(1);
+    }
+
+    @Test
+    void testShrinkIsrUsesLatestStateAfterLeaderChange() throws Exception {
+        TableBucket tb = new TableBucket(DATA1_TABLE_ID, 1);
+        Replica replica = makeLogReplica(DATA1_PHYSICAL_TABLE_PATH, tb);
+        NotifyLeaderAndIsrData leaderData =
+                new NotifyLeaderAndIsrData(
+                        DATA1_PHYSICAL_TABLE_PATH,
+                        tb,
+                        Arrays.asList(1, 2),
+                        new LeaderAndIsr(1, 0, Arrays.asList(1, 2), Collections.emptyList(), 0, 0));
+
+        Field lockField = Replica.class.getDeclaredField("leaderIsrUpdateLock");
+        lockField.setAccessible(true);
+        ReentrantReadWriteLock leaderIsrUpdateLock =
+                (ReentrantReadWriteLock) lockField.get(replica);
+
+        leaderIsrUpdateLock.writeLock().lock();
+        CompletableFuture<Void> makeLeaderFuture;
+        CompletableFuture<Void> advanceClockFuture;
+        CompletableFuture<Void> shrinkIsrFuture;
+        try {
+            makeLeaderFuture =
+                    CompletableFuture.runAsync(
+                            () -> {
+                                try {
+                                    replica.makeLeader(leaderData);
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+            retry(
+                    Duration.ofSeconds(10),
+                    () -> assertThat(leaderIsrUpdateLock.getQueueLength()).isEqualTo(1));
+
+            advanceClockFuture =
+                    CompletableFuture.runAsync(
+                            () -> {
+                                leaderIsrUpdateLock.writeLock().lock();
+                                try {
+                                    manualClock.advanceTime(
+                                            conf.get(ConfigOptions.LOG_REPLICA_MAX_LAG_TIME)
+                                                            .toMillis()
+                                                    + 1,
+                                            TimeUnit.MILLISECONDS);
+                                } finally {
+                                    leaderIsrUpdateLock.writeLock().unlock();
+                                }
+                            });
+            retry(
+                    Duration.ofSeconds(10),
+                    () -> assertThat(leaderIsrUpdateLock.getQueueLength()).isEqualTo(2));
+
+            shrinkIsrFuture = CompletableFuture.runAsync(replica::maybeShrinkIsr);
+            retry(
+                    Duration.ofSeconds(10),
+                    () -> assertThat(leaderIsrUpdateLock.getQueueLength()).isEqualTo(3));
+        } finally {
+            leaderIsrUpdateLock.writeLock().unlock();
+        }
+
+        makeLeaderFuture.get(10, TimeUnit.SECONDS);
+        advanceClockFuture.get(10, TimeUnit.SECONDS);
+        shrinkIsrFuture.get(10, TimeUnit.SECONDS);
+        assertThat(replica.getIsr()).containsExactly(1);
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/AdjustIsrTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/AdjustIsrTest.java
@@ -36,7 +36,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.fluss.record.TestData.DATA1;
@@ -145,54 +148,67 @@ public class AdjustIsrTest extends ReplicaTestBase {
         ReentrantReadWriteLock leaderIsrUpdateLock =
                 (ReentrantReadWriteLock) lockField.get(replica);
 
-        leaderIsrUpdateLock.writeLock().lock();
-        CompletableFuture<Void> makeLeaderFuture;
-        CompletableFuture<Void> advanceClockFuture;
-        CompletableFuture<Void> shrinkIsrFuture;
+        ExecutorService executor = Executors.newFixedThreadPool(3);
         try {
-            makeLeaderFuture =
-                    CompletableFuture.runAsync(
-                            () -> {
-                                try {
-                                    replica.makeLeader(leaderData);
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-            retry(
-                    Duration.ofSeconds(10),
-                    () -> assertThat(leaderIsrUpdateLock.getQueueLength()).isEqualTo(1));
+            AtomicReference<Thread> makeLeaderThread = new AtomicReference<>();
+            AtomicReference<Thread> advanceClockThread = new AtomicReference<>();
+            AtomicReference<Thread> shrinkIsrThread = new AtomicReference<>();
 
-            advanceClockFuture =
-                    CompletableFuture.runAsync(
-                            () -> {
-                                leaderIsrUpdateLock.writeLock().lock();
-                                try {
-                                    manualClock.advanceTime(
-                                            conf.get(ConfigOptions.LOG_REPLICA_MAX_LAG_TIME)
-                                                            .toMillis()
-                                                    + 1,
-                                            TimeUnit.MILLISECONDS);
-                                } finally {
-                                    leaderIsrUpdateLock.writeLock().unlock();
-                                }
-                            });
-            retry(
-                    Duration.ofSeconds(10),
-                    () -> assertThat(leaderIsrUpdateLock.getQueueLength()).isEqualTo(2));
+            leaderIsrUpdateLock.writeLock().lock();
+            CompletableFuture<Void> makeLeaderFuture;
+            CompletableFuture<Void> advanceClockFuture;
+            CompletableFuture<Void> shrinkIsrFuture;
+            try {
+                makeLeaderFuture =
+                        CompletableFuture.runAsync(
+                                () -> {
+                                    makeLeaderThread.set(Thread.currentThread());
+                                    try {
+                                        replica.makeLeader(leaderData);
+                                    } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                },
+                                executor);
+                waitUntilQueued(leaderIsrUpdateLock, makeLeaderThread);
 
-            shrinkIsrFuture = CompletableFuture.runAsync(replica::maybeShrinkIsr);
-            retry(
-                    Duration.ofSeconds(10),
-                    () -> assertThat(leaderIsrUpdateLock.getQueueLength()).isEqualTo(3));
+                advanceClockFuture =
+                        CompletableFuture.runAsync(
+                                () -> {
+                                    advanceClockThread.set(Thread.currentThread());
+                                    leaderIsrUpdateLock.writeLock().lock();
+                                    try {
+                                        manualClock.advanceTime(
+                                                conf.get(ConfigOptions.LOG_REPLICA_MAX_LAG_TIME)
+                                                                .toMillis()
+                                                        + 1,
+                                                TimeUnit.MILLISECONDS);
+                                    } finally {
+                                        leaderIsrUpdateLock.writeLock().unlock();
+                                    }
+                                },
+                                executor);
+                waitUntilQueued(leaderIsrUpdateLock, advanceClockThread);
+
+                shrinkIsrFuture =
+                        CompletableFuture.runAsync(
+                                () -> {
+                                    shrinkIsrThread.set(Thread.currentThread());
+                                    replica.maybeShrinkIsr();
+                                },
+                                executor);
+                waitUntilQueued(leaderIsrUpdateLock, shrinkIsrThread);
+            } finally {
+                leaderIsrUpdateLock.writeLock().unlock();
+            }
+
+            makeLeaderFuture.get(10, TimeUnit.SECONDS);
+            advanceClockFuture.get(10, TimeUnit.SECONDS);
+            shrinkIsrFuture.get(10, TimeUnit.SECONDS);
+            assertThat(replica.getIsr()).containsExactly(1);
         } finally {
-            leaderIsrUpdateLock.writeLock().unlock();
+            executor.shutdownNow();
         }
-
-        makeLeaderFuture.get(10, TimeUnit.SECONDS);
-        advanceClockFuture.get(10, TimeUnit.SECONDS);
-        shrinkIsrFuture.get(10, TimeUnit.SECONDS);
-        assertThat(replica.getIsr()).containsExactly(1);
     }
 
     @Test
@@ -310,6 +326,17 @@ public class AdjustIsrTest extends ReplicaTestBase {
                         tb, new FetchReqInfo(tb.getTableId(), fetchOffset, Integer.MAX_VALUE)),
                 null,
                 result -> {});
+    }
+
+    private static void waitUntilQueued(
+            ReentrantReadWriteLock lock, AtomicReference<Thread> threadReference) {
+        retry(
+                Duration.ofSeconds(10),
+                () -> {
+                    Thread thread = threadReference.get();
+                    assertThat(thread).isNotNull();
+                    assertThat(lock.hasQueuedThread(thread)).isTrue();
+                });
     }
 
     private void notifyLeaderAndIsr(

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/AdjustIsrTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/AdjustIsrTest.java
@@ -30,7 +30,6 @@ import org.apache.fluss.server.zk.data.LeaderAndIsr;
 
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -143,10 +142,7 @@ public class AdjustIsrTest extends ReplicaTestBase {
                         Arrays.asList(1, 2),
                         new LeaderAndIsr(1, 0, Arrays.asList(1, 2), Collections.emptyList(), 0, 0));
 
-        Field lockField = Replica.class.getDeclaredField("leaderIsrUpdateLock");
-        lockField.setAccessible(true);
-        ReentrantReadWriteLock leaderIsrUpdateLock =
-                (ReentrantReadWriteLock) lockField.get(replica);
+        ReentrantReadWriteLock leaderIsrUpdateLock = replica.getLeaderIsrUpdateLock();
 
         ExecutorService executor = Executors.newFixedThreadPool(3);
         try {


### PR DESCRIPTION
Re-read ISR state and recompute follower lag under the leader/ISR lock before preparing a shrink, preventing stale follower state from crossing a leader transition.

Reject AdjustISR proposals whose leader is absent from the new ISR as a coordinator-side safety net.


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3927

maybeShrinkIsr previously read isrState before acquiring the leader/ISR lock. If the replica became leader between that read and the shrink check, it could combine the new leader role with stale follower ISR state, potentially producing an invalid ISR that excluded the leader. This change keeps the state read and shrink calculation under the lock, with Coordinator-side validation as a safety net.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
