### PR TITLE
[flink] Fix hybrid lake split recovery

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/lake/reader/SeekableLakeSnapshotSplitScanner.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/lake/reader/SeekableLakeSnapshotSplitScanner.java
@@ -67,18 +67,20 @@ public class SeekableLakeSnapshotSplitScanner implements BatchScanner {
     @Nullable
     @Override
     public CloseableIterator<InternalRow> pollBatch(Duration timeout) throws IOException {
-        if (currentLakeRecordIterator == null) {
-            updateCurrentIterator();
-        }
+        while (true) {
+            if (currentLakeRecordIterator == null) {
+                updateCurrentIterator();
+            }
 
-        // has no next record in currentIterator, update currentIterator
-        if (currentLakeRecordIterator != null && !currentLakeRecordIterator.hasNext()) {
-            updateCurrentIterator();
-        }
+            if (currentLakeRecordIterator == null || currentLakeRecordIterator.hasNext()) {
+                return currentLakeRecordIterator;
+            }
 
-        return currentLakeRecordIterator != null && currentLakeRecordIterator.hasNext()
-                ? currentLakeRecordIterator
-                : null;
+            // An inner lake split may become empty after deletes or filtering. Keep looking for
+            // data instead of reporting the end of the whole bounded split.
+            currentLakeRecordIterator.close();
+            currentLakeRecordIterator = null;
+        }
     }
 
     private void updateCurrentIterator() throws IOException {

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/reader/BoundedSplitReader.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/reader/BoundedSplitReader.java
@@ -52,6 +52,7 @@ public class BoundedSplitReader implements AutoCloseable {
 
     private final BatchScanner splitScanner;
     private long currentReadRecordsCount;
+    private int currentSplitIndex;
     private long toSkip;
 
     private final BlockingQueue<RecordAndPosBatch> recordAndPosBatchPool;
@@ -60,6 +61,7 @@ public class BoundedSplitReader implements AutoCloseable {
         this.splitScanner = splitScanner;
         this.toSkip = toSkip;
         this.currentReadRecordsCount = 0;
+        this.currentSplitIndex = RecordAndPos.DEFAULT_SPLIT_INDEX;
         this.recordAndPosBatchPool = new ArrayBlockingQueue<>(1);
         this.recordAndPosBatchPool.add(new RecordAndPosBatch());
     }
@@ -102,6 +104,7 @@ public class BoundedSplitReader implements AutoCloseable {
 
     private CloseableIterator<ScanRecord> poll() throws IOException {
         CloseableIterator<ScanRecord> nextBatch = null;
+        long skippedRecordsCount = 0;
         // may skip records
         while (toSkip > 0) {
             // pool a batch of records
@@ -111,13 +114,18 @@ public class BoundedSplitReader implements AutoCloseable {
                 throw new RuntimeException(
                         String.format(
                                 "Skip more than the number of total records, has skipped %d record(s), but remain %s record(s) to skip.",
-                                currentReadRecordsCount, toSkip));
+                                skippedRecordsCount, toSkip));
             }
             // skip
             while (toSkip > 0 && nextBatch.hasNext()) {
                 nextBatch.next();
                 toSkip--;
                 currentReadRecordsCount++;
+                skippedRecordsCount++;
+            }
+            if (!nextBatch.hasNext()) {
+                nextBatch.close();
+                nextBatch = null;
             }
         }
         // if any batch remains while skipping, return the batch
@@ -133,7 +141,19 @@ public class BoundedSplitReader implements AutoCloseable {
 
     private CloseableIterator<ScanRecord> pollBatch() throws IOException {
         CloseableIterator<InternalRow> records = splitScanner.pollBatch(POLL_TIMEOUT);
-        return records == null ? null : new ScanRecordBatch(records);
+        if (records == null) {
+            return null;
+        }
+
+        ScanRecordBatch batch = new ScanRecordBatch(records);
+        int nextSplitIndex = batch.getCurrentSplitIndex();
+        if (currentSplitIndex != nextSplitIndex) {
+            currentSplitIndex = nextSplitIndex;
+            currentReadRecordsCount = 0;
+        }
+        // Keep toSkip unchanged across indexed batches. Existing checkpoints start at index 0 and
+        // store a global skip count, while newly emitted positions use a split-local count.
+        return batch;
     }
 
     @Override
@@ -143,13 +163,15 @@ public class BoundedSplitReader implements AutoCloseable {
 
     private static class ScanRecordBatch implements CloseableIterator<ScanRecord> {
         private final CloseableIterator<InternalRow> rowIterator;
-        private int currentSplitIndex;
+        private final int currentSplitIndex;
 
         public ScanRecordBatch(CloseableIterator<InternalRow> rowIterator) {
             this.rowIterator = rowIterator;
             if (rowIterator instanceof IndexedLakeSplitRecordIterator) {
                 currentSplitIndex =
                         ((IndexedLakeSplitRecordIterator) rowIterator).getCurrentLakeSplitIndex();
+            } else {
+                currentSplitIndex = RecordAndPos.DEFAULT_SPLIT_INDEX;
             }
         }
 
@@ -184,15 +206,17 @@ public class BoundedSplitReader implements AutoCloseable {
 
     private class RecordAndPosBatch implements CloseableIterator<RecordAndPos> {
         private CloseableIterator<ScanRecord> records;
+        private int currentSplitIndex;
 
         private final MutableRecordAndPos recordAndPosition = new MutableRecordAndPos();
 
         RecordAndPosBatch replace(CloseableIterator<ScanRecord> records) {
             this.records = records;
             if (records instanceof ScanRecordBatch) {
-                int currentSplitIndex = ((ScanRecordBatch) records).getCurrentSplitIndex();
+                currentSplitIndex = ((ScanRecordBatch) records).getCurrentSplitIndex();
                 recordAndPosition.setRecord(null, NO_READ_RECORDS_COUNT, currentSplitIndex);
             } else {
+                currentSplitIndex = RecordAndPos.DEFAULT_SPLIT_INDEX;
                 recordAndPosition.setRecord(null, NO_READ_RECORDS_COUNT);
             }
             return this;
@@ -205,7 +229,8 @@ public class BoundedSplitReader implements AutoCloseable {
 
         @Override
         public RecordAndPos next() {
-            recordAndPosition.setRecord(records.next(), ++currentReadRecordsCount);
+            recordAndPosition.setRecord(
+                    records.next(), ++currentReadRecordsCount, currentSplitIndex);
             return recordAndPosition;
         }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/lake/reader/SeekableLakeSnapshotSplitScannerTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/lake/reader/SeekableLakeSnapshotSplitScannerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.lake.reader;
+
+import org.apache.fluss.lake.source.LakeSource;
+import org.apache.fluss.lake.source.LakeSplit;
+import org.apache.fluss.lake.source.RecordReader;
+import org.apache.fluss.record.ChangeType;
+import org.apache.fluss.record.GenericRecord;
+import org.apache.fluss.record.LogRecord;
+import org.apache.fluss.row.InternalRow;
+import org.apache.fluss.utils.CloseableIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.fluss.testutils.DataTestUtils.row;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link SeekableLakeSnapshotSplitScanner}. */
+class SeekableLakeSnapshotSplitScannerTest {
+
+    @Test
+    void testSkipEmptyLakeSplits() throws Exception {
+        LakeSplit firstSplit = mock(LakeSplit.class);
+        LakeSplit emptySplit = mock(LakeSplit.class);
+        LakeSplit lastSplit = mock(LakeSplit.class);
+        InternalRow firstRow = row(1, "first");
+        InternalRow lastRow = row(2, "last");
+
+        Map<LakeSplit, List<InternalRow>> rowsBySplit = new HashMap<>();
+        rowsBySplit.put(firstSplit, Arrays.asList(firstRow));
+        rowsBySplit.put(emptySplit, new ArrayList<>());
+        rowsBySplit.put(lastSplit, Arrays.asList(lastRow));
+
+        LakeSource<LakeSplit> lakeSource = createLakeSource(rowsBySplit);
+        SeekableLakeSnapshotSplitScanner scanner =
+                new SeekableLakeSnapshotSplitScanner(
+                        lakeSource, Arrays.asList(firstSplit, emptySplit, lastSplit), 0);
+
+        List<InternalRow> actualRows = new ArrayList<>();
+        CloseableIterator<InternalRow> batch;
+        while ((batch = scanner.pollBatch(Duration.ZERO)) != null) {
+            while (batch.hasNext()) {
+                actualRows.add(batch.next());
+            }
+            batch.close();
+        }
+        scanner.close();
+
+        assertThat(actualRows).containsExactly(firstRow, lastRow);
+    }
+
+    @SuppressWarnings("unchecked")
+    private LakeSource<LakeSplit> createLakeSource(Map<LakeSplit, List<InternalRow>> rowsBySplit)
+            throws Exception {
+        LakeSource<LakeSplit> lakeSource = mock(LakeSource.class);
+        when(lakeSource.createRecordReader(any()))
+                .thenAnswer(
+                        invocation -> {
+                            LakeSource.ReaderContext<LakeSplit> context = invocation.getArgument(0);
+                            List<LogRecord> records = new ArrayList<>();
+                            for (InternalRow row : rowsBySplit.get(context.lakeSplit())) {
+                                records.add(new GenericRecord(0, 0, ChangeType.INSERT, row));
+                            }
+                            RecordReader reader = () -> CloseableIterator.wrap(records.iterator());
+                            return reader;
+                        });
+        return lakeSource;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/reader/BoundedSplitReaderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/reader/BoundedSplitReaderTest.java
@@ -18,6 +18,10 @@
 package org.apache.fluss.flink.source.reader;
 
 import org.apache.fluss.client.table.scanner.batch.BatchScanner;
+import org.apache.fluss.flink.lake.reader.IndexedLakeSplitRecordIterator;
+import org.apache.fluss.record.ChangeType;
+import org.apache.fluss.record.GenericRecord;
+import org.apache.fluss.record.LogRecord;
 import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.row.ProjectedRow;
 import org.apache.fluss.row.indexed.IndexedRow;
@@ -78,6 +82,54 @@ class BoundedSplitReaderTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage(
                         "Skip more than the number of total records, has skipped 10 record(s), but remain 1 record(s) to skip.");
+    }
+
+    @Test
+    void testReadPositionAcrossIndexedBatches() throws IOException {
+        List<List<InternalRow>> rowsBySplit = new ArrayList<>();
+        rowsBySplit.add(mockRows(2));
+        rowsBySplit.add(mockRows(2));
+        BoundedSplitReader reader =
+                new BoundedSplitReader(new TestingIndexedBatchScanner(rowsBySplit, 0), 0);
+
+        List<RecordAndPos> records = collectRecords(reader);
+
+        assertThat(records)
+                .extracting(RecordAndPos::getCurrentSplitIndex)
+                .containsExactly(0, 0, 1, 1);
+        assertThat(records)
+                .extracting(RecordAndPos::readRecordsCount)
+                .containsExactly(1L, 2L, 1L, 2L);
+    }
+
+    @Test
+    void testRestoreLegacyPositionAcrossIndexedBatches() throws IOException {
+        List<List<InternalRow>> rowsBySplit = new ArrayList<>();
+        rowsBySplit.add(mockRows(2));
+        rowsBySplit.add(mockRows(2));
+
+        // Existing checkpoints start at split 0 and store a global records-to-skip count.
+        BoundedSplitReader reader =
+                new BoundedSplitReader(new TestingIndexedBatchScanner(rowsBySplit, 0), 3);
+        List<RecordAndPos> records = collectRecords(reader);
+
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getCurrentSplitIndex()).isEqualTo(1);
+        assertThat(records.get(0).readRecordsCount()).isEqualTo(2);
+    }
+
+    @Test
+    void testRestoreSplitLocalPosition() throws IOException {
+        List<List<InternalRow>> rowsBySplit = new ArrayList<>();
+        rowsBySplit.add(mockRows(2));
+
+        BoundedSplitReader reader =
+                new BoundedSplitReader(new TestingIndexedBatchScanner(rowsBySplit, 1), 1);
+        List<RecordAndPos> records = collectRecords(reader);
+
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getCurrentSplitIndex()).isEqualTo(1);
+        assertThat(records.get(0).readRecordsCount()).isEqualTo(2);
     }
 
     @Test
@@ -164,6 +216,40 @@ class BoundedSplitReaderTest {
         }
     }
 
+    /** A testing scanner that returns one indexed batch for each inner lake split. */
+    private static class TestingIndexedBatchScanner implements BatchScanner {
+
+        private final List<List<InternalRow>> rowsBySplit;
+        private final int firstSplitIndex;
+        private int nextBatchIndex;
+
+        private TestingIndexedBatchScanner(
+                List<List<InternalRow>> rowsBySplit, int firstSplitIndex) {
+            this.rowsBySplit = rowsBySplit;
+            this.firstSplitIndex = firstSplitIndex;
+        }
+
+        @Override
+        @Nullable
+        public CloseableIterator<InternalRow> pollBatch(Duration timeout) {
+            if (nextBatchIndex >= rowsBySplit.size()) {
+                return null;
+            }
+
+            List<LogRecord> records = new ArrayList<>();
+            for (InternalRow row : rowsBySplit.get(nextBatchIndex)) {
+                records.add(new GenericRecord(0, 0, ChangeType.INSERT, row));
+            }
+            return new IndexedLakeSplitRecordIterator(
+                    CloseableIterator.wrap(records.iterator()), firstSplitIndex + nextBatchIndex++);
+        }
+
+        @Override
+        public void close() throws IOException {
+            // do nothing
+        }
+    }
+
     private List<InternalRow> mockRows(int numRows) {
         List<InternalRow> rows = new ArrayList<>(numRows);
         for (int i = 0; i < numRows; i++) {
@@ -206,7 +292,10 @@ class BoundedSplitReaderTest {
             while (recordIter.hasNext()) {
                 RecordAndPos recordAndPos = recordIter.next();
                 records.add(
-                        new RecordAndPos(recordAndPos.scanRecord, recordAndPos.readRecordsCount));
+                        new RecordAndPos(
+                                recordAndPos.scanRecord,
+                                recordAndPos.readRecordsCount,
+                                recordAndPos.getCurrentSplitIndex()));
             }
             recordIter.close();
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [x] Yes (please specify the tool below)
      - Codex (GPT-5)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: close #3931

Streaming hybrid reads of lake-enabled primary-key tables can stop the lake snapshot when an empty inner `LakeSplit` occurs before a later non-empty split. They also reset the emitted inner split index to 0, so checkpoint recovery rescans earlier lake splits.

This change makes the lake snapshot complete and records a resumable split-local position. The restore algorithm remains compatible with existing checkpoints that contain split index 0 and a global records-to-skip count.

### Brief change log

- Continue scanning across empty inner lake splits until data is found or all splits are exhausted.
- Preserve the actual inner split index in each `RecordAndPos` and reset the read count when that index changes.
- Keep the restore skip count across inner split boundaries so both existing global positions and new split-local positions use the same recovery path.
- Add regression tests for empty inner splits, index propagation, split-local counts, and existing checkpoint recovery semantics.

### Tests

- `./mvnw -nsu -pl fluss-flink/fluss-flink-common -Dtest=BoundedSplitReaderTest,SeekableLakeSnapshotSplitScannerTest test`
- `./mvnw -nsu -pl fluss-flink/fluss-flink-common verify` (560 unit tests and 56 integration tests passed)

### API and Format

No API or storage format changes. The source split serializer version is unchanged; existing checkpoint positions remain readable and recover through the unified skip algorithm.

### Documentation

No documentation changes are required for this bug fix.
