### PR TITLE
[fs] Relocate commons in S3/GS/Azure fs plugins to fix Spark conflict

### DIFF
--- a/fluss-filesystems/fluss-fs-azure/pom.xml
+++ b/fluss-filesystems/fluss-fs-azure/pom.xml
@@ -236,6 +236,12 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/fluss-filesystems/fluss-fs-gs/pom.xml
+++ b/fluss-filesystems/fluss-fs-gs/pom.xml
@@ -423,6 +423,12 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/fluss-filesystems/fluss-fs-s3/pom.xml
+++ b/fluss-filesystems/fluss-fs-s3/pom.xml
@@ -380,6 +380,12 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary
- The fluss-fs-s3, fluss-fs-gs and fluss-fs-azure shaded jars bundled unrelocated `org.apache.commons` classes (e.g. commons-text 1.4 from hadoop-common 3.3.4). When these plugin jars are placed on an engine classpath, the old classes shadow the engine's newer ones, e.g. Spark ships commons-text 1.10.0, causing `NoSuchMethodError: StringSubstitutor.setEnableUndefinedVariableException(boolean)`
- Relocate `org.apache.commons` to `org.apache.fluss.shaded.org.apache.commons` in all three plugins, consistent with fluss-fs-oss/cos/obs/hdfs

## Test Plan
- [x] `mvn verify -pl fluss-filesystems/fluss-fs-s3` passes
- [x] `mvn verify -pl fluss-filesystems/fluss-fs-gs` passes (19 tests)
- [x] `mvn test -pl fluss-filesystems/fluss-fs-azure` passes (18 tests)
- [x] Verified shaded jars contain no unrelocated `org/apache/commons/**` entries
- [x] Verified locally: Fluss S3 on Spark 3.5 no longer throws the `NoSuchMethodError`

🤖 AI-assisted changes - reviewed by human developer