### PR TITLE
[common] Extract NO_SNAPSHOT_ID sentinel to fluss-common

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/metadata/TableBucketSnapshot.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metadata/TableBucketSnapshot.java
@@ -21,6 +21,10 @@ import java.util.Objects;
 
 /** An entity for kv snapshot of table bucket. */
 public class TableBucketSnapshot {
+
+    /** Sentinel snapshot id indicating the bucket has no kv snapshot. */
+    public static final long NO_SNAPSHOT_ID = -1L;
+
     private final TableBucket tableBucket;
     private final long snapshotId;
 

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlussOnlyBatchSplitGenerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlussOnlyBatchSplitGenerator.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static org.apache.fluss.metadata.TableBucketSnapshot.NO_SNAPSHOT_ID;
 import static org.apache.fluss.utils.Preconditions.checkState;
 
 /** Generates bounded Fluss-only splits for batch scans. */
@@ -131,10 +132,7 @@ final class FlussOnlyBatchSplitGenerator {
         for (Integer bucketId : bucketsNeedInitOffset) {
             TableBucket tableBucket = new TableBucket(tableId, partitionId, bucketId);
             OptionalLong snapshotId = snapshots.getSnapshotId(bucketId);
-            long batchSnapshotId =
-                    snapshotId.isPresent()
-                            ? snapshotId.getAsLong()
-                            : HybridSnapshotLogSplit.NO_SNAPSHOT_ID;
+            long batchSnapshotId = snapshotId.isPresent() ? snapshotId.getAsLong() : NO_SNAPSHOT_ID;
             long logStartingOffset;
             if (snapshotId.isPresent()) {
                 OptionalLong logOffset = snapshots.getLogOffset(bucketId);

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/split/HybridSnapshotLogSplit.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/split/HybridSnapshotLogSplit.java
@@ -36,12 +36,6 @@ import static org.apache.fluss.utils.Preconditions.checkArgument;
  */
 public class HybridSnapshotLogSplit extends SnapshotSplit {
 
-    /**
-     * Snapshot id sentinel for a split that has no snapshot phase and should read only the bounded
-     * log range.
-     */
-    public static final long NO_SNAPSHOT_ID = -1L;
-
     private static final String HYBRID_SPLIT_PREFIX = "hybrid-snapshot-log-";
     private final boolean isSnapshotFinished;
     private final long logStartingOffset;

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseHandler.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseHandler.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.apache.fluss.metadata.TableBucketSnapshot.NO_SNAPSHOT_ID;
+
 /** handler of kv snapshot lease. */
 @NotThreadSafe
 public class KvSnapshotLeaseHandler {
@@ -127,8 +129,8 @@ public class KvSnapshotLeaseHandler {
      * Release a bucket from the lease id.
      *
      * @param tableBucket table bucket
-     * @return the snapshot id of the unregistered bucket, or -1 if the bucket was never registered
-     *     or the bucket id exceeds the current array size
+     * @return the snapshot id of the unregistered bucket, or {@code NO_SNAPSHOT_ID} if the bucket
+     *     was never registered or the bucket id exceeds the current array size
      */
     public long releaseBucket(TableBucket tableBucket) {
         Long[] bucketIndex;
@@ -137,7 +139,7 @@ public class KvSnapshotLeaseHandler {
         int bucketId = tableBucket.getBucket();
         KvSnapshotTableLease tableLease = tableIdToTableLease.get(tableId);
         if (tableLease == null) {
-            return -1L;
+            return NO_SNAPSHOT_ID;
         }
         if (partitionId == null) {
             // For none-partitioned table.
@@ -147,20 +149,20 @@ public class KvSnapshotLeaseHandler {
             bucketIndex = tableLease.getBucketSnapshots(partitionId);
         }
 
-        Long snapshotId = -1L;
+        Long snapshotId = NO_SNAPSHOT_ID;
         if (bucketIndex != null) {
             // The bucket id exceeds the current array size, meaning it was never registered
-            // under this lease. Return -1 directly.
+            // under this lease. Return NO_SNAPSHOT_ID directly.
             if (bucketId >= bucketIndex.length) {
-                return -1L;
+                return NO_SNAPSHOT_ID;
             }
 
             snapshotId = bucketIndex[bucketId];
-            bucketIndex[bucketId] = -1L;
+            bucketIndex[bucketId] = NO_SNAPSHOT_ID;
 
             boolean needRemove = true;
             for (Long bucket : bucketIndex) {
-                if (bucket != -1L) {
+                if (bucket != NO_SNAPSHOT_ID) {
                     needRemove = false;
                     break;
                 }
@@ -186,7 +188,8 @@ public class KvSnapshotLeaseHandler {
     }
 
     /**
-     * Expand the given array to the specified new size, filling new slots with -1L.
+     * Expand the given array to the specified new size, filling new slots with {@link
+     * org.apache.fluss.metadata.TableBucketSnapshot#NO_SNAPSHOT_ID}.
      *
      * @param original the original array
      * @param newSize the desired new size (must be greater than original.length)
@@ -194,7 +197,7 @@ public class KvSnapshotLeaseHandler {
      */
     private Long[] expandArray(Long[] original, int newSize) {
         Long[] expanded = Arrays.copyOf(original, newSize);
-        Arrays.fill(expanded, original.length, newSize, -1L);
+        Arrays.fill(expanded, original.length, newSize, NO_SNAPSHOT_ID);
         return expanded;
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseHandler.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseHandler.java
@@ -66,7 +66,8 @@ public class KvSnapshotLeaseHandler {
      * @param tableBucket table bucket
      * @param snapshotId snapshot id
      * @param maxBucketNum the max bucket num
-     * @return the original registered snapshotId. if -1 means the bucket is new registered
+     * @return the original registered snapshotId. if {@code NO_SNAPSHOT_ID} means the bucket is new
+     *     registered
      */
     public long acquireBucket(TableBucket tableBucket, long snapshotId, int maxBucketNum) {
         Long[] bucketSnapshot;
@@ -80,7 +81,7 @@ public class KvSnapshotLeaseHandler {
                             tableId,
                             k -> {
                                 Long[] array = new Long[maxBucketNum];
-                                Arrays.fill(array, -1L);
+                                Arrays.fill(array, NO_SNAPSHOT_ID);
                                 return new KvSnapshotTableLease(tableId, array);
                             });
             bucketSnapshot = tableLease.getBucketSnapshots();
@@ -104,7 +105,7 @@ public class KvSnapshotLeaseHandler {
                             partitionId,
                             k -> {
                                 Long[] array = new Long[maxBucketNum];
-                                Arrays.fill(array, -1L);
+                                Arrays.fill(array, NO_SNAPSHOT_ID);
                                 return array;
                             });
             // Dynamically expand the array if the maxBucketNum exceeds the current array size.

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseManager.java
@@ -231,7 +231,7 @@ public class KvSnapshotLeaseManager {
                             long originalSnapshotId =
                                     kvSnapshotLeaseHandle.acquireBucket(
                                             tableBucket, kvSnapshotId, maxBucketNum);
-                            if (originalSnapshotId == -1L) {
+                            if (originalSnapshotId == TableBucketSnapshot.NO_SNAPSHOT_ID) {
                                 leasedBucketCount.incrementAndGet();
                             } else {
                                 // clear the original ref.
@@ -353,12 +353,13 @@ public class KvSnapshotLeaseManager {
                         }
                         // Invariant: `snapshots` is indexed by bucketId starting at 0, contiguous,
                         // with length >= bucket count (auto-expanded by KvSnapshotLeaseHandler when
-                        // buckets are added). Slots not yet registered hold -1L (or null after
-                        // certain partitioned-table paths). See KvSnapshotLeaseHandler#addBucket
-                        // (bucketSnapshot[bucketId] = snapshotId) for the writer-side enforcement.
+                        // buckets are added). Slots not yet registered hold NO_SNAPSHOT_ID (or
+                        // null after certain partitioned-table paths). See
+                        // KvSnapshotLeaseHandler#addBucket (bucketSnapshot[bucketId] = snapshotId)
+                        // for the writer-side enforcement.
                         for (int bucketId = 0; bucketId < snapshots.length; bucketId++) {
                             Long snapId = snapshots[bucketId];
-                            if (snapId != null && snapId != -1L) {
+                            if (snapId != null && snapId != TableBucketSnapshot.NO_SNAPSHOT_ID) {
                                 result.computeIfAbsent(bucketId, k -> new HashSet<>()).add(snapId);
                             }
                         }
@@ -375,7 +376,7 @@ public class KvSnapshotLeaseManager {
             if (tableLease.getBucketSnapshots() != null) {
                 Long[] snapshots = tableLease.getBucketSnapshots();
                 for (int i = 0; i < snapshots.length; i++) {
-                    if (snapshots[i] == -1L) {
+                    if (snapshots[i] == TableBucketSnapshot.NO_SNAPSHOT_ID) {
                         continue;
                     }
 
@@ -388,7 +389,7 @@ public class KvSnapshotLeaseManager {
                     Long partitionId = entry.getKey();
                     Long[] snapshots = entry.getValue();
                     for (int i = 0; i < snapshots.length; i++) {
-                        if (snapshots[i] == -1L) {
+                        if (snapshots[i] == TableBucketSnapshot.NO_SNAPSHOT_ID) {
                             continue;
                         }
 
@@ -409,7 +410,7 @@ public class KvSnapshotLeaseManager {
             if (tableLease.getBucketSnapshots() != null) {
                 Long[] snapshots = tableLease.getBucketSnapshots();
                 for (int i = 0; i < snapshots.length; i++) {
-                    if (snapshots[i] == -1L) {
+                    if (snapshots[i] == TableBucketSnapshot.NO_SNAPSHOT_ID) {
                         continue;
                     }
                     decrementRefCount(
@@ -422,7 +423,7 @@ public class KvSnapshotLeaseManager {
                     Long partitionId = entry.getKey();
                     Long[] snapshots = entry.getValue();
                     for (int i = 0; i < snapshots.length; i++) {
-                        if (snapshots[i] == -1L) {
+                        if (snapshots[i] == TableBucketSnapshot.NO_SNAPSHOT_ID) {
                             continue;
                         }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/lease/KvSnapshotLeaseManager.java
@@ -269,7 +269,7 @@ public class KvSnapshotLeaseManager {
 
                     for (TableBucket bucket : tableBucketsToRelease) {
                         long snapshotId = lease.releaseBucket(bucket);
-                        if (snapshotId != -1L) {
+                        if (snapshotId != TableBucketSnapshot.NO_SNAPSHOT_ID) {
                             leasedBucketCount.decrementAndGet();
                             decrementRefCount(new TableBucketSnapshot(bucket, snapshotId));
                         }

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lease/KvSnapshotTableLease.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lease/KvSnapshotTableLease.java
@@ -17,6 +17,8 @@
 
 package org.apache.fluss.server.zk.data.lease;
 
+import org.apache.fluss.metadata.TableBucketSnapshot;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -82,14 +84,14 @@ public class KvSnapshotTableLease {
         int count = 0;
         if (bucketSnapshots != null) {
             for (Long snapshot : bucketSnapshots) {
-                if (snapshot != -1L) {
+                if (snapshot != TableBucketSnapshot.NO_SNAPSHOT_ID) {
                     count++;
                 }
             }
         } else {
             for (Long[] snapshots : partitionSnapshots.values()) {
                 for (Long snapshot : snapshots) {
-                    if (snapshot != -1L) {
+                    if (snapshot != TableBucketSnapshot.NO_SNAPSHOT_ID) {
                         count++;
                     }
                 }

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussInputPartition.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussInputPartition.scala
@@ -52,7 +52,8 @@ case class FlussAppendInputPartition(tableBucket: TableBucket, startOffset: Long
  * @param tableBucket
  *   the table bucket to read from
  * @param snapshotId
- *   the snapshot ID to read from, -1 if no snapshot
+ *   the snapshot ID to read from, [[org.apache.fluss.metadata.TableBucketSnapshot.NO_SNAPSHOT_ID]]
+ *   if no snapshot
  * @param logStartingOffset
  *   the log offset where incremental reading should start
  * @param logStoppingOffset

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussUpsertPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussUpsertPartitionReader.scala
@@ -22,7 +22,7 @@ import org.apache.fluss.client.table.scanner.batch.BatchScanner
 import org.apache.fluss.client.table.scanner.log.LogScanner
 import org.apache.fluss.config.Configuration
 import org.apache.fluss.memory.MemorySegment
-import org.apache.fluss.metadata.{TableBucket, TablePath}
+import org.apache.fluss.metadata.{TableBucket, TableBucketSnapshot, TablePath}
 import org.apache.fluss.record.LogRecord
 import org.apache.fluss.row.{encode, InternalRow => FlussInternalRow, KeyValueRow}
 import org.apache.fluss.spark.SparkFlussConf
@@ -197,7 +197,7 @@ class FlussUpsertPartitionReader(
       createLogChangesIterator()
     }
 
-    val snapshotIterators = if (snapshotId == -1) {
+    val snapshotIterators = if (snapshotId == TableBucketSnapshot.NO_SNAPSHOT_ID) {
       null
     } else {
       createSnapshotIterator()

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/SplitPlanner.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/SplitPlanner.scala
@@ -25,7 +25,7 @@ import org.apache.fluss.client.table.scanner.log.LogScanner
 import org.apache.fluss.config.Configuration
 import org.apache.fluss.exception.LakeTableSnapshotNotExistException
 import org.apache.fluss.lake.source.{LakeSource, LakeSplit}
-import org.apache.fluss.metadata.{LogFormat, PartitionInfo, ResolvedPartitionSpec, TableBucket, TableInfo, TablePath}
+import org.apache.fluss.metadata.{LogFormat, PartitionInfo, ResolvedPartitionSpec, TableBucket, TableBucketSnapshot, TableInfo, TablePath}
 import org.apache.fluss.predicate.{Predicate => FlussPredicate}
 import org.apache.fluss.spark.SparkFlussConf
 import org.apache.fluss.spark.read.lake.{FlussLakeInputPartition, FlussLakeUpsertInputPartition, FlussLakeUtils}
@@ -650,7 +650,11 @@ class UpsertPlanner(
               logStartingOffsetOpt.getAsLong,
               logEndingOffset)
           } else {
-            FlussUpsertInputPartition(tableBucket, -1L, LogScanner.EARLIEST_OFFSET, logEndingOffset)
+            FlussUpsertInputPartition(
+              tableBucket,
+              TableBucketSnapshot.NO_SNAPSHOT_ID,
+              LogScanner.EARLIEST_OFFSET,
+              logEndingOffset)
           }
       }
       .map(_.asInstanceOf[InputPartition])

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkPrimaryKeyTableReadTest.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkPrimaryKeyTableReadTest.scala
@@ -19,7 +19,7 @@ package org.apache.fluss.spark
 
 import org.apache.fluss.client.initializer.{BucketOffsetsRetrieverImpl, OffsetsInitializer}
 import org.apache.fluss.config.{ConfigOptions, Configuration}
-import org.apache.fluss.metadata.{TableBucket, TablePath}
+import org.apache.fluss.metadata.{TableBucket, TableBucketSnapshot, TablePath}
 import org.apache.fluss.spark.read.{FlussMetrics, FlussScan, FlussUpsertInputPartition, FlussUpsertScan}
 
 import org.apache.spark.sql.{DataFrame, Row}
@@ -316,7 +316,8 @@ class SparkPrimaryKeyTableReadTest extends FlussSparkTestBase {
     bucketIds.asScala.map {
       bucketId =>
         val tableBucket = new TableBucket(tableId, partitionId, bucketId)
-        val snapshotId = kvSnapshots.getSnapshotId(bucketId).orElse(-1L)
+        val snapshotId =
+          kvSnapshots.getSnapshotId(bucketId).orElse(TableBucketSnapshot.NO_SNAPSHOT_ID)
         val logStartingOffset = kvSnapshots.getLogOffset(bucketId).orElse(-2L)
         val logEndingOffset = bucketIdToLogOffset.get(bucketId)
 
@@ -329,7 +330,7 @@ class SparkPrimaryKeyTableReadTest extends FlussSparkTestBase {
   }
 
   private def hasSnapshotData(inputPartition: FlussUpsertInputPartition): Boolean = {
-    inputPartition.snapshotId >= 0
+    inputPartition.snapshotId != TableBucketSnapshot.NO_SNAPSHOT_ID
   }
 
   test("Spark Read: primary key table scan metrics") {

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/lake/SparkLakePrimaryKeyTableReadTestBase.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/lake/SparkLakePrimaryKeyTableReadTestBase.scala
@@ -18,7 +18,7 @@
 package org.apache.fluss.spark.lake
 
 import org.apache.fluss.config.{ConfigOptions, Configuration}
-import org.apache.fluss.metadata.DataLakeFormat
+import org.apache.fluss.metadata.{DataLakeFormat, TableBucketSnapshot}
 import org.apache.fluss.spark.SparkConnectorOptions.{BUCKET_NUMBER, PRIMARY_KEY}
 import org.apache.fluss.spark.read.FlussMetrics
 import org.apache.fluss.spark.read.FlussUpsertInputPartition
@@ -122,8 +122,9 @@ abstract class SparkLakePrimaryKeyTableReadTestBase extends SparkLakeTableReadTe
       val df = sql(s"SELECT * FROM $DEFAULT_DATABASE.t_fb_hybrid ORDER BY id")
       val partitions = lakeInputPartitions(df).map(_.asInstanceOf[FlussUpsertInputPartition])
       assert(
-        partitions.exists(_.snapshotId >= 0),
-        s"Expected at least one hybrid partition with snapshotId >= 0, got: ${partitions.mkString(", ")}")
+        partitions.exists(_.snapshotId != TableBucketSnapshot.NO_SNAPSHOT_ID),
+        s"Expected at least one hybrid partition with snapshotId >= 0, got: ${partitions.mkString(", ")}"
+      )
       checkAnswer(
         df,
         Row(1, "alice", 90) :: Row(2, "bob_updated", 100) ::
@@ -162,8 +163,9 @@ abstract class SparkLakePrimaryKeyTableReadTestBase extends SparkLakeTableReadTe
       val df = sql(s"SELECT * FROM $DEFAULT_DATABASE.t_fb_hybrid_partitioned ORDER BY id")
       val partitions = lakeInputPartitions(df).map(_.asInstanceOf[FlussUpsertInputPartition])
       assert(
-        partitions.exists(_.snapshotId >= 0),
-        s"Expected at least one hybrid partition with snapshotId >= 0, got: ${partitions.mkString(", ")}")
+        partitions.exists(_.snapshotId != TableBucketSnapshot.NO_SNAPSHOT_ID),
+        s"Expected at least one hybrid partition with snapshotId >= 0, got: ${partitions.mkString(", ")}"
+      )
       checkAnswer(
         df,
         Row(1, "alice", 90, "2026-01-01") ::


### PR DESCRIPTION
## Summary
- Extract the no-snapshot sentinel `NO_SNAPSHOT_ID = -1L` from flink's `HybridSnapshotLogSplit` into `TableBucketSnapshot` in fluss-common
- Replace scattered `-1L` magic numbers in Flink (`FlussOnlyBatchSplitGenerator`), Spark (`SplitPlanner`, `FlussUpsertPartitionReader`) and server kv snapshot lease code (`KvSnapshotLeaseHandler`, `KvSnapshotLeaseManager`, `KvSnapshotTableLease`), so all modules share one constant

## Test Plan
- [x] `mvn test-compile` passes for fluss-common / fluss-server / fluss-flink-common / fluss-spark-common / fluss-spark-ut
- [x] `spotless:check` passes
- Pure constant extraction/refactor, no behavior change

🤖 AI-assisted changes - reviewed by human developer