### PR TITLE
[FLUSS-3878] Fix unstable TableChangeWatcherTest.testTableRegistrationChange

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
@@ -424,6 +424,12 @@ class TableChangeWatcherTest {
         // verify TableRegistrationChangeEvent is generated
         expectedEvents.add(new TableRegistrationChangeEvent(tablePath, updatedTableRegistration));
 
+        retry(
+                Duration.ofMinutes(1),
+                () ->
+                        assertThat(eventManager.getEvents())
+                                .containsExactlyInAnyOrderElementsOf(expectedEvents));
+
         metadataManager.dropTable(tablePath, false);
         expectedEvents.add(new DropTableEvent(tableId, false, false));
 


### PR DESCRIPTION
### Purpose

Fixes #3878.

`testTableRegistrationChange` altered table properties and then immediately dropped the table before verifying that `TableChangeWatcher` had emitted the table registration change event. Since watcher events are processed asynchronously, the drop event could be observed while the registration change event was still missing, making the test flaky.

### Changes

Wait for the expected `TableRegistrationChangeEvent` after altering table properties before dropping the table.

### Tests

- `./mvnw -pl fluss-server -am -Dmaven.repo.local=.m2/repository -DfailIfNoTests=false -DskipITs -Dskip.archunit=true -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dtest=TableChangeWatcherTest#testTableRegistrationChange test`
- `./mvnw -pl fluss-server -am -Dmaven.repo.local=.m2/repository -DfailIfNoTests=false -DskipITs -Dskip.archunit=true -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dtest=TableChangeWatcherTest test`