### PR TITLE
[server] Fix remote log start offset of RemoteLogManifest may expose an expired physical prefix

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
+++ b/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
@@ -145,8 +145,8 @@ public class RemoteLogManifest {
     public long getRemoteLogStartOffset() {
         long startOffset = Long.MAX_VALUE;
         for (RemoteLogSegment remoteLogSegment : remoteLogSegmentList) {
-            if (remoteLogSegment.remoteLogStartOffset() < startOffset) {
-                startOffset = remoteLogSegment.remoteLogStartOffset();
+            if (remoteLogSegment.logicalStartOffset() < startOffset) {
+                startOffset = remoteLogSegment.logicalStartOffset();
             }
         }
         return startOffset;
@@ -155,8 +155,8 @@ public class RemoteLogManifest {
     public long getRemoteLogEndOffset() {
         long endOffset = -1;
         for (RemoteLogSegment remoteLogSegment : remoteLogSegmentList) {
-            if (endOffset == -1 || remoteLogSegment.remoteLogEndOffset() > endOffset) {
-                endOffset = remoteLogSegment.remoteLogEndOffset();
+            if (endOffset == -1 || remoteLogSegment.logicalEndOffset() > endOffset) {
+                endOffset = remoteLogSegment.logicalEndOffset();
             }
         }
         return endOffset;

--- a/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
+++ b/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
@@ -142,6 +142,15 @@ public class RemoteLogManifest {
                 physicalTablePath, tableBucket, newSegments, newHighestCopiedEndOffset);
     }
 
+    /**
+     * Returns the inclusive start offset of the logical range exposed by this manifest, or {@link
+     * Long#MAX_VALUE} if this manifest is empty.
+     *
+     * <p>Although this method retains the remote-log naming, the returned value describes the
+     * manifest-visible range rather than the physical range of its persisted segments. It may be
+     * greater than the physical start offset of the first segment when an overlapping prefix is
+     * hidden by the manifest.
+     */
     public long getRemoteLogStartOffset() {
         long startOffset = Long.MAX_VALUE;
         for (RemoteLogSegment remoteLogSegment : remoteLogSegmentList) {
@@ -152,6 +161,15 @@ public class RemoteLogManifest {
         return startOffset;
     }
 
+    /**
+     * Returns the exclusive end offset of the logical range exposed by this manifest, or {@code -1}
+     * if this manifest is empty.
+     *
+     * <p>Although this method retains the remote-log naming, the returned value describes the
+     * manifest-visible range rather than the physical range of its persisted segments. It may be
+     * less than the physical end offset of the last segment when an overlapping suffix is hidden by
+     * the manifest.
+     */
     public long getRemoteLogEndOffset() {
         long endOffset = -1;
         for (RemoteLogSegment remoteLogSegment : remoteLogSegmentList) {

--- a/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
+++ b/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
@@ -143,13 +143,12 @@ public class RemoteLogManifest {
     }
 
     /**
-     * Returns the inclusive start offset of the logical range exposed by this manifest, or {@link
+     * Returns the inclusive logical start offset exposed by this manifest, or {@link
      * Long#MAX_VALUE} if this manifest is empty.
      *
-     * <p>Although this method retains the remote-log naming, the returned value describes the
-     * manifest-visible range rather than the physical range of its persisted segments. It may be
-     * greater than the physical start offset of the first segment when an overlapping prefix is
-     * hidden by the manifest.
+     * <p>The returned value is the start of the logical range visible through the manifest, not
+     * necessarily the physical start offset of its first persisted segment. This method retains the
+     * remote-log naming for API compatibility.
      */
     public long getRemoteLogStartOffset() {
         long startOffset = Long.MAX_VALUE;
@@ -162,13 +161,12 @@ public class RemoteLogManifest {
     }
 
     /**
-     * Returns the exclusive end offset of the logical range exposed by this manifest, or {@code -1}
-     * if this manifest is empty.
+     * Returns the exclusive logical end offset exposed by this manifest, or {@code -1} if this
+     * manifest is empty.
      *
-     * <p>Although this method retains the remote-log naming, the returned value describes the
-     * manifest-visible range rather than the physical range of its persisted segments. It may be
-     * less than the physical end offset of the last segment when an overlapping suffix is hidden by
-     * the manifest.
+     * <p>The returned value is the end of the logical range visible through the manifest, rather
+     * than a physical segment boundary. This method retains the remote-log naming for API
+     * compatibility.
      */
     public long getRemoteLogEndOffset() {
         long endOffset = -1;

--- a/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
+++ b/fluss-common/src/main/java/org/apache/fluss/remote/RemoteLogManifest.java
@@ -147,8 +147,7 @@ public class RemoteLogManifest {
      * Long#MAX_VALUE} if this manifest is empty.
      *
      * <p>The returned value is the start of the logical range visible through the manifest, not
-     * necessarily the physical start offset of its first persisted segment. This method retains the
-     * remote-log naming for API compatibility.
+     * necessarily the physical start offset of its first persisted segment.
      */
     public long getRemoteLogStartOffset() {
         long startOffset = Long.MAX_VALUE;
@@ -165,8 +164,7 @@ public class RemoteLogManifest {
      * manifest is empty.
      *
      * <p>The returned value is the end of the logical range visible through the manifest, rather
-     * than a physical segment boundary. This method retains the remote-log naming for API
-     * compatibility.
+     * than a physical segment boundary.
      */
     public long getRemoteLogEndOffset() {
         long endOffset = -1;

--- a/fluss-common/src/test/java/org/apache/fluss/remote/RemoteLogManifestOverlapTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/remote/RemoteLogManifestOverlapTest.java
@@ -153,8 +153,16 @@ class RemoteLogManifestOverlapTest {
 
         assertThat(result.getRemoteLogSegmentList())
                 .containsExactly(replacement.withLogicalRange(10L, 25L));
-        assertThat(result.getRemoteLogStartOffset()).isEqualTo(5L);
+        assertThat(result.getRemoteLogStartOffset()).isEqualTo(10L);
         assertThat(result.getRemoteLogEndOffset()).isEqualTo(25L);
+    }
+
+    @Test
+    void testRemoteLogOffsetsUseLogicalRange() {
+        RemoteLogManifest result = manifest(segment(5L, 25L).withLogicalRange(10L, 20L));
+
+        assertThat(result.getRemoteLogStartOffset()).isEqualTo(10L);
+        assertThat(result.getRemoteLogEndOffset()).isEqualTo(20L);
     }
 
     @Test


### PR DESCRIPTION
<!-- Generated-by: Codex (gpt-5) following https://github.com/apache/fluss/blob/main/AGENTS.md -->

### Purpose

Remote log manifests can expose a logical range narrower than the physical ranges of their persisted segments. The aggregate manifest offsets are propagated as the remotely readable range, so they must be derived from logical boundaries.

### Brief change log

- Make `RemoteLogManifest#getRemoteLogStartOffset` return the minimum logical start offset.
- Make `RemoteLogManifest#getRemoteLogEndOffset` return the maximum logical end offset.
- Preserve the existing Java API and RPC field names.
- Add coverage for manifests with clipped physical prefixes and suffixes.

### Tests

- `mvn -o -pl fluss-common -Dtest=RemoteLogManifestOverlapTest test`
- Checkstyle and Spotless passed as part of the Maven lifecycle.

### API and Format

No API, RPC field, or storage-format changes.

### Documentation

No documentation changes.

### Generative AI disclosure

- [x] Yes — Codex (gpt-5)
