### PR TITLE
[flink] Fix BETWEEN literal extraction in PredicateConverter

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/PredicateConverter.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/PredicateConverter.java
@@ -130,8 +130,12 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
         } else if (func == BuiltInFunctionDefinitions.BETWEEN) {
             FieldReferenceExpression fieldRefExpr =
                     extractFieldReference(children.get(0)).orElseThrow(UnsupportedExpression::new);
+            Object lowerBound =
+                    extractLiteral(fieldRefExpr.getOutputDataType(), children.get(1));
+            Object upperBound =
+                    extractLiteral(fieldRefExpr.getOutputDataType(), children.get(2));
             return builder.between(
-                    builder.indexOf(fieldRefExpr.getName()), children.get(1), children.get(2));
+                    builder.indexOf(fieldRefExpr.getName()), lowerBound, upperBound);
         } else if (func == BuiltInFunctionDefinitions.LIKE) {
             FieldReferenceExpression fieldRefExpr =
                     extractFieldReference(children.get(0)).orElseThrow(UnsupportedExpression::new);

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/utils/PredicateConverterTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/utils/PredicateConverterTest.java
@@ -72,6 +72,33 @@ public class PredicateConverterTest {
 
     private static final PredicateConverter CONVERTER = new PredicateConverter(BUILDER);
 
+    /**
+     * Stronger than toString equality: BETWEEN must evaluate against rows. The parameterized
+     * toString check can pass even when Flink {@code ValueLiteralExpression} nodes were stored as
+     * literals without {@code extractLiteral}.
+     */
+    @Test
+    public void testBetweenEvaluatesAgainstRow() {
+        FieldReferenceExpression longRefExpr =
+                new FieldReferenceExpression(
+                        "long1", DataTypes.BIGINT(), Integer.MAX_VALUE, Integer.MAX_VALUE);
+        CallExpression between =
+                CallExpression.permanent(
+                        BuiltInFunctionDefinitions.BETWEEN,
+                        Arrays.asList(
+                                longRefExpr,
+                                new ValueLiteralExpression(10),
+                                new ValueLiteralExpression(20)),
+                        DataTypes.BOOLEAN());
+
+        Predicate predicate = between.accept(CONVERTER);
+        assertThat(predicate.test(GenericRow.of(15L))).isTrue();
+        assertThat(predicate.test(GenericRow.of(10L))).isTrue();
+        assertThat(predicate.test(GenericRow.of(20L))).isTrue();
+        assertThat(predicate.test(GenericRow.of(9L))).isFalse();
+        assertThat(predicate.test(GenericRow.of(21L))).isFalse();
+    }
+
     @MethodSource("provideResolvedExpression")
     @ParameterizedTest
     public void testVisitAndAutoTypeInference(ResolvedExpression expression, Predicate expected) {
@@ -252,7 +279,7 @@ public class PredicateConverterTest {
                                 BuiltInFunctionDefinitions.BETWEEN,
                                 Arrays.asList(longRefExpr, intLitExpr, intLitExpr2),
                                 DataTypes.BOOLEAN()),
-                        BUILDER.between(0, 10, 20)));
+                        BUILDER.between(0, 10L, 20L)));
     }
 
     @MethodSource("provideLikeExpressions")


### PR DESCRIPTION
## Summary

Fix `PredicateConverter` handling of Flink `BETWEEN` so lower/upper bounds are real Java literals instead of unextracted `ValueLiteralExpression` nodes.

fix https://github.com/apache/fluss/issues/4000

Previously the converter did:

```java
builder.between(idx, children.get(1), children.get(2));
```

which stored Flink AST nodes as predicate literals. That made `toString()`-based assertions pass (because `ValueLiteralExpression.toString()` looks like `"10"`), while `predicate.test(row)` failed at runtime (`Unsupported type: BIGINT` in `CompareUtils.compareLiteral`).

This change extracts both bounds via `extractLiteral(...)`, consistent with `EQUALS` / `IN` / `LIKE`, and adds a row-evaluation test that would have caught the bug.

## Changes

- **`PredicateConverter`**: extract `BETWEEN` lower/upper bounds with `extractLiteral` before calling `builder.between`.
- **`PredicateConverterTest`**:
  - add `testBetweenEvaluatesAgainstRow` (`predicate.test(GenericRow...)`)
  - align parameterized expected bounds to `10L` / `20L` (BIGINT field + literal cast)

## Why the old test passed

The parameterized case only compared:

```text
converter.visit(BETWEEN).toString()
  ==
BUILDER.between(...).toString()
```

Both printed as something like:

```text
And([GreaterOrEqual(long1, 10), LessOrEqual(long1, 20)])
```

even though one side held `ValueLiteralExpression` objects and the other held numeric literals. String equality hid the type mismatch.

## Test plan

- [x] `./mvnw -pl fluss-flink/fluss-flink-common -am test -Dtest=PredicateConverterTest`
- [x] Confirm `testBetweenEvaluatesAgainstRow` fails on the unfixed code and passes after the fix