### PR TITLE
[server] Clarify remote log start offset semantics

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/LogFetcher.java
@@ -541,7 +541,7 @@ public class LogFetcher implements Closeable {
             RemoteLogSegment segment = remoteLogSegments.get(i);
             if (i > 0) {
                 posInLogSegment = 0;
-                fetchOffset = segment.remoteLogStartOffset();
+                fetchOffset = segment.physicalStartOffset();
             }
             RemoteLogDownloadFuture downloadFuture =
                     remoteLogDownloader.requestRemoteLog(remoteLogTabletDir, segment);

--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloader.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloader.java
@@ -312,7 +312,7 @@ public class RemoteLogDownloader implements Closeable {
         FsPath remotePath =
                 remoteLogSegmentFile(
                         remoteLogSegmentDir(remoteLogTabletDir, segment.remoteLogSegmentId()),
-                        segment.remoteLogStartOffset());
+                        segment.physicalStartOffset());
         return new FsPathAndFileName(remotePath, getLocalFileNameOfRemoteSegment(segment));
     }
 
@@ -328,7 +328,7 @@ public class RemoteLogDownloader implements Closeable {
     private static String getLocalFileNameOfRemoteSegment(RemoteLogSegment segment) {
         return segment.remoteLogSegmentId()
                 + "_"
-                + FlussPaths.filenamePrefixFromOffset(segment.remoteLogStartOffset())
+                + FlussPaths.filenamePrefixFromOffset(segment.physicalStartOffset())
                 + LOG_FILE_SUFFIX;
     }
 
@@ -371,8 +371,7 @@ public class RemoteLogDownloader implements Closeable {
         public int compareTo(RemoteLogDownloadRequest o) {
             if (segment.tableBucket().equals(o.segment.tableBucket())) {
                 // strictly download in the offset order if they belong to the same bucket
-                return Long.compare(
-                        segment.remoteLogStartOffset(), o.segment.remoteLogStartOffset());
+                return Long.compare(segment.physicalStartOffset(), o.segment.physicalStartOffset());
             } else {
                 // download segment from old to new across buckets
                 return Long.compare(segment.maxTimestamp(), o.segment.maxTimestamp());

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteCompletedFetchTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteCompletedFetchTest.java
@@ -281,7 +281,7 @@ class RemoteCompletedFetchTest {
                         .tableBucket(tableBucket)
                         .physicalTablePath(physicalTablePath)
                         .remoteLogSegmentId(segmentId)
-                        .remoteLogStartOffset(0L)
+                        .physicalStartOffset(0L)
                         .remoteLogEndOffset(9L)
                         .segmentSizeInBytes(Integer.MAX_VALUE)
                         .build();

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
@@ -482,7 +482,7 @@ class RemoteLogDownloaderTest {
                                         String.format(
                                                 "(bucket=%s, offset=%s, ts=%s)",
                                                 r.segment.tableBucket().getBucket(),
-                                                r.segment.remoteLogStartOffset(),
+                                                r.segment.physicalStartOffset(),
                                                 r.segment.maxTimestamp()))
                         .collect(Collectors.toList());
         List<String> expected =
@@ -656,7 +656,7 @@ class RemoteLogDownloaderTest {
                         .tableBucket(tableBucket)
                         .physicalTablePath(DATA1_PHYSICAL_TABLE_PATH)
                         .remoteLogSegmentId(UUID.randomUUID())
-                        .remoteLogStartOffset(startOffset)
+                        .physicalStartOffset(startOffset)
                         .remoteLogEndOffset(startOffset + 10)
                         .maxTimestamp(maxTimestamp)
                         .segmentSizeInBytes(Integer.MAX_VALUE)
@@ -693,7 +693,7 @@ class RemoteLogDownloaderTest {
                             .tableBucket(tableBucket)
                             .physicalTablePath(physicalTablePath)
                             .remoteLogSegmentId(segmentId)
-                            .remoteLogStartOffset(baseOffset)
+                            .physicalStartOffset(baseOffset)
                             .remoteLogEndOffset(baseOffset + 9)
                             .maxTimestamp(maxTimestamp)
                             .segmentSizeInBytes(Integer.MAX_VALUE)

--- a/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
+++ b/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
@@ -96,7 +96,7 @@ public class RemoteLogManifest {
         newSegments.sort(Comparator.comparingLong(RemoteLogSegment::logicalStartOffset));
 
         List<RemoteLogSegment> sortedAddedSegments = new ArrayList<>(addedSegments);
-        sortedAddedSegments.sort(Comparator.comparingLong(RemoteLogSegment::remoteLogStartOffset));
+        sortedAddedSegments.sort(Comparator.comparingLong(RemoteLogSegment::physicalStartOffset));
         long newHighestCopiedEndOffset = highestCopiedEndOffset;
         for (RemoteLogSegment addedSegment : sortedAddedSegments) {
             newHighestCopiedEndOffset =
@@ -111,17 +111,16 @@ public class RemoteLogManifest {
             if (addedSegment.remoteLogEndOffset() <= currentEndOffset) {
                 continue;
             }
-            if (addedSegment.remoteLogStartOffset() > currentEndOffset) {
+            if (addedSegment.physicalStartOffset() > currentEndOffset) {
                 throw new IllegalArgumentException(
                         String.format(
                                 "Remote log segment [%s, %s) introduces a gap after logical end %s",
-                                addedSegment.remoteLogStartOffset(),
+                                addedSegment.physicalStartOffset(),
                                 addedSegment.remoteLogEndOffset(),
                                 currentEndOffset));
             }
 
-            long insertionOffset =
-                    Math.max(addedSegment.remoteLogStartOffset(), currentStartOffset);
+            long insertionOffset = Math.max(addedSegment.physicalStartOffset(), currentStartOffset);
             List<RemoteLogSegment> mergedSegments = new ArrayList<>();
             for (RemoteLogSegment currentSegment : newSegments) {
                 if (currentSegment.logicalEndOffset() <= insertionOffset) {
@@ -142,11 +141,12 @@ public class RemoteLogManifest {
                 physicalTablePath, tableBucket, newSegments, newHighestCopiedEndOffset);
     }
 
-    public long getRemoteLogStartOffset() {
+    /** Returns the first offset exposed by the manifest's logical segment ranges. */
+    public long getLogicalStartOffset() {
         long startOffset = Long.MAX_VALUE;
         for (RemoteLogSegment remoteLogSegment : remoteLogSegmentList) {
-            if (remoteLogSegment.remoteLogStartOffset() < startOffset) {
-                startOffset = remoteLogSegment.remoteLogStartOffset();
+            if (remoteLogSegment.logicalStartOffset() < startOffset) {
+                startOffset = remoteLogSegment.logicalStartOffset();
             }
         }
         return startOffset;

--- a/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifestJsonSerde.java
+++ b/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifestJsonSerde.java
@@ -86,9 +86,9 @@ public class RemoteLogManifestJsonSerde
             generator.writeStartObject();
             generator.writeStringField(
                     REMOTE_LOG_SEGMENT_ID_FIELD, remoteLogSegment.remoteLogSegmentId().toString());
-            generator.writeNumberField(START_OFFSET_FIELD, remoteLogSegment.remoteLogStartOffset());
+            generator.writeNumberField(START_OFFSET_FIELD, remoteLogSegment.physicalStartOffset());
             generator.writeNumberField(END_OFFSET_FIELD, remoteLogSegment.remoteLogEndOffset());
-            if (remoteLogSegment.logicalStartOffset() != remoteLogSegment.remoteLogStartOffset()) {
+            if (remoteLogSegment.logicalStartOffset() != remoteLogSegment.physicalStartOffset()) {
                 generator.writeNumberField(
                         LOGICAL_START_OFFSET_FIELD, remoteLogSegment.logicalStartOffset());
             }
@@ -140,7 +140,7 @@ public class RemoteLogManifestJsonSerde
                             .physicalTablePath(physicalTablePath)
                             .tableBucket(tableBucket)
                             .remoteLogSegmentId(UUID.fromString(remoteLogSegmentId))
-                            .remoteLogStartOffset(startOffset)
+                            .physicalStartOffset(startOffset)
                             .remoteLogEndOffset(endOffset)
                             .maxTimestamp(maxTimestamp)
                             .segmentSizeInBytes(segmentSizeInBytes);

--- a/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogSegment.java
+++ b/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogSegment.java
@@ -43,7 +43,7 @@ public class RemoteLogSegment {
     private final UUID remoteLogSegmentId;
 
     /** Inclusive physical start offset of this segment. */
-    private final long remoteLogStartOffset;
+    private final long physicalStartOffset;
 
     /** Exclusive physical end offset of this segment. */
     private final long remoteLogEndOffset;
@@ -63,7 +63,7 @@ public class RemoteLogSegment {
             PhysicalTablePath physicalTablePath,
             TableBucket tableBucket,
             UUID remoteLogSegmentId,
-            long remoteLogStartOffset,
+            long physicalStartOffset,
             long remoteLogEndOffset,
             @Nullable Long logicalStartOffset,
             @Nullable Long logicalEndOffset,
@@ -73,27 +73,27 @@ public class RemoteLogSegment {
         this.tableBucket = checkNotNull(tableBucket);
         this.remoteLogSegmentId = checkNotNull(remoteLogSegmentId);
 
-        if (remoteLogStartOffset < 0) {
+        if (physicalStartOffset < 0) {
             throw new IllegalArgumentException(
                     "Unexpected start offset: "
-                            + remoteLogStartOffset
+                            + physicalStartOffset
                             + ". StartOffset for a tiered segment cannot be negative");
         }
-        this.remoteLogStartOffset = remoteLogStartOffset;
+        this.physicalStartOffset = physicalStartOffset;
 
-        if (remoteLogEndOffset <= remoteLogStartOffset) {
+        if (remoteLogEndOffset <= physicalStartOffset) {
             throw new IllegalArgumentException(
                     "Unexpected remote log end offset: "
                             + remoteLogEndOffset
                             + ". The exclusive end offset for a remote segment must be greater "
                             + "than its start offset: "
-                            + remoteLogStartOffset);
+                            + physicalStartOffset);
         }
         this.remoteLogEndOffset = remoteLogEndOffset;
         this.logicalStartOffset =
-                logicalStartOffset == null ? remoteLogStartOffset : logicalStartOffset;
+                logicalStartOffset == null ? physicalStartOffset : logicalStartOffset;
         this.logicalEndOffset = logicalEndOffset == null ? remoteLogEndOffset : logicalEndOffset;
-        if (this.logicalStartOffset < remoteLogStartOffset
+        if (this.logicalStartOffset < physicalStartOffset
                 || this.logicalStartOffset >= this.logicalEndOffset
                 || this.logicalEndOffset > remoteLogEndOffset) {
             throw new IllegalArgumentException(
@@ -102,7 +102,7 @@ public class RemoteLogSegment {
                                     + "[%s, %s)",
                             this.logicalStartOffset,
                             this.logicalEndOffset,
-                            remoteLogStartOffset,
+                            physicalStartOffset,
                             remoteLogEndOffset));
         }
         this.maxTimestamp = maxTimestamp;
@@ -124,8 +124,8 @@ public class RemoteLogSegment {
     /**
      * @return physical start offset of this segment (inclusive)
      */
-    public long remoteLogStartOffset() {
-        return remoteLogStartOffset;
+    public long physicalStartOffset() {
+        return physicalStartOffset;
     }
 
     /**
@@ -156,7 +156,7 @@ public class RemoteLogSegment {
                 physicalTablePath,
                 tableBucket,
                 remoteLogSegmentId,
-                remoteLogStartOffset,
+                physicalStartOffset,
                 remoteLogEndOffset,
                 logicalStartOffset,
                 logicalEndOffset,
@@ -181,7 +181,7 @@ public class RemoteLogSegment {
             return false;
         }
         RemoteLogSegment that = (RemoteLogSegment) o;
-        return remoteLogStartOffset == that.remoteLogStartOffset
+        return physicalStartOffset == that.physicalStartOffset
                 && remoteLogEndOffset == that.remoteLogEndOffset
                 && logicalStartOffset == that.logicalStartOffset
                 && logicalEndOffset == that.logicalEndOffset
@@ -198,7 +198,7 @@ public class RemoteLogSegment {
                 physicalTablePath,
                 tableBucket,
                 remoteLogSegmentId,
-                remoteLogStartOffset,
+                physicalStartOffset,
                 remoteLogEndOffset,
                 logicalStartOffset,
                 logicalEndOffset,
@@ -215,8 +215,8 @@ public class RemoteLogSegment {
                 + tableBucket
                 + ", remoteLogSegmentId="
                 + remoteLogSegmentId
-                + ", remoteLogStartOffset="
-                + remoteLogStartOffset
+                + ", physicalStartOffset="
+                + physicalStartOffset
                 + ", remoteLogEndOffset="
                 + remoteLogEndOffset
                 + ", logicalStartOffset="
@@ -235,7 +235,7 @@ public class RemoteLogSegment {
         private PhysicalTablePath physicalTablePath;
         private TableBucket tableBucket;
         private UUID remoteLogSegmentId;
-        private long remoteLogStartOffset;
+        private long physicalStartOffset;
         private long remoteLogEndOffset;
         private @Nullable Long logicalStartOffset;
         private @Nullable Long logicalEndOffset;
@@ -251,8 +251,8 @@ public class RemoteLogSegment {
             return this;
         }
 
-        public Builder remoteLogStartOffset(long startOffset) {
-            this.remoteLogStartOffset = startOffset;
+        public Builder physicalStartOffset(long physicalStartOffset) {
+            this.physicalStartOffset = physicalStartOffset;
             return this;
         }
 
@@ -296,7 +296,7 @@ public class RemoteLogSegment {
                     physicalTablePath,
                     tableBucket,
                     remoteLogSegmentId,
-                    remoteLogStartOffset,
+                    physicalStartOffset,
                     remoteLogEndOffset,
                     logicalStartOffset,
                     logicalEndOffset,

--- a/fluss-common/src/main/java/org/apache/fluss/utils/FlussPaths.java
+++ b/fluss-common/src/main/java/org/apache/fluss/utils/FlussPaths.java
@@ -371,7 +371,7 @@ public class FlussPaths {
      * @param segment the remote log segment for the offset index.
      */
     public static File remoteOffsetIndexCacheFile(File cacheDir, RemoteLogSegment segment) {
-        String prefix = segment.remoteLogStartOffset() + "_" + segment.remoteLogSegmentId();
+        String prefix = segment.physicalStartOffset() + "_" + segment.remoteLogSegmentId();
         return new File(cacheDir, prefix + INDEX_FILE_SUFFIX);
     }
 
@@ -388,7 +388,7 @@ public class FlussPaths {
      * @param segment the remote log segment for the offset index.
      */
     public static File remoteTimeIndexCacheFile(File cacheDir, RemoteLogSegment segment) {
-        String prefix = segment.remoteLogStartOffset() + "_" + segment.remoteLogSegmentId();
+        String prefix = segment.physicalStartOffset() + "_" + segment.remoteLogSegmentId();
         return new File(cacheDir, prefix + TIME_INDEX_FILE_SUFFIX);
     }
 
@@ -522,7 +522,7 @@ public class FlussPaths {
                                 remoteLogSegment.physicalTablePath(),
                                 remoteLogSegment.tableBucket()),
                         remoteLogSegment.remoteLogSegmentId()),
-                remoteLogSegment.remoteLogStartOffset(),
+                remoteLogSegment.physicalStartOffset(),
                 indexSuffix);
     }
 

--- a/fluss-common/src/test/java/org/apache/fluss/remote/RemoteLogManifestJsonSerdeTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/remote/RemoteLogManifestJsonSerdeTest.java
@@ -45,7 +45,7 @@ class RemoteLogManifestJsonSerdeTest extends JsonSerdeTestBase<RemoteLogManifest
                                     .tableBucket(TABLE_BUCKET1)
                                     .remoteLogSegmentId(
                                             UUID.fromString("a4421366-4a1d-4c3b-a0f8-0be2e77b1368"))
-                                    .remoteLogStartOffset(0)
+                                    .physicalStartOffset(0)
                                     .remoteLogEndOffset(9)
                                     .maxTimestamp(1722225103853L)
                                     .segmentSizeInBytes(2850)
@@ -55,7 +55,7 @@ class RemoteLogManifestJsonSerdeTest extends JsonSerdeTestBase<RemoteLogManifest
                                     .tableBucket(TABLE_BUCKET1)
                                     .remoteLogSegmentId(
                                             UUID.fromString("dbfd0ade-23d9-411a-ac05-81e5fe1cabd5"))
-                                    .remoteLogStartOffset(100023)
+                                    .physicalStartOffset(100023)
                                     .remoteLogEndOffset(Long.MAX_VALUE)
                                     .maxTimestamp(Long.MAX_VALUE)
                                     .segmentSizeInBytes(Integer.MAX_VALUE)
@@ -75,7 +75,7 @@ class RemoteLogManifestJsonSerdeTest extends JsonSerdeTestBase<RemoteLogManifest
                                     .tableBucket(TABLE_BUCKET2)
                                     .remoteLogSegmentId(
                                             UUID.fromString("6e94fbd1-c056-446e-859c-77345dddcd96"))
-                                    .remoteLogStartOffset(10)
+                                    .physicalStartOffset(10)
                                     .remoteLogEndOffset(20)
                                     .maxTimestamp(1722225103853L)
                                     .segmentSizeInBytes(2850)
@@ -85,7 +85,7 @@ class RemoteLogManifestJsonSerdeTest extends JsonSerdeTestBase<RemoteLogManifest
                                     .tableBucket(TABLE_BUCKET2)
                                     .remoteLogSegmentId(
                                             UUID.fromString("22901b01-250f-4114-9b01-1a840dd28f4f"))
-                                    .remoteLogStartOffset(200023)
+                                    .physicalStartOffset(200023)
                                     .remoteLogEndOffset(Long.MAX_VALUE)
                                     .maxTimestamp(Long.MAX_VALUE)
                                     .segmentSizeInBytes(Integer.MAX_VALUE)

--- a/fluss-common/src/test/java/org/apache/fluss/remote/RemoteLogManifestOverlapTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/remote/RemoteLogManifestOverlapTest.java
@@ -88,7 +88,7 @@ class RemoteLogManifestOverlapTest {
                 .extracting(
                         segment ->
                                 Arrays.asList(
-                                        segment.remoteLogStartOffset(),
+                                        segment.physicalStartOffset(),
                                         segment.remoteLogEndOffset(),
                                         segment.logicalStartOffset(),
                                         segment.logicalEndOffset()))
@@ -153,7 +153,7 @@ class RemoteLogManifestOverlapTest {
 
         assertThat(result.getRemoteLogSegmentList())
                 .containsExactly(replacement.withLogicalRange(10L, 25L));
-        assertThat(result.getRemoteLogStartOffset()).isEqualTo(5L);
+        assertThat(result.getLogicalStartOffset()).isEqualTo(10L);
         assertThat(result.getRemoteLogEndOffset()).isEqualTo(25L);
     }
 
@@ -201,7 +201,7 @@ class RemoteLogManifestOverlapTest {
                 .physicalTablePath(TABLE_PATH)
                 .tableBucket(TABLE_BUCKET)
                 .remoteLogSegmentId(UUID.randomUUID())
-                .remoteLogStartOffset(startOffset)
+                .physicalStartOffset(startOffset)
                 .remoteLogEndOffset(endOffset)
                 .maxTimestamp(1L)
                 .segmentSizeInBytes(10)

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/action/orphan/build/ActiveRefsFetcher.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/action/orphan/build/ActiveRefsFetcher.java
@@ -306,7 +306,7 @@ public final class ActiveRefsFetcher {
         Set<String> relativePaths = new HashSet<>();
         for (RemoteLogSegment segment : manifest.getRemoteLogSegmentList()) {
             String segmentId = segment.remoteLogSegmentId().toString();
-            long startOffset = segment.remoteLogStartOffset();
+            long startOffset = segment.physicalStartOffset();
             long endOffset = segment.remoteLogEndOffset();
             String baseOffset = FlussPaths.filenamePrefixFromOffset(startOffset);
             String writerOffset = FlussPaths.filenamePrefixFromOffset(endOffset);

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/util/CommonRpcMessageUtils.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/util/CommonRpcMessageUtils.java
@@ -180,7 +180,7 @@ public class CommonRpcMessageUtils {
                                             UUID.fromString(
                                                     pbRemoteLogSegment.getRemoteLogSegmentId()))
                                     .remoteLogEndOffset(pbRemoteLogSegment.getRemoteLogEndOffset())
-                                    .remoteLogStartOffset(
+                                    .physicalStartOffset(
                                             pbRemoteLogSegment.getRemoteLogStartOffset())
                                     .segmentSizeInBytes(pbRemoteLogSegment.getSegmentSizeInBytes())
                                     .maxTimestamp(maxTimestamp)

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -2171,7 +2171,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
                                                 coordinatorContext.getFollowers(
                                                         tb, leaderAndIsr.leader()),
                                                 tb,
-                                                manifestData.getRemoteLogStartOffset(),
+                                                manifestData.getRemoteLogLogicalStartOffset(),
                                                 manifestData.getRemoteLogEndOffset(),
                                                 manifestData.getHighestCopiedEndOffset()));
         coordinatorRequestBatch.sendNotifyRemoteLogOffsetsRequest(

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatch.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatch.java
@@ -359,7 +359,7 @@ public class CoordinatorRequestBatch {
     public void addNotifyRemoteLogOffsetsRequestForTabletServers(
             List<Integer> tabletServers,
             TableBucket tableBucket,
-            long remoteLogStartOffset,
+            long logicalStartOffset,
             long remoteLogEndOffset,
             long highestCopiedEndOffset) {
         tabletServers.stream()
@@ -370,7 +370,7 @@ public class CoordinatorRequestBatch {
                                         id,
                                         makeNotifyRemoteLogOffsetsRequest(
                                                 tableBucket,
-                                                remoteLogStartOffset,
+                                                logicalStartOffset,
                                                 remoteLogEndOffset,
                                                 highestCopiedEndOffset)));
     }

--- a/fluss-server/src/main/java/org/apache/fluss/server/entity/CommitRemoteLogManifestData.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/entity/CommitRemoteLogManifestData.java
@@ -32,8 +32,8 @@ public class CommitRemoteLogManifestData {
     /** The location where the remote log manifest is stored in remote storage. */
     private final FsPath remoteLogManifestPath;
 
-    /** The start offset of the remote log. */
-    private final long remoteLogStartOffset;
+    /** The first offset exposed by the manifest's logical segment ranges. */
+    private final long remoteLogLogicalStartOffset;
 
     /** The end offset of the remote log. */
     private final long remoteLogEndOffset;
@@ -50,14 +50,14 @@ public class CommitRemoteLogManifestData {
     public CommitRemoteLogManifestData(
             TableBucket tableBucket,
             FsPath remoteLogManifestPath,
-            long remoteLogStartOffset,
+            long remoteLogLogicalStartOffset,
             long remoteLogEndOffset,
             int coordinatorEpoch,
             int bucketLeaderEpoch) {
         this(
                 tableBucket,
                 remoteLogManifestPath,
-                remoteLogStartOffset,
+                remoteLogLogicalStartOffset,
                 remoteLogEndOffset,
                 remoteLogEndOffset,
                 coordinatorEpoch,
@@ -67,14 +67,14 @@ public class CommitRemoteLogManifestData {
     public CommitRemoteLogManifestData(
             TableBucket tableBucket,
             FsPath remoteLogManifestPath,
-            long remoteLogStartOffset,
+            long remoteLogLogicalStartOffset,
             long remoteLogEndOffset,
             long highestCopiedEndOffset,
             int coordinatorEpoch,
             int bucketLeaderEpoch) {
         this.tableBucket = tableBucket;
         this.remoteLogManifestPath = remoteLogManifestPath;
-        this.remoteLogStartOffset = remoteLogStartOffset;
+        this.remoteLogLogicalStartOffset = remoteLogLogicalStartOffset;
         this.remoteLogEndOffset = remoteLogEndOffset;
         this.highestCopiedEndOffset = highestCopiedEndOffset;
         this.coordinatorEpoch = coordinatorEpoch;
@@ -89,8 +89,8 @@ public class CommitRemoteLogManifestData {
         return remoteLogManifestPath;
     }
 
-    public long getRemoteLogStartOffset() {
-        return remoteLogStartOffset;
+    public long getRemoteLogLogicalStartOffset() {
+        return remoteLogLogicalStartOffset;
     }
 
     public long getRemoteLogEndOffset() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/entity/NotifyRemoteLogOffsetsData.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/entity/NotifyRemoteLogOffsetsData.java
@@ -23,19 +23,19 @@ import org.apache.fluss.rpc.messages.NotifyRemoteLogOffsetsRequest;
 /** The data for request {@link NotifyRemoteLogOffsetsRequest}. */
 public class NotifyRemoteLogOffsetsData {
     private final TableBucket tableBucket;
-    private final long remoteLogStartOffset;
+    private final long remoteLogLogicalStartOffset;
     private final long remoteLogEndOffset;
     private final long highestCopiedEndOffset;
     private final int coordinatorEpoch;
 
     public NotifyRemoteLogOffsetsData(
             TableBucket tableBucket,
-            long remoteLogStartOffset,
+            long remoteLogLogicalStartOffset,
             long remoteLogEndOffset,
             int coordinatorEpoch) {
         this(
                 tableBucket,
-                remoteLogStartOffset,
+                remoteLogLogicalStartOffset,
                 remoteLogEndOffset,
                 remoteLogEndOffset,
                 coordinatorEpoch);
@@ -43,12 +43,12 @@ public class NotifyRemoteLogOffsetsData {
 
     public NotifyRemoteLogOffsetsData(
             TableBucket tableBucket,
-            long remoteLogStartOffset,
+            long remoteLogLogicalStartOffset,
             long remoteLogEndOffset,
             long highestCopiedEndOffset,
             int coordinatorEpoch) {
         this.tableBucket = tableBucket;
-        this.remoteLogStartOffset = remoteLogStartOffset;
+        this.remoteLogLogicalStartOffset = remoteLogLogicalStartOffset;
         this.remoteLogEndOffset = remoteLogEndOffset;
         this.highestCopiedEndOffset = highestCopiedEndOffset;
         this.coordinatorEpoch = coordinatorEpoch;
@@ -58,8 +58,8 @@ public class NotifyRemoteLogOffsetsData {
         return tableBucket;
     }
 
-    public long getRemoteLogStartOffset() {
-        return remoteLogStartOffset;
+    public long getRemoteLogLogicalStartOffset() {
+        return remoteLogLogicalStartOffset;
     }
 
     public long getRemoteLogEndOffset() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/RemoteLogFetcher.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/RemoteLogFetcher.java
@@ -266,7 +266,7 @@ public class RemoteLogFetcher implements Closeable {
     private File downloadSegment(RemoteLogSegment segment) throws IOException {
         File localFile =
                 tempDir.resolve(
-                                FlussPaths.filenamePrefixFromOffset(segment.remoteLogStartOffset())
+                                FlussPaths.filenamePrefixFromOffset(segment.physicalStartOffset())
                                         + ".log")
                         .toFile();
 
@@ -274,7 +274,7 @@ public class RemoteLogFetcher implements Closeable {
         LOG.info(
                 "Downloading remote log segment {} (offsets {}-{}) to {}",
                 segment.remoteLogSegmentId(),
-                segment.remoteLogStartOffset(),
+                segment.physicalStartOffset(),
                 segment.remoteLogEndOffset(),
                 localFile);
 
@@ -530,7 +530,7 @@ public class RemoteLogFetcher implements Closeable {
                     // fetchSegmentFile() already calls fillPrefetchWindow() in its finally block.
                     int startPosition = 0;
                     // if this segment contains data before currentOffset, find the right position
-                    if (segment.remoteLogStartOffset() < currentOffset) {
+                    if (segment.physicalStartOffset() < currentOffset) {
                         startPosition =
                                 remoteLogManager.lookupPositionForOffset(segment, currentOffset);
                     }

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -120,8 +120,8 @@ public final class LogTablet {
     // The minimum offset that should be retained in the local log. This is used to ensure that,
     // the offset of kv snapshot should be retained, otherwise, kv recovery will fail.
     private volatile long minRetainOffset;
-    // tracking the log start offset in remote storage
-    private volatile long remoteLogStartOffset = Long.MAX_VALUE;
+    // tracking the logical start offset exposed by the current remote log manifest
+    private volatile long remoteLogLogicalStartOffset = Long.MAX_VALUE;
     // tracking the log end offset in remote storage
     private volatile long remoteLogEndOffset = -1L;
     // tracking the highest exclusive offset successfully copied to remote storage
@@ -216,12 +216,13 @@ public final class LogTablet {
     }
 
     public boolean canFetchFromRemoteLog(long fetchOffset) {
-        return remoteLogStartOffset <= fetchOffset && fetchOffset < remoteLogEndOffset;
+        return remoteLogLogicalStartOffset <= fetchOffset && fetchOffset < remoteLogEndOffset;
     }
 
     /** The available start offset of the log tablet, maybe on local log or remote log. */
     public long logStartOffset() {
-        return Math.min(Math.min(localLogStartOffset(), remoteLogStartOffset), lakeLogStartOffset);
+        return Math.min(
+                Math.min(localLogStartOffset(), remoteLogLogicalStartOffset), lakeLogStartOffset);
     }
 
     public long localLogStartOffset() {
@@ -625,10 +626,11 @@ public final class LogTablet {
         return findOffset;
     }
 
-    public void updateRemoteLogStartOffset(long remoteLogStartOffset) {
-        long prev = this.remoteLogStartOffset;
-        if (prev == Long.MAX_VALUE || remoteLogStartOffset > prev) {
-            this.remoteLogStartOffset = remoteLogStartOffset;
+    public void updateRemoteLogLogicalStartOffset(long logicalStartOffset) {
+        long previousLogicalStartOffset = this.remoteLogLogicalStartOffset;
+        if (previousLogicalStartOffset == Long.MAX_VALUE
+                || logicalStartOffset > previousLogicalStartOffset) {
+            this.remoteLogLogicalStartOffset = logicalStartOffset;
         }
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/DefaultRemoteLogStorage.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/DefaultRemoteLogStorage.java
@@ -143,7 +143,7 @@ public class DefaultRemoteLogStorage implements RemoteLogStorage {
         LOG.debug("Deleting log segment and indexes for : {}", remoteLogSegment);
         try {
             FsPath segmentDir = remoteLogSegmentDir(remoteLogDir, remoteLogSegment);
-            long baseOffset = remoteLogSegment.remoteLogStartOffset();
+            long baseOffset = remoteLogSegment.physicalStartOffset();
             FsPath logFile = remoteLogSegmentFile(segmentDir, baseOffset);
             FsPath offsetIndex = remoteLogIndexFile(segmentDir, baseOffset, INDEX_FILE_SUFFIX);
             FsPath timeIndex = remoteLogIndexFile(segmentDir, baseOffset, TIME_INDEX_FILE_SUFFIX);
@@ -194,7 +194,7 @@ public class DefaultRemoteLogStorage implements RemoteLogStorage {
     public InputStream fetchLogData(RemoteLogSegment remoteLogSegment)
             throws RemoteStorageException {
         FsPath segmentDir = remoteLogSegmentDir(remoteLogDir, remoteLogSegment);
-        FsPath logFile = remoteLogSegmentFile(segmentDir, remoteLogSegment.remoteLogStartOffset());
+        FsPath logFile = remoteLogSegmentFile(segmentDir, remoteLogSegment.physicalStartOffset());
         try {
             return fileSystem.open(logFile);
         } catch (IOException e) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/LogTieringTask.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/LogTieringTask.java
@@ -298,7 +298,7 @@ public class LogTieringTask implements Runnable {
                             .physicalTablePath(physicalTablePath)
                             .tableBucket(tableBucket)
                             .remoteLogSegmentId(remoteLogSegmentId)
-                            .remoteLogStartOffset(segment.getBaseOffset())
+                            .physicalStartOffset(segment.getBaseOffset())
                             .remoteLogEndOffset(segmentEndOffset)
                             .maxTimestamp(segment.maxTimestampSoFar())
                             .segmentSizeInBytes(sizeInBytes)
@@ -360,7 +360,7 @@ public class LogTieringTask implements Runnable {
 
         // 2. sending the CommitRemoteLogManifestRequest to coordinator server
         // to try to commit this snapshot.
-        long newRemoteLogStartOffset = newRemoteLogManifest.getRemoteLogStartOffset();
+        long newLogicalStartOffset = newRemoteLogManifest.getLogicalStartOffset();
         long newRemoteLogEndOffset = newRemoteLogManifest.getRemoteLogEndOffset();
         long newRemoteLogSize = newRemoteLogManifest.getRemoteLogSize();
         int retrySendCommitTimes = 1;
@@ -371,7 +371,7 @@ public class LogTieringTask implements Runnable {
                                 new CommitRemoteLogManifestData(
                                         tableBucket,
                                         remoteLogManifestPath,
-                                        newRemoteLogStartOffset,
+                                        newLogicalStartOffset,
                                         newRemoteLogEndOffset,
                                         newRemoteLogManifest.getHighestCopiedEndOffset(),
                                         // TODO: manifest snapshot should include the epoch info,
@@ -395,7 +395,7 @@ public class LogTieringTask implements Runnable {
                     // TODO: commit with version to avoid the manifest has been updated
                     remoteLogTablet.loadRemoteLogManifest(newRemoteLogManifest);
                     LogTablet logTablet = replica.getLogTablet();
-                    logTablet.updateRemoteLogStartOffset(newRemoteLogStartOffset);
+                    logTablet.updateRemoteLogLogicalStartOffset(newLogicalStartOffset);
                     logTablet.updateHighestCopiedEndOffset(
                             newRemoteLogManifest.getHighestCopiedEndOffset());
                     // make the local log cleaner clean log segments that are committed to remote.

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogIndexCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogIndexCache.java
@@ -189,7 +189,7 @@ public class RemoteLogIndexCache implements Closeable {
     /**
      * Get the base offset of the given timestamp and startingOffset in the remote log segment. If
      * the timestamp lower than the smallest commit timestamp in this segment, return the
-     * remoteLogStartOffset.
+     * physicalStartOffset.
      */
     public long lookupOffsetForTimestamp(RemoteLogSegment remoteLogSegment, long timestamp) {
         return inReadLock(
@@ -223,7 +223,7 @@ public class RemoteLogIndexCache implements Closeable {
     }
 
     private Entry createCacheEntry(RemoteLogSegment remoteLogSegment) {
-        long startOffset = remoteLogSegment.remoteLogStartOffset();
+        long startOffset = remoteLogSegment.physicalStartOffset();
         try {
             File offsetIndexFile = remoteOffsetIndexCacheFile(cacheDir, remoteLogSegment);
             OffsetIndex offsetIndex =

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogManager.java
@@ -166,7 +166,7 @@ public class RemoteLogManager implements Closeable {
         }
         log.updateHighestCopiedEndOffset(remoteLog.getHighestCopiedEndOffset());
         log.updateRemoteLogEndOffset(remoteLog.getRemoteLogEndOffset().orElse(-1L));
-        log.updateRemoteLogStartOffset(remoteLog.getRemoteLogStartOffset());
+        log.updateRemoteLogLogicalStartOffset(remoteLog.getLogicalStartOffset());
         log.updateRemoteLogSize(remoteLog.getRemoteSizeInBytes());
         // leader needs to register the remote log metrics
         remoteLog.registerMetrics(replica.bucketMetrics());

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/remote/RemoteLogTablet.java
@@ -49,7 +49,7 @@ import static org.apache.fluss.utils.concurrent.LockUtils.inWriteLock;
 /** This class provides an in-memory cache of remote log manifest for each table bucket . */
 @ThreadSafe
 public class RemoteLogTablet {
-    private static final long INIT_REMOTE_LOG_START_OFFSET = Long.MAX_VALUE;
+    private static final long INIT_LOGICAL_START_OFFSET = Long.MAX_VALUE;
     private static final long INIT_REMOTE_LOG_END_OFFSET = -1L;
 
     /**
@@ -82,10 +82,8 @@ public class RemoteLogTablet {
 
     private volatile int numRemoteLogSegments;
 
-    /**
-     * It represents the remote log start offset of the segments that have copied to remote storage.
-     */
-    private volatile long remoteLogStartOffset;
+    /** The first offset exposed by the current manifest's logical segment ranges. */
+    private volatile long logicalStartOffset;
 
     /**
      * It represents the remote log end offset of the segments that have copied to remote storage.
@@ -115,10 +113,10 @@ public class RemoteLogTablet {
                     metricGroup.gauge(
                             MetricNames.LOG_START_OFFSET,
                             () -> {
-                                if (remoteLogStartOffset == INIT_REMOTE_LOG_START_OFFSET) {
+                                if (logicalStartOffset == INIT_LOGICAL_START_OFFSET) {
                                     return -1L;
                                 }
-                                return remoteLogStartOffset;
+                                return logicalStartOffset;
                             });
                     metricGroup.gauge(MetricNames.LOG_END_OFFSET, () -> remoteLogEndOffset);
                     metricGroup.gauge(MetricNames.REMOTE_LOG_SIZE, this::getRemoteSizeInBytes);
@@ -274,7 +272,7 @@ public class RemoteLogTablet {
         long previousPhysicalEndOffset = -1L;
         for (RemoteLogSegment segment : relevantSegments) {
             if (!contiguousPrefix.isEmpty()
-                    && segment.remoteLogStartOffset() != previousPhysicalEndOffset) {
+                    && segment.physicalStartOffset() != previousPhysicalEndOffset) {
                 break;
             }
             contiguousPrefix.add(segment);
@@ -283,8 +281,8 @@ public class RemoteLogTablet {
         return contiguousPrefix;
     }
 
-    public long getRemoteLogStartOffset() {
-        return remoteLogStartOffset;
+    public long getLogicalStartOffset() {
+        return logicalStartOffset;
     }
 
     public OptionalLong getRemoteLogEndOffset() {
@@ -318,7 +316,7 @@ public class RemoteLogTablet {
                     }
                     remoteSizeInBytes = manifestSnapshot.getRemoteLogSize();
                     numRemoteLogSegments = manifestSnapshot.getRemoteLogSegmentList().size();
-                    remoteLogStartOffset = manifestSnapshot.getRemoteLogStartOffset();
+                    logicalStartOffset = manifestSnapshot.getLogicalStartOffset();
                     remoteLogEndOffset = manifestSnapshot.getRemoteLogEndOffset();
                     currentManifest = manifestSnapshot;
                 });
@@ -346,7 +344,7 @@ public class RemoteLogTablet {
         timestampToRemoteLogSegmentId.clear();
         remoteSizeInBytes = 0L;
         numRemoteLogSegments = 0;
-        remoteLogStartOffset = INIT_REMOTE_LOG_START_OFFSET;
+        logicalStartOffset = INIT_LOGICAL_START_OFFSET;
         remoteLogEndOffset = INIT_REMOTE_LOG_END_OFFSET;
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1181,8 +1181,8 @@ public class ReplicaManager implements ServerReconfigurable {
                     LogTablet logTablet = getReplicaOrException(tb).getLogTablet();
                     logTablet.updateHighestCopiedEndOffset(
                             notifyRemoteLogOffsetsData.getHighestCopiedEndOffset());
-                    logTablet.updateRemoteLogStartOffset(
-                            notifyRemoteLogOffsetsData.getRemoteLogStartOffset());
+                    logTablet.updateRemoteLogLogicalStartOffset(
+                            notifyRemoteLogOffsetsData.getRemoteLogLogicalStartOffset());
                     logTablet.updateRemoteLogEndOffset(
                             notifyRemoteLogOffsetsData.getRemoteLogEndOffset());
                     responseCallback.accept(new NotifyRemoteLogOffsetsResponse());

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/ServerRpcMessageUtils.java
@@ -1032,7 +1032,7 @@ public class ServerRpcMessageUtils {
                     for (RemoteLogSegment logSegment : rlfInfo.remoteLogSegmentList()) {
                         PbRemoteLogSegment pbRemoteLogSegment =
                                 new PbRemoteLogSegment()
-                                        .setRemoteLogStartOffset(logSegment.remoteLogStartOffset())
+                                        .setRemoteLogStartOffset(logSegment.physicalStartOffset())
                                         .setRemoteLogSegmentId(
                                                 logSegment.remoteLogSegmentId().toString())
                                         .setRemoteLogEndOffset(logSegment.remoteLogEndOffset())
@@ -1702,7 +1702,8 @@ public class ServerRpcMessageUtils {
                 .setBucketId(tb.getBucket())
                 .setRemoteLogManifestPath(
                         commitRemoteLogManifestData.getRemoteLogManifestPath().toString())
-                .setRemoteLogStartOffset(commitRemoteLogManifestData.getRemoteLogStartOffset())
+                .setRemoteLogStartOffset(
+                        commitRemoteLogManifestData.getRemoteLogLogicalStartOffset())
                 .setRemoteLogEndOffset(commitRemoteLogManifestData.getRemoteLogEndOffset())
                 .setHighestCopiedEndOffset(commitRemoteLogManifestData.getHighestCopiedEndOffset())
                 .setCoordinatorEpoch(commitRemoteLogManifestData.getCoordinatorEpoch())
@@ -1711,14 +1712,14 @@ public class ServerRpcMessageUtils {
     }
 
     public static NotifyRemoteLogOffsetsRequest makeNotifyRemoteLogOffsetsRequest(
-            TableBucket tableBucket, long remoteLogStartOffset, long remoteLogEndOffset) {
+            TableBucket tableBucket, long logicalStartOffset, long remoteLogEndOffset) {
         return makeNotifyRemoteLogOffsetsRequest(
-                tableBucket, remoteLogStartOffset, remoteLogEndOffset, remoteLogEndOffset);
+                tableBucket, logicalStartOffset, remoteLogEndOffset, remoteLogEndOffset);
     }
 
     public static NotifyRemoteLogOffsetsRequest makeNotifyRemoteLogOffsetsRequest(
             TableBucket tableBucket,
-            long remoteLogStartOffset,
+            long logicalStartOffset,
             long remoteLogEndOffset,
             long highestCopiedEndOffset) {
         NotifyRemoteLogOffsetsRequest request = new NotifyRemoteLogOffsetsRequest();
@@ -1727,7 +1728,7 @@ public class ServerRpcMessageUtils {
         }
         request.setTableId(tableBucket.getTableId())
                 .setBucketId(tableBucket.getBucket())
-                .setRemoteStartOffset(remoteLogStartOffset)
+                .setRemoteStartOffset(logicalStartOffset)
                 .setRemoteEndOffset(remoteLogEndOffset)
                 .setHighestCopiedEndOffset(highestCopiedEndOffset);
         return request;

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/RemoteLogFetcherTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/RemoteLogFetcherTest.java
@@ -148,9 +148,9 @@ class RemoteLogFetcherTest extends RemoteLogTestBase {
                 copyLogSegmentToRemote(oldLeaderLog, remoteLogStorage, 0);
         RemoteLogSegment newLeaderSegment =
                 copySegmentToRemoteForBucket(newLeaderLog, 1, targetBucket);
-        assertThat(oldLeaderSegment.remoteLogStartOffset()).isZero();
+        assertThat(oldLeaderSegment.physicalStartOffset()).isZero();
         assertThat(oldLeaderSegment.remoteLogEndOffset()).isEqualTo(20L);
-        assertThat(newLeaderSegment.remoteLogStartOffset()).isEqualTo(10L);
+        assertThat(newLeaderSegment.physicalStartOffset()).isEqualTo(10L);
         assertThat(newLeaderSegment.remoteLogEndOffset()).isEqualTo(30L);
 
         RemoteLogManifest manifest =
@@ -232,7 +232,7 @@ class RemoteLogFetcherTest extends RemoteLogTestBase {
         assertThat(segments).hasSizeGreaterThanOrEqualTo(2);
 
         // Use the start offset of the second segment as localLogStartOffset.
-        long localLogStartOffset = segments.get(1).remoteLogStartOffset();
+        long localLogStartOffset = segments.get(1).physicalStartOffset();
 
         File logTabletDir = logTablet.getLogDir();
         try (RemoteLogFetcher fetcher = newFetcher(tb, logTabletDir)) {
@@ -368,7 +368,7 @@ class RemoteLogFetcherTest extends RemoteLogTestBase {
         assertThat(segments).isNotEmpty();
 
         // Empty range [x, x) — guards against advance() >= being changed to >.
-        long sameOffset = segments.get(0).remoteLogStartOffset();
+        long sameOffset = segments.get(0).physicalStartOffset();
 
         File logTabletDir = logTablet.getLogDir();
         try (RemoteLogFetcher fetcher = newFetcher(tb, logTabletDir)) {
@@ -967,7 +967,7 @@ class RemoteLogFetcherTest extends RemoteLogTestBase {
         RemoteLogSegment remoteSegment =
                 RemoteLogSegment.Builder.builder()
                         .remoteLogSegmentId(UUID.randomUUID())
-                        .remoteLogStartOffset(sourceSegment.getBaseOffset())
+                        .physicalStartOffset(sourceSegment.getBaseOffset())
                         .remoteLogEndOffset(nextOffset)
                         .maxTimestamp(sourceSegment.maxTimestampSoFar())
                         .segmentSizeInBytes(sourceSegment.getFileLogRecords().sizeInBytes())

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LogTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LogTabletTest.java
@@ -112,7 +112,7 @@ final class LogTabletTest extends LogTestBase {
 
     @Test
     void testRemoteLogEndOffsetCanReset() {
-        logTablet.updateRemoteLogStartOffset(0L);
+        logTablet.updateRemoteLogLogicalStartOffset(0L);
         logTablet.updateRemoteLogEndOffset(10L);
         assertThat(logTablet.canFetchFromRemoteLog(0L)).isTrue();
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogITCase.java
@@ -253,7 +253,7 @@ public class RemoteLogITCase {
         RemoteLogTablet remoteLogTablet = remoteLogManager.remoteLogTablet(tb);
 
         assertThat(remoteLogTablet.allRemoteLogSegments().size()).isGreaterThan(0);
-        assertThat(remoteLogTablet.getRemoteLogStartOffset()).isEqualTo(0L);
+        assertThat(remoteLogTablet.getLogicalStartOffset()).isEqualTo(0L);
 
         Replica leaderReplica = FLUSS_CLUSTER_EXTENSION.waitAndGetLeaderReplica(tb);
         LogTablet logTablet = leaderReplica.getLogTablet();
@@ -267,7 +267,7 @@ public class RemoteLogITCase {
                 Duration.ofMinutes(2),
                 () -> {
                     assertThat(remoteLogTablet.allRemoteLogSegments()).isEmpty();
-                    assertThat(remoteLogTablet.getRemoteLogStartOffset()).isEqualTo(Long.MAX_VALUE);
+                    assertThat(remoteLogTablet.getLogicalStartOffset()).isEqualTo(Long.MAX_VALUE);
                 });
 
         // ==================== Stage B: Dynamic Enable & Retention ====================
@@ -316,8 +316,8 @@ public class RemoteLogITCase {
         logTablet.updateLakeLogEndOffset(partialLakeOffset);
 
         final int expectedRemainingSegments = sortedSegments.size() - midIndex - 1;
-        // The new remoteLogStartOffset should be the start offset of the first remaining segment
-        final long expectedNewStartOffset = sortedSegments.get(midIndex + 1).remoteLogStartOffset();
+        // The new logical start offset should be the start offset of the first remaining segment
+        final long expectedNewStartOffset = sortedSegments.get(midIndex + 1).physicalStartOffset();
 
         // Wait for partial cleanup - only segments that have been tiered should be deleted
         retry(
@@ -326,9 +326,8 @@ public class RemoteLogITCase {
                     // Some segments should be deleted (those with endOffset <= partialLakeOffset)
                     int currentSegmentCount = remoteLogTablet.allRemoteLogSegments().size();
                     assertThat(currentSegmentCount).isEqualTo(expectedRemainingSegments);
-                    // Remote log start offset should be updated to the first remaining segment's
-                    // start
-                    assertThat(remoteLogTablet.getRemoteLogStartOffset())
+                    // Logical start offset should be updated to the first remaining segment's start
+                    assertThat(remoteLogTablet.getLogicalStartOffset())
                             .isEqualTo(expectedNewStartOffset);
                     // Remaining segments should have remoteLogEndOffset > partialLakeOffset
                     assertThat(remoteLogTablet.allRemoteLogSegments())
@@ -346,7 +345,7 @@ public class RemoteLogITCase {
                 Duration.ofMinutes(2),
                 () -> {
                     assertThat(remoteLogTablet.allRemoteLogSegments()).isEmpty();
-                    assertThat(remoteLogTablet.getRemoteLogStartOffset()).isEqualTo(Long.MAX_VALUE);
+                    assertThat(remoteLogTablet.getLogicalStartOffset()).isEqualTo(Long.MAX_VALUE);
                 });
 
         // ==================== Stage D: Dynamic Disable ====================
@@ -378,7 +377,7 @@ public class RemoteLogITCase {
                 Duration.ofMinutes(2),
                 () -> {
                     assertThat(remoteLogTablet.allRemoteLogSegments()).isEmpty();
-                    assertThat(remoteLogTablet.getRemoteLogStartOffset()).isEqualTo(Long.MAX_VALUE);
+                    assertThat(remoteLogTablet.getLogicalStartOffset()).isEqualTo(Long.MAX_VALUE);
                 });
     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogIndexCacheTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogIndexCacheTest.java
@@ -64,12 +64,12 @@ class RemoteLogIndexCacheTest extends RemoteLogTestBase {
         Path offsetIndexPath = entry.offsetIndex().file().toPath();
         Path timeIndexPath = entry.timeIndex().file().toPath();
         String expectedOffsetIndexFileName =
-                remoteLogSegment.remoteLogStartOffset()
+                remoteLogSegment.physicalStartOffset()
                         + "_"
                         + remoteLogSegment.remoteLogSegmentId()
                         + ".index";
         String expectedTimestampFileName =
-                remoteLogSegment.remoteLogStartOffset()
+                remoteLogSegment.physicalStartOffset()
                         + "_"
                         + remoteLogSegment.remoteLogSegmentId()
                         + ".timeindex";

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogManagerTest.java
@@ -91,7 +91,7 @@ class RemoteLogManagerTest extends RemoteLogTestBase {
         RemoteLogTablet remoteLogTablet = remoteLogManager.remoteLogTablet(tb);
         assertThat(remoteLogTablet).isNotNull();
         assertThat(remoteLogTablet.allRemoteLogSegments()).isEmpty();
-        assertThat(remoteLogTablet.getRemoteLogStartOffset()).isEqualTo(Long.MAX_VALUE);
+        assertThat(remoteLogTablet.getLogicalStartOffset()).isEqualTo(Long.MAX_VALUE);
         assertThat(remoteLogTablet.getRemoteLogEndOffset()).isNotPresent();
 
         // verify upload log segment to remote.
@@ -247,7 +247,7 @@ class RemoteLogManagerTest extends RemoteLogTestBase {
         assertThat(remoteLogSegments)
                 .hasSize(4)
                 .allSatisfy(s -> assertThat(s.maxTimestamp()).isEqualTo(ts1));
-        assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(0L);
+        assertThat(remoteLog.getLogicalStartOffset()).isEqualTo(0L);
         assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(40L);
         // check remote storage has the files
         assertThat(listRemoteLogFiles(tb))
@@ -263,7 +263,7 @@ class RemoteLogManagerTest extends RemoteLogTestBase {
 
         remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
         assertThat(remoteLog.allRemoteLogSegments()).isEqualTo(remoteLogSegments);
-        assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(0L);
+        assertThat(remoteLog.getLogicalStartOffset()).isEqualTo(0L);
         assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(40L);
         // remote storage should not delete files
         assertThat(listRemoteLogFiles(tb))
@@ -290,7 +290,7 @@ class RemoteLogManagerTest extends RemoteLogTestBase {
         assertThat(remoteLogSegments)
                 .hasSize(4)
                 .allSatisfy(s -> assertThat(s.maxTimestamp()).isEqualTo(ts1));
-        assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(0L);
+        assertThat(remoteLog.getLogicalStartOffset()).isEqualTo(0L);
         assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(40L);
         // check remote storage has the files
         assertThat(listRemoteLogFiles(tb))
@@ -306,7 +306,7 @@ class RemoteLogManagerTest extends RemoteLogTestBase {
 
         remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
         assertThat(remoteLog.allRemoteLogSegments()).isEqualTo(remoteLogSegments);
-        assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(0L);
+        assertThat(remoteLog.getLogicalStartOffset()).isEqualTo(0L);
         assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(40L);
         // remote storage should not delete files
         assertThat(listRemoteLogFiles(tb))
@@ -705,7 +705,7 @@ class RemoteLogManagerTest extends RemoteLogTestBase {
                                                 remoteLogManager.lookupOffsetForTimestamp(
                                                         tb, remoteLogSegment.maxTimestamp()))
                                         .isLessThan(remoteLogSegment.remoteLogEndOffset())
-                                        .isGreaterThan(remoteLogSegment.remoteLogStartOffset()));
+                                        .isGreaterThan(remoteLogSegment.physicalStartOffset()));
         assertThat(remoteLogManager.lookupOffsetForTimestamp(tb, startTimestamp + 5000))
                 .isEqualTo(-1L);
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogMaxUploadSegmentsTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogMaxUploadSegmentsTest.java
@@ -66,7 +66,7 @@ class RemoteLogMaxUploadSegmentsTest extends RemoteLogTestBase {
         RemoteLogTablet remoteLog = remoteLogManager.remoteLogTablet(tb);
         List<RemoteLogSegment> manifestSegments = remoteLog.allRemoteLogSegments();
         assertThat(manifestSegments).hasSize(5);
-        assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(0L);
+        assertThat(remoteLog.getLogicalStartOffset()).isEqualTo(0L);
         assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(50L);
 
         // Second tiering task execution - should upload the remaining 4 segments.

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTTLTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTTLTest.java
@@ -68,7 +68,7 @@ final class RemoteLogTTLTest extends RemoteLogTestBase {
         RemoteLogTablet remoteLog = remoteLogManager.remoteLogTablet(tb);
         assertThat(remoteLog.relevantRemoteLogSegments(0L).size()).isEqualTo(4);
         assertThat(remoteLog.allRemoteLogSegments().size()).isEqualTo(4);
-        assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(0L);
+        assertThat(remoteLog.getLogicalStartOffset()).isEqualTo(0L);
         assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(40L);
 
         // Materialize the index cache entries for all remote log segments.
@@ -76,17 +76,17 @@ final class RemoteLogTTLTest extends RemoteLogTestBase {
                 remoteLogManager.getRemoteLogIndexCache(logTablet.getDataDir());
         for (RemoteLogSegment remoteLogSegment : remoteLog.allRemoteLogSegments()) {
             remoteLogManager.lookupPositionForOffset(
-                    remoteLogSegment, remoteLogSegment.remoteLogStartOffset());
+                    remoteLogSegment, remoteLogSegment.physicalStartOffset());
         }
         assertThat(indexCache.getInternalCache().asMap()).hasSize(4);
         RemoteLogSegment expiredSegment =
                 remoteLog.allRemoteLogSegments().stream()
-                        .filter(segment -> segment.remoteLogStartOffset() < 20L)
+                        .filter(segment -> segment.physicalStartOffset() < 20L)
                         .findFirst()
                         .get();
         RemoteLogSegment retainedSegment =
                 remoteLog.allRemoteLogSegments().stream()
-                        .filter(segment -> segment.remoteLogStartOffset() >= 20L)
+                        .filter(segment -> segment.physicalStartOffset() >= 20L)
                         .findFirst()
                         .get();
         Entry expiredIndexEntry =
@@ -103,7 +103,7 @@ final class RemoteLogTTLTest extends RemoteLogTestBase {
         // the expired segments should not be deleted.
         remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
         assertThat(remoteLog.allRemoteLogSegments()).hasSize(4);
-        assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(0L);
+        assertThat(remoteLog.getLogicalStartOffset()).isEqualTo(0L);
 
         // set lake log end offset to 20, meaning only the first 2 segments
         // ([0,10) and [10,20)) have been tiered to lake
@@ -115,13 +115,13 @@ final class RemoteLogTTLTest extends RemoteLogTestBase {
         // only segments with remoteLogEndOffset <= 20 should be deleted (first 2 segments)
         // remaining segments: [20,30) and [30,40)
         assertThat(remoteLog.allRemoteLogSegments()).hasSize(2);
-        assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(20L);
+        assertThat(remoteLog.getLogicalStartOffset()).isEqualTo(20L);
         assertThat(remoteLog.getRemoteLogEndOffset()).hasValue(40L);
         // verify remaining segments have the expected offsets
         assertThat(remoteLog.allRemoteLogSegments())
                 .allSatisfy(
                         segment ->
-                                assertThat(segment.remoteLogStartOffset())
+                                assertThat(segment.physicalStartOffset())
                                         .isGreaterThanOrEqualTo(20L));
         assertThat(indexCache.getInternalCache().asMap())
                 .hasSize(2)
@@ -137,13 +137,13 @@ final class RemoteLogTTLTest extends RemoteLogTestBase {
         // trigger again, remaining expired segments should now be deleted
         remoteLogTaskScheduler.triggerPeriodicScheduledTasks();
         assertThat(remoteLog.allRemoteLogSegments()).isEmpty();
-        assertThat(remoteLog.getRemoteLogStartOffset()).isEqualTo(Long.MAX_VALUE);
+        assertThat(remoteLog.getLogicalStartOffset()).isEqualTo(Long.MAX_VALUE);
         assertThat(remoteLog.getHighestCopiedEndOffset()).isEqualTo(40L);
 
         // Fetch records from remote.
         // mock to update remote log end offset and remote log start offset as
         // NotifyRemoteLogOffsetsRequest do.
-        logTablet.updateRemoteLogStartOffset(40L);
+        logTablet.updateRemoteLogLogicalStartOffset(40L);
         logTablet.updateRemoteLogEndOffset(40L);
         CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> future =
                 new CompletableFuture<>();

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTabletOverlapTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTabletOverlapTest.java
@@ -52,6 +52,17 @@ class RemoteLogTabletOverlapTest {
     }
 
     @Test
+    void testLogicalStartOffsetExcludesClippedPhysicalPrefix() {
+        RemoteLogSegment segment = segment(5L, 25L).withLogicalRange(10L, 25L);
+        RemoteLogTablet tablet = new RemoteLogTablet(TABLE_PATH, TABLE_BUCKET, -1L);
+        tablet.loadRemoteLogManifest(
+                new RemoteLogManifest(
+                        TABLE_PATH, TABLE_BUCKET, Collections.singletonList(segment)));
+
+        assertThat(tablet.getLogicalStartOffset()).isEqualTo(10L);
+    }
+
+    @Test
     void testFetchV0StopsBeforePhysicalOverlap() {
         RemoteLogSegment first = segment(0L, 10L).withLogicalRange(0L, 5L);
         RemoteLogSegment second = segment(5L, 20L);
@@ -90,7 +101,7 @@ class RemoteLogTabletOverlapTest {
                 .physicalTablePath(TABLE_PATH)
                 .tableBucket(TABLE_BUCKET)
                 .remoteLogSegmentId(UUID.randomUUID())
-                .remoteLogStartOffset(startOffset)
+                .physicalStartOffset(startOffset)
                 .remoteLogEndOffset(endOffset)
                 .maxTimestamp(1L)
                 .segmentSizeInBytes(10)

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTabletTest.java
@@ -104,15 +104,15 @@ class RemoteLogTabletTest extends RemoteLogTestBase {
                         createLogSegmentWithMaxTimestamp(logTablet, 40, 30, 40),
                         createLogSegmentWithMaxTimestamp(logTablet, 50, 40, 50)));
 
-        assertThat(remoteLogTablet.findSegmentsByTimestamp(0L).get(0).remoteLogStartOffset())
+        assertThat(remoteLogTablet.findSegmentsByTimestamp(0L).get(0).physicalStartOffset())
                 .isEqualTo(0L);
-        assertThat(remoteLogTablet.findSegmentsByTimestamp(1L).get(0).remoteLogStartOffset())
+        assertThat(remoteLogTablet.findSegmentsByTimestamp(1L).get(0).physicalStartOffset())
                 .isEqualTo(0L);
-        assertThat(remoteLogTablet.findSegmentsByTimestamp(10L).get(0).remoteLogStartOffset())
+        assertThat(remoteLogTablet.findSegmentsByTimestamp(10L).get(0).physicalStartOffset())
                 .isEqualTo(0L);
-        assertThat(remoteLogTablet.findSegmentsByTimestamp(40L).get(0).remoteLogStartOffset())
+        assertThat(remoteLogTablet.findSegmentsByTimestamp(40L).get(0).physicalStartOffset())
                 .isEqualTo(30L);
-        assertThat(remoteLogTablet.findSegmentsByTimestamp(50L).get(0).remoteLogStartOffset())
+        assertThat(remoteLogTablet.findSegmentsByTimestamp(50L).get(0).physicalStartOffset())
                 .isEqualTo(40L);
         assertThat(remoteLogTablet.findSegmentsByTimestamp(51L)).isEmpty();
     }
@@ -151,11 +151,11 @@ class RemoteLogTabletTest extends RemoteLogTestBase {
     RemoteLogSegment createLogSegmentWithMaxTimestamp(
             LogTablet logTablet,
             long timestamp,
-            long remoteLogStartOffset,
+            long physicalStartOffset,
             long remoteLogEndOffset) {
         return RemoteLogSegment.Builder.builder()
                 .remoteLogSegmentId(UUID.randomUUID())
-                .remoteLogStartOffset(remoteLogStartOffset)
+                .physicalStartOffset(physicalStartOffset)
                 .remoteLogEndOffset(remoteLogEndOffset)
                 .maxTimestamp(timestamp)
                 .segmentSizeInBytes(1000)

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTestBase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/remote/RemoteLogTestBase.java
@@ -120,7 +120,7 @@ public class RemoteLogTestBase extends ReplicaTestBase {
         RemoteLogSegment remoteLogSegment =
                 RemoteLogSegment.Builder.builder()
                         .remoteLogSegmentId(remoteLogSegmentId)
-                        .remoteLogStartOffset(segment.getBaseOffset())
+                        .physicalStartOffset(segment.getBaseOffset())
                         .remoteLogEndOffset(nextOffset)
                         .maxTimestamp(segment.maxTimestampSoFar())
                         .segmentSizeInBytes(segment.getFileLogRecords().sizeInBytes())
@@ -146,7 +146,7 @@ public class RemoteLogTestBase extends ReplicaTestBase {
                             try {
                                 return RemoteLogSegment.Builder.builder()
                                         .remoteLogSegmentId(UUID.randomUUID())
-                                        .remoteLogStartOffset(segment.getBaseOffset())
+                                        .physicalStartOffset(segment.getBaseOffset())
                                         .remoteLogEndOffset(segment.getBaseOffset() + DATA1.size())
                                         .maxTimestamp(segment.maxTimestampSoFar())
                                         .segmentSizeInBytes(


### PR DESCRIPTION
### Purpose

Close #3943.

Keep the remote log start offset reported by the manifest and tablet aligned with the manifest-visible logical range. A replacement object may physically start before the current visible range; for example, a physical object covering `[5, 25)` can be visible only from offset `10`. Reporting physical offset `5` would incorrectly expose an expired prefix.

### Brief change log

- return the logical start offset from `RemoteLogManifest`
- rename physical segment start-offset APIs to `physicalStartOffset`
- rename propagated start-offset fields and variables so logical and physical semantics are explicit
- leave all remote log end-offset APIs and semantics unchanged
- add regression coverage for a physical start offset preceding the manifest-visible logical start

### Tests

- `mvn -o -pl fluss-common -DskipITs -Dfast -Dtest=RemoteLogManifestOverlapTest test`
- `mvn -o -pl fluss-server -am -DskipITs -Dfast -Dtest=RemoteLogTabletOverlapTest,RemoteLogTabletTest,RemoteLogManagerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -o -pl fluss-client,fluss-server,fluss-flink/fluss-flink-common -am -DskipTests -Dfast package`

### API and Format

This renames internal Java APIs for remote segment physical start offsets. It does not change the RPC wire format, manifest storage format, or remote log end-offset semantics.

### Documentation

No user-facing documentation changes are required.

### Generative AI disclosure

- [x] Yes — Codex (GPT-5)

<!-- Generated-by: Codex (GPT-5) following https://github.com/apache/fluss/blob/main/AGENTS.md -->