### PR TITLE
[rust] Support writing records to multiple tables

### DIFF
--- a/fluss-rust/crates/fluss/src/client/connection.rs
+++ b/fluss-rust/crates/fluss/src/client/connection.rs
@@ -148,9 +148,9 @@ impl FlussConnection {
     }
 
     /// Creates a writer that can route append, upsert, and delete records to multiple tables.
-    pub fn new_multi_table_writer(&self) -> Result<MultiTableWriter<'_>> {
+    pub fn new_multi_table_writer(&self) -> Result<MultiTableWriter> {
         Ok(MultiTableWriter::new(
-            self,
+            self.get_admin()?,
             self.get_or_create_writer_client()?,
         ))
     }

--- a/fluss-rust/crates/fluss/src/client/connection.rs
+++ b/fluss-rust/crates/fluss/src/client/connection.rs
@@ -19,7 +19,7 @@ use crate::client::WriterClient;
 use crate::client::admin::FlussAdmin;
 use crate::client::lookup::LookupClient;
 use crate::client::metadata::Metadata;
-use crate::client::table::FlussTable;
+use crate::client::table::{FlussTable, MultiTableWriter};
 use crate::config::Config;
 use crate::error::{Error, FlussError, Result};
 use crate::metadata::TablePath;
@@ -145,6 +145,14 @@ impl FlussConnection {
         // 5. Store and return the newly created client.
         *writer_guard = Some(new_client.clone());
         Ok(new_client)
+    }
+
+    /// Creates a writer that can route append, upsert, and delete records to multiple tables.
+    pub fn new_multi_table_writer(&self) -> Result<MultiTableWriter<'_>> {
+        Ok(MultiTableWriter::new(
+            self,
+            self.get_or_create_writer_client()?,
+        ))
     }
 
     #[cfg(feature = "integration_tests")]

--- a/fluss-rust/crates/fluss/src/client/table/mod.rs
+++ b/fluss-rust/crates/fluss/src/client/table/mod.rs
@@ -27,6 +27,7 @@ pub const EARLIEST_OFFSET: i64 = -2;
 mod append;
 mod batch_scanner;
 mod lookup;
+mod multi_table;
 
 mod log_fetch_buffer;
 mod partition_getter;
@@ -39,6 +40,7 @@ mod upsert;
 pub use append::{AppendWriter, TableAppend};
 pub use batch_scanner::LimitBatchScanner;
 pub use lookup::{LookupResult, Lookuper, PrefixKeyLookuper, TableLookup, TablePrefixLookup};
+pub use multi_table::{MultiTableWriteOperation, MultiTableWriteRecord, MultiTableWriter};
 pub use reader::{RecordBatchLogReader, SyncRecordBatchLogReader};
 pub use remote_log::{
     DEFAULT_REMOTE_FILE_DOWNLOAD_THREAD_NUM, DEFAULT_SCANNER_REMOTE_LOG_PREFETCH_NUM,

--- a/fluss-rust/crates/fluss/src/client/table/multi_table.rs
+++ b/fluss-rust/crates/fluss/src/client/table/multi_table.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::client::connection::FlussConnection;
+use crate::client::admin::FlussAdmin;
 use crate::client::table::{AppendWriter, TableAppend, TableUpsert, UpsertWriter};
 use crate::client::{WriteResultFuture, WriterClient};
 use crate::error::{Error, Result};
@@ -98,16 +98,16 @@ impl<'a, R: InternalRow> MultiTableWriteRecord<'a, R> {
 ///
 /// The writer is not thread-safe. It lazily resolves table metadata and caches an existing
 /// [`AppendWriter`] or [`UpsertWriter`] for each `(table path, schema id)` pair.
-pub struct MultiTableWriter<'a> {
-    connection: &'a FlussConnection,
+pub struct MultiTableWriter {
+    admin: Arc<FlussAdmin>,
     writer_client: Arc<WriterClient>,
     states: HashMap<(TablePath, i32), TableWriteState>,
 }
 
-impl<'a> MultiTableWriter<'a> {
-    pub(crate) fn new(connection: &'a FlussConnection, writer_client: Arc<WriterClient>) -> Self {
+impl MultiTableWriter {
+    pub(crate) fn new(admin: Arc<FlussAdmin>, writer_client: Arc<WriterClient>) -> Self {
         Self {
-            connection,
+            admin,
             writer_client,
             states: HashMap::new(),
         }
@@ -161,12 +161,7 @@ impl<'a> MultiTableWriter<'a> {
         table_path: &TablePath,
         schema_id: i32,
     ) -> Result<TableInfo> {
-        let latest = self
-            .connection
-            .get_table(table_path)
-            .await?
-            .get_table_info()
-            .clone();
+        let latest = self.admin.get_table_info(table_path).await?;
 
         if schema_id > latest.get_schema_id() {
             return Err(Error::IllegalArgument {
@@ -181,8 +176,7 @@ impl<'a> MultiTableWriter<'a> {
         }
 
         let schema_info = self
-            .connection
-            .get_admin()?
+            .admin
             .get_table_schema(table_path, Some(schema_id))
             .await?;
         if schema_info.schema_id() != schema_id {

--- a/fluss-rust/crates/fluss/src/client/table/multi_table.rs
+++ b/fluss-rust/crates/fluss/src/client/table/multi_table.rs
@@ -1,0 +1,281 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::client::connection::FlussConnection;
+use crate::client::table::{AppendWriter, TableAppend, TableUpsert, UpsertWriter};
+use crate::client::{WriteResultFuture, WriterClient};
+use crate::error::{Error, Result};
+use crate::metadata::{TableInfo, TablePath};
+use crate::row::InternalRow;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// An operation supported by [`MultiTableWriter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MultiTableWriteOperation {
+    /// Append a row to a log table.
+    Append,
+    /// Insert or update a row in a primary-key table.
+    Upsert,
+    /// Delete a row from a primary-key table.
+    Delete,
+}
+
+/// A row and its target table, operation, and write-time schema id.
+pub struct MultiTableWriteRecord<'a, R: InternalRow> {
+    table_path: TablePath,
+    operation: MultiTableWriteOperation,
+    row: &'a R,
+    schema_id: i32,
+}
+
+impl<'a, R: InternalRow> MultiTableWriteRecord<'a, R> {
+    /// Creates an append record for a log table.
+    pub fn for_append(table_path: &TablePath, row: &'a R, schema_id: i32) -> Self {
+        Self::new(table_path, MultiTableWriteOperation::Append, row, schema_id)
+    }
+
+    /// Creates an upsert record for a primary-key table.
+    pub fn for_upsert(table_path: &TablePath, row: &'a R, schema_id: i32) -> Self {
+        Self::new(table_path, MultiTableWriteOperation::Upsert, row, schema_id)
+    }
+
+    /// Creates a delete record for a primary-key table.
+    pub fn for_delete(table_path: &TablePath, row: &'a R, schema_id: i32) -> Self {
+        Self::new(table_path, MultiTableWriteOperation::Delete, row, schema_id)
+    }
+
+    fn new(
+        table_path: &TablePath,
+        operation: MultiTableWriteOperation,
+        row: &'a R,
+        schema_id: i32,
+    ) -> Self {
+        Self {
+            table_path: table_path.clone(),
+            operation,
+            row,
+            schema_id,
+        }
+    }
+
+    /// Returns the target table.
+    pub fn table_path(&self) -> &TablePath {
+        &self.table_path
+    }
+
+    /// Returns the write operation.
+    pub fn operation(&self) -> MultiTableWriteOperation {
+        self.operation
+    }
+
+    /// Returns the row payload.
+    pub fn row(&self) -> &R {
+        self.row
+    }
+
+    /// Returns the schema id used to encode the row.
+    pub fn schema_id(&self) -> i32 {
+        self.schema_id
+    }
+}
+
+/// Routes records to multiple log and primary-key tables.
+///
+/// The writer is not thread-safe. It lazily resolves table metadata and caches an existing
+/// [`AppendWriter`] or [`UpsertWriter`] for each `(table path, schema id)` pair.
+pub struct MultiTableWriter<'a> {
+    connection: &'a FlussConnection,
+    writer_client: Arc<WriterClient>,
+    states: HashMap<(TablePath, i32), TableWriteState>,
+}
+
+impl<'a> MultiTableWriter<'a> {
+    pub(crate) fn new(connection: &'a FlussConnection, writer_client: Arc<WriterClient>) -> Self {
+        Self {
+            connection,
+            writer_client,
+            states: HashMap::new(),
+        }
+    }
+
+    /// Resolves the target table and queues the record for writing.
+    ///
+    /// Await this method to finish metadata resolution. The returned [`WriteResultFuture`] can be
+    /// awaited for per-record acknowledgment or dropped when [`Self::flush`] is used later.
+    pub async fn write<R: InternalRow>(
+        &mut self,
+        record: MultiTableWriteRecord<'_, R>,
+    ) -> Result<WriteResultFuture> {
+        if !(0..=i16::MAX as i32).contains(&record.schema_id) {
+            return Err(Error::IllegalArgument {
+                message: format!(
+                    "Invalid schema id {} for table {}; expected a value from 0 to {}",
+                    record.schema_id,
+                    record.table_path,
+                    i16::MAX
+                ),
+            });
+        }
+
+        let key = (record.table_path.clone(), record.schema_id);
+        if !self.states.contains_key(&key) {
+            let table_info = self
+                .resolve_table_info(&record.table_path, record.schema_id)
+                .await?;
+            let state = TableWriteState::new(
+                &record.table_path,
+                table_info,
+                Arc::clone(&self.writer_client),
+            )?;
+            self.states.insert(key.clone(), state);
+        }
+
+        self.states
+            .get(&key)
+            .expect("write state was inserted")
+            .write(record.operation, record.row)
+    }
+
+    /// Flushes all pending writes queued through the connection's writer client.
+    pub async fn flush(&self) -> Result<()> {
+        self.writer_client.flush().await
+    }
+
+    async fn resolve_table_info(
+        &self,
+        table_path: &TablePath,
+        schema_id: i32,
+    ) -> Result<TableInfo> {
+        let latest = self
+            .connection
+            .get_table(table_path)
+            .await?
+            .get_table_info()
+            .clone();
+
+        if schema_id > latest.get_schema_id() {
+            return Err(Error::IllegalArgument {
+                message: format!(
+                    "Schema id mismatch for table {table_path}: record schema id {schema_id} is ahead of the current table schema id {}",
+                    latest.get_schema_id()
+                ),
+            });
+        }
+        if schema_id == latest.get_schema_id() {
+            return Ok(latest);
+        }
+
+        let schema_info = self
+            .connection
+            .get_admin()?
+            .get_table_schema(table_path, Some(schema_id))
+            .await?;
+        if schema_info.schema_id() != schema_id {
+            return Err(Error::UnexpectedError {
+                message: format!(
+                    "Requested schema id {schema_id} for table {table_path}, but server returned {}",
+                    schema_info.schema_id()
+                ),
+                source: None,
+            });
+        }
+
+        Ok(TableInfo::new(
+            table_path.clone(),
+            latest.get_table_id(),
+            schema_id,
+            schema_info.into_parts().0,
+            latest.get_bucket_keys().to_vec(),
+            Arc::clone(latest.get_partition_keys()),
+            latest.get_num_buckets(),
+            latest.get_properties().clone(),
+            latest.get_custom_properties().clone(),
+            latest.get_comment().map(str::to_owned),
+            latest.get_created_time(),
+            latest.get_modified_time(),
+        ))
+    }
+}
+
+enum TableWriteState {
+    Append(AppendWriter),
+    Upsert(UpsertWriter),
+}
+
+impl TableWriteState {
+    fn new(
+        table_path: &TablePath,
+        table_info: TableInfo,
+        writer_client: Arc<WriterClient>,
+    ) -> Result<Self> {
+        if table_info.has_primary_key() {
+            Ok(Self::Upsert(
+                TableUpsert::new(table_path.clone(), table_info, writer_client).create_writer()?,
+            ))
+        } else {
+            Ok(Self::Append(
+                TableAppend::new(table_path.clone(), Arc::new(table_info), writer_client)
+                    .create_writer()?,
+            ))
+        }
+    }
+
+    fn write<R: InternalRow>(
+        &self,
+        operation: MultiTableWriteOperation,
+        row: &R,
+    ) -> Result<WriteResultFuture> {
+        match (self, operation) {
+            (Self::Append(writer), MultiTableWriteOperation::Append) => writer.append(row),
+            (Self::Upsert(writer), MultiTableWriteOperation::Upsert) => writer.upsert(row),
+            (Self::Upsert(writer), MultiTableWriteOperation::Delete) => writer.delete(row),
+            (Self::Append(_), operation) => Err(Error::UnsupportedOperation {
+                message: format!("Operation {operation:?} is not supported for a log table"),
+            }),
+            (Self::Upsert(_), MultiTableWriteOperation::Append) => {
+                Err(Error::UnsupportedOperation {
+                    message: "Append is not supported for a primary-key table".to_string(),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::row::GenericRow;
+
+    #[test]
+    fn write_record_factories_preserve_fields() {
+        let table_path = TablePath::new("db", "table");
+        let row = GenericRow::new(1);
+
+        let append = MultiTableWriteRecord::for_append(&table_path, &row, 1);
+        assert_eq!(append.table_path(), &table_path);
+        assert_eq!(append.operation(), MultiTableWriteOperation::Append);
+        assert_eq!(append.row().get_field_count(), 1);
+        assert_eq!(append.schema_id(), 1);
+
+        let upsert = MultiTableWriteRecord::for_upsert(&table_path, &row, 2);
+        assert_eq!(upsert.operation(), MultiTableWriteOperation::Upsert);
+
+        let delete = MultiTableWriteRecord::for_delete(&table_path, &row, 3);
+        assert_eq!(delete.operation(), MultiTableWriteOperation::Delete);
+    }
+}

--- a/fluss-rust/crates/fluss/src/client/write/accumulator.rs
+++ b/fluss-rust/crates/fluss/src/client/write/accumulator.rs
@@ -262,7 +262,6 @@ impl RecordAccumulator {
 
     fn append_new_batch(
         &self,
-        cluster: &Cluster,
         record: &WriteRecord,
         dq: &mut VecDeque<WriteBatch>,
         permit: MemoryPermit,
@@ -270,8 +269,7 @@ impl RecordAccumulator {
         compression_ratio_estimator: Arc<ArrowCompressionRatioEstimator>,
     ) -> Result<RecordAppendResult> {
         let physical_table_path = &record.physical_table_path;
-        let table_path = physical_table_path.get_table_path();
-        let table_info = cluster.get_table(table_path)?;
+        let table_info = &record.table_info;
         let arrow_compression_info = table_info.get_table_config().get_arrow_compression_info()?;
         let row_type = &table_info.row_type;
 
@@ -328,8 +326,7 @@ impl RecordAccumulator {
         abort_if_batch_full: bool,
     ) -> Result<RecordAppendResult> {
         let physical_table_path = &record.physical_table_path;
-        let table_path = physical_table_path.get_table_path();
-        let table_info = cluster.get_table(table_path)?;
+        let table_info = &record.table_info;
         let is_partitioned_table = table_info.is_partitioned();
 
         let partition_id = if is_partitioned_table {
@@ -395,7 +392,6 @@ impl RecordAccumulator {
         }
 
         self.append_new_batch(
-            cluster,
             record,
             &mut dq_guard,
             permit,

--- a/fluss-rust/crates/fluss/src/client/write/batch.rs
+++ b/fluss-rust/crates/fluss/src/client/write/batch.rs
@@ -239,6 +239,7 @@ impl WriteBatch {
 pub struct ArrowLogWriteBatch {
     pub write_batch: InnerWriteBatch,
     pub arrow_builder: MemoryLogRecordsArrowBuilder,
+    schema_id: i32,
     built_records: Option<Bytes>,
 }
 
@@ -266,6 +267,7 @@ impl ArrowLogWriteBatch {
                 write_limit,
                 compression_ratio_estimator,
             )?,
+            schema_id,
             built_records: None,
         })
     }
@@ -275,6 +277,9 @@ impl ArrowLogWriteBatch {
     }
 
     pub fn try_append(&mut self, write_record: &WriteRecord) -> Result<Option<ResultHandle>> {
+        if self.schema_id != write_record.schema_id {
+            return Ok(None);
+        }
         if self.arrow_builder.is_closed() || self.arrow_builder.is_full() {
             Ok(None)
         } else {
@@ -366,13 +371,7 @@ impl KvWriteBatch {
         let key = kv_write_record.key.as_ref();
 
         if self.schema_id != write_record.schema_id {
-            return Err(Error::UnexpectedError {
-                message: format!(
-                    "schema id {} of the write record to append is not the same as the current schema id {} in the batch.",
-                    write_record.schema_id, self.schema_id
-                ),
-                source: None,
-            });
+            return Ok(None);
         };
 
         if self.target_columns != kv_write_record.target_columns {
@@ -561,6 +560,61 @@ mod tests {
             batch.try_append(&record).unwrap();
         }
         assert_eq!(batch.record_count(), 3);
+    }
+
+    #[test]
+    fn schema_change_requires_new_arrow_and_kv_batches() {
+        use crate::compression::{ArrowCompressionType, DEFAULT_NON_ZSTD_COMPRESSION_LEVEL};
+        use crate::metadata::{DataField, DataTypes, KvFormat};
+        use crate::row::GenericRow;
+
+        let table_path = TablePath::new("db", "tbl");
+        let table_info = Arc::new(build_table_info(table_path.clone(), 1, 1));
+        let physical_path = Arc::new(PhysicalTablePath::of(Arc::new(table_path)));
+        let row = GenericRow::from_data(vec![1_i32]);
+        let record =
+            WriteRecord::for_append(Arc::clone(&table_info), Arc::clone(&physical_path), 2, &row);
+        let mut batch = WriteBatch::ArrowLog(
+            ArrowLogWriteBatch::new(
+                1,
+                Arc::clone(&physical_path),
+                1,
+                ArrowCompressionInfo {
+                    compression_type: ArrowCompressionType::None,
+                    compression_level: DEFAULT_NON_ZSTD_COMPRESSION_LEVEL,
+                },
+                &RowType::new(vec![DataField::new("id", DataTypes::int(), None)]),
+                0,
+                false,
+                1024,
+                Arc::new(ArrowCompressionRatioEstimator::default()),
+            )
+            .expect("batch"),
+        );
+
+        assert!(batch.try_append(&record).expect("append check").is_none());
+
+        let record = WriteRecord::for_upsert(
+            table_info,
+            Arc::clone(&physical_path),
+            2,
+            Bytes::from_static(b"key"),
+            None,
+            WriteFormat::CompactedKv,
+            None,
+            Some(RowBytes::Owned(Bytes::from_static(b"value"))),
+        );
+        let mut batch = WriteBatch::Kv(KvWriteBatch::new(
+            2,
+            physical_path,
+            1,
+            1024,
+            KvFormat::COMPACTED,
+            None,
+            0,
+        ));
+
+        assert!(batch.try_append(&record).expect("upsert check").is_none());
     }
 
     #[test]

--- a/fluss-rust/crates/fluss/tests/integration/multi_table_writer.rs
+++ b/fluss-rust/crates/fluss/tests/integration/multi_table_writer.rs
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[cfg(test)]
+mod multi_table_writer_test {
+    use crate::integration::utils::{
+        DEFAULT_POLL_TIMEOUT, create_table, get_shared_cluster, poll_until_count,
+    };
+    use fluss::client::{EARLIEST_OFFSET, MultiTableWriteRecord};
+    use fluss::metadata::{
+        AddColumn, AlterTableChanges, ColumnPositionType, DataTypes, JsonSerde, Schema,
+        TableDescriptor, TablePath,
+    };
+    use fluss::row::{DataGetters, GenericRow};
+    use std::time::Duration;
+
+    fn row(id: i32, value: &str) -> GenericRow<'_> {
+        let mut row = GenericRow::new(2);
+        row.set_field(0, id);
+        row.set_field(1, value);
+        row
+    }
+
+    #[tokio::test]
+    async fn writes_cdc_records_to_multiple_tables() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("admin");
+        let log_path = TablePath::new("fluss", "test_multi_writer_log");
+        let first_pk_path = TablePath::new("fluss", "test_multi_writer_pk_1");
+        let second_pk_path = TablePath::new("fluss", "test_multi_writer_pk_2");
+
+        let log_descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("id", DataTypes::int())
+                    .column("value", DataTypes::string())
+                    .build()
+                    .expect("log schema"),
+            )
+            .build()
+            .expect("log table");
+        let pk_descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("id", DataTypes::int())
+                    .column("value", DataTypes::string())
+                    .primary_key(vec!["id"])
+                    .build()
+                    .expect("pk schema"),
+            )
+            .build()
+            .expect("pk table");
+        create_table(&admin, &log_path, &log_descriptor).await;
+        create_table(&admin, &first_pk_path, &pk_descriptor).await;
+        create_table(&admin, &second_pk_path, &pk_descriptor).await;
+
+        let log_schema_id = admin
+            .get_table_info(&log_path)
+            .await
+            .expect("log info")
+            .get_schema_id();
+        let first_pk_schema_id = admin
+            .get_table_info(&first_pk_path)
+            .await
+            .expect("first pk info")
+            .get_schema_id();
+        let second_pk_schema_id = admin
+            .get_table_info(&second_pk_path)
+            .await
+            .expect("second pk info")
+            .get_schema_id();
+
+        let mut writer = connection
+            .new_multi_table_writer()
+            .expect("multi-table writer");
+        let log_row = row(1, "created");
+        let first_pk_row = row(1, "updated");
+        let second_pk_row = row(2, "deleted");
+
+        writer
+            .write(MultiTableWriteRecord::for_append(
+                &log_path,
+                &log_row,
+                log_schema_id,
+            ))
+            .await
+            .expect("append");
+        writer
+            .write(MultiTableWriteRecord::for_upsert(
+                &first_pk_path,
+                &first_pk_row,
+                first_pk_schema_id,
+            ))
+            .await
+            .expect("first upsert");
+        writer
+            .write(MultiTableWriteRecord::for_upsert(
+                &second_pk_path,
+                &second_pk_row,
+                second_pk_schema_id,
+            ))
+            .await
+            .expect("second upsert");
+        writer
+            .write(MultiTableWriteRecord::for_delete(
+                &second_pk_path,
+                &second_pk_row,
+                second_pk_schema_id,
+            ))
+            .await
+            .expect("delete");
+
+        let invalid_operation = writer
+            .write(MultiTableWriteRecord::for_upsert(
+                &log_path,
+                &log_row,
+                log_schema_id,
+            ))
+            .await
+            .expect_err("upsert on log table should fail");
+        assert!(format!("{invalid_operation}").contains("not supported for a log table"));
+
+        let invalid_append = writer
+            .write(MultiTableWriteRecord::for_append(
+                &first_pk_path,
+                &first_pk_row,
+                first_pk_schema_id,
+            ))
+            .await
+            .expect_err("append on primary-key table should fail");
+        assert!(format!("{invalid_append}").contains("not supported for a primary-key table"));
+
+        let ahead_schema = writer
+            .write(MultiTableWriteRecord::for_upsert(
+                &first_pk_path,
+                &first_pk_row,
+                first_pk_schema_id + 1,
+            ))
+            .await
+            .expect_err("ahead schema id should fail");
+        assert!(format!("{ahead_schema}").contains("ahead of the current table schema id"));
+
+        writer.flush().await.expect("flush all tables");
+
+        let log_table = connection.get_table(&log_path).await.expect("log table");
+        let log_scanner = log_table
+            .new_scan()
+            .create_log_scanner()
+            .expect("log scanner");
+        log_scanner
+            .subscribe(0, EARLIEST_OFFSET)
+            .await
+            .expect("subscribe log table");
+        let log_rows = poll_until_count(
+            1,
+            DEFAULT_POLL_TIMEOUT,
+            Duration::from_millis(500),
+            async |timeout| {
+                log_scanner
+                    .poll(timeout)
+                    .await
+                    .expect("poll log table")
+                    .into_iter()
+                    .map(|record| record.row().get_string(1).expect("log value").to_string())
+                    .collect()
+            },
+        )
+        .await;
+        assert_eq!(log_rows, vec!["created"]);
+
+        let extra_type_json = serde_json::to_vec(
+            &DataTypes::string()
+                .serialize_json()
+                .expect("serialize string type"),
+        )
+        .expect("serialize add-column payload");
+        admin
+            .alter_table(
+                &log_path,
+                false,
+                AlterTableChanges {
+                    add_columns: vec![AddColumn {
+                        column_name: "extra".to_string(),
+                        data_type_json: extra_type_json,
+                        comment: None,
+                        position: ColumnPositionType::Last,
+                    }],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("alter log table");
+        let latest_log_schema_id = admin
+            .get_table_info(&log_path)
+            .await
+            .expect("updated log info")
+            .get_schema_id();
+
+        let mut schema_writer = connection
+            .new_multi_table_writer()
+            .expect("schema-aware writer");
+        let old_schema_row = row(2, "old-schema");
+        let mut new_schema_row = GenericRow::new(3);
+        new_schema_row.set_field(0, 3);
+        new_schema_row.set_field(1, "new-schema");
+        new_schema_row.set_field(2, "extra");
+        schema_writer
+            .write(MultiTableWriteRecord::for_append(
+                &log_path,
+                &old_schema_row,
+                log_schema_id,
+            ))
+            .await
+            .expect("historical schema append");
+        schema_writer
+            .write(MultiTableWriteRecord::for_append(
+                &log_path,
+                &new_schema_row,
+                latest_log_schema_id,
+            ))
+            .await
+            .expect("latest schema append");
+        schema_writer.flush().await.expect("flush schema writes");
+
+        let mut schema_ids = poll_until_count(
+            2,
+            DEFAULT_POLL_TIMEOUT,
+            Duration::from_millis(500),
+            async |timeout| {
+                log_scanner
+                    .poll(timeout)
+                    .await
+                    .expect("poll schema writes")
+                    .into_iter()
+                    .map(|record| record.row().get_int(0).expect("log id"))
+                    .collect()
+            },
+        )
+        .await;
+        schema_ids.sort();
+        assert_eq!(schema_ids, vec![2, 3]);
+
+        let first_pk_table = connection
+            .get_table(&first_pk_path)
+            .await
+            .expect("first pk");
+        let mut first_lookup = first_pk_table
+            .new_lookup()
+            .expect("first lookup")
+            .create_lookuper()
+            .expect("first lookuper");
+        let mut key = GenericRow::new(2);
+        key.set_field(0, 1);
+        assert!(
+            first_lookup
+                .lookup(&key)
+                .await
+                .expect("first lookup result")
+                .get_single_row()
+                .expect("first row decode")
+                .is_some()
+        );
+
+        let second_pk_table = connection
+            .get_table(&second_pk_path)
+            .await
+            .expect("second pk");
+        let mut second_lookup = second_pk_table
+            .new_lookup()
+            .expect("second lookup")
+            .create_lookuper()
+            .expect("second lookuper");
+        key.set_field(0, 2);
+        assert!(
+            second_lookup
+                .lookup(&key)
+                .await
+                .expect("second lookup result")
+                .get_single_row()
+                .expect("second row decode")
+                .is_none()
+        );
+    }
+}

--- a/fluss-rust/crates/fluss/tests/test_fluss.rs
+++ b/fluss-rust/crates/fluss/tests/test_fluss.rs
@@ -26,6 +26,7 @@ mod integration {
     mod kv_changelog;
     mod kv_table;
     mod log_table;
+    mod multi_table_writer;
     mod record_batch_log_reader;
     mod sasl_auth;
 

--- a/fluss-rust/website/docs/user-guide/rust/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/rust/api-reference.md
@@ -39,6 +39,7 @@ Complete API reference for the Fluss Rust client.
 | `async fn new(config: Config) -> Result<Self>`                                | Create a new connection to a Fluss cluster     |
 | `fn get_admin(&self) -> Result<Arc<FlussAdmin>>`                              | Get the admin interface for cluster management |
 | `async fn get_table(&self, table_path: &TablePath) -> Result<FlussTable<'_>>` | Get a table for read/write operations          |
+| `fn new_multi_table_writer(&self) -> Result<MultiTableWriter<'_>>`            | Create a writer for multi-table CDC records    |
 | `fn config(&self) -> &Config`                                                 | Get a reference to the connection config       |
 
 ## `FlussAdmin`
@@ -137,6 +138,17 @@ gauges). Unlike scanner metrics, these are **unlabeled** (global per process),
 matching Java's single `WriterMetricGroup` per client (Java scopes only by
 `client_id`, which the Rust `metrics` facade has no concept of yet). The same
 series are shared by `AppendWriter` (log tables) and `UpsertWriter` (PK tables).
+
+## `MultiTableWriter`
+
+`MultiTableWriter` routes records to multiple tables and caches write state by table and schema id.
+Use `MultiTableWriteRecord::for_append` for log tables and `for_upsert` / `for_delete` for
+primary-key tables.
+
+| Method | Description |
+|--------|-------------|
+| `async fn write(&mut self, record: MultiTableWriteRecord<'_, R>) -> Result<WriteResultFuture>` | Resolve the target table and queue one CDC record |
+| `async fn flush(&self) -> Result<()>` | Flush all writes pending in the connection writer client |
 
 ## `TableScan<'a>`
 

--- a/fluss-rust/website/docs/user-guide/rust/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/rust/api-reference.md
@@ -39,7 +39,7 @@ Complete API reference for the Fluss Rust client.
 | `async fn new(config: Config) -> Result<Self>`                                | Create a new connection to a Fluss cluster     |
 | `fn get_admin(&self) -> Result<Arc<FlussAdmin>>`                              | Get the admin interface for cluster management |
 | `async fn get_table(&self, table_path: &TablePath) -> Result<FlussTable<'_>>` | Get a table for read/write operations          |
-| `fn new_multi_table_writer(&self) -> Result<MultiTableWriter<'_>>`            | Create a writer for multi-table CDC records    |
+| `fn new_multi_table_writer(&self) -> Result<MultiTableWriter>`                | Create a writer for multi-table CDC records    |
 | `fn config(&self) -> &Config`                                                 | Get a reference to the connection config       |
 
 ## `FlussAdmin`


### PR DESCRIPTION
Generated-by: Codex following AGENTS.md

### Purpose

Linked issue: close #3961

The Rust client currently requires CDC consumers to manage one table writer per target table. Add a connection-level multi-table writer that routes append, upsert, and delete records while preserving the schema id carried by each record.

### Brief change log

- Add `MultiTableWriter`, `MultiTableWriteRecord`, and `MultiTableWriteOperation` to the Rust client API.
- Cache existing append/upsert writer state by table path and schema id.
- Resolve historical schemas and validate table/operation/schema combinations.
- Build write batches from each record's table metadata and split Arrow/KV batches on schema changes.
- Document the new Rust API.

### Tests

- `cargo build --workspace --all-targets --exclude fluss_python --exclude fluss-cpp --exclude fluss_nif`
- `cargo test --all-targets --workspace --exclude fluss_python --exclude fluss-cpp --exclude fluss_nif -- --skip client::metadata::tests::parse_bootstrap_preserves_later_entries_when_one_entry_is_unresolvable` (618 passed; one unrelated DNS-dependent test skipped locally)
- `cargo test -p fluss-rs --features integration_tests writes_cdc_records_to_multiple_tables --test test_fluss -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --workspace -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --exclude fluss_python`
- `cargo deny check licenses`
- Apache SkyWalking Eyes license header check
- `npm run build` in `fluss-rust/website`

### API and Format

Adds public Rust client APIs. No wire protocol or storage format changes.

### Documentation

Updates the Rust API reference with the multi-table CDC writer.
