### PR TITLE
[server] Fix equals/hashCode contract in ISR states and remote log manifest handle

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/IsrState.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/IsrState.java
@@ -22,6 +22,7 @@ import org.apache.fluss.server.zk.data.LeaderAndIsr;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /* This file is based on source code of Apache Kafka Project (https://kafka.apache.org/), licensed by the Apache
  * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
@@ -91,6 +92,11 @@ public interface IsrState {
             }
             CommittedIsrState that = (CommittedIsrState) o;
             return isr.equals(that.isr);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(isr);
         }
 
         @Override
@@ -182,6 +188,11 @@ public interface IsrState {
         }
 
         @Override
+        public int hashCode() {
+            return Objects.hash(newInSyncReplicaId, sentLeaderAndIsr, lastCommittedState);
+        }
+
+        @Override
         public String toString() {
             return "PendingExpandIsrState{"
                     + "newInSyncReplicaId="
@@ -252,6 +263,11 @@ public interface IsrState {
             return outOfSyncReplicaIds.equals(that.outOfSyncReplicaIds)
                     && sentLeaderAndIsr.equals(that.sentLeaderAndIsr)
                     && lastCommittedState.equals(that.lastCommittedState);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(outOfSyncReplicaIds, sentLeaderAndIsr, lastCommittedState);
         }
 
         @Override

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/data/RemoteLogManifestHandle.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/data/RemoteLogManifestHandle.java
@@ -19,6 +19,8 @@ package org.apache.fluss.server.zk.data;
 
 import org.apache.fluss.fs.FsPath;
 
+import java.util.Objects;
+
 /**
  * The remote log manifest handle of a table bucket stored in {@link ZkData.BucketRemoteLogsZNode}.
  *
@@ -56,6 +58,11 @@ public class RemoteLogManifestHandle {
         RemoteLogManifestHandle that = (RemoteLogManifestHandle) o;
         return remoteLogManifestPath.equals(that.remoteLogManifestPath)
                 && remoteLogEndOffset == that.remoteLogEndOffset;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(remoteLogManifestPath, remoteLogEndOffset);
     }
 
     @Override

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/IsrStateTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/IsrStateTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.replica;
+
+import org.apache.fluss.server.replica.IsrState.CommittedIsrState;
+import org.apache.fluss.server.replica.IsrState.PendingExpandIsrState;
+import org.apache.fluss.server.replica.IsrState.PendingShrinkIsrState;
+import org.apache.fluss.server.zk.data.LeaderAndIsr;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test the {@code equals}/{@code hashCode} contract of the {@link IsrState} implementations. */
+class IsrStateTest {
+
+    private static final List<Integer> ISR = Arrays.asList(1, 2, 3);
+    private static final List<Integer> STANDBY = Collections.singletonList(4);
+
+    private static LeaderAndIsr leaderAndIsr() {
+        return new LeaderAndIsr(1, 0, Arrays.asList(1, 2, 3), Collections.singletonList(4), 0, 0);
+    }
+
+    @Test
+    void testCommittedIsrStateEqualsAndHashCode() {
+        CommittedIsrState state1 = new CommittedIsrState(ISR, STANDBY);
+        CommittedIsrState state2 = new CommittedIsrState(Arrays.asList(1, 2, 3), STANDBY);
+
+        assertThat(state1).isEqualTo(state2);
+        assertThat(state1).hasSameHashCodeAs(state2);
+    }
+
+    @Test
+    void testCommittedIsrStateHashCodeDiffersForDifferentIsr() {
+        CommittedIsrState state1 = new CommittedIsrState(ISR, STANDBY);
+        CommittedIsrState state2 = new CommittedIsrState(Arrays.asList(1, 2), STANDBY);
+
+        assertThat(state1).isNotEqualTo(state2);
+        assertThat(state1.hashCode()).isNotEqualTo(state2.hashCode());
+    }
+
+    @Test
+    void testPendingExpandIsrStateEqualsAndHashCode() {
+        CommittedIsrState committed = new CommittedIsrState(ISR, STANDBY);
+        PendingExpandIsrState state1 =
+                new PendingExpandIsrState(5, leaderAndIsr(), new CommittedIsrState(ISR, STANDBY));
+        PendingExpandIsrState state2 = new PendingExpandIsrState(5, leaderAndIsr(), committed);
+
+        assertThat(state1).isEqualTo(state2);
+        assertThat(state1).hasSameHashCodeAs(state2);
+    }
+
+    @Test
+    void testPendingExpandIsrStateHashCodeDiffersForDifferentReplica() {
+        CommittedIsrState committed = new CommittedIsrState(ISR, STANDBY);
+        PendingExpandIsrState state1 = new PendingExpandIsrState(5, leaderAndIsr(), committed);
+        PendingExpandIsrState state2 = new PendingExpandIsrState(6, leaderAndIsr(), committed);
+
+        assertThat(state1).isNotEqualTo(state2);
+        assertThat(state1.hashCode()).isNotEqualTo(state2.hashCode());
+    }
+
+    @Test
+    void testPendingShrinkIsrStateEqualsAndHashCode() {
+        CommittedIsrState committed = new CommittedIsrState(ISR, STANDBY);
+        PendingShrinkIsrState state1 =
+                new PendingShrinkIsrState(
+                        Collections.singletonList(3),
+                        leaderAndIsr(),
+                        new CommittedIsrState(ISR, STANDBY));
+        PendingShrinkIsrState state2 =
+                new PendingShrinkIsrState(Collections.singletonList(3), leaderAndIsr(), committed);
+
+        assertThat(state1).isEqualTo(state2);
+        assertThat(state1).hasSameHashCodeAs(state2);
+    }
+
+    @Test
+    void testPendingShrinkIsrStateHashCodeDiffersForDifferentOutOfSyncReplicas() {
+        CommittedIsrState committed = new CommittedIsrState(ISR, STANDBY);
+        PendingShrinkIsrState state1 =
+                new PendingShrinkIsrState(Collections.singletonList(3), leaderAndIsr(), committed);
+        PendingShrinkIsrState state2 =
+                new PendingShrinkIsrState(Arrays.asList(2, 3), leaderAndIsr(), committed);
+
+        assertThat(state1).isNotEqualTo(state2);
+        assertThat(state1.hashCode()).isNotEqualTo(state2.hashCode());
+    }
+
+    @Test
+    void testEqualStatesDeduplicateInHashSet() {
+        Set<IsrState> states = new HashSet<>();
+        states.add(new CommittedIsrState(ISR, STANDBY));
+        states.add(new CommittedIsrState(Arrays.asList(1, 2, 3), STANDBY));
+
+        assertThat(states).hasSize(1);
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/zk/data/RemoteLogManifestHandleTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/zk/data/RemoteLogManifestHandleTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.zk.data;
+
+import org.apache.fluss.fs.FsPath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test the {@code equals}/{@code hashCode} contract of {@link RemoteLogManifestHandle}. */
+class RemoteLogManifestHandleTest {
+
+    private static final String PATH = "/tmp/remote/log/manifest";
+
+    @Test
+    void testEqualsAndHashCode() {
+        RemoteLogManifestHandle handle1 = new RemoteLogManifestHandle(new FsPath(PATH), 100L);
+        RemoteLogManifestHandle handle2 = new RemoteLogManifestHandle(new FsPath(PATH), 100L);
+
+        assertThat(handle1).isEqualTo(handle2);
+        assertThat(handle1).hasSameHashCodeAs(handle2);
+    }
+
+    @Test
+    void testHashCodeDiffersForDifferentEndOffset() {
+        RemoteLogManifestHandle handle1 = new RemoteLogManifestHandle(new FsPath(PATH), 100L);
+        RemoteLogManifestHandle handle2 = new RemoteLogManifestHandle(new FsPath(PATH), 101L);
+
+        assertThat(handle1).isNotEqualTo(handle2);
+        assertThat(handle1.hashCode()).isNotEqualTo(handle2.hashCode());
+    }
+
+    @Test
+    void testHashCodeDiffersForDifferentPath() {
+        RemoteLogManifestHandle handle1 = new RemoteLogManifestHandle(new FsPath(PATH), 100L);
+        RemoteLogManifestHandle handle2 =
+                new RemoteLogManifestHandle(new FsPath(PATH + "/other"), 100L);
+
+        assertThat(handle1).isNotEqualTo(handle2);
+        assertThat(handle1.hashCode()).isNotEqualTo(handle2.hashCode());
+    }
+
+    @Test
+    void testEqualHandlesDeduplicateInHashSet() {
+        Set<RemoteLogManifestHandle> handles = new HashSet<>();
+        handles.add(new RemoteLogManifestHandle(new FsPath(PATH), 100L));
+        handles.add(new RemoteLogManifestHandle(new FsPath(PATH), 100L));
+
+        assertThat(handles).hasSize(1);
+    }
+}


### PR DESCRIPTION
<!--
Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: close #3973

Follow-up to #3951 / #3952, which fix the same defect in the record-batch classes.
`CommittedIsrState`, `PendingExpandIsrState`, `PendingShrinkIsrState` and
`RemoteLogManifestHandle` override `equals()` with value semantics but never override
`hashCode()`. Each extends `Object` and none delegates to `super.equals()`, so `hashCode()` is
the identity hash: equal instances hash differently, violating the general contract of
`Object.hashCode()`.

The four belong in one change. `PendingExpandIsrState.equals()` and
`PendingShrinkIsrState.equals()` both compare `lastCommittedState`, a `CommittedIsrState`, so a
correct hash for either pending state has to fold in `CommittedIsrState.hashCode()` — fixing the
pending states without `CommittedIsrState` would leave the composed hash identity-derived.
`LeaderAndIsr`, the other field they compare, already implements both methods consistently.

### Brief change log

- `IsrState.CommittedIsrState`: `hashCode()` over `isr`.
- `IsrState.PendingExpandIsrState`: over `newInSyncReplicaId`, `sentLeaderAndIsr`, `lastCommittedState`.
- `IsrState.PendingShrinkIsrState`: over `outOfSyncReplicaIds`, `sentLeaderAndIsr`, `lastCommittedState`.
- `RemoteLogManifestHandle`: over `remoteLogManifestPath`, `remoteLogEndOffset`.

Each covers exactly the fields its own `equals()` already compares, using `Objects.hash(...)` to
match the existing idiom in `LeaderAndIsr` in the same module.

`CommittedIsrState` holds `standbyReplicas` as well as `isr`, but its `equals()` compares only
`isr`, so `hashCode()` hashes only `isr`. I kept it consistent with the `equals()` that exists
today rather than widening equality, since changing ISR-state equality is a behavioural change
that deserves its own discussion — flagged in #3973 in case that omission is itself unintended.

### Tests

New `IsrStateTest` (7 tests) and `RemoteLogManifestHandleTest` (4 tests): for each class, two
independently constructed equal instances must share a hash code, unequal instances must hash
differently, and equal instances must deduplicate in a `HashSet`.

**6 of the 11 fail without the production change** and all 11 pass with it. The other 5 are the
"different contents hash differently" cases, which identity hashing also satisfies; they are there
to guard against an over-broad hash later.

Verified locally: `mvn test -pl fluss-server -Dtest='IsrStateTest,RemoteLogManifestHandleTest'`
passes, `checkstyle:check` reports 0 violations, and `spotless:apply` leaves the tree clean.

### API and Format

No API or storage-format change; `hashCode()` is additive. The only behavioural difference would
be for a `HashSet`/`HashMap` keyed on these types, and nothing keys them today.

### Documentation

No new feature, no documentation change.

### Scope

Two cases from the same sweep are deliberately excluded, and I would rather say why than leave
them looking overlooked:

- `TieringSourceEnumeratorState` (`fluss-flink-common`) has no `hashCode()` either, but its
  `equals()` is `this.toString().equals(that.toString())` against any non-null argument — it is
  asymmetric and accepts unrelated types. A `hashCode()` alone would half-fix it, so it needs its
  own issue.
- `WriteResultForBucket` and subclasses, and the `ModifyColumn*` classes in the Flink 1.18/1.19
  modules, inherit a `hashCode()` from a base that hashes a subset of the `equals()` fields. That
  is legal, only a weaker hash, so they are untouched.

### Generative AI disclosure

- [x] Yes — Claude Code (Opus 5). All changes reviewed by me before submitting.
