### PR TITLE
[common] Fix equals/hashCode contract in value and kv record batches

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/record/DefaultKvRecordBatch.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/DefaultKvRecordBatch.java
@@ -23,6 +23,7 @@ import org.apache.fluss.exception.CorruptMessageException;
 import org.apache.fluss.memory.MemorySegment;
 import org.apache.fluss.record.bytesview.BytesView;
 import org.apache.fluss.utils.CloseableIterator;
+import org.apache.fluss.utils.MurmurHashUtils;
 import org.apache.fluss.utils.crc.Crc32C;
 
 import java.nio.ByteBuffer;
@@ -217,6 +218,11 @@ public class DefaultKvRecordBatch implements KvRecordBatch {
         int sizeInBytes = sizeInBytes();
         return sizeInBytes == that.sizeInBytes()
                 && segment.equalTo(that.segment, position, that.position, sizeInBytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return MurmurHashUtils.hashBytes(segment, position, sizeInBytes());
     }
 
     abstract class KvRecordIterator implements CloseableIterator<KvRecord> {

--- a/fluss-common/src/main/java/org/apache/fluss/record/DefaultValueRecordBatch.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/DefaultValueRecordBatch.java
@@ -21,6 +21,7 @@ import org.apache.fluss.memory.MemorySegment;
 import org.apache.fluss.memory.MemorySegmentOutputView;
 import org.apache.fluss.row.BinaryRow;
 import org.apache.fluss.utils.CloseableIterator;
+import org.apache.fluss.utils.MurmurHashUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -130,6 +131,11 @@ public class DefaultValueRecordBatch implements ValueRecordBatch {
         int sizeInBytes = sizeInBytes();
         return sizeInBytes == that.sizeInBytes()
                 && segment.equalTo(that.segment, position, that.position, sizeInBytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return MurmurHashUtils.hashBytes(segment, position, sizeInBytes());
     }
 
     // ------------------------------------------------------------------------------------------

--- a/fluss-common/src/test/java/org/apache/fluss/record/DefaultKvRecordBatchTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/record/DefaultKvRecordBatchTest.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.fluss.record.TestData.DATA1_ROW_TYPE;
 import static org.apache.fluss.record.TestData.DATA1_SCHEMA;
+import static org.apache.fluss.testutils.DataTestUtils.compactedRow;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link DefaultKvRecordBatch}. */
@@ -75,5 +77,40 @@ class DefaultKvRecordBatchTest extends KvTestBase {
         }
 
         builder.close();
+    }
+
+    @Test
+    void testEqualsAndHashCode() throws Exception {
+        DefaultKvRecordBatch batch1 = buildBatch();
+        DefaultKvRecordBatch batch2 = buildBatch();
+
+        assertThat(batch1).isEqualTo(batch2);
+        assertThat(batch1).hasSameHashCodeAs(batch2);
+    }
+
+    @Test
+    void testHashCodeDiffersForDifferentContents() throws Exception {
+        DefaultKvRecordBatch batch1 = buildBatch();
+        DefaultKvRecordBatch batch2 = buildBatch(new byte[] {(byte) 9, (byte) 9});
+
+        assertThat(batch1).isNotEqualTo(batch2);
+        assertThat(batch1.hashCode()).isNotEqualTo(batch2.hashCode());
+    }
+
+    private DefaultKvRecordBatch buildBatch() throws Exception {
+        return buildBatch(new byte[] {(byte) 1, (byte) 1});
+    }
+
+    private DefaultKvRecordBatch buildBatch(byte[] key) throws Exception {
+        KvRecordBatchBuilder builder =
+                KvRecordBatchBuilder.builder(
+                        schemaId,
+                        Integer.MAX_VALUE,
+                        new UnmanagedPagedOutputView(100),
+                        KvFormat.COMPACTED);
+        builder.append(key, compactedRow(DATA1_ROW_TYPE, new Object[] {1, "a1"}));
+        DefaultKvRecordBatch batch = DefaultKvRecordBatch.pointToBytesView(builder.build());
+        builder.close();
+        return batch;
     }
 }

--- a/fluss-common/src/test/java/org/apache/fluss/record/DefaultValueRecordBatchTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/record/DefaultValueRecordBatchTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.record;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.fluss.record.TestData.DATA1_ROW_TYPE;
+import static org.apache.fluss.record.TestData.DEFAULT_SCHEMA_ID;
+import static org.apache.fluss.testutils.DataTestUtils.compactedRow;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link DefaultValueRecordBatch}. */
+class DefaultValueRecordBatchTest {
+
+    @Test
+    void testEqualsAndHashCode() throws Exception {
+        DefaultValueRecordBatch batch1 = buildBatch();
+        DefaultValueRecordBatch batch2 = buildBatch();
+
+        assertThat(batch1).isEqualTo(batch2);
+        assertThat(batch1).hasSameHashCodeAs(batch2);
+    }
+
+    @Test
+    void testHashCodeDiffersForDifferentContents() throws Exception {
+        DefaultValueRecordBatch.Builder builder = DefaultValueRecordBatch.builder();
+        builder.append(DEFAULT_SCHEMA_ID, compactedRow(DATA1_ROW_TYPE, new Object[] {1, "a1"}));
+        DefaultValueRecordBatch batch1 = builder.build();
+
+        DefaultValueRecordBatch.Builder otherBuilder = DefaultValueRecordBatch.builder();
+        otherBuilder.append(
+                DEFAULT_SCHEMA_ID, compactedRow(DATA1_ROW_TYPE, new Object[] {2, "a2"}));
+        DefaultValueRecordBatch batch2 = otherBuilder.build();
+
+        assertThat(batch1).isNotEqualTo(batch2);
+        assertThat(batch1.hashCode()).isNotEqualTo(batch2.hashCode());
+    }
+
+    @Test
+    void testEmptyBatchesAreEqualAndShareHashCode() throws Exception {
+        DefaultValueRecordBatch batch1 = DefaultValueRecordBatch.builder().build();
+        DefaultValueRecordBatch batch2 = DefaultValueRecordBatch.builder().build();
+
+        assertThat(batch1).isEqualTo(batch2);
+        assertThat(batch1).hasSameHashCodeAs(batch2);
+    }
+
+    private static DefaultValueRecordBatch buildBatch() throws Exception {
+        DefaultValueRecordBatch.Builder builder = DefaultValueRecordBatch.builder();
+        builder.append(DEFAULT_SCHEMA_ID, compactedRow(DATA1_ROW_TYPE, new Object[] {1, "a1"}));
+        builder.append(DEFAULT_SCHEMA_ID, compactedRow(DATA1_ROW_TYPE, new Object[] {2, "a2"}));
+        return builder.build();
+    }
+}


### PR DESCRIPTION
<!--
Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: close #3951

`DefaultValueRecordBatch` and `DefaultKvRecordBatch` override `equals()` with value
semantics but never override `hashCode()`. Both classes only `implements` their interface,
so their superclass is `Object`, and neither `equals()` delegates to `super.equals()` —
`hashCode()` is therefore the identity hash. Two byte-identical batches are `equals()` but
return different hash codes, which violates the general contract of `Object.hashCode()`.

The third batch implementation in the same package, `DefaultLogRecordBatch`, has the
identical `equals()` shape and *does* hash the same byte range
([`DefaultLogRecordBatch.java:316`](https://github.com/apache/fluss/blob/main/fluss-common/src/main/java/org/apache/fluss/record/DefaultLogRecordBatch.java#L316)),
which is why this reads as an oversight rather than a deliberate choice. The Checkstyle
`EqualsHashCode` module is not enabled in `tools/maven/checkstyle.xml`, so CI does not flag
it today.

### Brief change log

- `DefaultValueRecordBatch`: add `hashCode()`, mirroring `DefaultLogRecordBatch` exactly.
- `DefaultKvRecordBatch`: same.

Both use `MurmurHashUtils.hashBytes(segment, position, sizeInBytes())`. `equals()` compares
the byte range `[position, position + sizeInBytes())` via
`segment.equalTo(that.segment, position, that.position, sizeInBytes)`, and `hashBytes`
hashes exactly that range, so `equals()` and `hashCode()` are consistent by construction.

### Tests

New in `DefaultValueRecordBatchTest` (new file) and `DefaultKvRecordBatchTest`:

| Test | Asserts |
| --- | --- |
| `testEqualsAndHashCode` | two independently built, byte-identical batches are equal **and** share a hash code (fails before this change) |
| `testHashCodeDiffersForDifferentContents` | batches with different contents are unequal and hash differently |
| `testEmptyBatchesAreEqualAndShareHashCode` | (value batch only) the empty-batch case, which is the shape asserted in `ReplicaManagerTest#testLimitScanPrimaryKeyTable` |

Verified locally with `mvn clean verify -pl fluss-common`: 1748 + 186 tests pass, Checkstyle
reports 0 violations, `spotless:check` and `apache-rat:check` pass.

### API and Format

No API or storage-format change. `hashCode()` is additive.

The only behavioural change is for a `HashSet`/`HashMap` **keyed** on one of these batches,
which would previously have used the identity hash. Nothing does that today — the batches
appear only as map *value* types (e.g. `Map<TableBucket, KvRecordBatch>` in
`ServerRpcMessageUtils#getPutKvData` and `ReplicaManager#putRecordsToKv`), where
`hashCode()` is never consulted.

### Documentation

No new feature, no documentation change.

### Note on #3877

I found this while diagnosing the flaky `ReplicaManagerTest#testLimitScanPrimaryKeyTable`
in #3877. This PR does **not** fix that flakiness — why the two batches genuinely differ
there is a separate question. It does make the failure message more useful: neither class
overrides `toString()`, so `Object.toString()` renders the identity hash, and the
`...@60eebc2e` vs `...@1408822` in that CI log cannot tell a reader whether the contents
actually differ (two *equal* batches would also print different suffixes). With a
content-derived `hashCode()`, differing suffixes do mean differing bytes.

### Generative AI disclosure

- [x] Yes — Claude Code (Opus 5). All changes reviewed by me before submitting.
