### PR TITLE
[server] Fall back to rack-unaware assignment for partial rack info

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
@@ -22,7 +22,6 @@ import org.apache.fluss.cluster.Endpoint;
 import org.apache.fluss.cluster.ServerType;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
-import org.apache.fluss.exception.InvalidServerRackInfoException;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metrics.registry.MetricRegistry;
 import org.apache.fluss.rpc.GatewayClientProxy;
@@ -103,8 +102,9 @@ public class TabletServer extends ServerBase {
      * rack-aware scenarios, this may lead to an inability to guarantee proper awareness
      * capabilities.
      *
-     * <p>Note: Either all tabletServers are configured with rack, or none of them are configured;
-     * otherwise, an {@link InvalidServerRackInfoException} will be thrown.
+     * <p>Rack-aware assignment is enabled only when all live tabletServers are configured with rack
+     * information. During a rolling configuration update, assignment falls back to rack-unaware
+     * mode until all live tabletServers report rack information.
      */
     private final @Nullable String rack;
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/TableAssignmentUtils.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/TableAssignmentUtils.java
@@ -21,7 +21,6 @@ import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.cluster.TabletServerInfo;
 import org.apache.fluss.exception.InvalidBucketsException;
 import org.apache.fluss.exception.InvalidReplicationFactorException;
-import org.apache.fluss.exception.InvalidServerRackInfoException;
 import org.apache.fluss.server.zk.data.BucketAssignment;
 import org.apache.fluss.server.zk.data.TableAssignment;
 
@@ -62,7 +61,7 @@ public class TableAssignmentUtils {
                             replicationFactor, servers.length));
         }
 
-        if (Arrays.stream(servers).noneMatch(tsInfo -> tsInfo.getRack() != null)) {
+        if (Arrays.stream(servers).anyMatch(tsInfo -> tsInfo.getRack() == null)) {
             return generateRackUnawareAssignment(
                     nBuckets,
                     replicationFactor,
@@ -70,13 +69,8 @@ public class TableAssignmentUtils {
                     startIndex,
                     nextReplicaShift);
         } else {
-            if (Arrays.stream(servers).anyMatch(tsInfo -> tsInfo.getRack() == null)) {
-                throw new InvalidServerRackInfoException(
-                        "Not all tabletServers have rack information for replica rack aware assignment.");
-            } else {
-                return generateRackAwareAssignment(
-                        nBuckets, replicationFactor, servers, startIndex, nextReplicaShift);
-            }
+            return generateRackAwareAssignment(
+                    nBuckets, replicationFactor, servers, startIndex, nextReplicaShift);
         }
     }
 
@@ -88,7 +82,8 @@ public class TableAssignmentUtils {
      *   <li>For buckets assigned to a particular tabletServer, their other replicas are spread over
      *       the other tabletServers.
      *   <li>If all tabletServers have rack information, assign the replicas for each bucket to
-     *       different racks if possible
+     *       different racks if possible. If any tabletServer has no rack information, fall back to
+     *       rack-unaware assignment to support rolling rack configuration updates.
      * </ol>
      *
      * <p>To achieve this goal for replica assignment, we:

--- a/fluss-server/src/test/java/org/apache/fluss/server/utils/TableAssignmentUtilsTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/utils/TableAssignmentUtilsTest.java
@@ -20,7 +20,6 @@ package org.apache.fluss.server.utils;
 import org.apache.fluss.cluster.TabletServerInfo;
 import org.apache.fluss.exception.InvalidBucketsException;
 import org.apache.fluss.exception.InvalidReplicationFactorException;
-import org.apache.fluss.exception.InvalidServerRackInfoException;
 import org.apache.fluss.server.zk.data.BucketAssignment;
 import org.apache.fluss.server.zk.data.TableAssignment;
 
@@ -468,7 +467,7 @@ class TableAssignmentUtilsTest {
     }
 
     @Test
-    void testPartialTabletServersHaveRackInfo() {
+    void testFallBackToRackUnawareAssignmentWhenRackInfoIsPartial() {
         Map<Integer, String> rackMap = new HashMap<>();
         rackMap.put(0, "rack1");
         rackMap.put(1, null);
@@ -476,13 +475,20 @@ class TableAssignmentUtilsTest {
         rackMap.put(3, null);
         rackMap.put(4, "rack3");
 
-        assertThatThrownBy(
-                        () ->
-                                generateAssignment(
-                                        6, 3, toTabletServerInfo(rackMap, Collections.emptyList())))
-                .isInstanceOf(InvalidServerRackInfoException.class)
-                .hasMessageContaining(
-                        "Not all tabletServers have rack information for replica rack aware assignment.");
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        6, 3, toTabletServerInfo(rackMap, Collections.emptyList()), 0, 0);
+        TableAssignment expectedAssignment =
+                TableAssignment.builder()
+                        .add(0, BucketAssignment.of(0, 1, 2))
+                        .add(1, BucketAssignment.of(1, 2, 3))
+                        .add(2, BucketAssignment.of(2, 3, 4))
+                        .add(3, BucketAssignment.of(3, 4, 0))
+                        .add(4, BucketAssignment.of(4, 0, 1))
+                        .add(5, BucketAssignment.of(0, 2, 3))
+                        .build();
+
+        assertThat(tableAssignment).isEqualTo(expectedAssignment);
     }
 
     private static void checkTableAssignment(

--- a/website/docs/maintenance/operations/racks.md
+++ b/website/docs/maintenance/operations/racks.md
@@ -16,7 +16,10 @@ tablet-server.rack: RACK1
 ```
 
 :::note
-1. If rack awareness is enabled, the `tablet-server.rack` setting must be configured for each TabletServer. Failure to do so will prevent Fluss from starting and will result in an exception being thrown.
+Rack-aware assignment is enabled only when every live TabletServer reports a `tablet-server.rack` value. If any live
+TabletServer has no rack information, new tables and partitions fall back to rack-unaware assignment. This makes it
+possible to add rack configuration with a rolling restart, but assignments created during the transition are not
+guaranteed to span racks and are not automatically rearranged afterward.
 :::
 
 When a table is created, the rack constraint is honored, ensuring that replicas are spread across as many racks as possible. 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #3945 

<!-- What is the purpose of the change -->

Rack-aware assignment currently fails when only some live `TabletServers` report rack information. This can block table and automatic partition creation while enabling rack awareness through a rolling restart.

Fall back to rack-unaware assignment whenever an eligible live `TabletServer` is missing rack information. Rack-aware assignment is automatically used once all eligible live TabletServers report a rack.

Add regression coverage for partial rack information and update the rack-aware deployment documentation.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
