### PR TITLE
[test] Stabilize RemoteLogDownloader prefetch test

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/RemoteLogDownloaderTest.java
@@ -93,13 +93,26 @@ class RemoteLogDownloaderTest {
     @Test
     void testPrefetchNum() throws Exception {
         RemoteFileDownloader remoteFileDownloader = new RemoteFileDownloader(1);
+        CountDownLatch fetchLoopBlocked = new CountDownLatch(1);
+        CountDownLatch continueFetchLoop = new CountDownLatch(1);
         RemoteLogDownloader remoteLogDownloader =
                 new RemoteLogDownloader(
                         DATA1_TABLE_PATH.toString(),
                         conf,
                         remoteFileDownloader,
                         scannerMetricGroup,
-                        10L);
+                        10L) {
+                    @Override
+                    void fetchOnce() throws Exception {
+                        // Pause after all requests are scheduled so the loop cannot acquire a
+                        // recycled permit before it is asserted below.
+                        if (scannerMetricGroup.remoteFetchRequestCount().getCount() >= 5) {
+                            fetchLoopBlocked.countDown();
+                            continueFetchLoop.await();
+                        }
+                        super.fetchOnce();
+                    }
+                };
         try {
             // trigger auto download.
             remoteLogDownloader.start();
@@ -139,9 +152,11 @@ class RemoteLogDownloaderTest {
                             remoteLogSegmentFilesLength(remoteLogSegments, remoteLogTabletDir, 5));
             assertThat(remoteLogDownloader.getPrefetchSemaphore().availablePermits()).isEqualTo(0);
 
+            assertThat(fetchLoopBlocked.await(30, TimeUnit.SECONDS)).isTrue();
             futures.get(1).getRecycleCallback().run();
             futures.get(2).getRecycleCallback().run();
             assertThat(remoteLogDownloader.getPrefetchSemaphore().availablePermits()).isEqualTo(2);
+            continueFetchLoop.countDown();
             // the removal of log files are async, so we need to wait for the removal.
             retry(
                     Duration.ofMinutes(1),
@@ -151,6 +166,7 @@ class RemoteLogDownloaderTest {
             remoteLogDownloader.close();
             assertThat(localLogDir.toFile().exists()).isFalse();
         } finally {
+            continueFetchLoop.countDown();
             IOUtils.closeQuietly(remoteLogDownloader);
             IOUtils.closeQuietly(remoteFileDownloader);
         }


### PR DESCRIPTION
<!-- Generated-by: Codex (GPT-5) following https://github.com/apache/fluss/blob/main/AGENTS.md -->

### Purpose

Linked issue: close #3460

`RemoteLogDownloaderTest.testPrefetchNum` can observe one available prefetch permit instead of two because the downloader thread may acquire a recycled permit while polling the empty request queue.

### Brief change log

- Pause the downloader fetch loop after all remote log requests are scheduled.
- Assert that both recycled prefetch permits are available while the fetch loop is paused.
- Resume the fetch loop after the assertion and ensure it is unblocked during cleanup.

### Tests

- `mvn -pl fluss-client -am -Dtest=RemoteLogDownloaderTest#testPrefetchNum -Dsurefire.failIfNoSpecifiedTests=false test`
- Repeated `RemoteLogDownloaderTest#testPrefetchNum` 10 times.
- `mvn -pl fluss-client -am verify` (blocked by unrelated local JMX/RMI connection failures in `JMXServerTest` and `JMXReporterTest`).

### API and Format

No API or storage-format changes.

### Documentation

No documentation changes.

### Generative AI disclosure

- [x] Yes — Codex (GPT-5)
