### PR TITLE
[rust] add support of iceberg format key encoder

### DIFF
--- a/fluss-rust/crates/fluss/src/row/binary/iceberg_binary_row_writer.rs
+++ b/fluss-rust/crates/fluss/src/row/binary/iceberg_binary_row_writer.rs
@@ -61,11 +61,6 @@ impl IcebergBinaryRowWriter {
         }
     }
 
-    // Dependency order note:
-    // 1) Keep this PR scoped to writer-level Java parity.
-    // 2) Wire the writer through IcebergKeyEncoder in follow-up #308.
-    // TODO(#308): add end-to-end key-encoding tests via IcebergKeyEncoder
-    // (similar to CompactedKeyEncoder tests for CompactedKeyWriter).
     pub fn create_value_writer(field_type: &DataType) -> Result<ValueWriter> {
         match field_type {
             // Match Java IcebergBinaryRowWriter.createFieldWriter() supported types exactly.

--- a/fluss-rust/crates/fluss/src/row/encode/iceberg_key_encoder.rs
+++ b/fluss-rust/crates/fluss/src/row/encode/iceberg_key_encoder.rs
@@ -1,0 +1,210 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use bytes::Bytes;
+
+use crate::error::Error::IllegalArgument;
+use crate::error::Result;
+use crate::metadata::RowType;
+use crate::row::binary::{BinaryWriter, IcebergBinaryRowWriter, ValueWriter};
+use crate::row::encode::KeyEncoder;
+use crate::row::field_getter::FieldGetter;
+use crate::row::{Datum, InternalRow};
+
+/// Rust port of Java's `org.apache.fluss.row.encode.iceberg.IcebergKeyEncoder`.
+///
+/// Iceberg currently supports exactly one bucket key field. The field is
+/// encoded with Iceberg's single-value binary representation before being
+/// passed to the Iceberg bucketing function.
+pub struct IcebergKeyEncoder {
+    field_getter: FieldGetter,
+    field_encoder: ValueWriter,
+    writer: IcebergBinaryRowWriter,
+}
+
+impl IcebergKeyEncoder {
+    /// Construct an Iceberg key encoder for the single key in `keys`.
+    pub fn new(row_type: &RowType, keys: &[String]) -> Result<Self> {
+        if keys.len() != 1 {
+            return Err(IllegalArgument {
+                message: format!(
+                    "Key fields must have exactly one field for iceberg format, but got: {keys:?}"
+                ),
+            });
+        }
+
+        let key = &keys[0];
+        let index = row_type
+            .get_field_index(key)
+            .ok_or_else(|| IllegalArgument {
+                message: format!("Field {key:?} not found in input row type {row_type:?}"),
+            })?;
+        let data_type = row_type.fields()[index].data_type();
+
+        Ok(Self {
+            field_getter: FieldGetter::create(data_type, index),
+            field_encoder: IcebergBinaryRowWriter::create_value_writer(data_type)?,
+            writer: IcebergBinaryRowWriter::new(),
+        })
+    }
+}
+
+impl KeyEncoder for IcebergKeyEncoder {
+    fn encode_key(&mut self, row: &dyn InternalRow) -> Result<Bytes> {
+        self.writer.reset();
+
+        let datum = self.field_getter.get_field(row)?;
+        if datum == Datum::Null {
+            return Err(IllegalArgument {
+                message: "Iceberg key columns do not support null values".to_string(),
+            });
+        }
+        self.field_encoder
+            .write_value(&mut self.writer, 0, &datum)?;
+
+        Ok(self.writer.to_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::{DataType, DataTypes};
+    use crate::row::{Date, Decimal, GenericRow, Time, TimestampNtz};
+
+    fn encode(data_type: DataType, datum: Datum<'static>) -> Bytes {
+        let row_type = RowType::with_data_types_and_field_names(vec![data_type], vec!["key"]);
+        let mut encoder = IcebergKeyEncoder::new(&row_type, &["key".to_string()]).unwrap();
+        encoder
+            .encode_key(&GenericRow::from_data(vec![datum]))
+            .unwrap()
+    }
+
+    #[test]
+    fn rejects_key_counts_other_than_one() {
+        let row_type = RowType::with_data_types_and_field_names(
+            vec![DataTypes::int(), DataTypes::string()],
+            vec!["id", "name"],
+        );
+
+        for keys in [Vec::new(), vec!["id".to_string(), "name".to_string()]] {
+            let error = match IcebergKeyEncoder::new(&row_type, &keys) {
+                Ok(_) => panic!("expected IllegalArgument"),
+                Err(error) => error,
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains("Key fields must have exactly one field for iceberg format")
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_key_field() {
+        let row_type = RowType::with_data_types_and_field_names(vec![DataTypes::int()], vec!["id"]);
+        let error = match IcebergKeyEncoder::new(&row_type, &["missing".to_string()]) {
+            Ok(_) => panic!("expected IllegalArgument"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("not found in input row type"));
+    }
+
+    #[test]
+    fn encodes_values_with_iceberg_binary_layout() {
+        assert_eq!(
+            encode(DataTypes::int(), Datum::from(42_i32)).as_ref(),
+            42_i64.to_le_bytes()
+        );
+        assert_eq!(
+            encode(
+                DataTypes::bigint(),
+                Datum::from(1_234_567_890_123_456_789_i64),
+            )
+            .as_ref(),
+            1_234_567_890_123_456_789_i64.to_le_bytes()
+        );
+        assert_eq!(
+            encode(DataTypes::string(), Datum::from("Hello Iceberg")).as_ref(),
+            b"Hello Iceberg"
+        );
+        assert_eq!(
+            encode(DataTypes::date(), Datum::Date(Date::new(19_655))).as_ref(),
+            19_655_i64.to_le_bytes()
+        );
+        assert_eq!(
+            encode(DataTypes::time(), Datum::Time(Time::new(34_200_000))).as_ref(),
+            34_200_000_000_i64.to_le_bytes()
+        );
+        assert_eq!(
+            encode(
+                DataTypes::timestamp_with_precision(6),
+                Datum::TimestampNtz(
+                    TimestampNtz::from_millis_nanos(1_698_235_273_182, 123_456).unwrap(),
+                ),
+            )
+            .as_ref(),
+            1_698_235_273_182_123_i64.to_le_bytes()
+        );
+        assert_eq!(
+            encode(
+                DataTypes::decimal(10, 2),
+                Datum::Decimal(Decimal::from_unscaled_long(12_345, 10, 2).unwrap()),
+            )
+            .as_ref(),
+            [0x30, 0x39]
+        );
+        assert_eq!(
+            encode(DataTypes::bytes(), Datum::from(&b"binary data"[..])).as_ref(),
+            b"binary data"
+        );
+    }
+
+    #[test]
+    fn rejects_null_key_without_panicking() {
+        let row_type = RowType::with_data_types_and_field_names(vec![DataTypes::int()], vec!["id"]);
+        let mut encoder = IcebergKeyEncoder::new(&row_type, &["id".to_string()]).unwrap();
+        let error = encoder
+            .encode_key(&GenericRow::from_data(vec![Datum::Null]))
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Iceberg key columns do not support null values")
+        );
+    }
+
+    #[test]
+    fn reuses_writer_across_rows() {
+        let row_type =
+            RowType::with_data_types_and_field_names(vec![DataTypes::string()], vec!["id"]);
+        let mut encoder = IcebergKeyEncoder::new(&row_type, &["id".to_string()]).unwrap();
+
+        let first = encoder
+            .encode_key(&GenericRow::from_data(vec![Datum::from(
+                "a longer first key",
+            )]))
+            .unwrap();
+        let second = encoder
+            .encode_key(&GenericRow::from_data(vec![Datum::from("short")]))
+            .unwrap();
+
+        assert_eq!(first.as_ref(), b"a longer first key");
+        assert_eq!(second.as_ref(), b"short");
+    }
+}

--- a/fluss-rust/crates/fluss/src/row/encode/iceberg_key_encoder.rs
+++ b/fluss-rust/crates/fluss/src/row/encode/iceberg_key_encoder.rs
@@ -83,7 +83,8 @@ impl KeyEncoder for IcebergKeyEncoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metadata::{DataType, DataTypes};
+    use crate::bucketing::BucketingFunction;
+    use crate::metadata::{DataLakeFormat, DataType, DataTypes};
     use crate::row::{Date, Decimal, GenericRow, Time, TimestampNtz};
 
     fn encode(data_type: DataType, datum: Datum<'static>) -> Bytes {
@@ -92,6 +93,15 @@ mod tests {
         encoder
             .encode_key(&GenericRow::from_data(vec![datum]))
             .unwrap()
+    }
+
+    fn assert_iceberg_hash(data_type: DataType, datum: Datum<'static>, expected_hash: i32) {
+        let encoded = encode(data_type, datum);
+        let bucketing = <dyn BucketingFunction>::of(Some(&DataLakeFormat::Iceberg));
+        // With i32::MAX buckets, the bucket id is the raw hash with its sign bit cleared.
+        let actual = bucketing.bucketing(&encoded, i32::MAX).unwrap();
+
+        assert_eq!(actual, expected_hash & i32::MAX);
     }
 
     #[test]
@@ -125,52 +135,49 @@ mod tests {
     }
 
     #[test]
-    fn encodes_values_with_iceberg_binary_layout() {
-        assert_eq!(
-            encode(DataTypes::int(), Datum::from(42_i32)).as_ref(),
-            42_i64.to_le_bytes()
+    fn hashes_iceberg_appendix_b_vectors() {
+        // https://iceberg.apache.org/spec/#appendix-b-32-bit-hash-requirements
+        assert_iceberg_hash(DataTypes::int(), Datum::from(34_i32), 2_017_239_379);
+        assert_iceberg_hash(DataTypes::bigint(), Datum::from(34_i64), 2_017_239_379);
+        assert_iceberg_hash(
+            DataTypes::decimal(4, 2),
+            Datum::Decimal(Decimal::from_unscaled_long(1_420, 4, 2).unwrap()),
+            -500_754_589,
         );
-        assert_eq!(
-            encode(
-                DataTypes::bigint(),
-                Datum::from(1_234_567_890_123_456_789_i64),
-            )
-            .as_ref(),
-            1_234_567_890_123_456_789_i64.to_le_bytes()
+        assert_iceberg_hash(
+            DataTypes::date(),
+            // 2017-11-16, as days from the Unix epoch.
+            Datum::Date(Date::new(17_486)),
+            -653_330_422,
         );
-        assert_eq!(
-            encode(DataTypes::string(), Datum::from("Hello Iceberg")).as_ref(),
-            b"Hello Iceberg"
+        assert_iceberg_hash(
+            DataTypes::time(),
+            // 22:31:08, as milliseconds from midnight.
+            Datum::Time(Time::new(81_068_000)),
+            -662_762_989,
         );
-        assert_eq!(
-            encode(DataTypes::date(), Datum::Date(Date::new(19_655))).as_ref(),
-            19_655_i64.to_le_bytes()
+        assert_iceberg_hash(
+            DataTypes::timestamp_with_precision(6),
+            // 2017-11-16T22:31:08.
+            Datum::TimestampNtz(TimestampNtz::new(1_510_871_468_000)),
+            -2_047_944_441,
         );
-        assert_eq!(
-            encode(DataTypes::time(), Datum::Time(Time::new(34_200_000))).as_ref(),
-            34_200_000_000_i64.to_le_bytes()
+        assert_iceberg_hash(
+            DataTypes::timestamp_with_precision(6),
+            // 2017-11-16T22:31:08.000001.
+            Datum::TimestampNtz(TimestampNtz::from_millis_nanos(1_510_871_468_000, 1_000).unwrap()),
+            -1_207_196_810,
         );
-        assert_eq!(
-            encode(
-                DataTypes::timestamp_with_precision(6),
-                Datum::TimestampNtz(
-                    TimestampNtz::from_millis_nanos(1_698_235_273_182, 123_456).unwrap(),
-                ),
-            )
-            .as_ref(),
-            1_698_235_273_182_123_i64.to_le_bytes()
+        assert_iceberg_hash(DataTypes::string(), Datum::from("iceberg"), 1_210_000_089);
+        assert_iceberg_hash(
+            DataTypes::binary(4),
+            Datum::from(vec![0_u8, 1, 2, 3]),
+            -188_683_207,
         );
-        assert_eq!(
-            encode(
-                DataTypes::decimal(10, 2),
-                Datum::Decimal(Decimal::from_unscaled_long(12_345, 10, 2).unwrap()),
-            )
-            .as_ref(),
-            [0x30, 0x39]
-        );
-        assert_eq!(
-            encode(DataTypes::bytes(), Datum::from(&b"binary data"[..])).as_ref(),
-            b"binary data"
+        assert_iceberg_hash(
+            DataTypes::bytes(),
+            Datum::from(vec![0_u8, 1, 2, 3]),
+            -188_683_207,
         );
     }
 

--- a/fluss-rust/crates/fluss/src/row/encode/mod.rs
+++ b/fluss-rust/crates/fluss/src/row/encode/mod.rs
@@ -17,12 +17,14 @@
 
 mod compacted_key_encoder;
 mod compacted_row_encoder;
+mod iceberg_key_encoder;
 mod paimon_key_encoder;
 
 use crate::error::{Error, Result};
 use crate::metadata::{DataLakeFormat, KvFormat, RowType};
 use crate::row::encode::compacted_key_encoder::CompactedKeyEncoder;
 use crate::row::encode::compacted_row_encoder::CompactedRowEncoder;
+use crate::row::encode::iceberg_key_encoder::IcebergKeyEncoder;
 use crate::row::encode::paimon_key_encoder::PaimonKeyEncoder;
 use crate::row::{Datum, InternalRow};
 use bytes::Bytes;
@@ -111,9 +113,9 @@ impl KeyEncoderFactory {
             Some(DataLakeFormat::Lance) => Ok(Box::new(CompactedKeyEncoder::create_key_encoder(
                 row_type, key_fields,
             )?)),
-            Some(DataLakeFormat::Iceberg) => Err(Error::UnsupportedOperation {
-                message: "KeyEncoder for Iceberg format is not yet implemented".to_string(),
-            }),
+            Some(DataLakeFormat::Iceberg) => {
+                Ok(Box::new(IcebergKeyEncoder::new(row_type, key_fields)?))
+            }
             None => Ok(Box::new(CompactedKeyEncoder::create_key_encoder(
                 row_type, key_fields,
             )?)),

--- a/fluss-rust/crates/fluss/tests/integration/kv_table.rs
+++ b/fluss-rust/crates/fluss/tests/integration/kv_table.rs
@@ -1258,6 +1258,83 @@ mod kv_table_test {
         assert_eq!(row.get_string(2).unwrap(), "value1");
     }
 
+    /// Verifies that Iceberg key encoding and bucketing are wired through KV
+    /// upsert, lookup, and delete operations.
+    #[tokio::test]
+    async fn upsert_delete_and_lookup_with_iceberg_format() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().unwrap();
+        let table_path = TablePath::new("fluss", "test_kv_iceberg_format");
+
+        let table_descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("id", DataTypes::int())
+                    .column("name", DataTypes::string())
+                    .primary_key(vec!["id"])
+                    .build()
+                    .expect("Failed to build schema"),
+            )
+            .distributed_by(Some(3), vec!["id".to_string()])
+            .property("table.datalake.format", "iceberg")
+            .build()
+            .expect("Failed to build table");
+
+        create_table(&admin, &table_path, &table_descriptor).await;
+
+        let table = connection.get_table(&table_path).await.unwrap();
+        let upsert_writer = table
+            .new_upsert()
+            .expect("Failed to create upsert")
+            .create_writer()
+            .expect("Failed to create Iceberg writer");
+
+        for (id, name) in [(1, "Frost"), (2, "Ember")] {
+            let mut row = GenericRow::new(2);
+            row.set_field(0, id);
+            row.set_field(1, name);
+            upsert_writer
+                .upsert(&row)
+                .expect("Failed to upsert Iceberg row");
+        }
+        upsert_writer.flush().await.expect("Failed to flush");
+
+        let mut lookuper = table
+            .new_lookup()
+            .expect("Failed to create lookup")
+            .create_lookuper()
+            .expect("Failed to create Iceberg lookuper");
+
+        for (id, expected_name) in [(1, "Frost"), (2, "Ember")] {
+            let result = lookuper
+                .lookup(&make_key_with_field_count(id, 1))
+                .await
+                .expect("Failed to lookup Iceberg row");
+            let row = result.get_single_row().unwrap().expect("Row should exist");
+            assert_eq!(row.get_string(1).unwrap(), expected_name);
+        }
+
+        let mut delete_row = GenericRow::new(2);
+        delete_row.set_field(0, 1);
+        upsert_writer
+            .delete(&delete_row)
+            .expect("Failed to delete Iceberg row")
+            .await
+            .expect("Failed to wait for delete acknowledgment");
+
+        let result = lookuper
+            .lookup(&make_key_with_field_count(1, 1))
+            .await
+            .expect("Failed to lookup deleted Iceberg row");
+        assert!(result.get_single_row().unwrap().is_none());
+
+        admin
+            .drop_table(&table_path, false)
+            .await
+            .expect("Failed to drop table");
+    }
+
     /// Verifies upsert/lookup/update/delete on a KV table whose data lake format
     /// is `paimon`, exercising every scalar `DataType` supported by Paimon's
     /// BinaryRow encoder. With the default `kv_format_version=1`, the client

--- a/fluss-rust/crates/fluss/tests/integration/log_table.rs
+++ b/fluss-rust/crates/fluss/tests/integration/log_table.rs
@@ -159,6 +159,97 @@ mod table_test {
     }
 
     #[tokio::test]
+    async fn append_and_scan_with_iceberg_format() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("Failed to get admin");
+        let table_path = TablePath::new("fluss", "test_append_with_iceberg_format");
+
+        let table_descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("id", DataTypes::int())
+                    .column("name", DataTypes::string())
+                    .build()
+                    .expect("Failed to build schema"),
+            )
+            .distributed_by(Some(3), vec!["id".to_string()])
+            .property("table.datalake.format", "iceberg")
+            .build()
+            .expect("Failed to build table");
+
+        create_table(&admin, &table_path, &table_descriptor).await;
+
+        let table = connection
+            .get_table(&table_path)
+            .await
+            .expect("Failed to get table");
+        let append_writer = table
+            .new_append()
+            .expect("Failed to create append")
+            .create_writer()
+            .expect("Failed to create Iceberg writer");
+
+        for (id, name) in [(34, "Frost"), (35, "Ember"), (36, "Gale")] {
+            let mut row = GenericRow::new(2);
+            row.set_field(0, id);
+            row.set_field(1, name);
+            append_writer
+                .append(&row)
+                .expect("Failed to append Iceberg row");
+        }
+        append_writer.flush().await.expect("Failed to flush");
+
+        let log_scanner = table
+            .new_scan()
+            .create_log_scanner()
+            .expect("Failed to create log scanner");
+        for bucket_id in 0..table.get_table_info().get_num_buckets() {
+            log_scanner
+                .subscribe(bucket_id, EARLIEST_OFFSET)
+                .await
+                .expect("Failed to subscribe with EARLIEST_OFFSET");
+        }
+
+        let mut collected = poll_until_count(
+            3,
+            DEFAULT_POLL_TIMEOUT,
+            Duration::from_millis(500),
+            async |d| {
+                log_scanner
+                    .poll(d)
+                    .await
+                    .expect("Failed to poll records")
+                    .into_iter()
+                    .map(|record| {
+                        let row = record.row();
+                        (
+                            row.get_int(0).unwrap(),
+                            row.get_string(1).unwrap().to_string(),
+                        )
+                    })
+                    .collect()
+            },
+        )
+        .await;
+
+        collected.sort();
+        assert_eq!(
+            collected,
+            vec![
+                (34, "Frost".to_string()),
+                (35, "Ember".to_string()),
+                (36, "Gale".to_string()),
+            ]
+        );
+
+        admin
+            .drop_table(&table_path, false)
+            .await
+            .expect("Failed to drop table");
+    }
+
+    #[tokio::test]
     async fn list_offsets() {
         let cluster = get_shared_cluster();
         let connection = cluster.get_fluss_connection().await;


### PR DESCRIPTION
### Purpose

add support of iceberg format key encoder

### Brief change log


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
