### PR TITLE
[tiering] Trigger job failover when coordinator epoch changes

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumerator.java
@@ -419,6 +419,7 @@ public class TieringSourceEnumerator
                     waitHeartbeatResponse(
                             coordinatorGateway.lakeTieringHeartbeat(
                                     heartBeatWithRequestNewTieringTable(tieringHeartbeatRequest)));
+            checkCoordinatorEpoch(heartbeatResponse);
             if (heartbeatResponse.hasTieringTable()) {
                 PbLakeTieringTableInfo tieringTable = heartbeatResponse.getTieringTable();
                 lakeTieringInfo =
@@ -435,7 +436,10 @@ public class TieringSourceEnumerator
             }
         } else {
             // report heartbeat to fluss coordinator
-            waitHeartbeatResponse(coordinatorGateway.lakeTieringHeartbeat(tieringHeartbeatRequest));
+            LakeTieringHeartbeatResponse heartbeatResponse =
+                    waitHeartbeatResponse(
+                            coordinatorGateway.lakeTieringHeartbeat(tieringHeartbeatRequest));
+            checkCoordinatorEpoch(heartbeatResponse);
         }
 
         // if come to here, we can remove currentFinishedTables/failedTableEpochs to avoid send
@@ -443,6 +447,17 @@ public class TieringSourceEnumerator
         currentFinishedTables.forEach(finishedTables::remove);
         currentFailedTableEpochs.forEach(failedTableEpochs::remove);
         return lakeTieringInfo;
+    }
+
+    @VisibleForTesting
+    void checkCoordinatorEpoch(LakeTieringHeartbeatResponse heartbeatResponse) {
+        int currentCoordinatorEpoch = heartbeatResponse.getCoordinatorEpoch();
+        if (currentCoordinatorEpoch != flussCoordinatorEpoch) {
+            throw new FlinkRuntimeException(
+                    String.format(
+                            "Fluss Coordinator epoch changed from %d to %d. Triggering Tiering job failover.",
+                            flussCoordinatorEpoch, currentCoordinatorEpoch));
+        }
     }
 
     private void generateTieringSplits(Tuple3<Long, Long, TablePath> tieringTable)

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumeratorTest.java
@@ -35,6 +35,8 @@ import org.apache.fluss.metadata.TableChange;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.rpc.messages.CommitLakeTableSnapshotRequest;
+import org.apache.fluss.rpc.messages.LakeTieringHeartbeatRequest;
+import org.apache.fluss.rpc.messages.LakeTieringHeartbeatResponse;
 import org.apache.fluss.rpc.messages.PbLakeTableOffsetForBucket;
 import org.apache.fluss.rpc.messages.PbLakeTableSnapshotInfo;
 
@@ -63,7 +65,9 @@ import static org.apache.fluss.client.table.scanner.log.LogScanner.EARLIEST_OFFS
 import static org.apache.fluss.config.ConfigOptions.TABLE_AUTO_PARTITION_NUM_PRECREATE;
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 /** Unit tests for {@link TieringSourceEnumerator} and {@link TieringSplitGenerator}. */
 class TieringSourceEnumeratorTest extends TieringTestBase {
@@ -826,6 +830,39 @@ class TieringSourceEnumeratorTest extends TieringTestBase {
                             new NetworkException("coordinator disconnected"));
             assertThatThrownBy(() -> enumerator.generateAndAssignSplits(null, networkError))
                     .isSameAs(networkError);
+        }
+    }
+
+    @Test
+    void testCoordinatorEpochChangeTriggersFailover() throws Exception {
+        try (FlussMockSplitEnumeratorContext<TieringSplit> context =
+                        new FlussMockSplitEnumeratorContext<>(1);
+                TieringSourceEnumerator enumerator =
+                        createTieringSourceEnumerator(flussConf, context)) {
+            enumerator.start();
+
+            int coordinatorEpoch =
+                    coordinatorGateway
+                            .lakeTieringHeartbeat(new LakeTieringHeartbeatRequest())
+                            .get()
+                            .getCoordinatorEpoch();
+            LakeTieringHeartbeatResponse sameEpochResponse =
+                    new LakeTieringHeartbeatResponse().setCoordinatorEpoch(coordinatorEpoch);
+            assertThatCode(() -> enumerator.checkCoordinatorEpoch(sameEpochResponse))
+                    .doesNotThrowAnyException();
+
+            int newCoordinatorEpoch = coordinatorEpoch + 1;
+            LakeTieringHeartbeatResponse newEpochResponse =
+                    new LakeTieringHeartbeatResponse().setCoordinatorEpoch(newCoordinatorEpoch);
+            FlinkRuntimeException epochChangeError =
+                    catchThrowableOfType(
+                            () -> enumerator.checkCoordinatorEpoch(newEpochResponse),
+                            FlinkRuntimeException.class);
+            assertThat(epochChangeError)
+                    .hasMessageContaining(String.valueOf(coordinatorEpoch))
+                    .hasMessageContaining(String.valueOf(newCoordinatorEpoch));
+            assertThatThrownBy(() -> enumerator.generateAndAssignSplits(null, epochChangeError))
+                    .isSameAs(epochChangeError);
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3921 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
