### PR TITLE
[server] Ignore lake snapshot refresh failures during leader election

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1286,17 +1286,21 @@ public class ReplicaManager implements ServerReconfigurable {
     }
 
     // NOTE: This method can be removed when fetchFromLake is deprecated
-    private void updateWithLakeTableSnapshot(Replica replica) throws Exception {
+    private void updateWithLakeTableSnapshot(Replica replica) {
         TableBucket tb = replica.getTableBucket();
-        Optional<LakeTableSnapshot> optLakeTableSnapshot =
-                zkClient.getLakeTableSnapshot(replica.getTableBucket().getTableId(), null);
-        if (optLakeTableSnapshot.isPresent()) {
-            LakeTableSnapshot lakeTableSnapshot = optLakeTableSnapshot.get();
-            long snapshotId = optLakeTableSnapshot.get().getSnapshotId();
-            replica.getLogTablet().updateLakeTableSnapshotId(snapshotId);
-            lakeTableSnapshot
-                    .getLogEndOffset(tb)
-                    .ifPresent(replica.getLogTablet()::updateLakeLogEndOffset);
+        try {
+            Optional<LakeTableSnapshot> optLakeTableSnapshot =
+                    zkClient.getLakeTableSnapshot(replica.getTableBucket().getTableId(), null);
+            if (optLakeTableSnapshot.isPresent()) {
+                LakeTableSnapshot lakeTableSnapshot = optLakeTableSnapshot.get();
+                long snapshotId = optLakeTableSnapshot.get().getSnapshotId();
+                replica.getLogTablet().updateLakeTableSnapshotId(snapshotId);
+                lakeTableSnapshot
+                        .getLogEndOffset(tb)
+                        .ifPresent(replica.getLogTablet()::updateLakeLogEndOffset);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to update replica {} with lake table snapshot.", tb, e);
         }
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1300,6 +1300,9 @@ public class ReplicaManager implements ServerReconfigurable {
                         .ifPresent(replica.getLogTablet()::updateLakeLogEndOffset);
             }
         } catch (Exception e) {
+            // Lake commit cleanup can race with this best-effort refresh and remove the
+            // referenced offsets file. A failure only leaves the snapshot/offset state stale
+            // until the next synchronization, so it must not fail the leader transition.
             LOG.warn("Failed to update replica {} with lake table snapshot.", tb, e);
         }
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -27,6 +27,7 @@ import org.apache.fluss.exception.InvalidCoordinatorException;
 import org.apache.fluss.exception.InvalidRequiredAcksException;
 import org.apache.fluss.exception.NotLeaderOrFollowerException;
 import org.apache.fluss.exception.UnknownTableOrBucketException;
+import org.apache.fluss.fs.FsPath;
 import org.apache.fluss.metadata.DataLakeFormat;
 import org.apache.fluss.metadata.KvFormat;
 import org.apache.fluss.metadata.LogFormat;
@@ -82,6 +83,7 @@ import org.apache.fluss.server.testutils.KvTestUtils;
 import org.apache.fluss.server.testutils.ServerTestTags;
 import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.server.zk.data.TableRegistration;
+import org.apache.fluss.server.zk.data.lake.LakeTable;
 import org.apache.fluss.testutils.DataTestUtils;
 import org.apache.fluss.types.DataField;
 import org.apache.fluss.types.DataTypes;
@@ -1725,6 +1727,47 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                                 + "TableBucket{tableId=150001, bucket=1}")));
         assertReplicaEpochEquals(
                 replicaManager.getReplicaOrException(tb), true, 1, INITIAL_BUCKET_EPOCH);
+    }
+
+    @Test
+    void testLakeSnapshotReadFailureDoesNotFailLeaderTransition() throws Exception {
+        TablePath tablePath = TablePath.of("test_db", "lake_table");
+        long tableId = 2998233L;
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ConfigOptions.TABLE_DATALAKE_FORMAT.key(), DataLakeFormat.PAIMON.toString());
+        registerTableInZkClient(
+                tablePath, DATA1_SCHEMA, tableId, Collections.emptyList(), properties);
+
+        FsPath missingOffsetsPath =
+                new FsPath(new File(tempDir, "missing.offsets").getAbsolutePath());
+        zkClient.upsertLakeTable(
+                tableId,
+                new LakeTable(
+                        new LakeTable.LakeSnapshotMetadata(
+                                1L, missingOffsetsPath, missingOffsetsPath)),
+                false);
+
+        TableBucket tableBucket = new TableBucket(tableId, 0);
+        CompletableFuture<List<NotifyLeaderAndIsrResultForBucket>> future =
+                new CompletableFuture<>();
+        replicaManager.becomeLeaderOrFollower(
+                INITIAL_COORDINATOR_EPOCH,
+                Collections.singletonList(
+                        new NotifyLeaderAndIsrData(
+                                PhysicalTablePath.of(tablePath),
+                                tableBucket,
+                                Collections.singletonList(TABLET_SERVER_ID),
+                                new LeaderAndIsr(
+                                        TABLET_SERVER_ID,
+                                        INITIAL_LEADER_EPOCH,
+                                        Collections.singletonList(TABLET_SERVER_ID),
+                                        Collections.emptyList(),
+                                        INITIAL_COORDINATOR_EPOCH,
+                                        INITIAL_BUCKET_EPOCH))),
+                future::complete);
+
+        assertThat(future.get()).containsOnly(new NotifyLeaderAndIsrResultForBucket(tableBucket));
+        assertThat(replicaManager.getReplicaOrException(tableBucket).isLeader()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
<!--
Generated-by: Codex (GPT-5.6) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: close #3919

A lake table commit may clean an old offsets file while a TabletServer is still reading snapshot metadata that references it. The resulting read failure currently rejects the replica leader transition. Lake snapshot initialization is best-effort state that will be refreshed by the next synchronization, so it should not block leader election.

### Brief change log

- Catch and log failures from `updateWithLakeTableSnapshot` instead of propagating them through `makeLeaders`.
- Add a regression test with lake snapshot metadata that references a missing offsets file and verify that the replica still becomes leader.

### Tests

- `./mvnw -o -pl fluss-server -DskipITs -Dfast -Dtest=ReplicaManagerTest#testLakeSnapshotReadFailureDoesNotFailLeaderTransition test` (passed; also ran Checkstyle and Spotless with 0 violations)
- `./mvnw -o -pl fluss-server -DskipITs -Dfast -Dtest=ReplicaManagerTest test` (attempted; unrelated tests were blocked because the local disk usage was about 90%, above the configured 85% write-lock threshold)

### API and Format

No API or storage format changes.

### Documentation

No documentation changes; this is a bug fix.