### PR TITLE
[build] Move Spark Scala 2.13 tests to nightly

### DIFF
--- a/.github/workflows/ci-template.yaml
+++ b/.github/workflows/ci-template.yaml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         default: ""
+      run-spark-scala213:
+        description: "Whether to run the Spark tests with Scala 2.13."
+        required: false
+        type: boolean
+        default: false
 jobs:
   build:
     runs-on: self-hosted
@@ -37,15 +42,13 @@ jobs:
       fail-fast: false
       matrix:
         module: [ core, flink1, flink2, spark3, spark3-lake, spark3-scala213, lake ]
+        exclude: ${{ fromJSON(inputs.run-spark-scala213 && '[]' || '[{"module":"spark3-scala213"}]') }}
         include:
           - module: flink1
             test-profile: "test-flink1"
           - module: flink2
             test-profile: "test-flink2"
           - module: spark3-lake
-            test-profile: "test-spark3"
-          - module: spark3-scala213
-            scala-profile: "-Pscala-2.13"
             test-profile: "test-spark3"
     name: "${{ matrix.module }}"
     steps:
@@ -58,14 +61,14 @@ jobs:
           distribution: 'temurin'
       - name: Build
         run: |
-          mvn -T 1C -B clean install -DskipTests ${{ matrix.scala-profile }} ${{ inputs.maven-parameters }}
+          mvn -T 1C -B clean install -DskipTests ${{ matrix.module == 'spark3-scala213' && '-Pscala-2.13' || '' }} ${{ inputs.maven-parameters }}
       - name: Test
         timeout-minutes: 60
         run: |
           TEST_MODULES=$(./.github/workflows/stage.sh ${{ matrix.module }})
           echo "github ref: ${{ github.ref }}"
           echo "Start testing modules: $TEST_MODULES"
-          mvn -B verify $TEST_MODULES -Ptest-coverage -P${{ matrix.test-profile || format('test-{0}', matrix.module) }} ${{ matrix.scala-profile }} -Dlog.dir=${{ runner.temp }}/fluss-logs -Dlog4j.configurationFile=${{ github.workspace }}/tools/ci/log4j.properties ${{ inputs.maven-parameters }}
+          mvn -B verify $TEST_MODULES -Ptest-coverage -P${{ matrix.module == 'spark3-scala213' && 'test-spark3' || matrix.test-profile || format('test-{0}', matrix.module) }} -Dlog.dir=${{ runner.temp }}/fluss-logs -Dlog4j.configurationFile=${{ github.workspace }}/tools/ci/log4j.properties ${{ inputs.maven-parameters }}
         env:
           MAVEN_OPTS: -Xmx4096m
           ARTIFACTS_OSS_ENDPOINT: ${{ secrets.ARTIFACTS_OSS_ENDPOINT }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,6 +20,7 @@ on:
   schedule:
     # Run at 20:00 UTC daily which is the lowest traffic time for Fluss project.
     - cron: "0 20 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.number || github.run_id }}
@@ -32,3 +33,4 @@ jobs:
     with:
       java-version: "8"
       maven-parameters: "-Pjava8"
+      run-spark-scala213: true


### PR DESCRIPTION
### Purpose

Linked issue: close #3936

Move the Spark Scala 2.13 compatibility lane out of the default pull-request CI to reduce duplicated load on the self-hosted runners, while preserving the existing coverage in Nightly.

### Brief change log

- Exclude `spark3-scala213` from reusable CI workflow calls by default.
- Enable `spark3-scala213` explicitly in the Nightly workflow.
- Allow the Nightly workflow to be triggered manually when Scala 2.13 coverage is needed.
- Preserve the existing Scala 2.13 Spark module and test selection from `stage.sh`.

### Tests

- `actionlint .github/workflows/ci-template.yaml .github/workflows/ci.yaml .github/workflows/nightly.yaml`
- `bash -n .github/workflows/stage.sh`
- Verified `./.github/workflows/stage.sh spark3-scala213` still selects `-Pscala-2.13`, excludes `SparkLakeTest`, and runs the existing Spark modules.
- `./mvnw spotless:check`
- `git diff --check apache/main...HEAD`

### API and Format

No public API or storage format changes.

### Documentation

No documentation changes. This change only updates CI workflow scheduling.

Generative AI disclosure:
- [ ] No generative AI tools used
- [x] Yes: Codex (OpenAI)

Generated-by: Codex (OpenAI) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
