### PR TITLE
[rust] Validate append_arrow_batch nullability before enqueue

### DIFF
--- a/fluss-rust/crates/fluss/src/client/table/append.rs
+++ b/fluss-rust/crates/fluss/src/client/table/append.rs
@@ -21,6 +21,7 @@ use crate::client::{WriteRecord, WriteResultFuture, WriterClient};
 use crate::error::Error::{IllegalArgument, UnexpectedError};
 use crate::error::Result;
 use crate::metadata::{PhysicalTablePath, TableInfo, TablePath};
+use crate::record::validate_append_record_batch;
 use crate::row::encode::{KeyEncoder, KeyEncoderFactory};
 use crate::row::{ColumnarRow, InternalRow};
 use arrow::array::{RecordBatch, UInt32Array};
@@ -174,6 +175,7 @@ impl AppendWriter {
             // Nothing to write; also avoids a keyless send to a bucket-key table.
             return Ok(WriteResultFuture::join(Vec::new()));
         }
+        validate_append_record_batch(&batch, self.table_info.row_type())?;
         let physical_table_path = if self.partition_getter.is_some() {
             let first_row = ColumnarRow::new(
                 Arc::new(batch.clone()),

--- a/fluss-rust/crates/fluss/src/record/arrow.rs
+++ b/fluss-rust/crates/fluss/src/record/arrow.rs
@@ -25,7 +25,7 @@ use crate::record::ScanRecord;
 use crate::row::column_vector::TypedBatch;
 use crate::row::column_writer::{ColumnWriter, round_up_to_8};
 use crate::row::{ColumnarRow, InternalRow};
-use arrow::array::{ArrayBuilder, ArrayRef, new_null_array};
+use arrow::array::{Array, ArrayBuilder, ArrayRef, new_null_array};
 use arrow::{
     array::RecordBatch,
     buffer::Buffer,
@@ -124,10 +124,20 @@ pub trait ArrowRecordBatchInnerBuilder: Send {
     fn estimated_size_in_bytes(&self) -> usize;
 }
 
-#[derive(Default)]
-pub struct PrebuiltRecordBatchBuilder {
+pub(crate) struct PrebuiltRecordBatchBuilder {
+    row_type: RowType,
     arrow_record_batch: Option<Arc<RecordBatch>>,
     records_count: i32,
+}
+
+impl PrebuiltRecordBatchBuilder {
+    fn new(row_type: RowType) -> Self {
+        Self {
+            row_type,
+            arrow_record_batch: None,
+            records_count: 0,
+        }
+    }
 }
 
 impl ArrowRecordBatchInnerBuilder for PrebuiltRecordBatchBuilder {
@@ -144,6 +154,7 @@ impl ArrowRecordBatchInnerBuilder for PrebuiltRecordBatchBuilder {
         if self.arrow_record_batch.is_some() {
             return Ok(false);
         }
+        validate_append_record_batch(record_batch.as_ref(), &self.row_type)?;
         self.records_count = record_batch.num_rows() as i32;
         self.arrow_record_batch = Some(record_batch);
         Ok(true)
@@ -291,7 +302,7 @@ impl MemoryLogRecordsArrowBuilder {
         } = config;
         let arrow_batch_builder: Box<dyn ArrowRecordBatchInnerBuilder> = {
             if to_append_record_batch {
-                Box::new(PrebuiltRecordBatchBuilder::default())
+                Box::new(PrebuiltRecordBatchBuilder::new(row_type.clone()))
             } else {
                 Box::new(RowAppendRecordBatchBuilder::new(&row_type)?)
             }
@@ -674,6 +685,11 @@ fn parse_ipc_message(
     let body_buffer = Buffer::from(body_data);
 
     Ok((batch_metadata, body_buffer, message.version()))
+}
+
+pub(crate) fn validate_append_record_batch(batch: &RecordBatch, row_type: &RowType) -> Result<()> {
+    let typed = TypedBatch::build(batch, row_type)?;
+    typed.check_not_null(row_type)
 }
 
 pub fn to_arrow_schema(fluss_schema: &RowType) -> Result<SchemaRef> {
@@ -1423,6 +1439,748 @@ mod tests {
                 .expect("build should succeed for NOT NULL column");
             assert!(!bytes.is_empty());
         }
+    }
+
+    #[test]
+    fn validate_append_record_batch_rejects_nulls_in_not_null_column() {
+        let row_type = RowType::new(vec![DataField::new(
+            "id",
+            DataTypes::bigint().as_non_nullable(),
+            None,
+        )]);
+
+        // Caller marks the Arrow field nullable (common from pyarrow) and includes a null.
+        let poison = single_col_batch(
+            "id",
+            Arc::new(arrow::array::Int64Array::from(vec![
+                Some(1_i64),
+                None,
+                Some(3_i64),
+            ])),
+        );
+        let ok_batch = single_col_batch(
+            "id",
+            Arc::new(arrow::array::Int64Array::from(vec![1_i64, 2_i64])),
+        );
+        assert_rejects_null_in_not_null(&row_type, &poison, &ok_batch);
+    }
+
+    #[test]
+    fn prebuilt_builder_rejects_nulls_in_not_null_column() {
+        let row_type = RowType::new(vec![DataField::new(
+            "id",
+            DataTypes::bigint().as_non_nullable(),
+            None,
+        )]);
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let table_info = Arc::new(build_table_info(table_path.clone(), 1, 1));
+        let physical_table_path = Arc::new(PhysicalTablePath::of(Arc::new(table_path)));
+
+        let mut builder = MemoryLogRecordsArrowBuilder::new(
+            uncompressed_arrow_batch_config(1, &row_type, usize::MAX),
+            true,
+        )
+        .expect("NOT NULL prebuilt builder should construct");
+
+        let batch_schema = Arc::new(arrow_schema::Schema::new(vec![Field::new(
+            "id",
+            arrow_schema::DataType::Int64,
+            true,
+        )]));
+        let poison = RecordBatch::try_new(
+            batch_schema,
+            vec![
+                Arc::new(arrow::array::Int64Array::from(vec![Some(1_i64), None]))
+                    as arrow::array::ArrayRef,
+            ],
+        )
+        .expect("poison batch");
+        let record = WriteRecord::for_append_record_batch(
+            Arc::clone(&table_info),
+            physical_table_path,
+            1,
+            poison,
+        );
+        assert_not_null_violation(
+            builder
+                .append(&record)
+                .expect_err("prebuilt append must reject null in NOT NULL"),
+        );
+    }
+
+    fn assert_not_null_violation(err: impl std::fmt::Display) {
+        let text = err.to_string();
+        assert!(
+            text.contains("declared as non-nullable but contains null values"),
+            "unexpected error: {text}"
+        );
+    }
+
+    fn single_col_batch(name: &str, array: ArrayRef) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(arrow_schema::Schema::new(vec![Field::new(
+                name,
+                array.data_type().clone(),
+                true,
+            )])),
+            vec![array],
+        )
+        .expect("single-column batch")
+    }
+
+    fn assert_rejects_null_in_not_null(row_type: &RowType, poison: &RecordBatch, ok: &RecordBatch) {
+        assert_not_null_violation(
+            validate_append_record_batch(poison, row_type)
+                .expect_err("null in NOT NULL nested column must be rejected"),
+        );
+        validate_append_record_batch(ok, row_type)
+            .expect("null-free nested batch must be accepted");
+    }
+
+    fn list_array(values: ArrayRef, offsets: Vec<i32>, validity: Option<Vec<bool>>) -> ArrayRef {
+        use arrow::array::ListArray;
+        use arrow::buffer::{NullBuffer, OffsetBuffer};
+
+        Arc::new(ListArray::new(
+            Arc::new(Field::new("item", values.data_type().clone(), true)),
+            OffsetBuffer::new(offsets.into()),
+            values,
+            validity.map(NullBuffer::from),
+        ))
+    }
+
+    fn list_int_array(
+        values: Vec<Option<i32>>,
+        offsets: Vec<i32>,
+        validity: Option<Vec<bool>>,
+    ) -> ArrayRef {
+        list_array(
+            Arc::new(arrow::array::Int32Array::from(values)),
+            offsets,
+            validity,
+        )
+    }
+
+    fn map_string_array(
+        keys: Vec<&str>,
+        values: ArrayRef,
+        offsets: Vec<i32>,
+        validity: Option<Vec<bool>>,
+    ) -> ArrayRef {
+        use arrow::array::{MapArray, StringArray, StructArray};
+        use arrow::buffer::{NullBuffer, OffsetBuffer};
+
+        let key_field = Arc::new(Field::new("key", ArrowDataType::Utf8, false));
+        let value_field = Arc::new(Field::new("value", values.data_type().clone(), true));
+        let entries = StructArray::from(vec![
+            (key_field, Arc::new(StringArray::from(keys)) as ArrayRef),
+            (value_field, values),
+        ]);
+        Arc::new(MapArray::new(
+            Arc::new(Field::new("entries", entries.data_type().clone(), false)),
+            OffsetBuffer::new(offsets.into()),
+            entries,
+            validity.map(NullBuffer::from),
+            false,
+        ))
+    }
+
+    fn map_string_int_array(
+        keys: Vec<&str>,
+        values: Vec<Option<i32>>,
+        offsets: Vec<i32>,
+        validity: Option<Vec<bool>>,
+    ) -> ArrayRef {
+        map_string_array(
+            keys,
+            Arc::new(arrow::array::Int32Array::from(values)),
+            offsets,
+            validity,
+        )
+    }
+
+    fn struct_with_field(name: &str, child: ArrayRef, validity: Option<Vec<bool>>) -> ArrayRef {
+        use arrow::array::StructArray;
+        use arrow::buffer::NullBuffer;
+
+        let fields =
+            arrow_schema::Fields::from(vec![Field::new(name, child.data_type().clone(), true)]);
+        Arc::new(StructArray::new(
+            fields,
+            vec![child],
+            validity.map(NullBuffer::from),
+        ))
+    }
+
+    fn struct_int_string_array(
+        seq: Vec<Option<i32>>,
+        label: Vec<Option<&str>>,
+        validity: Option<Vec<bool>>,
+    ) -> ArrayRef {
+        use arrow::array::{StringArray, StructArray};
+        use arrow::buffer::NullBuffer;
+
+        let fields = arrow_schema::Fields::from(vec![
+            Field::new("seq", ArrowDataType::Int32, true),
+            Field::new("label", ArrowDataType::Utf8, true),
+        ]);
+        Arc::new(StructArray::new(
+            fields,
+            vec![
+                Arc::new(arrow::array::Int32Array::from(seq)) as ArrayRef,
+                Arc::new(StringArray::from(label)) as ArrayRef,
+            ],
+            validity.map(NullBuffer::from),
+        ))
+    }
+
+    fn assert_full_and_sliced_not_null(row_type: &RowType, poison: &RecordBatch, ok: &RecordBatch) {
+        assert_rejects_null_in_not_null(row_type, poison, ok);
+        validate_append_record_batch(&poison.slice(1, 1), row_type)
+            .expect("sliced-away nested null must not reject the live rows");
+        assert_not_null_violation(
+            validate_append_record_batch(&poison.slice(0, 1), row_type)
+                .expect_err("live slice that still contains the nested null must reject"),
+        );
+    }
+
+    #[test]
+    fn validate_append_record_batch_rejects_null_nested_container() {
+        // Only the container is null here; the element type is nullable.
+        let array_type = RowType::new(vec![DataField::new(
+            "tags",
+            DataTypes::array(DataTypes::int()).as_non_nullable(),
+            None,
+        )]);
+        assert_rejects_null_in_not_null(
+            &array_type,
+            &single_col_batch(
+                "tags",
+                list_int_array(
+                    vec![Some(1), Some(2)],
+                    vec![0, 2, 2],
+                    Some(vec![true, false]),
+                ),
+            ),
+            &single_col_batch(
+                "tags",
+                list_int_array(vec![Some(1), Some(2), Some(3)], vec![0, 2, 3], None),
+            ),
+        );
+    }
+
+    #[test]
+    fn validate_append_record_batch_allows_null_elements_in_not_null_array() {
+        let row_type = RowType::new(vec![DataField::new(
+            "tags",
+            DataTypes::array(DataTypes::int()).as_non_nullable(),
+            None,
+        )]);
+        let batch = single_col_batch(
+            "tags",
+            list_int_array(vec![Some(1), None, Some(3)], vec![0, 3], None),
+        );
+        validate_append_record_batch(&batch, &row_type)
+            .expect("null elements in a non-null ARRAY value must be accepted");
+    }
+
+    #[test]
+    fn validate_append_record_batch_rejects_nulls_inside_not_null_nested_fields() {
+        let array_type = RowType::new(vec![DataField::new(
+            "tags",
+            DataTypes::array(DataTypes::int().as_non_nullable()).as_non_nullable(),
+            None,
+        )]);
+        assert_rejects_null_in_not_null(
+            &array_type,
+            &single_col_batch(
+                "tags",
+                list_int_array(vec![Some(1), None, Some(3)], vec![0, 3], None),
+            ),
+            &single_col_batch(
+                "tags",
+                list_int_array(vec![Some(1), Some(2), Some(3)], vec![0, 3], None),
+            ),
+        );
+
+        let map_type = RowType::new(vec![DataField::new(
+            "attrs",
+            DataTypes::map(DataTypes::string(), DataTypes::int().as_non_nullable())
+                .as_non_nullable(),
+            None,
+        )]);
+        assert_rejects_null_in_not_null(
+            &map_type,
+            &single_col_batch(
+                "attrs",
+                map_string_int_array(vec!["a", "b"], vec![Some(1), None], vec![0, 2], None),
+            ),
+            &single_col_batch(
+                "attrs",
+                map_string_int_array(vec!["a", "b"], vec![Some(1), Some(2)], vec![0, 2], None),
+            ),
+        );
+
+        let row_col_type = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![
+                DataField::new("seq", DataTypes::int().as_non_nullable(), None),
+                DataField::new("label", DataTypes::string(), None),
+            ])
+            .as_non_nullable(),
+            None,
+        )]);
+        assert_rejects_null_in_not_null(
+            &row_col_type,
+            &single_col_batch(
+                "nested",
+                struct_int_string_array(vec![Some(1), None], vec![Some("x"), Some("y")], None),
+            ),
+            &single_col_batch(
+                "nested",
+                struct_int_string_array(vec![Some(1), Some(2)], vec![Some("x"), Some("y")], None),
+            ),
+        );
+    }
+
+    #[test]
+    fn validate_append_record_batch_allows_null_parent_with_not_null_child() {
+        let row_col_type = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![
+                DataField::new("seq", DataTypes::int().as_non_nullable(), None),
+                DataField::new("label", DataTypes::string(), None),
+            ]),
+            None,
+        )]);
+        let batch = single_col_batch(
+            "nested",
+            struct_int_string_array(vec![None], vec![None], Some(vec![false])),
+        );
+        validate_append_record_batch(&batch, &row_col_type).expect(
+            "null ROW value must be accepted when the row column is nullable even if seq is NOT NULL",
+        );
+
+        let nested_row_type = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![DataField::new(
+                "inner",
+                DataTypes::row(vec![DataField::new(
+                    "seq",
+                    DataTypes::int().as_non_nullable(),
+                    None,
+                )]),
+                None,
+            )]),
+            None,
+        )]);
+        let nested_row = |outer_valid| {
+            struct_with_field(
+                "inner",
+                struct_with_field(
+                    "seq",
+                    Arc::new(arrow::array::Int32Array::from(vec![None])) as ArrayRef,
+                    None,
+                ),
+                Some(vec![outer_valid]),
+            )
+        };
+        validate_append_record_batch(
+            &single_col_batch("nested", nested_row(false)),
+            &nested_row_type,
+        )
+        .expect("null outer ROW must mask leftover poison in a valid inner ROW");
+        assert_not_null_violation(
+            validate_append_record_batch(
+                &single_col_batch("nested", nested_row(true)),
+                &nested_row_type,
+            )
+            .expect_err("inner ROW poison under a live outer ROW must reject"),
+        );
+
+        // An empty child range under a null list is the usual builder layout.
+        let array_type = RowType::new(vec![DataField::new(
+            "tags",
+            DataTypes::array(DataTypes::int().as_non_nullable()),
+            None,
+        )]);
+        validate_append_record_batch(
+            &single_col_batch(
+                "tags",
+                list_int_array(vec![Some(1)], vec![0, 0, 1], Some(vec![false, true])),
+            ),
+            &array_type,
+        )
+        .expect("null ARRAY with empty leftover range must be accepted");
+        validate_append_record_batch(
+            &single_col_batch(
+                "tags",
+                list_int_array(vec![None, Some(1)], vec![0, 1, 2], Some(vec![false, true])),
+            ),
+            &array_type,
+        )
+        .expect("null ARRAY leftover values() slots must not count as live elements");
+
+        let map_type = RowType::new(vec![DataField::new(
+            "attrs",
+            DataTypes::map(DataTypes::string(), DataTypes::int().as_non_nullable()),
+            None,
+        )]);
+        validate_append_record_batch(
+            &single_col_batch(
+                "attrs",
+                map_string_int_array(
+                    vec!["a"],
+                    vec![Some(1)],
+                    vec![0, 0, 1],
+                    Some(vec![false, true]),
+                ),
+            ),
+            &map_type,
+        )
+        .expect("null MAP with empty leftover range must be accepted");
+        validate_append_record_batch(
+            &single_col_batch(
+                "attrs",
+                map_string_int_array(
+                    vec!["x", "a"],
+                    vec![None, Some(1)],
+                    vec![0, 1, 2],
+                    Some(vec![false, true]),
+                ),
+            ),
+            &map_type,
+        )
+        .expect("null MAP leftover values() slots must not count as live entries");
+
+        // Nested child under a null container: leftover ROW field / inner-list
+        // element poison must not reject. The same poison on a live row must.
+        let array_of_row = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::array(DataTypes::row(vec![
+                DataField::new("seq", DataTypes::int().as_non_nullable(), None),
+                DataField::new("label", DataTypes::string(), None),
+            ])),
+            None,
+        )]);
+        validate_append_record_batch(
+            &single_col_batch(
+                "nested",
+                list_array(
+                    struct_int_string_array(vec![None, Some(2)], vec![Some("x"), Some("y")], None),
+                    vec![0, 1, 2],
+                    Some(vec![false, true]),
+                ),
+            ),
+            &array_of_row,
+        )
+        .expect("leftover ROW field poison under a null list must be accepted");
+        assert_not_null_violation(
+            validate_append_record_batch(
+                &single_col_batch(
+                    "nested",
+                    list_array(
+                        struct_int_string_array(
+                            vec![None, Some(2)],
+                            vec![Some("x"), Some("y")],
+                            None,
+                        ),
+                        vec![0, 1, 2],
+                        Some(vec![true, false]),
+                    ),
+                ),
+                &array_of_row,
+            )
+            .expect_err("ROW field poison on the live list must reject"),
+        );
+
+        let array_of_array = RowType::new(vec![DataField::new(
+            "tags",
+            DataTypes::array(DataTypes::array(DataTypes::int().as_non_nullable())),
+            None,
+        )]);
+        validate_append_record_batch(
+            &single_col_batch(
+                "tags",
+                list_array(
+                    list_int_array(vec![None, Some(1)], vec![0, 1, 2], None),
+                    vec![0, 1, 2],
+                    Some(vec![false, true]),
+                ),
+            ),
+            &array_of_array,
+        )
+        .expect("leftover inner-list poison under a null outer list must be accepted");
+    }
+
+    #[test]
+    fn validate_append_record_batch_ignores_nulls_in_sliced_away_nested_values() {
+        let array_type = RowType::new(vec![DataField::new(
+            "tags",
+            DataTypes::array(DataTypes::int().as_non_nullable()).as_non_nullable(),
+            None,
+        )]);
+        let lists = single_col_batch(
+            "tags",
+            list_int_array(
+                vec![Some(1), None, Some(3), Some(4), Some(5)],
+                vec![0, 3, 5],
+                None,
+            ),
+        );
+        validate_append_record_batch(&lists.slice(1, 1), &array_type)
+            .expect("sliced-away ARRAY element nulls must not reject the live rows");
+        assert_not_null_violation(
+            validate_append_record_batch(&lists.slice(0, 1), &array_type)
+                .expect_err("live slice that still contains the element null must reject"),
+        );
+
+        let map_type = RowType::new(vec![DataField::new(
+            "attrs",
+            DataTypes::map(DataTypes::string(), DataTypes::int().as_non_nullable())
+                .as_non_nullable(),
+            None,
+        )]);
+        let maps = single_col_batch(
+            "attrs",
+            map_string_int_array(
+                vec!["a", "b", "c"],
+                vec![Some(1), None, Some(2)],
+                vec![0, 2, 3],
+                None,
+            ),
+        );
+        validate_append_record_batch(&maps.slice(1, 1), &map_type)
+            .expect("sliced-away MAP value nulls must not reject the live rows");
+        assert_not_null_violation(
+            validate_append_record_batch(&maps.slice(0, 1), &map_type)
+                .expect_err("live slice that still contains the map value null must reject"),
+        );
+
+        let row_col_type = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![
+                DataField::new("seq", DataTypes::int().as_non_nullable(), None),
+                DataField::new("label", DataTypes::string(), None),
+            ])
+            .as_non_nullable(),
+            None,
+        )]);
+        let structs = single_col_batch(
+            "nested",
+            struct_int_string_array(vec![None, Some(2)], vec![Some("x"), Some("y")], None),
+        );
+        validate_append_record_batch(&structs.slice(1, 1), &row_col_type)
+            .expect("sliced-away ROW field nulls must not reject the live rows");
+        assert_not_null_violation(
+            validate_append_record_batch(&structs.slice(0, 1), &row_col_type)
+                .expect_err("live slice that still contains the ROW field null must reject"),
+        );
+    }
+
+    #[test]
+    fn validate_append_record_batch_ignores_leftover_nested_poison_under_null_row() {
+        // A null ROW row can still leave non-null child container data behind.
+        // That leftover is dead (the row is null) and must not false-reject.
+        let array_field = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![DataField::new(
+                "tags",
+                DataTypes::array(DataTypes::int().as_non_nullable()),
+                None,
+            )]),
+            None,
+        )]);
+        validate_append_record_batch(
+            &single_col_batch(
+                "nested",
+                struct_with_field(
+                    "tags",
+                    list_int_array(vec![Some(1), None, Some(2), Some(3)], vec![0, 2, 4], None),
+                    Some(vec![false, true]),
+                ),
+            ),
+            &array_field,
+        )
+        .expect("leftover ARRAY poison under a null ROW row must be accepted");
+        // Sanity: same poison on the live row still rejects.
+        assert_not_null_violation(
+            validate_append_record_batch(
+                &single_col_batch(
+                    "nested",
+                    struct_with_field(
+                        "tags",
+                        list_int_array(vec![Some(1), None, Some(2), Some(3)], vec![0, 2, 4], None),
+                        Some(vec![true, false]),
+                    ),
+                ),
+                &array_field,
+            )
+            .expect_err("poison element on the live ROW row must reject"),
+        );
+
+        let map_field = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![DataField::new(
+                "attrs",
+                DataTypes::map(DataTypes::string(), DataTypes::int().as_non_nullable()),
+                None,
+            )]),
+            None,
+        )]);
+        validate_append_record_batch(
+            &single_col_batch(
+                "nested",
+                struct_with_field(
+                    "attrs",
+                    map_string_int_array(
+                        vec!["a", "b", "c", "d"],
+                        vec![Some(1), None, Some(2), Some(3)],
+                        vec![0, 2, 4],
+                        None,
+                    ),
+                    Some(vec![false, true]),
+                ),
+            ),
+            &map_field,
+        )
+        .expect("leftover MAP poison under a null ROW row must be accepted");
+    }
+
+    #[test]
+    fn validate_append_record_batch_nested_nested_nullability() {
+        // One case per pair of nested containers.
+        let array_of_array = RowType::new(vec![DataField::new(
+            "tags",
+            DataTypes::array(DataTypes::array(DataTypes::int().as_non_nullable()))
+                .as_non_nullable(),
+            None,
+        )]);
+        assert_full_and_sliced_not_null(
+            &array_of_array,
+            &single_col_batch(
+                "tags",
+                list_array(
+                    list_int_array(vec![Some(1), None, Some(4), Some(5)], vec![0, 2, 4], None),
+                    vec![0, 1, 2],
+                    None,
+                ),
+            ),
+            &single_col_batch(
+                "tags",
+                list_array(
+                    list_int_array(
+                        vec![Some(1), Some(2), Some(4), Some(5)],
+                        vec![0, 2, 4],
+                        None,
+                    ),
+                    vec![0, 1, 2],
+                    None,
+                ),
+            ),
+        );
+
+        let row_of_array = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![DataField::new(
+                "tags",
+                DataTypes::array(DataTypes::int().as_non_nullable()),
+                None,
+            )])
+            .as_non_nullable(),
+            None,
+        )]);
+        assert_full_and_sliced_not_null(
+            &row_of_array,
+            &single_col_batch(
+                "nested",
+                struct_with_field(
+                    "tags",
+                    list_int_array(vec![Some(1), None, Some(4), Some(5)], vec![0, 2, 4], None),
+                    None,
+                ),
+            ),
+            &single_col_batch(
+                "nested",
+                struct_with_field(
+                    "tags",
+                    list_int_array(
+                        vec![Some(1), Some(2), Some(4), Some(5)],
+                        vec![0, 2, 4],
+                        None,
+                    ),
+                    None,
+                ),
+            ),
+        );
+
+        let array_of_row = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::array(DataTypes::row(vec![
+                DataField::new("seq", DataTypes::int().as_non_nullable(), None),
+                DataField::new("label", DataTypes::string(), None),
+            ]))
+            .as_non_nullable(),
+            None,
+        )]);
+        assert_full_and_sliced_not_null(
+            &array_of_row,
+            &single_col_batch(
+                "nested",
+                list_array(
+                    struct_int_string_array(vec![None, Some(2)], vec![Some("x"), Some("y")], None),
+                    vec![0, 1, 2],
+                    None,
+                ),
+            ),
+            &single_col_batch(
+                "nested",
+                list_array(
+                    struct_int_string_array(
+                        vec![Some(1), Some(2)],
+                        vec![Some("x"), Some("y")],
+                        None,
+                    ),
+                    vec![0, 1, 2],
+                    None,
+                ),
+            ),
+        );
+
+        let map_of_array = RowType::new(vec![DataField::new(
+            "attrs",
+            DataTypes::map(
+                DataTypes::string(),
+                DataTypes::array(DataTypes::int().as_non_nullable()),
+            )
+            .as_non_nullable(),
+            None,
+        )]);
+        assert_full_and_sliced_not_null(
+            &map_of_array,
+            &single_col_batch(
+                "attrs",
+                map_string_array(
+                    vec!["a", "b"],
+                    list_int_array(vec![Some(1), None, Some(4), Some(5)], vec![0, 2, 4], None),
+                    vec![0, 1, 2],
+                    None,
+                ),
+            ),
+            &single_col_batch(
+                "attrs",
+                map_string_array(
+                    vec!["a", "b"],
+                    list_int_array(
+                        vec![Some(1), Some(2), Some(4), Some(5)],
+                        vec![0, 2, 4],
+                        None,
+                    ),
+                    vec![0, 1, 2],
+                    None,
+                ),
+            ),
+        );
     }
 
     fn single_int_read_context() -> (ReadContext, SchemaRef) {

--- a/fluss-rust/crates/fluss/src/record/arrow.rs
+++ b/fluss-rust/crates/fluss/src/record/arrow.rs
@@ -514,34 +514,18 @@ impl MemoryLogRecordsArrowBuilder {
     }
 
     fn write_batch_header(&self, buffer: &mut [u8], statistics_length: usize) -> Result<()> {
-        let total_len = buffer.len();
-        let mut cursor = Cursor::new(buffer);
-        cursor.write_i64::<LittleEndian>(self.base_log_offset)?;
-        cursor
-            .write_i32::<LittleEndian>((total_len - BASE_OFFSET_LENGTH - LENGTH_LENGTH) as i32)?;
-        cursor.write_u8(self.magic)?;
-        cursor.write_i64::<LittleEndian>(0)?; // timestamp placeholder
-        cursor.write_u32::<LittleEndian>(0)?; // crc placeholder
-        cursor.write_i16::<LittleEndian>(self.schema_id as i16)?;
-
-        let record_count = self.arrow_record_batch_builder.records_count();
-        // todo: curerntly, always is append only
-        let append_only = true;
-        cursor.write_u8(if append_only { 1 } else { 0 })?;
-        cursor.write_i32::<LittleEndian>(if record_count > 0 {
-            record_count - 1
-        } else {
-            0
-        })?;
-
-        cursor.write_i64::<LittleEndian>(self.writer_id)?;
-        cursor.write_i32::<LittleEndian>(self.batch_sequence)?;
-        cursor.write_i32::<LittleEndian>(record_count)?;
-
-        if self.magic >= LOG_MAGIC_VALUE_V1 {
-            cursor.write_i32::<LittleEndian>(statistics_length as i32)?;
-        }
-        Ok(())
+        write_batch_header_fields(
+            buffer,
+            BatchHeaderFields {
+                base_log_offset: self.base_log_offset,
+                magic: self.magic,
+                schema_id: self.schema_id,
+                writer_id: self.writer_id,
+                batch_sequence: self.batch_sequence,
+                record_count: self.arrow_record_batch_builder.records_count(),
+                statistics_length,
+            },
+        )
     }
 
     pub fn set_writer_state(&mut self, writer_id: i64, batch_base_sequence: i32) {
@@ -690,6 +674,51 @@ fn parse_ipc_message(
 pub(crate) fn validate_append_record_batch(batch: &RecordBatch, row_type: &RowType) -> Result<()> {
     let typed = TypedBatch::build(batch, row_type)?;
     typed.check_not_null(row_type)
+}
+
+/// The fixed fields of a log record batch header.
+pub(crate) struct BatchHeaderFields {
+    pub base_log_offset: i64,
+    pub magic: u8,
+    pub schema_id: i32,
+    pub writer_id: i64,
+    pub batch_sequence: i32,
+    pub record_count: i32,
+    /// Only written for V1 and above.
+    pub statistics_length: usize,
+}
+
+/// `buffer` must be the whole batch. Timestamp and CRC are left for the caller.
+pub(crate) fn write_batch_header_fields(
+    buffer: &mut [u8],
+    fields: BatchHeaderFields,
+) -> Result<()> {
+    let total_len = buffer.len();
+    let mut cursor = Cursor::new(buffer);
+    cursor.write_i64::<LittleEndian>(fields.base_log_offset)?;
+    cursor.write_i32::<LittleEndian>((total_len - BASE_OFFSET_LENGTH - LENGTH_LENGTH) as i32)?;
+    cursor.write_u8(fields.magic)?;
+    cursor.write_i64::<LittleEndian>(0)?; // timestamp placeholder
+    cursor.write_u32::<LittleEndian>(0)?; // crc placeholder
+    cursor.write_i16::<LittleEndian>(fields.schema_id as i16)?;
+
+    // todo: curerntly, always is append only
+    let append_only = true;
+    cursor.write_u8(if append_only { 1 } else { 0 })?;
+    cursor.write_i32::<LittleEndian>(if fields.record_count > 0 {
+        fields.record_count - 1
+    } else {
+        0
+    })?;
+
+    cursor.write_i64::<LittleEndian>(fields.writer_id)?;
+    cursor.write_i32::<LittleEndian>(fields.batch_sequence)?;
+    cursor.write_i32::<LittleEndian>(fields.record_count)?;
+
+    if fields.magic >= LOG_MAGIC_VALUE_V1 {
+        cursor.write_i32::<LittleEndian>(fields.statistics_length as i32)?;
+    }
+    Ok(())
 }
 
 pub fn to_arrow_schema(fluss_schema: &RowType) -> Result<SchemaRef> {
@@ -1744,176 +1773,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_append_record_batch_allows_null_parent_with_not_null_child() {
-        let row_col_type = RowType::new(vec![DataField::new(
-            "nested",
-            DataTypes::row(vec![
-                DataField::new("seq", DataTypes::int().as_non_nullable(), None),
-                DataField::new("label", DataTypes::string(), None),
-            ]),
-            None,
-        )]);
-        let batch = single_col_batch(
-            "nested",
-            struct_int_string_array(vec![None], vec![None], Some(vec![false])),
-        );
-        validate_append_record_batch(&batch, &row_col_type).expect(
-            "null ROW value must be accepted when the row column is nullable even if seq is NOT NULL",
-        );
-
-        let nested_row_type = RowType::new(vec![DataField::new(
-            "nested",
-            DataTypes::row(vec![DataField::new(
-                "inner",
-                DataTypes::row(vec![DataField::new(
-                    "seq",
-                    DataTypes::int().as_non_nullable(),
-                    None,
-                )]),
-                None,
-            )]),
-            None,
-        )]);
-        let nested_row = |outer_valid| {
-            struct_with_field(
-                "inner",
-                struct_with_field(
-                    "seq",
-                    Arc::new(arrow::array::Int32Array::from(vec![None])) as ArrayRef,
-                    None,
-                ),
-                Some(vec![outer_valid]),
-            )
-        };
-        validate_append_record_batch(
-            &single_col_batch("nested", nested_row(false)),
-            &nested_row_type,
-        )
-        .expect("null outer ROW must mask leftover poison in a valid inner ROW");
-        assert_not_null_violation(
-            validate_append_record_batch(
-                &single_col_batch("nested", nested_row(true)),
-                &nested_row_type,
-            )
-            .expect_err("inner ROW poison under a live outer ROW must reject"),
-        );
-
-        // An empty child range under a null list is the usual builder layout.
-        let array_type = RowType::new(vec![DataField::new(
-            "tags",
-            DataTypes::array(DataTypes::int().as_non_nullable()),
-            None,
-        )]);
-        validate_append_record_batch(
-            &single_col_batch(
-                "tags",
-                list_int_array(vec![Some(1)], vec![0, 0, 1], Some(vec![false, true])),
-            ),
-            &array_type,
-        )
-        .expect("null ARRAY with empty leftover range must be accepted");
-        validate_append_record_batch(
-            &single_col_batch(
-                "tags",
-                list_int_array(vec![None, Some(1)], vec![0, 1, 2], Some(vec![false, true])),
-            ),
-            &array_type,
-        )
-        .expect("null ARRAY leftover values() slots must not count as live elements");
-
-        let map_type = RowType::new(vec![DataField::new(
-            "attrs",
-            DataTypes::map(DataTypes::string(), DataTypes::int().as_non_nullable()),
-            None,
-        )]);
-        validate_append_record_batch(
-            &single_col_batch(
-                "attrs",
-                map_string_int_array(
-                    vec!["a"],
-                    vec![Some(1)],
-                    vec![0, 0, 1],
-                    Some(vec![false, true]),
-                ),
-            ),
-            &map_type,
-        )
-        .expect("null MAP with empty leftover range must be accepted");
-        validate_append_record_batch(
-            &single_col_batch(
-                "attrs",
-                map_string_int_array(
-                    vec!["x", "a"],
-                    vec![None, Some(1)],
-                    vec![0, 1, 2],
-                    Some(vec![false, true]),
-                ),
-            ),
-            &map_type,
-        )
-        .expect("null MAP leftover values() slots must not count as live entries");
-
-        // Nested child under a null container: leftover ROW field / inner-list
-        // element poison must not reject. The same poison on a live row must.
-        let array_of_row = RowType::new(vec![DataField::new(
-            "nested",
-            DataTypes::array(DataTypes::row(vec![
-                DataField::new("seq", DataTypes::int().as_non_nullable(), None),
-                DataField::new("label", DataTypes::string(), None),
-            ])),
-            None,
-        )]);
-        validate_append_record_batch(
-            &single_col_batch(
-                "nested",
-                list_array(
-                    struct_int_string_array(vec![None, Some(2)], vec![Some("x"), Some("y")], None),
-                    vec![0, 1, 2],
-                    Some(vec![false, true]),
-                ),
-            ),
-            &array_of_row,
-        )
-        .expect("leftover ROW field poison under a null list must be accepted");
-        assert_not_null_violation(
-            validate_append_record_batch(
-                &single_col_batch(
-                    "nested",
-                    list_array(
-                        struct_int_string_array(
-                            vec![None, Some(2)],
-                            vec![Some("x"), Some("y")],
-                            None,
-                        ),
-                        vec![0, 1, 2],
-                        Some(vec![true, false]),
-                    ),
-                ),
-                &array_of_row,
-            )
-            .expect_err("ROW field poison on the live list must reject"),
-        );
-
-        let array_of_array = RowType::new(vec![DataField::new(
-            "tags",
-            DataTypes::array(DataTypes::array(DataTypes::int().as_non_nullable())),
-            None,
-        )]);
-        validate_append_record_batch(
-            &single_col_batch(
-                "tags",
-                list_array(
-                    list_int_array(vec![None, Some(1)], vec![0, 1, 2], None),
-                    vec![0, 1, 2],
-                    Some(vec![false, true]),
-                ),
-            ),
-            &array_of_array,
-        )
-        .expect("leftover inner-list poison under a null outer list must be accepted");
-    }
-
-    #[test]
     fn validate_append_record_batch_ignores_nulls_in_sliced_away_nested_values() {
         let array_type = RowType::new(vec![DataField::new(
             "tags",
@@ -1976,75 +1835,6 @@ mod tests {
             validate_append_record_batch(&structs.slice(0, 1), &row_col_type)
                 .expect_err("live slice that still contains the ROW field null must reject"),
         );
-    }
-
-    #[test]
-    fn validate_append_record_batch_ignores_leftover_nested_poison_under_null_row() {
-        // A null ROW row can still leave non-null child container data behind.
-        // That leftover is dead (the row is null) and must not false-reject.
-        let array_field = RowType::new(vec![DataField::new(
-            "nested",
-            DataTypes::row(vec![DataField::new(
-                "tags",
-                DataTypes::array(DataTypes::int().as_non_nullable()),
-                None,
-            )]),
-            None,
-        )]);
-        validate_append_record_batch(
-            &single_col_batch(
-                "nested",
-                struct_with_field(
-                    "tags",
-                    list_int_array(vec![Some(1), None, Some(2), Some(3)], vec![0, 2, 4], None),
-                    Some(vec![false, true]),
-                ),
-            ),
-            &array_field,
-        )
-        .expect("leftover ARRAY poison under a null ROW row must be accepted");
-        // Sanity: same poison on the live row still rejects.
-        assert_not_null_violation(
-            validate_append_record_batch(
-                &single_col_batch(
-                    "nested",
-                    struct_with_field(
-                        "tags",
-                        list_int_array(vec![Some(1), None, Some(2), Some(3)], vec![0, 2, 4], None),
-                        Some(vec![true, false]),
-                    ),
-                ),
-                &array_field,
-            )
-            .expect_err("poison element on the live ROW row must reject"),
-        );
-
-        let map_field = RowType::new(vec![DataField::new(
-            "nested",
-            DataTypes::row(vec![DataField::new(
-                "attrs",
-                DataTypes::map(DataTypes::string(), DataTypes::int().as_non_nullable()),
-                None,
-            )]),
-            None,
-        )]);
-        validate_append_record_batch(
-            &single_col_batch(
-                "nested",
-                struct_with_field(
-                    "attrs",
-                    map_string_int_array(
-                        vec!["a", "b", "c", "d"],
-                        vec![Some(1), None, Some(2), Some(3)],
-                        vec![0, 2, 4],
-                        None,
-                    ),
-                    Some(vec![false, true]),
-                ),
-            ),
-            &map_field,
-        )
-        .expect("leftover MAP poison under a null ROW row must be accepted");
     }
 
     #[test]
@@ -2862,5 +2652,353 @@ mod tests {
         .err()
         .expect("an out-of-range statistics index must be rejected");
         assert!(err.to_string().contains("out of range"));
+    }
+
+    /// Encodes `batch` without going through `MemoryLogRecordsArrowBuilder`, so a
+    /// batch that validation rejects can still be handed to the reader.
+    fn encode_batch_bypassing_validation(batch: &RecordBatch) -> Vec<u8> {
+        use arrow::ipc::writer::StreamWriter;
+
+        let mut ipc = Vec::new();
+        let mut writer =
+            StreamWriter::try_new(&mut ipc, batch.schema().as_ref()).expect("ipc writer");
+        let schema_message_len = writer.get_ref().len();
+        writer.write(batch).expect("write batch");
+        drop(writer);
+        let payload = &ipc[schema_message_len..];
+
+        let mut bytes = vec![0u8; RECORD_BATCH_HEADER_SIZE + payload.len()];
+        write_batch_header_fields(
+            &mut bytes,
+            BatchHeaderFields {
+                base_log_offset: BUILDER_DEFAULT_OFFSET,
+                magic: CURRENT_LOG_MAGIC_VALUE,
+                schema_id: 1,
+                writer_id: NO_WRITER_ID,
+                batch_sequence: NO_BATCH_SEQUENCE,
+                record_count: batch.num_rows() as i32,
+                statistics_length: 0,
+            },
+        )
+        .expect("write header");
+        bytes[RECORD_BATCH_HEADER_SIZE..].copy_from_slice(payload);
+
+        let crc = crc32c(&bytes[SCHEMA_ID_OFFSET..]);
+        bytes[CRC_OFFSET..CRC_OFFSET + CRC_LENGTH].copy_from_slice(&crc.to_le_bytes());
+        bytes
+    }
+
+    /// A batch validation accepts must decode; one that fails to decode must be
+    /// rejected. Pairing the two verdicts keeps the masking rules out of the test.
+    fn assert_validation_matches_reader(label: &str, batch: &RecordBatch, row_type: &RowType) {
+        let accepted = validate_append_record_batch(batch, row_type).is_ok();
+        let bytes = encode_batch_bypassing_validation(batch);
+        let read_context = ReadContext::new(
+            to_arrow_schema(row_type).expect("arrow schema"),
+            Arc::new(row_type.clone()),
+            false,
+        );
+        let decodes = LogRecordsBatches::new(bytes)
+            .next()
+            .expect("one batch")
+            .expect("batch header")
+            .records(&read_context)
+            .map(|records| records.count())
+            .is_ok();
+
+        assert_eq!(
+            accepted,
+            decodes,
+            "{label}: validation {} but the reader {}",
+            if accepted { "accepted" } else { "rejected" },
+            if decodes {
+                "decoded it"
+            } else {
+                "could not decode it"
+            }
+        );
+    }
+
+    #[test]
+    fn validation_agrees_with_reader_on_nested_nullability() {
+        let array_of_not_null = RowType::new(vec![DataField::new(
+            "tags",
+            DataTypes::array(DataTypes::int().as_non_nullable()),
+            None,
+        )]);
+        let row_of_not_null_array = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![DataField::new(
+                "tags",
+                DataTypes::array(DataTypes::int().as_non_nullable()),
+                None,
+            )]),
+            None,
+        )]);
+        let row_of_not_null_field = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![DataField::new(
+                "seq",
+                DataTypes::int().as_non_nullable(),
+                None,
+            )]),
+            None,
+        )]);
+
+        assert_validation_matches_reader(
+            "poison on a live list row",
+            &single_col_batch(
+                "tags",
+                list_int_array(vec![Some(1), None], vec![0, 2], None),
+            ),
+            &array_of_not_null,
+        );
+        assert_validation_matches_reader(
+            "leftover under a null list row",
+            &single_col_batch(
+                "tags",
+                list_int_array(vec![Some(1), None], vec![0, 1, 2], Some(vec![true, false])),
+            ),
+            &array_of_not_null,
+        );
+        assert_validation_matches_reader(
+            "null list row owning no elements",
+            &single_col_batch(
+                "tags",
+                list_int_array(vec![Some(1)], vec![0, 1, 1], Some(vec![true, false])),
+            ),
+            &array_of_not_null,
+        );
+        assert_validation_matches_reader(
+            "null ROW row masking its own field",
+            &single_col_batch(
+                "nested",
+                struct_with_field(
+                    "seq",
+                    Arc::new(arrow::array::Int32Array::from(vec![None, Some(2)])) as ArrayRef,
+                    Some(vec![false, true]),
+                ),
+            ),
+            &row_of_not_null_field,
+        );
+        assert_validation_matches_reader(
+            "null ROW row above a live list",
+            &single_col_batch(
+                "nested",
+                struct_with_field(
+                    "tags",
+                    list_int_array(vec![None, Some(7)], vec![0, 1, 2], None),
+                    Some(vec![false, true]),
+                ),
+            ),
+            &row_of_not_null_array,
+        );
+        assert_validation_matches_reader(
+            "poison removed by a slice",
+            &single_col_batch(
+                "tags",
+                list_int_array(vec![None, Some(7), Some(8)], vec![0, 1, 3], None),
+            )
+            .slice(1, 1),
+            &array_of_not_null,
+        );
+    }
+
+    #[test]
+    fn validation_agrees_with_reader_on_maps_and_deeper_nesting() {
+        let map_of_not_null_value = RowType::new(vec![DataField::new(
+            "attrs",
+            DataTypes::map(DataTypes::string(), DataTypes::int().as_non_nullable()),
+            None,
+        )]);
+        assert_validation_matches_reader(
+            "MAP: poison on a live entry",
+            &single_col_batch(
+                "attrs",
+                map_string_int_array(vec!["a", "b"], vec![Some(1), None], vec![0, 2], None),
+            ),
+            &map_of_not_null_value,
+        );
+        assert_validation_matches_reader(
+            "MAP: leftover under a null entry",
+            &single_col_batch(
+                "attrs",
+                map_string_int_array(
+                    vec!["a", "b"],
+                    vec![Some(1), None],
+                    vec![0, 1, 2],
+                    Some(vec![true, false]),
+                ),
+            ),
+            &map_of_not_null_value,
+        );
+        assert_validation_matches_reader(
+            "MAP: null entry owning nothing",
+            &single_col_batch(
+                "attrs",
+                map_string_int_array(
+                    vec!["a"],
+                    vec![Some(1)],
+                    vec![0, 1, 1],
+                    Some(vec![true, false]),
+                ),
+            ),
+            &map_of_not_null_value,
+        );
+
+        let array_of_array = RowType::new(vec![DataField::new(
+            "grid",
+            DataTypes::array(DataTypes::array(DataTypes::int().as_non_nullable())),
+            None,
+        )]);
+        let inner_with_poison = || list_int_array(vec![None, Some(4)], vec![0, 1, 2], None);
+        assert_validation_matches_reader(
+            "ARRAY<ARRAY>: poison on a live outer row",
+            &single_col_batch("grid", list_array(inner_with_poison(), vec![0, 2], None)),
+            &array_of_array,
+        );
+        assert_validation_matches_reader(
+            "ARRAY<ARRAY>: poison sliced away",
+            &single_col_batch("grid", list_array(inner_with_poison(), vec![0, 1, 2], None))
+                .slice(1, 1),
+            &array_of_array,
+        );
+
+        let array_of_row = RowType::new(vec![DataField::new(
+            "items",
+            DataTypes::array(DataTypes::row(vec![
+                DataField::new("seq", DataTypes::int().as_non_nullable(), None),
+                DataField::new("label", DataTypes::string(), None),
+            ])),
+            None,
+        )]);
+        assert_validation_matches_reader(
+            "ARRAY<ROW>: poison on a live list row",
+            &single_col_batch(
+                "items",
+                list_array(
+                    struct_int_string_array(vec![None, Some(2)], vec![Some("x"), Some("y")], None),
+                    vec![0, 2],
+                    None,
+                ),
+            ),
+            &array_of_row,
+        );
+        assert_validation_matches_reader(
+            "ARRAY<ROW>: leftover under a null list row",
+            &single_col_batch(
+                "items",
+                list_array(
+                    struct_int_string_array(vec![None, Some(2)], vec![Some("x"), Some("y")], None),
+                    vec![0, 1, 2],
+                    Some(vec![false, true]),
+                ),
+            ),
+            &array_of_row,
+        );
+
+        let row_of_row = RowType::new(vec![DataField::new(
+            "outer",
+            DataTypes::row(vec![DataField::new(
+                "inner",
+                DataTypes::row(vec![DataField::new(
+                    "seq",
+                    DataTypes::int().as_non_nullable(),
+                    None,
+                )]),
+                None,
+            )]),
+            None,
+        )]);
+        // A null ROW row above a live MAP.
+        assert_validation_matches_reader(
+            "ROW<MAP>: null ROW row above a live map",
+            &single_col_batch(
+                "nested",
+                struct_with_field(
+                    "attrs",
+                    map_string_int_array(vec!["a", "b"], vec![Some(1), None], vec![0, 2], None),
+                    Some(vec![false]),
+                ),
+            ),
+            &RowType::new(vec![DataField::new(
+                "nested",
+                DataTypes::row(vec![DataField::new(
+                    "attrs",
+                    DataTypes::map(DataTypes::string(), DataTypes::int().as_non_nullable()),
+                    None,
+                )]),
+                None,
+            )]),
+        );
+
+        assert_validation_matches_reader(
+            "ROW<ROW>: null outer over a live inner",
+            &single_col_batch(
+                "outer",
+                struct_with_field(
+                    "inner",
+                    struct_with_field(
+                        "seq",
+                        Arc::new(arrow::array::Int32Array::from(vec![None, Some(2)])) as ArrayRef,
+                        None,
+                    ),
+                    Some(vec![false, true]),
+                ),
+            ),
+            &row_of_row,
+        );
+    }
+
+    #[test]
+    fn validation_agrees_with_reader_across_element_types() {
+        use arrow::array::{Float64Array, StringArray, TimestampMillisecondArray};
+
+        let cases: Vec<(&str, DataType, ArrayRef)> = vec![
+            (
+                "STRING",
+                DataTypes::string().as_non_nullable(),
+                Arc::new(StringArray::from(vec![Some("a"), None])),
+            ),
+            (
+                "DOUBLE",
+                DataTypes::double().as_non_nullable(),
+                Arc::new(Float64Array::from(vec![Some(1.5), None])),
+            ),
+            (
+                "TIMESTAMP",
+                DataTypes::timestamp_with_precision(3).as_non_nullable(),
+                Arc::new(TimestampMillisecondArray::from(vec![
+                    Some(1_700_000_000_000),
+                    None,
+                ])),
+            ),
+            (
+                "BIGINT",
+                DataTypes::bigint().as_non_nullable(),
+                Arc::new(arrow::array::Int64Array::from(vec![Some(7_i64), None])),
+            ),
+        ];
+
+        for (name, element_type, values) in cases {
+            let row_type = RowType::new(vec![DataField::new(
+                "tags",
+                DataTypes::array(element_type),
+                None,
+            )]);
+            assert_validation_matches_reader(
+                &format!("ARRAY<{name} NOT NULL>: poison on a live row"),
+                &single_col_batch("tags", list_array(Arc::clone(&values), vec![0, 2], None)),
+                &row_type,
+            );
+            assert_validation_matches_reader(
+                &format!("ARRAY<{name} NOT NULL>: leftover under a null row"),
+                &single_col_batch(
+                    "tags",
+                    list_array(values, vec![0, 1, 2], Some(vec![true, false])),
+                ),
+                &row_type,
+            );
+        }
     }
 }

--- a/fluss-rust/crates/fluss/src/row/column_vector.rs
+++ b/fluss-rust/crates/fluss/src/row/column_vector.rs
@@ -34,78 +34,42 @@ use arrow::array::{
 use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
 use std::sync::Arc;
 
-struct AncestorValidity<'a> {
-    array: &'a dyn Array,
-    parent: Option<&'a AncestorValidity<'a>>,
-}
-
-impl AncestorValidity<'_> {
-    fn all_valid(&self) -> bool {
-        self.array.null_count() == 0 && self.parent.is_none_or(Self::all_valid)
-    }
-
-    fn is_valid(&self, index: usize) -> bool {
-        !self.array.is_null(index) && self.parent.is_none_or(|parent| parent.is_valid(index))
-    }
-}
-
-/// True when `array[start..end)` has a null at an index where all ancestors are valid.
-/// `ListArray::values()` / `MapArray::keys()` keep the full child, so a sliced
-/// parent or a null container can leave leftover slots outside the live window;
-/// those must not count.
+/// True when `array[start..end)` is null anywhere `parent` is valid.
 fn has_null_in_range(
     array: &dyn Array,
     start: usize,
     end: usize,
-    ancestors: Option<&AncestorValidity<'_>>,
+    parent: Option<&dyn Array>,
 ) -> bool {
     debug_assert!(start <= end && end <= array.len());
     if start == end || array.null_count() == 0 {
         return false;
     }
-    if let Some(ancestors) = ancestors.filter(|ancestors| !ancestors.all_valid()) {
-        return (start..end).any(|i| array.is_null(i) && ancestors.is_valid(i));
+    if let Some(parent) = parent.filter(|parent| parent.null_count() > 0) {
+        return (start..end).any(|i| array.is_null(i) && !parent.is_null(i));
     }
     (start == 0 && end == array.len()) || array.slice(start, end - start).null_count() > 0
 }
 
-/// Walks child slots of live list/map rows in `rows` on the already-typed
-/// child. A row is dead when the container itself is null, or when an ancestor
-/// (e.g. the enclosing ROW's struct) is null.
+/// Checks the child slots `rows` covers. A null list/map entry does not hide the
+/// values in its range - Arrow checks them against the element type either way -
+/// so only the offset window matters, and IPC compacts a sliced parent away.
 fn check_offset_window_not_null(
     child: &TypedColumn,
     offsets: &[i32],
     container: &dyn Array,
-    ancestors: Option<&AncestorValidity<'_>>,
     fluss_type: &DataType,
     path: String,
     rows: std::ops::Range<usize>,
 ) -> Result<()> {
     debug_assert!(rows.end <= container.len());
-    let ancestor_all_valid = ancestors.is_none_or(AncestorValidity::all_valid);
-    if container.null_count() == 0 && ancestor_all_valid {
-        return child.check_range_not_null(
-            offsets[rows.start] as usize,
-            offsets[rows.end] as usize,
-            fluss_type,
-            &path,
-            None,
-        );
-    }
-    for i in rows {
-        let dead = container.is_null(i) || ancestors.is_some_and(|a| !a.is_valid(i));
-        if dead {
-            continue;
-        }
-        child.check_range_not_null(
-            offsets[i] as usize,
-            offsets[i + 1] as usize,
-            fluss_type,
-            &path,
-            None,
-        )?;
-    }
-    Ok(())
+    child.check_range_not_null(
+        offsets[rows.start] as usize,
+        offsets[rows.end] as usize,
+        fluss_type,
+        &path,
+        None,
+    )
 }
 
 /// One typed Arrow column.
@@ -314,9 +278,9 @@ impl TypedColumn {
         &self,
         fluss_type: &DataType,
         path: &str,
-        ancestors: Option<&AncestorValidity<'_>>,
+        parent: Option<&dyn Array>,
     ) -> Result<()> {
-        self.check_range_not_null(0, self.outer_array().len(), fluss_type, path, ancestors)
+        self.check_range_not_null(0, self.outer_array().len(), fluss_type, path, parent)
     }
 
     fn check_range_not_null(
@@ -325,10 +289,9 @@ impl TypedColumn {
         end: usize,
         fluss_type: &DataType,
         path: &str,
-        ancestors: Option<&AncestorValidity<'_>>,
+        parent: Option<&dyn Array>,
     ) -> Result<()> {
-        if !fluss_type.is_nullable() && has_null_in_range(self.outer_array(), start, end, ancestors)
-        {
+        if !fluss_type.is_nullable() && has_null_in_range(self.outer_array(), start, end, parent) {
             return Err(IllegalArgument {
                 message: format!("{path} is declared as non-nullable but contains null values"),
             });
@@ -339,7 +302,6 @@ impl TypedColumn {
                     element,
                     list_arr.value_offsets(),
                     list_arr,
-                    ancestors,
                     array_type.get_element_type(),
                     format!("{path} element"),
                     start..end,
@@ -351,7 +313,6 @@ impl TypedColumn {
                     key,
                     offsets,
                     map_arr,
-                    ancestors,
                     map_type.key_type(),
                     format!("{path} key"),
                     start..end,
@@ -360,24 +321,19 @@ impl TypedColumn {
                     value,
                     offsets,
                     map_arr,
-                    ancestors,
                     map_type.value_type(),
                     format!("{path} value"),
                     start..end,
                 )
             }
             (Self::Row(struct_arr, inner), DataType::Row(row_type)) => {
-                let row_ancestors = AncestorValidity {
-                    array: struct_arr,
-                    parent: ancestors,
-                };
                 for (field, column) in row_type.fields().iter().zip(inner.columns.iter()) {
                     column.check_range_not_null(
                         start,
                         end,
                         field.data_type(),
                         &format!("{path}.{}", field.name()),
-                        Some(&row_ancestors),
+                        Some(struct_arr),
                     )?;
                 }
                 Ok(())

--- a/fluss-rust/crates/fluss/src/row/column_vector.rs
+++ b/fluss-rust/crates/fluss/src/row/column_vector.rs
@@ -34,6 +34,80 @@ use arrow::array::{
 use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
 use std::sync::Arc;
 
+struct AncestorValidity<'a> {
+    array: &'a dyn Array,
+    parent: Option<&'a AncestorValidity<'a>>,
+}
+
+impl AncestorValidity<'_> {
+    fn all_valid(&self) -> bool {
+        self.array.null_count() == 0 && self.parent.is_none_or(Self::all_valid)
+    }
+
+    fn is_valid(&self, index: usize) -> bool {
+        !self.array.is_null(index) && self.parent.is_none_or(|parent| parent.is_valid(index))
+    }
+}
+
+/// True when `array[start..end)` has a null at an index where all ancestors are valid.
+/// `ListArray::values()` / `MapArray::keys()` keep the full child, so a sliced
+/// parent or a null container can leave leftover slots outside the live window;
+/// those must not count.
+fn has_null_in_range(
+    array: &dyn Array,
+    start: usize,
+    end: usize,
+    ancestors: Option<&AncestorValidity<'_>>,
+) -> bool {
+    debug_assert!(start <= end && end <= array.len());
+    if start == end || array.null_count() == 0 {
+        return false;
+    }
+    if let Some(ancestors) = ancestors.filter(|ancestors| !ancestors.all_valid()) {
+        return (start..end).any(|i| array.is_null(i) && ancestors.is_valid(i));
+    }
+    (start == 0 && end == array.len()) || array.slice(start, end - start).null_count() > 0
+}
+
+/// Walks child slots of live list/map rows in `rows` on the already-typed
+/// child. A row is dead when the container itself is null, or when an ancestor
+/// (e.g. the enclosing ROW's struct) is null.
+fn check_offset_window_not_null(
+    child: &TypedColumn,
+    offsets: &[i32],
+    container: &dyn Array,
+    ancestors: Option<&AncestorValidity<'_>>,
+    fluss_type: &DataType,
+    path: String,
+    rows: std::ops::Range<usize>,
+) -> Result<()> {
+    debug_assert!(rows.end <= container.len());
+    let ancestor_all_valid = ancestors.is_none_or(AncestorValidity::all_valid);
+    if container.null_count() == 0 && ancestor_all_valid {
+        return child.check_range_not_null(
+            offsets[rows.start] as usize,
+            offsets[rows.end] as usize,
+            fluss_type,
+            &path,
+            None,
+        );
+    }
+    for i in rows {
+        let dead = container.is_null(i) || ancestors.is_some_and(|a| !a.is_valid(i));
+        if dead {
+            continue;
+        }
+        child.check_range_not_null(
+            offsets[i] as usize,
+            offsets[i + 1] as usize,
+            fluss_type,
+            &path,
+            None,
+        )?;
+    }
+    Ok(())
+}
+
 /// One typed Arrow column.
 #[derive(Debug, Clone)]
 pub(crate) enum TypedColumn {
@@ -116,6 +190,18 @@ impl TypedBatch {
             num_rows: batch.num_rows(),
             record_batch: Some(batch.clone()),
         })
+    }
+
+    /// Rejects nulls on any schema-tree node whose Fluss type is NOT NULL.
+    pub(crate) fn check_not_null(&self, row_type: &RowType) -> Result<()> {
+        for (field, column) in row_type.fields().iter().zip(self.columns.iter()) {
+            column.check_not_null(
+                field.data_type(),
+                &format!("Column '{}'", field.name()),
+                None,
+            )?;
+        }
+        Ok(())
     }
 
     fn from_struct(struct_arr: &StructArray, row_type: &RowType) -> Result<Self> {
@@ -221,6 +307,82 @@ impl TypedColumn {
             Self::Array(a, _) => a,
             Self::Map(a, _, _) => a,
             Self::Row(a, _) => a,
+        }
+    }
+
+    fn check_not_null(
+        &self,
+        fluss_type: &DataType,
+        path: &str,
+        ancestors: Option<&AncestorValidity<'_>>,
+    ) -> Result<()> {
+        self.check_range_not_null(0, self.outer_array().len(), fluss_type, path, ancestors)
+    }
+
+    fn check_range_not_null(
+        &self,
+        start: usize,
+        end: usize,
+        fluss_type: &DataType,
+        path: &str,
+        ancestors: Option<&AncestorValidity<'_>>,
+    ) -> Result<()> {
+        if !fluss_type.is_nullable() && has_null_in_range(self.outer_array(), start, end, ancestors)
+        {
+            return Err(IllegalArgument {
+                message: format!("{path} is declared as non-nullable but contains null values"),
+            });
+        }
+        match (self, fluss_type) {
+            (Self::Array(list_arr, element), DataType::Array(array_type)) => {
+                check_offset_window_not_null(
+                    element,
+                    list_arr.value_offsets(),
+                    list_arr,
+                    ancestors,
+                    array_type.get_element_type(),
+                    format!("{path} element"),
+                    start..end,
+                )
+            }
+            (Self::Map(map_arr, key, value), DataType::Map(map_type)) => {
+                let offsets = map_arr.value_offsets();
+                check_offset_window_not_null(
+                    key,
+                    offsets,
+                    map_arr,
+                    ancestors,
+                    map_type.key_type(),
+                    format!("{path} key"),
+                    start..end,
+                )?;
+                check_offset_window_not_null(
+                    value,
+                    offsets,
+                    map_arr,
+                    ancestors,
+                    map_type.value_type(),
+                    format!("{path} value"),
+                    start..end,
+                )
+            }
+            (Self::Row(struct_arr, inner), DataType::Row(row_type)) => {
+                let row_ancestors = AncestorValidity {
+                    array: struct_arr,
+                    parent: ancestors,
+                };
+                for (field, column) in row_type.fields().iter().zip(inner.columns.iter()) {
+                    column.check_range_not_null(
+                        start,
+                        end,
+                        field.data_type(),
+                        &format!("{path}.{}", field.name()),
+                        Some(&row_ancestors),
+                    )?;
+                }
+                Ok(())
+            }
+            _ => Ok(()),
         }
     }
 

--- a/fluss-rust/crates/fluss/tests/integration/log_table.rs
+++ b/fluss-rust/crates/fluss/tests/integration/log_table.rs
@@ -25,7 +25,12 @@ mod table_test {
         poll_until_count, poll_until_nonempty, row_dt_basics_columns, scalar_dt_columns,
         wait_for_partitions_ready, wait_for_table_buckets_ready, wait_for_table_ready,
     };
-    use arrow::array::record_batch;
+    use arrow::array::{
+        Array, ArrayRef, Int32Array, Int64Array, ListArray, MapArray, RecordBatch, StringArray,
+        StructArray, record_batch,
+    };
+    use arrow::buffer::{NullBuffer, OffsetBuffer};
+    use arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
     use fluss::client::{EARLIEST_OFFSET, FlussAdmin, FlussTable, TableScan};
     use fluss::error::FlussError;
     use fluss::metadata::{
@@ -42,7 +47,16 @@ mod table_test {
     };
     use fluss::rpc::message::OffsetSpec;
     use std::collections::HashMap;
+    use std::sync::Arc;
     use std::time::Duration;
+
+    fn reject_null(err: impl std::fmt::Display) {
+        let text = err.to_string();
+        assert!(
+            text.contains("declared as non-nullable but contains null values"),
+            "unexpected error: {text}"
+        );
+    }
 
     #[tokio::test]
     async fn append_record_batch_and_scan() {
@@ -79,6 +93,51 @@ mod table_test {
             .create_writer()
             .expect("Failed to create writer");
 
+        {
+            // Distinct c1 values hash across buckets; none may be enqueued.
+            let poison_schema = Arc::new(ArrowSchema::new(vec![
+                Field::new("c1", ArrowDataType::Int32, true),
+                Field::new("c2", ArrowDataType::Utf8, true),
+                Field::new("c3", ArrowDataType::Int64, true),
+            ]));
+            let poison = RecordBatch::try_new(
+                poison_schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5, 6])),
+                    Arc::new(StringArray::from(vec!["a", "b", "c", "d", "e", "f"])),
+                    Arc::new(Int64Array::from(vec![
+                        Some(10),
+                        Some(20),
+                        None,
+                        Some(40),
+                        Some(50),
+                        Some(60),
+                    ])),
+                ],
+            )
+            .expect("poison batch");
+            let err = append_writer
+                .append_arrow_batch(poison)
+                .expect_err("null in NOT NULL column must be rejected before the bucket split");
+            reject_null(err);
+
+            // Offsets only move on flush.
+            append_writer
+                .flush()
+                .await
+                .expect("flush after rejected poison must not send rows");
+            wait_for_table_ready(&admin, &table_path).await;
+            let buckets: Vec<i32> = (0..table.get_table_info().get_num_buckets()).collect();
+            let latest = admin
+                .list_offsets(&table_path, &buckets, OffsetSpec::Latest)
+                .await
+                .expect("list_offsets after poison reject");
+            assert!(
+                latest.values().all(|&offset| offset == 0),
+                "poison batch must not enqueue any bucket, latest={latest:?}"
+            );
+        }
+
         let batch1 = record_batch!(
             ("c1", Int32, [1, 2, 3]),
             ("c2", Utf8, ["a1", "a2", "a3"]),
@@ -89,15 +148,23 @@ mod table_test {
             .append_arrow_batch(batch1)
             .expect("Failed to append batch with mixed nullability");
 
-        let batch2 = record_batch!(
-            ("c1", Int32, [4, 5, 6]),
-            ("c2", Utf8, ["a4", "a5", "a6"]),
-            ("c3", Int64, [40, 50, 60])
+        let batch2_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("c1", ArrowDataType::Int32, true),
+            Field::new("c2", ArrowDataType::Utf8, true),
+            Field::new("c3", ArrowDataType::Int64, true),
+        ]));
+        let batch2 = RecordBatch::try_new(
+            batch2_schema,
+            vec![
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(StringArray::from(vec!["a4", "a5", "a6"])),
+                Arc::new(Int64Array::from(vec![40_i64, 50_i64, 60_i64])),
+            ],
         )
-        .unwrap();
+        .expect("nullable-metadata batch without nulls");
         append_writer
             .append_arrow_batch(batch2)
-            .expect("Failed to append batch with mixed nullability");
+            .expect("Failed to append nullable-metadata batch without null values");
 
         // Flush to ensure all writes are acknowledged
         append_writer.flush().await.expect("Failed to flush");
@@ -168,6 +235,283 @@ mod table_test {
             log_scanner.unsubscribe_partition(0, 0).await.is_err(),
             "unsubscribe_partition should fail on a non-partitioned table"
         );
+    }
+
+    #[tokio::test]
+    async fn append_arrow_batch_nested_not_null_columns() {
+        fn nested_batch(tags: ArrayRef, attrs: ArrayRef, nested: ArrayRef) -> RecordBatch {
+            RecordBatch::try_new(
+                Arc::new(ArrowSchema::new(vec![
+                    Field::new("tags", tags.data_type().clone(), true),
+                    Field::new("attrs", attrs.data_type().clone(), true),
+                    Field::new("nested", nested.data_type().clone(), true),
+                ])),
+                vec![tags, attrs, nested],
+            )
+            .expect("nested batch")
+        }
+
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("Failed to get admin");
+
+        let table_path = TablePath::new("fluss", "test_append_arrow_batch_nested_not_null");
+        let table_descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("tags", DataTypes::array(DataTypes::int()).as_non_nullable())
+                    .column(
+                        "attrs",
+                        DataTypes::map(DataTypes::string(), DataTypes::int()).as_non_nullable(),
+                    )
+                    .column(
+                        "nested",
+                        DataTypes::row(vec![
+                            DataField::new("seq", DataTypes::int(), None),
+                            DataField::new("label", DataTypes::string(), None),
+                        ])
+                        .as_non_nullable(),
+                    )
+                    .build()
+                    .expect("schema"),
+            )
+            .build()
+            .expect("table descriptor");
+        create_table(&admin, &table_path, &table_descriptor).await;
+
+        let table = connection.get_table(&table_path).await.expect("table");
+        let writer = table
+            .new_append()
+            .expect("append")
+            .create_writer()
+            .expect("writer");
+
+        let item_field = Arc::new(Field::new("item", ArrowDataType::Int32, true));
+        let ok_list: ArrayRef = Arc::new(ListArray::new(
+            Arc::clone(&item_field),
+            OffsetBuffer::new(vec![0_i32, 2].into()),
+            Arc::new(Int32Array::from(vec![10, 20])),
+            None,
+        ));
+        let null_list: ArrayRef = Arc::new(ListArray::new(
+            item_field,
+            OffsetBuffer::new(vec![0_i32, 0].into()),
+            Arc::new(Int32Array::from(Vec::<i32>::new())),
+            Some(NullBuffer::from(vec![false])),
+        ));
+
+        let key_field = Arc::new(Field::new("key", ArrowDataType::Utf8, false));
+        let value_field = Arc::new(Field::new("value", ArrowDataType::Int32, true));
+        let ok_entries = StructArray::from(vec![
+            (
+                Arc::clone(&key_field),
+                Arc::new(StringArray::from(vec!["x", "y"])) as ArrayRef,
+            ),
+            (
+                Arc::clone(&value_field),
+                Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+            ),
+        ]);
+        let ok_map: ArrayRef = Arc::new(MapArray::new(
+            Arc::new(Field::new("entries", ok_entries.data_type().clone(), false)),
+            OffsetBuffer::new(vec![0_i32, 2].into()),
+            ok_entries,
+            None,
+            false,
+        ));
+        let empty_entries = StructArray::from(vec![
+            (
+                key_field,
+                Arc::new(StringArray::from(Vec::<&str>::new())) as ArrayRef,
+            ),
+            (
+                value_field,
+                Arc::new(Int32Array::from(Vec::<i32>::new())) as ArrayRef,
+            ),
+        ]);
+        let null_map: ArrayRef = Arc::new(MapArray::new(
+            Arc::new(Field::new(
+                "entries",
+                empty_entries.data_type().clone(),
+                false,
+            )),
+            OffsetBuffer::new(vec![0_i32, 0].into()),
+            empty_entries,
+            Some(NullBuffer::from(vec![false])),
+            false,
+        ));
+
+        let row_fields = arrow::datatypes::Fields::from(vec![
+            Field::new("seq", ArrowDataType::Int32, true),
+            Field::new("label", ArrowDataType::Utf8, true),
+        ]);
+        let ok_struct: ArrayRef = Arc::new(StructArray::new(
+            row_fields.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![42])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["hello"])) as ArrayRef,
+            ],
+            None,
+        ));
+        let null_struct: ArrayRef = Arc::new(StructArray::new(
+            row_fields,
+            vec![
+                Arc::new(Int32Array::from(vec![None])) as ArrayRef,
+                Arc::new(StringArray::from(vec![None::<&str>])) as ArrayRef,
+            ],
+            Some(NullBuffer::from(vec![false])),
+        ));
+
+        reject_null(
+            writer
+                .append_arrow_batch(nested_batch(
+                    Arc::clone(&null_list),
+                    Arc::clone(&ok_map),
+                    Arc::clone(&ok_struct),
+                ))
+                .expect_err("null ARRAY value in NOT NULL column"),
+        );
+        reject_null(
+            writer
+                .append_arrow_batch(nested_batch(
+                    Arc::clone(&ok_list),
+                    Arc::clone(&null_map),
+                    Arc::clone(&ok_struct),
+                ))
+                .expect_err("null MAP value in NOT NULL column"),
+        );
+        reject_null(
+            writer
+                .append_arrow_batch(nested_batch(
+                    Arc::clone(&ok_list),
+                    Arc::clone(&ok_map),
+                    Arc::clone(&null_struct),
+                ))
+                .expect_err("null ROW value in NOT NULL column"),
+        );
+
+        writer
+            .append_arrow_batch(nested_batch(ok_list, ok_map, ok_struct))
+            .expect("populated nested values must be accepted");
+        writer.flush().await.expect("flush");
+
+        let records = scan_table(&table, |scan| scan).await;
+        assert_eq!(records.len(), 1);
+        let row = records[0].row();
+
+        let tags = row.get_array(0).expect("tags");
+        assert_eq!(tags.size(), 2);
+        assert_eq!(tags.get_int(0).unwrap(), 10);
+        assert_eq!(tags.get_int(1).unwrap(), 20);
+
+        let attrs = row.get_map(1).expect("attrs");
+        assert_eq!(attrs.size(), 2);
+        assert_eq!(attrs.key_array().get_string(0).unwrap(), "x");
+        assert_eq!(attrs.value_array().get_int(0).unwrap(), 1);
+        assert_eq!(attrs.key_array().get_string(1).unwrap(), "y");
+        assert_eq!(attrs.value_array().get_int(1).unwrap(), 2);
+
+        let nested = row.get_row(2).expect("nested");
+        assert_eq!(nested.get_int(0).unwrap(), 42);
+        assert_eq!(nested.get_string(1).unwrap(), "hello");
+    }
+
+    #[tokio::test]
+    async fn append_arrow_batch_rejects_nulls_inside_not_null_nested_fields() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("Failed to get admin");
+        let table_path = TablePath::new("fluss", "test_append_arrow_batch_not_null_inside_nested");
+        let table_descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column(
+                        "tags",
+                        DataTypes::array(DataTypes::int().as_non_nullable()).as_non_nullable(),
+                    )
+                    .column(
+                        "nested",
+                        DataTypes::row(vec![
+                            DataField::new("seq", DataTypes::int().as_non_nullable(), None),
+                            DataField::new("label", DataTypes::string(), None),
+                        ])
+                        .as_non_nullable(),
+                    )
+                    .build()
+                    .expect("schema"),
+            )
+            .build()
+            .expect("table descriptor");
+        create_table(&admin, &table_path, &table_descriptor).await;
+
+        let table = connection.get_table(&table_path).await.expect("table");
+        let writer = table
+            .new_append()
+            .expect("append")
+            .create_writer()
+            .expect("writer");
+
+        let item_field = Arc::new(Field::new("item", ArrowDataType::Int32, true));
+        let ok_list: ArrayRef = Arc::new(ListArray::new(
+            Arc::clone(&item_field),
+            OffsetBuffer::new(vec![0_i32, 3].into()),
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            None,
+        ));
+        let poison_list: ArrayRef = Arc::new(ListArray::new(
+            item_field,
+            OffsetBuffer::new(vec![0_i32, 3].into()),
+            Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])),
+            None,
+        ));
+
+        let row_fields = arrow::datatypes::Fields::from(vec![
+            Field::new("seq", ArrowDataType::Int32, true),
+            Field::new("label", ArrowDataType::Utf8, true),
+        ]);
+        let ok_struct: ArrayRef = Arc::new(StructArray::new(
+            row_fields.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![42])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["hello"])) as ArrayRef,
+            ],
+            None,
+        ));
+        let poison_struct: ArrayRef = Arc::new(StructArray::new(
+            row_fields,
+            vec![
+                Arc::new(Int32Array::from(vec![None])) as ArrayRef,
+                Arc::new(StringArray::from(vec![Some("hello")])) as ArrayRef,
+            ],
+            None,
+        ));
+
+        fn batch(tags: ArrayRef, nested: ArrayRef) -> RecordBatch {
+            RecordBatch::try_new(
+                Arc::new(ArrowSchema::new(vec![
+                    Field::new("tags", tags.data_type().clone(), true),
+                    Field::new("nested", nested.data_type().clone(), true),
+                ])),
+                vec![tags, nested],
+            )
+            .expect("batch")
+        }
+
+        reject_null(
+            writer
+                .append_arrow_batch(batch(Arc::clone(&poison_list), Arc::clone(&ok_struct)))
+                .expect_err("null ARRAY element in ARRAY<INT NOT NULL>"),
+        );
+        reject_null(
+            writer
+                .append_arrow_batch(batch(Arc::clone(&ok_list), Arc::clone(&poison_struct)))
+                .expect_err("null ROW field in ROW<seq INT NOT NULL>"),
+        );
+
+        writer
+            .append_arrow_batch(batch(ok_list, ok_struct))
+            .expect("null-free nested values must be accepted");
+        writer.flush().await.expect("flush");
     }
 
     #[tokio::test]


### PR DESCRIPTION

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3949 

<!-- What is the purpose of the change -->

### Brief change log

`append_arrow_batch` can accept a caller-provided Arrow `RecordBatch` where a NOT NULL Fluss column contains null values. The write is accepted in some paths and the failure appears later during decode/scan.


### Tests
- add unit tests and integration tests

