### PR TITLE
[flink] Support batch scan for virtual log tables

### DIFF
--- a/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/source/Flink118BinlogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/source/Flink118BinlogVirtualTableITCase.java
@@ -17,5 +17,14 @@
 
 package org.apache.fluss.flink.source;
 
+import org.junit.jupiter.api.Disabled;
+
 /** IT case for {@link BinlogVirtualTableITCase} in Flink 1.18. */
-public class Flink118BinlogVirtualTableITCase extends BinlogVirtualTableITCase {}
+public class Flink118BinlogVirtualTableITCase extends BinlogVirtualTableITCase {
+
+    @Disabled("Flink 1.18 has a bug in timestamp_ltz type, see FLINK-35318")
+    @Override
+    public void testBatchReadBinlogTableWithCommitTimestampFilter() throws Exception {
+        super.testBatchReadBinlogTableWithCommitTimestampFilter();
+    }
+}

--- a/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/source/Flink118ChangelogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/source/Flink118ChangelogVirtualTableITCase.java
@@ -17,5 +17,14 @@
 
 package org.apache.fluss.flink.source;
 
+import org.junit.jupiter.api.Disabled;
+
 /** IT case for {@link ChangelogVirtualTableITCase} in Flink 1.18. */
-public class Flink118ChangelogVirtualTableITCase extends ChangelogVirtualTableITCase {}
+public class Flink118ChangelogVirtualTableITCase extends ChangelogVirtualTableITCase {
+
+    @Disabled("Flink 1.18 has a bug in timestamp_ltz type, see FLINK-35318")
+    @Override
+    public void testBatchReadChangelogTableWithCommitTimestampFilter() throws Exception {
+        super.testBatchReadChangelogTableWithCommitTimestampFilter();
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkTableFactory.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkTableFactory.java
@@ -322,15 +322,6 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
         FlinkConnectorOptionsUtils.validateTableSourceOptions(tableOptions);
     }
 
-    private static void validateVirtualLogTableRuntimeMode(
-            String virtualTableSuffix, boolean isStreamingMode) {
-        if (!isStreamingMode) {
-            throw new UnsupportedOperationException(
-                    String.format(
-                            "%s virtual tables only support streaming mode.", virtualTableSuffix));
-        }
-    }
-
     /** Creates a ChangelogFlinkTableSource for $changelog virtual tables. */
     private DynamicTableSource createChangelogTableSource(
             Context context, ObjectIdentifier tableIdentifier, String tableName) {
@@ -342,7 +333,6 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
         boolean isStreamingMode =
                 context.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
                         == RuntimeExecutionMode.STREAMING;
-        validateVirtualLogTableRuntimeMode(FlinkCatalog.CHANGELOG_TABLE_SUFFIX, isStreamingMode);
 
         // tableOutputType includes metadata columns: [_change_type, _log_offset, _commit_timestamp,
         // data_cols...]
@@ -405,7 +395,6 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
         boolean isStreamingMode =
                 context.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
                         == RuntimeExecutionMode.STREAMING;
-        validateVirtualLogTableRuntimeMode(FlinkCatalog.BINLOG_TABLE_SUFFIX, isStreamingMode);
 
         // tableOutputType: [_change_type, _log_offset, _commit_timestamp, before ROW<...>, after
         // ROW<...>]

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/catalog/FlinkTableFactoryTest.java
@@ -19,6 +19,8 @@ package org.apache.fluss.flink.catalog;
 
 import org.apache.fluss.flink.FlinkConnectorOptions;
 import org.apache.fluss.flink.sink.FlinkTableSink;
+import org.apache.fluss.flink.source.BinlogFlinkTableSource;
+import org.apache.fluss.flink.source.ChangelogFlinkTableSource;
 import org.apache.fluss.flink.source.FlinkTableSource;
 import org.apache.fluss.flink.source.lookup.FlinkAsyncLookupFunction;
 import org.apache.fluss.flink.source.lookup.FlinkLookupFunction;
@@ -188,33 +190,29 @@ abstract class FlinkTableFactoryTest {
     }
 
     @Test
-    void testVirtualLogTableSourceDoesNotSupportBatchMode() {
+    void testVirtualLogTableSourceSupportsBatchMode() {
         ResolvedSchema schema = createBasicSchema();
         Map<String, String> properties = getBasicOptions();
         Configuration configuration = new Configuration();
         configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
 
-        assertThatThrownBy(
-                        () ->
-                                createTableSource(
-                                        CHANGELOG_TABLE_IDENTIFIER,
-                                        schema,
-                                        properties,
-                                        Collections.emptyMap(),
-                                        configuration))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessageContaining("$changelog virtual tables only support streaming mode.");
+        assertThat(
+                        createTableSource(
+                                CHANGELOG_TABLE_IDENTIFIER,
+                                schema,
+                                properties,
+                                Collections.emptyMap(),
+                                configuration))
+                .isInstanceOf(ChangelogFlinkTableSource.class);
 
-        assertThatThrownBy(
-                        () ->
-                                createTableSource(
-                                        BINLOG_TABLE_IDENTIFIER,
-                                        createBinlogSchema(),
-                                        properties,
-                                        Collections.emptyMap(),
-                                        configuration))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessageContaining("$binlog virtual tables only support streaming mode.");
+        assertThat(
+                        createTableSource(
+                                BINLOG_TABLE_IDENTIFIER,
+                                createBinlogSchema(),
+                                properties,
+                                Collections.emptyMap(),
+                                configuration))
+                .isInstanceOf(BinlogFlinkTableSource.class);
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/BinlogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/BinlogVirtualTableITCase.java
@@ -295,14 +295,16 @@ abstract class BinlogVirtualTableITCase {
                         "+I[insert, null, null, 1, Alice]",
                         "+I[update, 1, Alice, 1, Alice-updated]");
 
+        // Filters on _commit_timestamp are covered by
+        // testBatchReadBinlogTableWithCommitTimestampFilter, which is disabled on Flink 1.18
+        // (FLINK-35318).
         List<String> metadataFiltered =
                 collectBatchRows(
                         tEnv.executeSql(
                                         "SELECT _change_type, _log_offset, before.id "
                                                 + "FROM batch_binlog_test$binlog "
                                                 + "WHERE _change_type = 'delete' "
-                                                + "AND _log_offset = 4 "
-                                                + "AND _commit_timestamp = TO_TIMESTAMP_LTZ(3000, 3)")
+                                                + "AND _log_offset = 4")
                                 .collect());
         assertThat(metadataFiltered).containsExactly("+I[delete, 4, 2]");
 
@@ -317,6 +319,46 @@ abstract class BinlogVirtualTableITCase {
                                                 + "ORDER BY _log_offset")
                                 .collect());
         assertThat(timestampStartup).containsExactly("+I[update, 2]", "+I[delete, 4]");
+    }
+
+    /**
+     * Bounded reads with a predicate on the {@code _commit_timestamp} metadata column.
+     *
+     * <p>This is kept apart from {@code testBatchReadBinlogTable} because Flink 1.18 rebuilds the
+     * remaining TIMESTAMP_LTZ filter using the session time zone instead of UTC after {@code
+     * applyFilters()} (FLINK-35318, fixed in Flink 1.19.2 and 1.20.0), which shifts the literal and
+     * drops all rows in non-UTC environments. The Flink 1.18 subclass therefore disables this test
+     * only, keeping the rest of the batch coverage.
+     */
+    @Test
+    public void testBatchReadBinlogTableWithCommitTimestampFilter() throws Exception {
+        tEnv.executeSql(
+                "CREATE TABLE batch_binlog_ts_test ("
+                        + "  id INT NOT NULL,"
+                        + "  name STRING,"
+                        + "  PRIMARY KEY (id) NOT ENFORCED"
+                        + ") WITH ('bucket.num' = '1')");
+
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "batch_binlog_ts_test");
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        writeRows(conn, tablePath, Arrays.asList(row(1, "Alice"), row(2, "Bob")), false);
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        writeRows(conn, tablePath, Arrays.asList(row(1, "Alice-updated")), false);
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        deleteRows(conn, tablePath, Arrays.asList(row(2, "Bob")));
+
+        tEnv = initBatchTableEnvironment();
+
+        List<String> metadataFiltered =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset, before.id "
+                                                + "FROM batch_binlog_ts_test$binlog "
+                                                + "WHERE _change_type = 'delete' "
+                                                + "AND _log_offset = 4 "
+                                                + "AND _commit_timestamp = TO_TIMESTAMP_LTZ(3000, 3)")
+                                .collect());
+        assertThat(metadataFiltered).containsExactly("+I[delete, 4, 2]");
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/BinlogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/BinlogVirtualTableITCase.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
+import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.collectBatchRows;
 import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.collectRowsWithTimeout;
 import static org.apache.fluss.flink.utils.FlinkTestBase.writeRows;
 import static org.apache.fluss.server.testutils.FlussClusterExtension.BUILTIN_DATABASE;
@@ -236,7 +237,7 @@ abstract class BinlogVirtualTableITCase {
     }
 
     @Test
-    public void testBatchReadBinlogTableFailsFast() throws Exception {
+    public void testBatchReadBinlogTable() throws Exception {
         tEnv.executeSql(
                 "CREATE TABLE batch_binlog_test ("
                         + "  id INT NOT NULL,"
@@ -244,11 +245,78 @@ abstract class BinlogVirtualTableITCase {
                         + "  PRIMARY KEY (id) NOT ENFORCED"
                         + ") WITH ('bucket.num' = '1')");
 
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "batch_binlog_test");
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        writeRows(conn, tablePath, Arrays.asList(row(1, "Alice"), row(2, "Bob")), false);
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        writeRows(conn, tablePath, Arrays.asList(row(1, "Alice-updated")), false);
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        deleteRows(conn, tablePath, Arrays.asList(row(2, "Bob")));
+
         tEnv = initBatchTableEnvironment();
 
-        assertThatThrownBy(() -> tEnv.explainSql("SELECT * FROM batch_binlog_test$binlog"))
-                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
-                .hasRootCauseMessage("$binlog virtual tables only support streaming mode.");
+        // The batch source resolves the configured starting offsets and captures the latest log
+        // offsets as stopping offsets, so historical binlog replay completes as a bounded query.
+        List<String> allChanges =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset, "
+                                                + "before.id, before.name, after.id, after.name "
+                                                + "FROM batch_binlog_test$binlog "
+                                                + "ORDER BY _log_offset")
+                                .collect());
+        assertThat(allChanges)
+                .containsExactly(
+                        "+I[insert, 0, null, null, 1, Alice]",
+                        "+I[insert, 1, null, null, 2, Bob]",
+                        "+I[update, 2, 1, Alice, 1, Alice-updated]",
+                        "+I[delete, 4, 2, Bob, null, null]");
+
+        List<String> limited =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset "
+                                                + "FROM batch_binlog_test$binlog "
+                                                + "ORDER BY _log_offset LIMIT 2")
+                                .collect());
+        assertThat(limited).containsExactly("+I[insert, 0]", "+I[insert, 1]");
+
+        List<String> primaryKeyFiltered =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, before.id, before.name, "
+                                                + "after.id, after.name "
+                                                + "FROM batch_binlog_test$binlog "
+                                                + "WHERE after.id = 1 "
+                                                + "ORDER BY _log_offset")
+                                .collect());
+        assertThat(primaryKeyFiltered)
+                .containsExactly(
+                        "+I[insert, null, null, 1, Alice]",
+                        "+I[update, 1, Alice, 1, Alice-updated]");
+
+        List<String> metadataFiltered =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset, before.id "
+                                                + "FROM batch_binlog_test$binlog "
+                                                + "WHERE _change_type = 'delete' "
+                                                + "AND _log_offset = 4 "
+                                                + "AND _commit_timestamp = TO_TIMESTAMP_LTZ(3000, 3)")
+                                .collect());
+        assertThat(metadataFiltered).containsExactly("+I[delete, 4, 2]");
+
+        List<String> timestampStartup =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset "
+                                                + "FROM batch_binlog_test$binlog "
+                                                + "/*+ OPTIONS("
+                                                + "'scan.startup.mode' = 'timestamp', "
+                                                + "'scan.startup.timestamp' = '1500') */ "
+                                                + "ORDER BY _log_offset")
+                                .collect());
+        assertThat(timestampStartup).containsExactly("+I[update, 2]", "+I[delete, 4]");
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
@@ -59,12 +59,12 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
+import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.collectBatchRows;
 import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.collectRowsWithTimeout;
 import static org.apache.fluss.flink.utils.FlinkTestBase.writeRows;
 import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.apache.fluss.testutils.common.CommonTestUtils.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Integration test for $changelog virtual table functionality. */
 abstract class ChangelogVirtualTableITCase {
@@ -249,7 +249,7 @@ abstract class ChangelogVirtualTableITCase {
     }
 
     @Test
-    public void testBatchReadChangelogTableFailsFast() throws Exception {
+    public void testBatchReadChangelogTable() throws Exception {
         tEnv.executeSql(
                 "CREATE TABLE batch_changelog_test ("
                         + "  id INT NOT NULL,"
@@ -257,11 +257,109 @@ abstract class ChangelogVirtualTableITCase {
                         + "  PRIMARY KEY (id) NOT ENFORCED"
                         + ") WITH ('bucket.num' = '1')");
 
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "batch_changelog_test");
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        writeRows(conn, tablePath, Arrays.asList(row(1, "Alice"), row(2, "Bob")), false);
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        writeRows(conn, tablePath, Arrays.asList(row(1, "Alice-updated")), false);
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        deleteRows(conn, tablePath, Arrays.asList(row(2, "Bob")));
+
         tEnv = initBatchTableEnvironment();
 
-        assertThatThrownBy(() -> tEnv.explainSql("SELECT * FROM batch_changelog_test$changelog"))
-                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
-                .hasRootCauseMessage("$changelog virtual tables only support streaming mode.");
+        // The default FULL startup mode maps to the earliest log offset for virtual tables. The
+        // batch source captures the latest offsets as stopping offsets and terminates after
+        // replaying the bounded changelog.
+        List<String> allChanges =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset, id, name "
+                                                + "FROM batch_changelog_test$changelog "
+                                                + "ORDER BY _log_offset")
+                                .collect());
+        assertThat(allChanges)
+                .containsExactly(
+                        "+I[insert, 0, 1, Alice]",
+                        "+I[insert, 1, 2, Bob]",
+                        "+I[update_before, 2, 1, Alice]",
+                        "+I[update_after, 3, 1, Alice-updated]",
+                        "+I[delete, 4, 2, Bob]");
+
+        List<String> primaryKeyFilteredAndLimited =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset, id, name "
+                                                + "FROM batch_changelog_test$changelog "
+                                                + "WHERE id = 1 "
+                                                + "ORDER BY _log_offset LIMIT 2")
+                                .collect());
+        assertThat(primaryKeyFilteredAndLimited)
+                .containsExactly("+I[insert, 0, 1, Alice]", "+I[update_before, 2, 1, Alice]");
+
+        List<String> timestampRangeFiltered =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset, id, name "
+                                                + "FROM batch_changelog_test$changelog "
+                                                + "WHERE _commit_timestamp >= TO_TIMESTAMP_LTZ(2000, 3) "
+                                                + "AND _commit_timestamp < TO_TIMESTAMP_LTZ(3000, 3) "
+                                                + "ORDER BY _log_offset")
+                                .collect());
+        assertThat(timestampRangeFiltered)
+                .containsExactly(
+                        "+I[update_before, 2, 1, Alice]", "+I[update_after, 3, 1, Alice-updated]");
+
+        List<String> metadataFiltered =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset, id "
+                                                + "FROM batch_changelog_test$changelog "
+                                                + "WHERE _change_type = 'delete' "
+                                                + "AND _log_offset = 4 "
+                                                + "AND _commit_timestamp = TO_TIMESTAMP_LTZ(3000, 3)")
+                                .collect());
+        assertThat(metadataFiltered).containsExactly("+I[delete, 4, 2]");
+
+        List<String> timestampStartup =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset "
+                                                + "FROM batch_changelog_test$changelog "
+                                                + "/*+ OPTIONS("
+                                                + "'scan.startup.mode' = 'timestamp', "
+                                                + "'scan.startup.timestamp' = '1500') */ "
+                                                + "ORDER BY _log_offset")
+                                .collect());
+        assertThat(timestampStartup)
+                .containsExactly("+I[update_before, 2]", "+I[update_after, 3]", "+I[delete, 4]");
+
+        tEnv.executeSql(
+                "CREATE TABLE partitioned_batch_changelog_test ("
+                        + "  id INT NOT NULL,"
+                        + "  name STRING,"
+                        + "  region STRING NOT NULL,"
+                        + "  PRIMARY KEY (id, region) NOT ENFORCED"
+                        + ") PARTITIONED BY (region) WITH ('bucket.num' = '1')");
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        tEnv.executeSql(
+                        "INSERT INTO partitioned_batch_changelog_test VALUES "
+                                + "(1, 'Item-1', 'us'), "
+                                + "(2, 'Item-2', 'us'), "
+                                + "(3, 'Item-3', 'eu')")
+                .await();
+
+        List<String> partitionedChanges =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, id, name, region "
+                                                + "FROM partitioned_batch_changelog_test$changelog "
+                                                + "ORDER BY region, id")
+                                .collect());
+        assertThat(partitionedChanges)
+                .containsExactly(
+                        "+I[insert, 3, Item-3, eu]",
+                        "+I[insert, 1, Item-1, us]",
+                        "+I[insert, 2, Item-2, us]");
     }
 
     @Test

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
@@ -296,27 +296,16 @@ abstract class ChangelogVirtualTableITCase {
         assertThat(primaryKeyFilteredAndLimited)
                 .containsExactly("+I[insert, 0, 1, Alice]", "+I[update_before, 2, 1, Alice]");
 
-        List<String> timestampRangeFiltered =
-                collectBatchRows(
-                        tEnv.executeSql(
-                                        "SELECT _change_type, _log_offset, id, name "
-                                                + "FROM batch_changelog_test$changelog "
-                                                + "WHERE _commit_timestamp >= TO_TIMESTAMP_LTZ(2000, 3) "
-                                                + "AND _commit_timestamp < TO_TIMESTAMP_LTZ(3000, 3) "
-                                                + "ORDER BY _log_offset")
-                                .collect());
-        assertThat(timestampRangeFiltered)
-                .containsExactly(
-                        "+I[update_before, 2, 1, Alice]", "+I[update_after, 3, 1, Alice-updated]");
-
+        // Filters on _commit_timestamp are covered by
+        // testBatchReadChangelogTableWithCommitTimestampFilter, which is disabled on Flink 1.18
+        // (FLINK-35318).
         List<String> metadataFiltered =
                 collectBatchRows(
                         tEnv.executeSql(
                                         "SELECT _change_type, _log_offset, id "
                                                 + "FROM batch_changelog_test$changelog "
                                                 + "WHERE _change_type = 'delete' "
-                                                + "AND _log_offset = 4 "
-                                                + "AND _commit_timestamp = TO_TIMESTAMP_LTZ(3000, 3)")
+                                                + "AND _log_offset = 4")
                                 .collect());
         assertThat(metadataFiltered).containsExactly("+I[delete, 4, 2]");
 
@@ -360,6 +349,59 @@ abstract class ChangelogVirtualTableITCase {
                         "+I[insert, 3, Item-3, eu]",
                         "+I[insert, 1, Item-1, us]",
                         "+I[insert, 2, Item-2, us]");
+    }
+
+    /**
+     * Bounded reads with a predicate on the {@code _commit_timestamp} metadata column.
+     *
+     * <p>This is kept apart from {@code testBatchReadChangelogTable} because Flink 1.18 rebuilds
+     * the remaining TIMESTAMP_LTZ filter using the session time zone instead of UTC after {@code
+     * applyFilters()} (FLINK-35318, fixed in Flink 1.19.2 and 1.20.0), which shifts the literal and
+     * drops all rows in non-UTC environments. The Flink 1.18 subclass therefore disables this test
+     * only, keeping the rest of the batch coverage.
+     */
+    @Test
+    public void testBatchReadChangelogTableWithCommitTimestampFilter() throws Exception {
+        tEnv.executeSql(
+                "CREATE TABLE batch_changelog_ts_test ("
+                        + "  id INT NOT NULL,"
+                        + "  name STRING,"
+                        + "  PRIMARY KEY (id) NOT ENFORCED"
+                        + ") WITH ('bucket.num' = '1')");
+
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "batch_changelog_ts_test");
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        writeRows(conn, tablePath, Arrays.asList(row(1, "Alice"), row(2, "Bob")), false);
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        writeRows(conn, tablePath, Arrays.asList(row(1, "Alice-updated")), false);
+        CLOCK.advanceTime(Duration.ofMillis(1000));
+        deleteRows(conn, tablePath, Arrays.asList(row(2, "Bob")));
+
+        tEnv = initBatchTableEnvironment();
+
+        List<String> timestampRangeFiltered =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset, id, name "
+                                                + "FROM batch_changelog_ts_test$changelog "
+                                                + "WHERE _commit_timestamp >= TO_TIMESTAMP_LTZ(2000, 3) "
+                                                + "AND _commit_timestamp < TO_TIMESTAMP_LTZ(3000, 3) "
+                                                + "ORDER BY _log_offset")
+                                .collect());
+        assertThat(timestampRangeFiltered)
+                .containsExactly(
+                        "+I[update_before, 2, 1, Alice]", "+I[update_after, 3, 1, Alice-updated]");
+
+        List<String> metadataFiltered =
+                collectBatchRows(
+                        tEnv.executeSql(
+                                        "SELECT _change_type, _log_offset, id "
+                                                + "FROM batch_changelog_ts_test$changelog "
+                                                + "WHERE _change_type = 'delete' "
+                                                + "AND _log_offset = 4 "
+                                                + "AND _commit_timestamp = TO_TIMESTAMP_LTZ(3000, 3)")
+                                .collect());
+        assertThat(metadataFiltered).containsExactly("+I[delete, 4, 2]");
     }
 
     @Test

--- a/website/docs/engine-flink/reads.md
+++ b/website/docs/engine-flink/reads.md
@@ -234,6 +234,31 @@ The server evaluates these predicates against per-batch column statistics and sk
 
 ## Batch Read
 
+### Virtual Table Batch Read
+
+The `$changelog` and `$binlog` virtual tables support bounded batch scans. A batch query starts from the position configured by `scan.startup.mode`, captures the latest offset of each bucket as its stopping offset, and terminates after consuming all bounded splits. Unlike a streaming query, it does not wait for changes written after the stopping offsets are captured.
+
+```sql title="Flink SQL"
+SET 'execution.runtime-mode' = 'batch';
+
+-- Replay changes from a timestamp up to the bounded stopping offsets.
+SELECT _change_type, _log_offset, order_id, amount
+FROM orders$changelog
+/*+ OPTIONS(
+  'scan.startup.mode' = 'timestamp',
+  'scan.startup.timestamp' = '1705312200000'
+) */
+ORDER BY _log_offset;
+
+-- Query before/after images from a primary-key table.
+SELECT _change_type, `before`, `after`
+FROM orders$binlog
+WHERE `after`.order_id = 1001
+LIMIT 100;
+```
+
+`$changelog` is available for Primary Key Tables and Log Tables, while `$binlog` is available only for Primary Key Tables. See [Virtual Tables](/table-design/virtual-tables.md#flink-runtime-modes) for schemas, startup modes, and detailed bounded-read semantics.
+
 ### Limit Read
 The Fluss source supports limiting reads for both primary-key tables and log tables, making it convenient to preview the latest `N` records in a table.
 

--- a/website/docs/table-design/virtual-tables.md
+++ b/website/docs/table-design/virtual-tables.md
@@ -15,6 +15,39 @@ Fluss supports the following virtual table types:
 | [Changelog](#changelog-table) | `$changelog` | Provides access to the raw changelog stream with metadata | Primary Key Tables, Log Tables |
 | [Binlog](#binlog-table) | `$binlog` | Provides binlog format with before/after metadata         | Primary Key Tables only |
 
+## Flink Runtime Modes
+
+Both `$changelog` and `$binlog` can be queried in Flink streaming or batch runtime.
+
+| Runtime Mode | Behavior |
+|--------------|----------|
+| Streaming | Reads from the configured starting position and continues waiting for new changes. |
+| Batch | Reads a bounded range and terminates after reaching the stopping offset of every bucket. |
+
+For a batch scan, Fluss resolves the starting offset from `scan.startup.mode` and captures the latest offset of each bucket as its stopping offset when the bounded splits are initialized. The scan reads the range `[starting offset, stopping offset)`. Records appended to a bucket after its stopping offset is captured are not included in that batch query.
+
+:::note
+A batch scan does not wait for future changes. Therefore, `scan.startup.mode = 'latest'` is generally useful for streaming queries, but is typically not useful for historical replay in batch runtime.
+
+Virtual tables currently read directly from the Fluss log and do not reconstruct historical changes from lake snapshots. The `full` and `earliest` modes start from the earliest log offset still available in Fluss. Batch scans always use the latest offset captured during split initialization as the stopping offset; a separate stopping offset cannot be configured.
+:::
+
+For example, the following query replays a historical part of a changelog and terminates as a bounded Flink job:
+
+```sql title="Flink SQL"
+SET 'execution.runtime-mode' = 'batch';
+
+SELECT _change_type, _log_offset, order_id, amount
+FROM orders$changelog
+/*+ OPTIONS(
+  'scan.startup.mode' = 'timestamp',
+  'scan.startup.timestamp' = '1705312200000'
+) */
+WHERE _commit_timestamp < TO_TIMESTAMP_LTZ(1705398600000, 3)
+ORDER BY _log_offset
+LIMIT 100;
+```
+
 ## Changelog Table
 
 The `$changelog` virtual table provides read-only access to the raw changelog stream of a table, allowing you to audit and process all data changes with their associated metadata.
@@ -107,18 +140,22 @@ Output:
 
 | Mode | Description |
 |------|-------------|
+| `full` | Start reading from the beginning of the log (default) |
 | `earliest` | Start reading from the beginning of the log |
-| `latest` | Start reading from the current end of the log (only new changes) |
+| `latest` | Use the current end of the log as the starting position |
 | `timestamp` | Start reading from a specific timestamp (milliseconds since epoch) |
 
 
 The changelog table supports different startup modes to control where reading begins:
 
 ```sql title="Flink SQL"
--- Read from the beginning (default)
+-- Read from the beginning (default full mode)
+SELECT * FROM orders$changelog;
+
+-- Explicitly read from the earliest offset
 SELECT * FROM orders$changelog /*+ OPTIONS('scan.startup.mode' = 'earliest') */;
 
--- Read only new changes from now
+-- Use the current log end as the starting position
 SELECT * FROM orders$changelog /*+ OPTIONS('scan.startup.mode' = 'latest') */;
 
 -- Read from a specific timestamp
@@ -224,18 +261,22 @@ WHERE _change_type = 'update';
 
 | Mode | Description |
 |------|-------------|
+| `full` | Start reading from the beginning of the log (default) |
 | `earliest` | Start reading from the beginning of the log |
-| `latest` | Start reading from the current end of the log (only new changes) |
+| `latest` | Use the current end of the log as the starting position |
 | `timestamp` | Start reading from a specific timestamp (milliseconds since epoch) |
 
 
 The binlog table supports different startup modes to control where reading begins:
 
 ```sql title="Flink SQL"
--- Read from the beginning (default)
+-- Read from the beginning (default full mode)
+SELECT * FROM orders$binlog;
+
+-- Explicitly read from the earliest offset
 SELECT * FROM orders$binlog /*+ OPTIONS('scan.startup.mode' = 'earliest') */;
 
--- Read only new changes from now
+-- Use the current log end as the starting position
 SELECT * FROM orders$binlog /*+ OPTIONS('scan.startup.mode' = 'latest') */;
 
 -- Read from a specific timestamp

--- a/website/docs/table-design/virtual-tables.md
+++ b/website/docs/table-design/virtual-tables.md
@@ -48,6 +48,10 @@ ORDER BY _log_offset
 LIMIT 100;
 ```
 
+:::warning
+On Flink 1.18, a predicate on `_commit_timestamp` (or on any other `TIMESTAMP_LTZ` column) returns wrong results when the session time zone is not UTC. Flink 1.18 rebuilds such a predicate using the session time zone instead of UTC after the filter is pushed into the source, which shifts the literal by the zone offset and typically makes the query return no rows. This is [FLINK-35318](https://issues.apache.org/jira/browse/FLINK-35318), fixed in Flink 1.19.2 and 1.20.0 and never backported to 1.18. On Flink 1.18, either avoid `TIMESTAMP_LTZ` predicates or set `table.local-time-zone` to `UTC`.
+:::
+
 ## Changelog Table
 
 The `$changelog` virtual table provides read-only access to the raw changelog stream of a table, allowing you to audit and process all data changes with their associated metadata.


### PR DESCRIPTION
### Purpose

Linked issue: close #3723

Support bounded batch scans for Fluss `$changelog` and `$binlog` virtual tables.

This enables historical changelog replay, incremental export, audit queries, data backfill, and log archival in Flink batch runtime.

### Brief change log

- Remove the streaming-only runtime validation for `$changelog` and `$binlog` virtual tables.
- Allow `ChangelogFlinkTableSource` and `BinlogFlinkTableSource` to be created in batch mode.
- Reuse the existing bounded Fluss log source path in batch runtime to:
  - resolve the configured starting offset;
  - capture the latest offset of each bucket as its stopping offset;
  - terminate after all bounded log splits are consumed.
- Replace the previous batch fail-fast tests with batch query coverage for:
  - full changelog and binlog replay;
  - `LIMIT`;
  - primary-key and nested-field filters;
  - virtual-table metadata filters;
  - timestamp startup mode;
  - timestamp-range queries;
  - partitioned changelog tables.

This PR does not change `FlinkSourceSplitReader` or introduce a separate batch reader. Filters and `LIMIT` continue to be planned and executed by Flink. No virtual-table filter or projection pushdown is introduced.

### Tests

Added or updated:

- `FlinkTableFactoryTest#testVirtualLogTableSourceSupportsBatchMode`
- `ChangelogVirtualTableITCase#testBatchReadChangelogTable`
- `BinlogVirtualTableITCase#testBatchReadBinlogTable`

Verified with:

- `Flink120TableFactoryTest`: 5 tests passed
- `Flink120ChangelogVirtualTableITCase`: 9 tests passed
- `Flink120BinlogVirtualTableITCase`: 8 tests passed
- Spotless check
- Checkstyle check
- `git diff --check`

### API and Format

No public API or storage format changes.

### Documentation

This introduces batch runtime support for the existing `$changelog` and `$binlog` virtual-table syntax. No new SQL syntax or connector options are introduced.

### Generative AI disclosure

- [ ] No generative AI tools used
- [x] Yes, Codex was used to assist with implementation and testing.

<!--
Generated-by: Codex following https://github.com/apache/fluss/blob/main/AGENTS.md
-->