### PR TITLE
[Security]support oauth authenrization

### DIFF
--- a/fluss-client/src/main/resources/META-INF/NOTICE
+++ b/fluss-client/src/main/resources/META-INF/NOTICE
@@ -10,6 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.ververica:frocksdbjni:6.20.3-ververica-2.0
 - org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-math3:3.6.1
+- org.bitbucket.b_c:jose4j:0.9.6
 - at.yawk.lz4:lz4-java:1.10.2
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)

--- a/fluss-client/src/test/java/org/apache/fluss/client/OAuthBearerAuthenticationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/OAuthBearerAuthenticationITCase.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.client;
+
+import org.apache.fluss.client.admin.Admin;
+import org.apache.fluss.client.lookup.Lookuper;
+import org.apache.fluss.client.table.Table;
+import org.apache.fluss.client.table.writer.UpsertWriter;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.Password;
+import org.apache.fluss.metadata.Schema;
+import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.row.InternalRow;
+import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.types.DataTypes;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_MECHANISM;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_ID;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_TOKEN_ENDPOINT;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SECURITY_PROTOCOL;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_ENABLED_MECHANISMS_CONFIG;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_EXPECTED_AUDIENCES;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_EXPECTED_ISSUER;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_ENDPOINT;
+import static org.apache.fluss.security.auth.sasl.oauthbearer.OAuthBearerClientAuthenticator.OAUTHBEARER_MECHANISM;
+import static org.apache.fluss.server.testutils.FlussClusterExtension.BUILTIN_DATABASE;
+import static org.apache.fluss.testutils.DataTestUtils.row;
+import static org.apache.fluss.testutils.InternalRowAssert.assertThatRow;
+
+/** End-to-end test for SASL/OAUTHBEARER authentication. */
+class OAuthBearerAuthenticationITCase {
+    private static final String KEY_ID = "test-key";
+    private static final String ISSUER = "test-issuer";
+    private static final String AUDIENCE = "fluss";
+
+    @Test
+    void testOAuthBearerAuthenticationWithTableOperations() throws Exception {
+        try (TestingIdentityProvider identityProvider = new TestingIdentityProvider()) {
+            FlussClusterExtension clusterExtension =
+                    FlussClusterExtension.builder()
+                            .setNumOfTabletServers(1)
+                            .setCoordinatorServerListeners(
+                                    "FLUSS://localhost:0, CLIENT://localhost:0")
+                            .setTabletServerListeners("FLUSS://localhost:0, CLIENT://localhost:0")
+                            .setClusterConf(serverConfiguration(identityProvider))
+                            .build();
+
+            try {
+                clusterExtension.start();
+                verifyTableOperations(clusterExtension, identityProvider);
+            } finally {
+                clusterExtension.close();
+            }
+        }
+    }
+
+    private static void verifyTableOperations(
+            FlussClusterExtension clusterExtension, TestingIdentityProvider identityProvider)
+            throws Exception {
+        Configuration clientConfiguration = clusterExtension.getClientConfig("CLIENT");
+        clientConfiguration.set(CLIENT_SECURITY_PROTOCOL, "SASL");
+        clientConfiguration.set(CLIENT_SASL_MECHANISM, OAUTHBEARER_MECHANISM);
+        clientConfiguration.set(
+                CLIENT_SASL_OAUTHBEARER_TOKEN_ENDPOINT, identityProvider.tokenEndpoint());
+        clientConfiguration.set(CLIENT_SASL_OAUTHBEARER_CLIENT_ID, "test-client");
+        clientConfiguration.set(CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET, new Password("test-secret"));
+
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column("value", DataTypes.STRING())
+                        .primaryKey("id")
+                        .build();
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder().schema(schema).distributedBy(1, "id").build();
+        TablePath tablePath = TablePath.of(BUILTIN_DATABASE, "oauth_bearer_e2e");
+
+        try (Connection connection = ConnectionFactory.createConnection(clientConfiguration);
+                Admin admin = connection.getAdmin()) {
+            admin.createTable(tablePath, tableDescriptor, false).get();
+            try {
+                try (Table table = connection.getTable(tablePath)) {
+                    UpsertWriter writer = table.newUpsert().createWriter();
+                    writer.upsert(row(1, "value")).get();
+                    writer.flush();
+
+                    Lookuper lookuper = table.newLookup().createLookuper();
+                    InternalRow actualRow = lookuper.lookup(row(1)).get().getSingletonRow();
+                    assertThatRow(actualRow)
+                            .withSchema(schema.getRowType())
+                            .isEqualTo(row(1, "value"));
+                }
+            } finally {
+                admin.dropTable(tablePath, true).get();
+            }
+        }
+    }
+
+    private static Configuration serverConfiguration(TestingIdentityProvider identityProvider) {
+        Configuration configuration = new Configuration();
+        configuration.setString(
+                ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP.key(), "FLUSS:PLAINTEXT,CLIENT:SASL");
+        configuration.set(
+                SERVER_SASL_ENABLED_MECHANISMS_CONFIG,
+                Collections.singletonList(OAUTHBEARER_MECHANISM));
+        configuration.set(SERVER_SASL_OAUTHBEARER_JWKS_ENDPOINT, identityProvider.jwksEndpoint());
+        configuration.set(SERVER_SASL_OAUTHBEARER_EXPECTED_ISSUER, ISSUER);
+        configuration.set(
+                SERVER_SASL_OAUTHBEARER_EXPECTED_AUDIENCES, Collections.singletonList(AUDIENCE));
+        return configuration;
+    }
+
+    private static final class TestingIdentityProvider implements AutoCloseable {
+        private final HttpServer server;
+
+        private TestingIdentityProvider() throws Exception {
+            KeyPair keyPair = generateRsaKey();
+            String token =
+                    signedToken(keyPair, "test-client", System.currentTimeMillis() / 1000 + 300);
+            String tokenResponse =
+                    "{\"access_token\":\""
+                            + token
+                            + "\",\"token_type\":\"Bearer\",\"expires_in\":300}";
+
+            server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/token", exchange -> respond(exchange, tokenResponse));
+            server.createContext("/jwks", exchange -> respond(exchange, jwks(keyPair)));
+            server.start();
+        }
+
+        private String tokenEndpoint() {
+            return endpoint("/token");
+        }
+
+        private String jwksEndpoint() {
+            return endpoint("/jwks");
+        }
+
+        private String endpoint(String path) {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    private static String signedToken(KeyPair keyPair, String subject, long expirationSeconds)
+            throws Exception {
+        String unsigned =
+                encode("{\"alg\":\"RS256\",\"kid\":\"" + KEY_ID + "\"}")
+                        + "."
+                        + encode(
+                                "{\"sub\":\""
+                                        + subject
+                                        + "\",\"iss\":\""
+                                        + ISSUER
+                                        + "\",\"aud\":\""
+                                        + AUDIENCE
+                                        + "\",\"exp\":"
+                                        + expirationSeconds
+                                        + "}");
+        Signature signature = Signature.getInstance("SHA256withRSA");
+        signature.initSign(keyPair.getPrivate());
+        signature.update(unsigned.getBytes(StandardCharsets.US_ASCII));
+        return unsigned
+                + "."
+                + Base64.getUrlEncoder().withoutPadding().encodeToString(signature.sign());
+    }
+
+    private static String jwks(KeyPair keyPair) {
+        RSAPublicKey key = (RSAPublicKey) keyPair.getPublic();
+        return "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\""
+                + KEY_ID
+                + "\",\"use\":\"sig\",\"alg\":\"RS256\",\"n\":\""
+                + encodeUnsigned(key.getModulus())
+                + "\",\"e\":\""
+                + encodeUnsigned(key.getPublicExponent())
+                + "\"}]}";
+    }
+
+    private static KeyPair generateRsaKey() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    private static String encode(String value) {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String encodeUnsigned(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        if (bytes.length > 1 && bytes[0] == 0) {
+            bytes = Arrays.copyOfRange(bytes, 1, bytes.length);
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private static void respond(HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream output = exchange.getResponseBody()) {
+            output.write(bytes);
+        }
+    }
+}

--- a/fluss-common/pom.xml
+++ b/fluss-common/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>fluss-shaded-jackson</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+        </dependency>
+
         <!-- Netty dependencies used for LogRecords -->
         <dependency>
             <groupId>org.apache.fluss</groupId>

--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -402,6 +402,40 @@ public class ConfigOptions {
     public static final ConfigOption<List<String>> SERVER_SASL_ENABLED_MECHANISMS_CONFIG =
             key("security.sasl.enabled.mechanisms").stringType().asList().noDefaultValue();
 
+    public static final ConfigOption<String> SERVER_SASL_OAUTHBEARER_JWKS_ENDPOINT =
+            key("security.sasl.oauthbearer.jwks.endpoint")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The HTTP(S) endpoint used to retrieve OAuth2 JWKS keys.");
+
+    public static final ConfigOption<String> SERVER_SASL_OAUTHBEARER_EXPECTED_ISSUER =
+            key("security.sasl.oauthbearer.expected-issuer")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The issuer expected in OAuth2 JWT access tokens.");
+
+    public static final ConfigOption<List<String>> SERVER_SASL_OAUTHBEARER_EXPECTED_AUDIENCES =
+            key("security.sasl.oauthbearer.expected-audiences")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Audiences accepted in OAuth2 JWT access tokens. At least one configured audience must match.");
+
+    public static final ConfigOption<Duration> SERVER_SASL_OAUTHBEARER_JWKS_REQUEST_TIMEOUT =
+            key("security.sasl.oauthbearer.jwks.request-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(5))
+                    .withDescription(
+                            "Timeout for connecting to and reading from the JWKS endpoint.");
+
+    public static final ConfigOption<Duration> SERVER_SASL_OAUTHBEARER_JWKS_REFRESH_MIN_INTERVAL =
+            key("security.sasl.oauthbearer.jwks.refresh-min-interval")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDescription(
+                            "Minimum reprieve before refreshing non-empty cached JWKS keys again for an unknown key ID.");
+
     public static final ConfigOption<Integer> SERVER_IO_POOL_SIZE =
             key("server.io-pool.size")
                     .intType()
@@ -1589,7 +1623,39 @@ public class ConfigOptions {
                     .stringType()
                     .defaultValue("PLAIN")
                     .withDescription(
-                            "SASL mechanism to use for authentication.Currently, we only support plain.");
+                            "SASL mechanism to use for authentication. Supported values are PLAIN and OAUTHBEARER.");
+
+    public static final ConfigOption<String> CLIENT_SASL_OAUTHBEARER_TOKEN_ENDPOINT =
+            key("client.security.sasl.oauthbearer.token.endpoint")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The HTTP(S) token endpoint used with the OAuth2 client credentials grant.");
+
+    public static final ConfigOption<String> CLIENT_SASL_OAUTHBEARER_CLIENT_ID =
+            key("client.security.sasl.oauthbearer.client-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The OAuth2 client ID.");
+
+    public static final ConfigOption<Password> CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET =
+            key("client.security.sasl.oauthbearer.client-secret")
+                    .passwordType()
+                    .noDefaultValue()
+                    .withDescription("The OAuth2 client secret. The value is redacted in logs.");
+
+    public static final ConfigOption<String> CLIENT_SASL_OAUTHBEARER_SCOPE =
+            key("client.security.sasl.oauthbearer.scope")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Optional OAuth2 scope sent to the token endpoint.");
+
+    public static final ConfigOption<Duration> CLIENT_SASL_OAUTHBEARER_REQUEST_TIMEOUT =
+            key("client.security.sasl.oauthbearer.request-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(10))
+                    .withDescription(
+                            "Timeout for connecting to and reading from the token endpoint.");
 
     public static final ConfigOption<String> CLIENT_SASL_JAAS_CONFIG =
             key("client.security.sasl.jaas.config")

--- a/fluss-common/src/main/java/org/apache/fluss/security/acl/FlussPrincipal.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/acl/FlussPrincipal.java
@@ -41,7 +41,10 @@ import java.util.Objects;
  */
 @PublicEvolving
 public class FlussPrincipal implements Principal {
-    public static final FlussPrincipal ANONYMOUS = new FlussPrincipal("ANONYMOUS", "User");
+    /** The principal type used for authenticated users. */
+    public static final String USER_TYPE = "User";
+
+    public static final FlussPrincipal ANONYMOUS = new FlussPrincipal("ANONYMOUS", USER_TYPE);
     /** The wildcard principal, which represents all principals. */
     public static final FlussPrincipal WILD_CARD_PRINCIPAL = new FlussPrincipal("*", "*");
 

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/AuthenticationFactory.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/AuthenticationFactory.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
@@ -93,19 +94,27 @@ public class AuthenticationFactory {
             Configuration configuration) {
         PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
         Map<String, Supplier<ServerAuthenticator>> serverAuthenticators = new HashMap<>();
+        Map<String, ServerAuthenticationPlugin> authenticatorPlugins = new HashMap<>();
         Map<String, String> protocolMap =
                 configuration.getMap(ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP);
         for (Map.Entry<String, String> protocolEntry : protocolMap.entrySet()) {
             String serverAuthenticateProtocol = protocolEntry.getValue();
+            String normalizedProtocol = serverAuthenticateProtocol.toLowerCase(Locale.ROOT);
             ServerAuthenticationPlugin serverAuthenticatorPlugin =
-                    discoverPlugin(
-                            serverAuthenticateProtocol,
-                            ServerAuthenticationPlugin.class,
-                            pluginManager);
+                    authenticatorPlugins.get(normalizedProtocol);
+            if (serverAuthenticatorPlugin == null) {
+                serverAuthenticatorPlugin =
+                        discoverPlugin(
+                                serverAuthenticateProtocol,
+                                ServerAuthenticationPlugin.class,
+                                pluginManager);
+                authenticatorPlugins.put(normalizedProtocol, serverAuthenticatorPlugin);
+            }
 
+            ServerAuthenticationPlugin sharedPlugin = serverAuthenticatorPlugin;
             serverAuthenticators.put(
                     protocolEntry.getKey(),
-                    () -> serverAuthenticatorPlugin.createServerAuthenticator(configuration));
+                    () -> sharedPlugin.createServerAuthenticator(configuration));
         }
         return serverAuthenticators;
     }

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/ServerAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/ServerAuthenticator.java
@@ -96,6 +96,9 @@ public interface ServerAuthenticator extends Closeable {
      */
     FlussPrincipal createPrincipal();
 
+    /** Validates that the authenticated connection session is still valid. */
+    default void validateSession() throws AuthenticationException {}
+
     /** Close the authenticator. */
     default void close() throws IOException {}
 

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/SaslAuthenticatorFactory.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/SaslAuthenticatorFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl;
+
+import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.AuthenticationException;
+import org.apache.fluss.security.auth.ClientAuthenticator;
+import org.apache.fluss.security.auth.ServerAuthenticator;
+import org.apache.fluss.security.auth.sasl.authenticator.PlainSaslServerAuthenticator;
+import org.apache.fluss.security.auth.sasl.authenticator.SaslClientAuthenticator;
+import org.apache.fluss.security.auth.sasl.plain.PlainSaslServer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+
+/** Factory for creating connection-local SASL authenticators. */
+@Internal
+public final class SaslAuthenticatorFactory {
+    private static final Map<String, AuthenticatorCreators> AUTHENTICATOR_CREATORS;
+
+    static {
+        Map<String, AuthenticatorCreators> creators = new HashMap<>();
+        creators.put(
+                PlainSaslServer.PLAIN_MECHANISM,
+                new AuthenticatorCreators(
+                        configuration -> new SaslClientAuthenticator(configuration),
+                        configuration -> new PlainSaslServerAuthenticator(configuration)));
+        AUTHENTICATOR_CREATORS = Collections.unmodifiableMap(creators);
+    }
+
+    private SaslAuthenticatorFactory() {}
+
+    /** Creates a connection-local client SASL authenticator. */
+    public static ClientAuthenticator createClientAuthenticator(Configuration configuration) {
+        String mechanism = configuration.get(ConfigOptions.CLIENT_SASL_MECHANISM);
+        String normalizedMechanism = mechanism.toUpperCase(Locale.ROOT);
+        AuthenticatorCreators creators = AUTHENTICATOR_CREATORS.get(normalizedMechanism);
+        if (creators == null) {
+            throw new AuthenticationException(
+                    "Unable to find a matching SASL mechanism for " + normalizedMechanism);
+        }
+        return creators.clientCreator.apply(configuration);
+    }
+
+    /** Creates a server authenticator for the requested mechanism. */
+    public static ServerAuthenticator createServerAuthenticator(
+            String mechanism, Configuration configuration) {
+        String normalizedMechanism = mechanism.toUpperCase(Locale.ROOT);
+        AuthenticatorCreators creators = AUTHENTICATOR_CREATORS.get(normalizedMechanism);
+        if (creators == null) {
+            throw new AuthenticationException(
+                    "Unable to find a matching SASL mechanism for " + normalizedMechanism);
+        }
+        return creators.serverCreator.apply(configuration);
+    }
+
+    /** Returns whether the server supports the requested mechanism. */
+    public static boolean supportsServerMechanism(String mechanism) {
+        return AUTHENTICATOR_CREATORS.containsKey(mechanism.toUpperCase(Locale.ROOT));
+    }
+
+    private static final class AuthenticatorCreators {
+        private final Function<Configuration, ClientAuthenticator> clientCreator;
+        private final Function<Configuration, ServerAuthenticator> serverCreator;
+
+        private AuthenticatorCreators(
+                Function<Configuration, ClientAuthenticator> clientCreator,
+                Function<Configuration, ServerAuthenticator> serverCreator) {
+            this.clientCreator = clientCreator;
+            this.serverCreator = serverCreator;
+        }
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/SaslAuthenticatorFactory.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/SaslAuthenticatorFactory.java
@@ -22,9 +22,8 @@ import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.AuthenticationException;
 import org.apache.fluss.security.auth.ClientAuthenticator;
-import org.apache.fluss.security.auth.ServerAuthenticator;
-import org.apache.fluss.security.auth.sasl.authenticator.PlainSaslServerAuthenticator;
 import org.apache.fluss.security.auth.sasl.authenticator.SaslClientAuthenticator;
+import org.apache.fluss.security.auth.sasl.oauthbearer.OAuthBearerClientAuthenticator;
 import org.apache.fluss.security.auth.sasl.plain.PlainSaslServer;
 
 import java.util.Collections;
@@ -36,16 +35,18 @@ import java.util.function.Function;
 /** Factory for creating connection-local SASL authenticators. */
 @Internal
 public final class SaslAuthenticatorFactory {
-    private static final Map<String, AuthenticatorCreators> AUTHENTICATOR_CREATORS;
+    private static final Map<String, Function<Configuration, ClientAuthenticator>>
+            CLIENT_AUTHENTICATOR_CREATORS;
 
     static {
-        Map<String, AuthenticatorCreators> creators = new HashMap<>();
+        Map<String, Function<Configuration, ClientAuthenticator>> creators = new HashMap<>();
         creators.put(
                 PlainSaslServer.PLAIN_MECHANISM,
-                new AuthenticatorCreators(
-                        configuration -> new SaslClientAuthenticator(configuration),
-                        configuration -> new PlainSaslServerAuthenticator(configuration)));
-        AUTHENTICATOR_CREATORS = Collections.unmodifiableMap(creators);
+                configuration -> new SaslClientAuthenticator(configuration));
+        creators.put(
+                OAuthBearerClientAuthenticator.OAUTHBEARER_MECHANISM,
+                configuration -> new OAuthBearerClientAuthenticator(configuration));
+        CLIENT_AUTHENTICATOR_CREATORS = Collections.unmodifiableMap(creators);
     }
 
     private SaslAuthenticatorFactory() {}
@@ -54,40 +55,12 @@ public final class SaslAuthenticatorFactory {
     public static ClientAuthenticator createClientAuthenticator(Configuration configuration) {
         String mechanism = configuration.get(ConfigOptions.CLIENT_SASL_MECHANISM);
         String normalizedMechanism = mechanism.toUpperCase(Locale.ROOT);
-        AuthenticatorCreators creators = AUTHENTICATOR_CREATORS.get(normalizedMechanism);
-        if (creators == null) {
+        Function<Configuration, ClientAuthenticator> creator =
+                CLIENT_AUTHENTICATOR_CREATORS.get(normalizedMechanism);
+        if (creator == null) {
             throw new AuthenticationException(
                     "Unable to find a matching SASL mechanism for " + normalizedMechanism);
         }
-        return creators.clientCreator.apply(configuration);
-    }
-
-    /** Creates a server authenticator for the requested mechanism. */
-    public static ServerAuthenticator createServerAuthenticator(
-            String mechanism, Configuration configuration) {
-        String normalizedMechanism = mechanism.toUpperCase(Locale.ROOT);
-        AuthenticatorCreators creators = AUTHENTICATOR_CREATORS.get(normalizedMechanism);
-        if (creators == null) {
-            throw new AuthenticationException(
-                    "Unable to find a matching SASL mechanism for " + normalizedMechanism);
-        }
-        return creators.serverCreator.apply(configuration);
-    }
-
-    /** Returns whether the server supports the requested mechanism. */
-    public static boolean supportsServerMechanism(String mechanism) {
-        return AUTHENTICATOR_CREATORS.containsKey(mechanism.toUpperCase(Locale.ROOT));
-    }
-
-    private static final class AuthenticatorCreators {
-        private final Function<Configuration, ClientAuthenticator> clientCreator;
-        private final Function<Configuration, ServerAuthenticator> serverCreator;
-
-        private AuthenticatorCreators(
-                Function<Configuration, ClientAuthenticator> clientCreator,
-                Function<Configuration, ServerAuthenticator> serverCreator) {
-            this.clientCreator = clientCreator;
-            this.serverCreator = serverCreator;
-        }
+        return creator.apply(configuration);
     }
 }

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/PlainSaslServerAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/PlainSaslServerAuthenticator.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl.authenticator;
+
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.AuthenticationException;
+import org.apache.fluss.security.acl.FlussPrincipal;
+import org.apache.fluss.security.auth.ServerAuthenticator;
+import org.apache.fluss.security.auth.sasl.jaas.JaasContext;
+import org.apache.fluss.security.auth.sasl.jaas.LoginManager;
+import org.apache.fluss.security.auth.sasl.jaas.SaslServerFactory;
+import org.apache.fluss.security.auth.sasl.plain.PlainSaslServer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+import java.util.Locale;
+import java.util.Map;
+
+/** A connection-local SASL/PLAIN server authenticator. */
+public final class PlainSaslServerAuthenticator implements ServerAuthenticator {
+    private static final Logger LOG = LoggerFactory.getLogger(PlainSaslServerAuthenticator.class);
+    private static final String SERVER_AUTHENTICATOR_PREFIX = "security.sasl.";
+
+    private final Map<String, String> configs;
+    private SaslServer saslServer;
+
+    public PlainSaslServerAuthenticator(Configuration configuration) {
+        this.configs = configuration.toMap();
+    }
+
+    @Override
+    public String protocol() {
+        return PlainSaslServer.PLAIN_MECHANISM;
+    }
+
+    @Override
+    public void initialize(AuthenticateContext context) {
+        String dynamicJaasConfig = findJaasConfig(context.listenerName());
+        JaasContext contextConfig =
+                JaasContext.loadServerContext(context.listenerName(), dynamicJaasConfig);
+        try {
+            LoginManager loginManager = LoginManager.acquireLoginManager(contextConfig);
+            saslServer =
+                    SaslServerFactory.createSaslServer(
+                            PlainSaslServer.PLAIN_MECHANISM,
+                            context.ipAddress(),
+                            configs,
+                            loginManager,
+                            contextConfig.configurationEntries());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public byte[] evaluateResponse(byte[] token) throws AuthenticationException {
+        try {
+            return saslServer.evaluateResponse(token);
+        } catch (SaslException e) {
+            throw new AuthenticationException(
+                    String.format(
+                            "Failed to evaluate SASL response, reason is %s", e.getMessage()));
+        }
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return saslServer != null && saslServer.isComplete();
+    }
+
+    @Override
+    public FlussPrincipal createPrincipal() {
+        return new FlussPrincipal(saslServer.getAuthorizationID(), "User");
+    }
+
+    private String findJaasConfig(String listenerName) {
+        String listenerMechanismKey =
+                String.format(
+                        SERVER_AUTHENTICATOR_PREFIX
+                                + "listener.name.%s.%s."
+                                + JaasContext.SASL_JAAS_CONFIG,
+                        listenerName.toLowerCase(Locale.ROOT),
+                        PlainSaslServer.PLAIN_MECHANISM.toLowerCase(Locale.ROOT));
+        String dynamicJaasConfig = configs.get(listenerMechanismKey);
+        if (dynamicJaasConfig != null && !dynamicJaasConfig.isEmpty()) {
+            return dynamicJaasConfig;
+        }
+
+        String globalMechanismKey =
+                SERVER_AUTHENTICATOR_PREFIX
+                        + PlainSaslServer.PLAIN_MECHANISM.toLowerCase(Locale.ROOT)
+                        + "."
+                        + JaasContext.SASL_JAAS_CONFIG;
+        LOG.debug(
+                "No listener-mechanism JAAS config found for key: '{}'. Falling back to mechanism-level config: '{}'",
+                listenerMechanismKey,
+                globalMechanismKey);
+        dynamicJaasConfig = configs.get(globalMechanismKey);
+        if (dynamicJaasConfig == null || dynamicJaasConfig.isEmpty()) {
+            LOG.warn(
+                    "No mechanism-level JAAS config found for key: '{}'. Falling back to JVM option: -D{}",
+                    globalMechanismKey,
+                    JaasContext.JAVA_LOGIN_CONFIG_PARAM);
+        }
+        return dynamicJaasConfig;
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/PlainSaslServerAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/PlainSaslServerAuthenticator.java
@@ -89,7 +89,7 @@ public final class PlainSaslServerAuthenticator implements ServerAuthenticator {
 
     @Override
     public FlussPrincipal createPrincipal() {
-        return new FlussPrincipal(saslServer.getAuthorizationID(), "User");
+        return new FlussPrincipal(saslServer.getAuthorizationID(), FlussPrincipal.USER_TYPE);
     }
 
     private String findJaasConfig(String listenerName) {

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslAuthenticationPlugin.java
@@ -22,6 +22,7 @@ import org.apache.fluss.security.auth.ClientAuthenticationPlugin;
 import org.apache.fluss.security.auth.ClientAuthenticator;
 import org.apache.fluss.security.auth.ServerAuthenticationPlugin;
 import org.apache.fluss.security.auth.ServerAuthenticator;
+import org.apache.fluss.security.auth.sasl.SaslAuthenticatorFactory;
 
 /** Authentication plugin for SASL. */
 public class SaslAuthenticationPlugin
@@ -30,7 +31,7 @@ public class SaslAuthenticationPlugin
 
     @Override
     public ClientAuthenticator createClientAuthenticator(Configuration configuration) {
-        return new SaslClientAuthenticator(configuration);
+        return SaslAuthenticatorFactory.createClientAuthenticator(configuration);
     }
 
     @Override

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslAuthenticationPlugin.java
@@ -29,6 +29,8 @@ public class SaslAuthenticationPlugin
         implements ClientAuthenticationPlugin, ServerAuthenticationPlugin {
     static final String SASL_AUTH_PROTOCOL = "sasl";
 
+    private volatile SaslServerMechanismFactory mechanismFactory;
+
     @Override
     public ClientAuthenticator createClientAuthenticator(Configuration configuration) {
         return SaslAuthenticatorFactory.createClientAuthenticator(configuration);
@@ -36,7 +38,14 @@ public class SaslAuthenticationPlugin
 
     @Override
     public ServerAuthenticator createServerAuthenticator(Configuration configuration) {
-        return new SaslServerAuthenticator(configuration);
+        if (mechanismFactory == null) {
+            synchronized (this) {
+                if (mechanismFactory == null) {
+                    mechanismFactory = new SaslServerMechanismFactory(configuration);
+                }
+            }
+        }
+        return new SaslServerAuthenticator(configuration, mechanismFactory);
     }
 
     @Override

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslServerAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslServerAuthenticator.java
@@ -21,7 +21,6 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.AuthenticationException;
 import org.apache.fluss.security.acl.FlussPrincipal;
 import org.apache.fluss.security.auth.ServerAuthenticator;
-import org.apache.fluss.security.auth.sasl.SaslAuthenticatorFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,13 +36,14 @@ import static org.apache.fluss.security.auth.sasl.authenticator.SaslAuthenticati
 public class SaslServerAuthenticator implements ServerAuthenticator {
     private static final Logger LOG = LoggerFactory.getLogger(SaslServerAuthenticator.class);
 
-    private final Configuration configuration;
     private final List<String> enabledMechanisms;
+    private final SaslServerMechanismFactory mechanismFactory;
 
     private ServerAuthenticator delegate;
 
-    public SaslServerAuthenticator(Configuration configuration) {
-        this.configuration = configuration;
+    public SaslServerAuthenticator(
+            Configuration configuration, SaslServerMechanismFactory mechanismFactory) {
+        this.mechanismFactory = mechanismFactory;
         List<String> enabledMechanisms = configuration.get(SERVER_SASL_ENABLED_MECHANISMS_CONFIG);
         if (enabledMechanisms == null || enabledMechanisms.isEmpty()) {
             throw new IllegalArgumentException("No SASL mechanisms are enabled");
@@ -58,7 +58,7 @@ public class SaslServerAuthenticator implements ServerAuthenticator {
     public void initialize(AuthenticateContext context) {
         String mechanism = context.protocol().toUpperCase(Locale.ROOT);
         matchProtocol(mechanism);
-        delegate = SaslAuthenticatorFactory.createServerAuthenticator(mechanism, configuration);
+        delegate = mechanismFactory.createAuthenticator(mechanism);
         delegate.initialize(context);
     }
 
@@ -75,7 +75,7 @@ public class SaslServerAuthenticator implements ServerAuthenticator {
                             "SASL server enables %s while protocol of client is '%s'",
                             enabledMechanisms, protocol));
         }
-        if (!SaslAuthenticatorFactory.supportsServerMechanism(protocol)) {
+        if (!mechanismFactory.supportsMechanism(protocol)) {
             throw new AuthenticationException(
                     "Unable to find a matching SASL mechanism for "
                             + protocol.toUpperCase(Locale.ROOT));
@@ -95,6 +95,11 @@ public class SaslServerAuthenticator implements ServerAuthenticator {
     @Override
     public FlussPrincipal createPrincipal() {
         return delegate.createPrincipal();
+    }
+
+    @Override
+    public void validateSession() throws AuthenticationException {
+        delegate.validateSession();
     }
 
     @Override

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslServerAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslServerAuthenticator.java
@@ -21,99 +21,45 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.AuthenticationException;
 import org.apache.fluss.security.acl.FlussPrincipal;
 import org.apache.fluss.security.auth.ServerAuthenticator;
-import org.apache.fluss.security.auth.sasl.jaas.JaasContext;
-import org.apache.fluss.security.auth.sasl.jaas.LoginManager;
+import org.apache.fluss.security.auth.sasl.SaslAuthenticatorFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.security.sasl.SaslException;
-import javax.security.sasl.SaslServer;
-
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_ENABLED_MECHANISMS_CONFIG;
 import static org.apache.fluss.security.auth.sasl.authenticator.SaslAuthenticationPlugin.SASL_AUTH_PROTOCOL;
-import static org.apache.fluss.security.auth.sasl.jaas.JaasContext.SASL_JAAS_CONFIG;
-import static org.apache.fluss.security.auth.sasl.jaas.SaslServerFactory.createSaslServer;
 
-/** An authenticator that uses SASL to authenticate clients. */
+/** A connection-local authenticator that selects one SASL mechanism. */
 public class SaslServerAuthenticator implements ServerAuthenticator {
     private static final Logger LOG = LoggerFactory.getLogger(SaslServerAuthenticator.class);
-    private static final String SERVER_AUTHENTICATOR_PREFIX = "security.sasl.";
+
+    private final Configuration configuration;
     private final List<String> enabledMechanisms;
-    private SaslServer saslServer;
-    private final Map<String, String> configs;
+
+    private ServerAuthenticator delegate;
 
     public SaslServerAuthenticator(Configuration configuration) {
-        this.configs = configuration.toMap();
+        this.configuration = configuration;
         List<String> enabledMechanisms = configuration.get(SERVER_SASL_ENABLED_MECHANISMS_CONFIG);
         if (enabledMechanisms == null || enabledMechanisms.isEmpty()) {
             throw new IllegalArgumentException("No SASL mechanisms are enabled");
         }
         this.enabledMechanisms =
-                enabledMechanisms.stream().map(String::toUpperCase).collect(Collectors.toList());
+                enabledMechanisms.stream()
+                        .map(mechanism -> mechanism.toUpperCase(Locale.ROOT))
+                        .collect(Collectors.toList());
     }
 
     @Override
     public void initialize(AuthenticateContext context) {
-        String mechanism = context.protocol();
-        String listenerName = context.listenerName();
-        String address = context.ipAddress();
+        String mechanism = context.protocol().toUpperCase(Locale.ROOT);
         matchProtocol(mechanism);
-        // Try to load JAAS config in the following order:
-        // 1. security.sasl.listener.name.{listenerName}.{mechanism}.jaas.config (fine-grained per
-        // listener and mechanism)
-        // 2. security.sasl.{mechanism}.jaas.config (fallback global config for mechanism)
-        // 3. JVM option -Djava.security.auth.login.config (system-level fallback)
-
-        String dynamicJaasConfig;
-
-        // 1. Check listener-specific and mechanism-specific config
-        String listenerMechanismKey =
-                String.format(
-                        SERVER_AUTHENTICATOR_PREFIX + "listener.name.%s.%s." + SASL_JAAS_CONFIG,
-                        listenerName.toLowerCase(Locale.ROOT),
-                        mechanism.toLowerCase(Locale.ROOT));
-        dynamicJaasConfig = configs.get(listenerMechanismKey);
-
-        if (dynamicJaasConfig == null || dynamicJaasConfig.isEmpty()) {
-            String globalMechanismKey =
-                    SERVER_AUTHENTICATOR_PREFIX
-                            + mechanism.toLowerCase(Locale.ROOT)
-                            + "."
-                            + SASL_JAAS_CONFIG;
-            LOG.debug(
-                    "No listener-mechanism JAAS config found for key: '{}'. Falling back to mechanism-level config: '{}'",
-                    listenerMechanismKey,
-                    globalMechanismKey);
-            // 2. Fallback to global mechanism-level config
-            dynamicJaasConfig = configs.get(globalMechanismKey);
-            if (dynamicJaasConfig == null || dynamicJaasConfig.isEmpty()) {
-                LOG.warn(
-                        "No mechanism-level JAAS config found for key: '{}'. Falling back to JVM option: -D{}",
-                        globalMechanismKey,
-                        JaasContext.JAVA_LOGIN_CONFIG_PARAM);
-            }
-        }
-
-        JaasContext jaasContext = JaasContext.loadServerContext(listenerName, dynamicJaasConfig);
-
-        try {
-            LoginManager loginManager = LoginManager.acquireLoginManager(jaasContext);
-            saslServer =
-                    createSaslServer(
-                            mechanism,
-                            address,
-                            configs,
-                            loginManager,
-                            jaasContext.configurationEntries());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        delegate = SaslAuthenticatorFactory.createServerAuthenticator(mechanism, configuration);
+        delegate.initialize(context);
     }
 
     @Override
@@ -123,31 +69,43 @@ public class SaslServerAuthenticator implements ServerAuthenticator {
 
     @Override
     public void matchProtocol(String protocol) {
-        if (!enabledMechanisms.contains(protocol.toUpperCase())) {
+        if (!enabledMechanisms.contains(protocol.toUpperCase(Locale.ROOT))) {
             throw new AuthenticationException(
                     String.format(
                             "SASL server enables %s while protocol of client is '%s'",
                             enabledMechanisms, protocol));
         }
-    }
-
-    @Override
-    public byte[] evaluateResponse(byte[] token) throws AuthenticationException {
-        try {
-            return saslServer.evaluateResponse(token);
-        } catch (SaslException e) {
+        if (!SaslAuthenticatorFactory.supportsServerMechanism(protocol)) {
             throw new AuthenticationException(
-                    String.format("Failed to evaluate SASL response，reason is %s", e.getMessage()));
+                    "Unable to find a matching SASL mechanism for "
+                            + protocol.toUpperCase(Locale.ROOT));
         }
     }
 
     @Override
+    public byte[] evaluateResponse(byte[] token) throws AuthenticationException {
+        return delegate.evaluateResponse(token);
+    }
+
+    @Override
     public boolean isCompleted() {
-        return saslServer != null && saslServer.isComplete();
+        return delegate != null && delegate.isCompleted();
     }
 
     @Override
     public FlussPrincipal createPrincipal() {
-        return new FlussPrincipal(saslServer.getAuthorizationID(), "User");
+        return delegate.createPrincipal();
+    }
+
+    @Override
+    public void close() {
+        if (delegate != null) {
+            try {
+                delegate.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close SASL server authenticator.", e);
+            }
+            delegate = null;
+        }
     }
 }

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslServerMechanismFactory.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/authenticator/SaslServerMechanismFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl.authenticator;
+
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.AuthenticationException;
+import org.apache.fluss.security.auth.ServerAuthenticator;
+import org.apache.fluss.security.auth.sasl.oauthbearer.OAuthBearerClientAuthenticator;
+import org.apache.fluss.security.auth.sasl.oauthbearer.OAuthBearerJwksResolver;
+import org.apache.fluss.security.auth.sasl.oauthbearer.OAuthBearerServerAuthenticator;
+import org.apache.fluss.security.auth.sasl.plain.PlainSaslServer;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.apache.fluss.utils.Preconditions.checkNotNull;
+
+/** Creates connection-local SASL authenticators and owns shared mechanism state. */
+final class SaslServerMechanismFactory {
+    private final Configuration configuration;
+    private final OAuthBearerJwksResolver jwksResolver;
+
+    SaslServerMechanismFactory(Configuration configuration) {
+        this.configuration = configuration;
+        List<String> mechanisms =
+                configuration.get(ConfigOptions.SERVER_SASL_ENABLED_MECHANISMS_CONFIG);
+        this.jwksResolver =
+                containsOAuthBearer(mechanisms) ? new OAuthBearerJwksResolver(configuration) : null;
+    }
+
+    ServerAuthenticator createAuthenticator(String mechanism) {
+        switch (normalize(mechanism)) {
+            case PlainSaslServer.PLAIN_MECHANISM:
+                return new PlainSaslServerAuthenticator(configuration);
+            case OAuthBearerClientAuthenticator.OAUTHBEARER_MECHANISM:
+                return new OAuthBearerServerAuthenticator(
+                        configuration, checkNotNull(jwksResolver));
+            default:
+                throw new AuthenticationException(
+                        "Unable to find a matching SASL mechanism for " + normalize(mechanism));
+        }
+    }
+
+    boolean supportsMechanism(String mechanism) {
+        switch (normalize(mechanism)) {
+            case PlainSaslServer.PLAIN_MECHANISM:
+            case OAuthBearerClientAuthenticator.OAUTHBEARER_MECHANISM:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static boolean containsOAuthBearer(List<String> mechanisms) {
+        return mechanisms != null
+                && mechanisms.stream()
+                        .anyMatch(
+                                OAuthBearerClientAuthenticator.OAUTHBEARER_MECHANISM
+                                        ::equalsIgnoreCase);
+    }
+
+    private static String normalize(String mechanism) {
+        return mechanism.toUpperCase(Locale.ROOT);
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerClientAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerClientAuthenticator.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl.oauthbearer;
+
+import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.Password;
+import org.apache.fluss.exception.AuthenticationException;
+import org.apache.fluss.security.auth.ClientAuthenticator;
+import org.apache.fluss.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.fluss.utils.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_ID;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_REQUEST_TIMEOUT;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_SCOPE;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_TOKEN_ENDPOINT;
+
+/** A connection-local SASL OAUTHBEARER client authenticator. */
+@Internal
+public final class OAuthBearerClientAuthenticator implements ClientAuthenticator {
+    private static final Logger LOG = LoggerFactory.getLogger(OAuthBearerClientAuthenticator.class);
+
+    /** The SASL mechanism name. */
+    public static final String OAUTHBEARER_MECHANISM = "OAUTHBEARER";
+
+    private static final String HTTP_POST_METHOD = "POST";
+    private static final String BASIC_AUTHORIZATION_PREFIX = "Basic ";
+    /** Required by RFC 6749, Section 4.4.2 for a client credentials token request. */
+    private static final String CLIENT_CREDENTIALS_GRANT_PARAMETER =
+            "grant_type=client_credentials";
+
+    private static final String SCOPE_PARAMETER_PREFIX = "&scope=";
+    private static final String ACCESS_TOKEN_FIELD = "access_token";
+    private static final String TOKEN_TYPE_FIELD = "token_type";
+    private static final String BEARER_TOKEN_TYPE = "Bearer";
+
+    private final URI endpoint;
+    private final String authorization;
+    private final byte[] requestBody;
+    private final int timeoutMs;
+
+    private String token;
+    private boolean completed;
+
+    /** Creates a connection-local authenticator from the client configuration. */
+    public OAuthBearerClientAuthenticator(Configuration configuration) {
+        endpoint =
+                OAuthBearerUtils.validateHttpEndpoint(
+                        configuration.get(CLIENT_SASL_OAUTHBEARER_TOKEN_ENDPOINT),
+                        CLIENT_SASL_OAUTHBEARER_TOKEN_ENDPOINT.key());
+        if ("http".equalsIgnoreCase(endpoint.getScheme())) {
+            LOG.warn("OAuth token endpoint uses insecure HTTP: {}", endpoint);
+        }
+
+        String clientId = configuration.get(CLIENT_SASL_OAUTHBEARER_CLIENT_ID);
+        if (StringUtils.isNullOrWhitespaceOnly(clientId)) {
+            throw new AuthenticationException(
+                    "Configuration '" + CLIENT_SASL_OAUTHBEARER_CLIENT_ID.key() + "' must be set");
+        }
+        Password secret = configuration.get(CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET);
+        if (secret == null || secret.value().isEmpty()) {
+            throw new AuthenticationException(
+                    "Configuration '"
+                            + CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET.key()
+                            + "' must be set");
+        }
+        authorization =
+                BASIC_AUTHORIZATION_PREFIX
+                        + Base64.getEncoder()
+                                .encodeToString(
+                                        (formEncode(clientId) + ":" + formEncode(secret.value()))
+                                                .getBytes(StandardCharsets.UTF_8));
+
+        StringBuilder body = new StringBuilder(CLIENT_CREDENTIALS_GRANT_PARAMETER);
+        String scope = configuration.get(CLIENT_SASL_OAUTHBEARER_SCOPE);
+        if (scope != null && !scope.trim().isEmpty()) {
+            body.append(SCOPE_PARAMETER_PREFIX).append(formEncode(scope));
+        }
+        requestBody = body.toString().getBytes(StandardCharsets.UTF_8);
+
+        Duration timeout = configuration.get(CLIENT_SASL_OAUTHBEARER_REQUEST_TIMEOUT);
+        long timeoutMillis = timeout == null ? 0 : timeout.toMillis();
+        if (timeoutMillis <= 0 || timeoutMillis > Integer.MAX_VALUE) {
+            throw new AuthenticationException(
+                    "Configuration '"
+                            + CLIENT_SASL_OAUTHBEARER_REQUEST_TIMEOUT.key()
+                            + "' must fit in positive milliseconds");
+        }
+        timeoutMs = (int) timeoutMillis;
+    }
+
+    @Override
+    public String protocol() {
+        return OAUTHBEARER_MECHANISM;
+    }
+
+    @Override
+    public byte[] authenticate(byte[] data) throws AuthenticationException {
+        if (token == null) {
+            token = fetchToken();
+        }
+        completed = true;
+        return OAuthBearerSaslMessage.createInitialResponse(token);
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    @Override
+    public boolean hasInitialTokenResponse() {
+        return true;
+    }
+
+    @Override
+    public void initialize(AuthenticateContext context) {
+        completed = false;
+    }
+
+    private String fetchToken() {
+        JsonNode response =
+                OAuthBearerUtils.execute(
+                        endpoint, HTTP_POST_METHOD, timeoutMs, authorization, requestBody);
+        String token = requiredText(response, ACCESS_TOKEN_FIELD);
+        if (!BEARER_TOKEN_TYPE.equalsIgnoreCase(requiredText(response, TOKEN_TYPE_FIELD))) {
+            throw new AuthenticationException("OAuth token endpoint returned a non-Bearer token");
+        }
+        return token;
+    }
+
+    private static String requiredText(JsonNode object, String field) {
+        JsonNode node = object == null ? null : object.get(field);
+        if (node == null || !node.isTextual() || node.textValue().trim().isEmpty()) {
+            throw new AuthenticationException(
+                    "OAuth token endpoint response must contain a non-empty " + field);
+        }
+        return node.textValue();
+    }
+
+    private static String formEncode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (Exception e) {
+            throw new AuthenticationException("Failed to encode OAuth request", e);
+        }
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerJwksResolver.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerJwksResolver.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl.oauthbearer;
+
+import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.AuthenticationException;
+
+import org.jose4j.http.Get;
+import org.jose4j.jwk.HttpsJwks;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwx.JsonWebStructure;
+import org.jose4j.keys.resolvers.HttpsJwksVerificationKeyResolver;
+import org.jose4j.keys.resolvers.VerificationKeyResolver;
+import org.jose4j.lang.UnresolvableKeyException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.security.Key;
+import java.time.Duration;
+import java.util.List;
+
+/** Resolves JWT verification keys using jose4j's shared JWKS cache. */
+@Internal
+public final class OAuthBearerJwksResolver implements VerificationKeyResolver {
+    private static final Logger LOG = LoggerFactory.getLogger(OAuthBearerJwksResolver.class);
+
+    private final HttpsJwksVerificationKeyResolver delegate;
+
+    /** Creates a process-local JWKS resolver from the server configuration. */
+    public OAuthBearerJwksResolver(Configuration configuration) {
+        URI endpoint =
+                OAuthBearerUtils.validateHttpEndpoint(
+                        configuration.get(ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_ENDPOINT),
+                        ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_ENDPOINT.key());
+        if ("http".equalsIgnoreCase(endpoint.getScheme())) {
+            LOG.warn("OAuth JWKS endpoint uses insecure HTTP: {}", endpoint);
+        }
+
+        Duration timeout =
+                configuration.get(ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_REQUEST_TIMEOUT);
+        long timeoutMillis = timeout == null ? 0 : timeout.toMillis();
+        if (timeoutMillis <= 0 || timeoutMillis > Integer.MAX_VALUE) {
+            throw new AuthenticationException(
+                    "Configuration '"
+                            + ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_REQUEST_TIMEOUT.key()
+                            + "' must fit in positive milliseconds");
+        }
+        int timeoutMs = (int) timeoutMillis;
+        Get httpGet = new Get();
+        httpGet.setConnectTimeout(timeoutMs);
+        httpGet.setReadTimeout(timeoutMs);
+        httpGet.setRetries(0);
+        httpGet.setResponseBodySizeLimit(OAuthBearerUtils.MAX_HTTP_RESPONSE_SIZE);
+
+        Duration refreshInterval =
+                configuration.get(ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_REFRESH_MIN_INTERVAL);
+        if (refreshInterval == null || refreshInterval.isNegative()) {
+            throw new AuthenticationException(
+                    "Configuration '"
+                            + ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_REFRESH_MIN_INTERVAL.key()
+                            + "' must not be negative");
+        }
+
+        HttpsJwks httpsJwks = new HttpsJwks(endpoint.toString());
+        httpsJwks.setSimpleHttpGet(httpGet);
+        httpsJwks.setRefreshReprieveThreshold(refreshInterval.toMillis());
+        delegate = new HttpsJwksVerificationKeyResolver(httpsJwks);
+    }
+
+    @Override
+    public Key resolveKey(JsonWebSignature jws, List<JsonWebStructure> nestingContext)
+            throws UnresolvableKeyException {
+        return delegate.resolveKey(jws, nestingContext);
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerJwtValidator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerJwtValidator.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl.oauthbearer;
+
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.AuthenticationException;
+import org.apache.fluss.utils.StringUtils;
+
+import org.jose4j.jwa.AlgorithmConstraints.ConstraintType;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.ErrorCodes;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_EXPECTED_AUDIENCES;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_EXPECTED_ISSUER;
+
+/** Validates RS256 JWT access tokens using a shared JWKS cache. */
+final class OAuthBearerJwtValidator {
+    private final JwtConsumer jwtConsumer;
+
+    OAuthBearerJwtValidator(Configuration configuration, OAuthBearerJwksResolver jwksResolver) {
+        String expectedIssuer = configuration.get(SERVER_SASL_OAUTHBEARER_EXPECTED_ISSUER);
+        if (StringUtils.isNullOrWhitespaceOnly(expectedIssuer)) {
+            throw new AuthenticationException(
+                    "Configuration '"
+                            + SERVER_SASL_OAUTHBEARER_EXPECTED_ISSUER.key()
+                            + "' must be set");
+        }
+        List<String> audiences = configuration.get(SERVER_SASL_OAUTHBEARER_EXPECTED_AUDIENCES);
+        String[] expectedAudiences =
+                audiences == null
+                        ? new String[0]
+                        : audiences.stream()
+                                .filter(Objects::nonNull)
+                                .map(String::trim)
+                                .filter(audience -> !audience.isEmpty())
+                                .toArray(String[]::new);
+        if (expectedAudiences.length == 0) {
+            throw new AuthenticationException(
+                    "Configuration '"
+                            + SERVER_SASL_OAUTHBEARER_EXPECTED_AUDIENCES.key()
+                            + "' must be set");
+        }
+        jwtConsumer =
+                new JwtConsumerBuilder()
+                        .setExpectedIssuer(expectedIssuer)
+                        .setExpectedAudience(expectedAudiences)
+                        .setRequireExpirationTime()
+                        .setRequireSubject()
+                        .setVerificationKeyResolver(
+                                (jsonWebSignature, nestingContext) -> {
+                                    String keyId = jsonWebSignature.getKeyIdHeaderValue();
+                                    if (StringUtils.isNullOrWhitespaceOnly(keyId)) {
+                                        throw new AuthenticationException(
+                                                "JWT access token must contain a non-empty kid claim");
+                                    }
+                                    return jwksResolver.resolveKey(
+                                            jsonWebSignature, nestingContext);
+                                })
+                        .setJwsAlgorithmConstraints(
+                                ConstraintType.PERMIT, AlgorithmIdentifiers.RSA_USING_SHA256)
+                        .build();
+    }
+
+    ValidatedToken validate(String token) {
+        if (token == null || token.isEmpty() || token.length() > OAuthBearerUtils.MAX_JWT_SIZE) {
+            throw new AuthenticationException("Invalid JWT access token");
+        }
+
+        try {
+            JwtClaims claims = jwtConsumer.processToClaims(token);
+            String subject = claims.getSubject();
+            if (StringUtils.isNullOrWhitespaceOnly(subject)) {
+                throw new AuthenticationException(
+                        "JWT access token must contain a non-empty sub claim");
+            }
+            return new ValidatedToken(subject, claims.getExpirationTime().getValueInMillis());
+        } catch (InvalidJwtException e) {
+            throw invalidToken(e);
+        } catch (MalformedClaimException e) {
+            throw new AuthenticationException("Invalid JWT access token claims", e);
+        }
+    }
+
+    private static AuthenticationException invalidToken(InvalidJwtException exception) {
+        if (exception.hasExpired()) {
+            return new AuthenticationException("JWT access token is expired", exception);
+        }
+        if (exception.hasErrorCode(ErrorCodes.NOT_YET_VALID)) {
+            return new AuthenticationException("JWT access token is not active yet", exception);
+        }
+        if (exception.hasErrorCode(ErrorCodes.AUDIENCE_MISSING)
+                || exception.hasErrorCode(ErrorCodes.AUDIENCE_INVALID)) {
+            return new AuthenticationException(
+                    "JWT audience does not match configured audiences", exception);
+        }
+        if (exception.hasErrorCode(ErrorCodes.ISSUER_MISSING)
+                || exception.hasErrorCode(ErrorCodes.ISSUER_INVALID)) {
+            return new AuthenticationException(
+                    "JWT issuer does not match configured issuer", exception);
+        }
+        if (exception.hasErrorCode(ErrorCodes.SIGNATURE_INVALID)
+                || exception.hasErrorCode(ErrorCodes.SIGNATURE_MISSING)) {
+            return new AuthenticationException("JWT signature validation failed", exception);
+        }
+        return new AuthenticationException("Invalid JWT access token", exception);
+    }
+
+    static final class ValidatedToken {
+        private final String subject;
+        private final long expiresAtMs;
+
+        private ValidatedToken(String subject, long expiresAtMs) {
+            this.subject = subject;
+            this.expiresAtMs = expiresAtMs;
+        }
+
+        String subject() {
+            return subject;
+        }
+
+        long expiresAtMs() {
+            return expiresAtMs;
+        }
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerSaslMessage.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerSaslMessage.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl.oauthbearer;
+
+import org.apache.fluss.exception.AuthenticationException;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Builds and parses the minimal SASL OAUTHBEARER message supported by Fluss.
+ *
+ * <p>The message format follows <a
+ * href="https://datatracker.ietf.org/doc/html/rfc7628#section-3.1">RFC 7628, Section 3.1</a>. The
+ * {@code n,,} GS2 header means that channel binding and the authorization identity are not used,
+ * and {@code \u0001} is the {@code kvsep} separator.
+ */
+final class OAuthBearerSaslMessage {
+    private static final String KV_SEPARATOR = "\u0001";
+    private static final String PREFIX = "n,," + KV_SEPARATOR;
+    private static final String BEARER_ATTRIBUTE = "auth=Bearer ";
+
+    private OAuthBearerSaslMessage() {}
+
+    static byte[] createInitialResponse(String token) {
+        return (PREFIX + BEARER_ATTRIBUTE + token + KV_SEPARATOR + KV_SEPARATOR)
+                .getBytes(StandardCharsets.UTF_8);
+    }
+
+    static String parseToken(byte[] responseBytes) {
+        if (responseBytes == null || responseBytes.length == 0) {
+            throw new AuthenticationException("SASL OAUTHBEARER response is empty");
+        }
+        String response = new String(responseBytes, StandardCharsets.UTF_8);
+        if (!response.startsWith(PREFIX) || !response.endsWith(KV_SEPARATOR + KV_SEPARATOR)) {
+            throw new AuthenticationException("Invalid SASL OAUTHBEARER response format");
+        }
+        String[] attributes = response.substring(PREFIX.length()).split(KV_SEPARATOR, -1);
+        String bearerToken = null;
+        for (String attribute : attributes) {
+            if (attribute.startsWith(BEARER_ATTRIBUTE)) {
+                if (bearerToken != null) {
+                    throw new AuthenticationException(
+                            "SASL OAUTHBEARER response contains multiple auth attributes");
+                }
+                bearerToken = attribute.substring(BEARER_ATTRIBUTE.length());
+            }
+        }
+        if (bearerToken == null || bearerToken.isEmpty()) {
+            throw new AuthenticationException(
+                    "SASL OAUTHBEARER response does not contain a Bearer token");
+        }
+        return bearerToken;
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerServerAuthenticator.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerServerAuthenticator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl.oauthbearer;
+
+import org.apache.fluss.annotation.Internal;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.AuthenticationException;
+import org.apache.fluss.security.acl.FlussPrincipal;
+import org.apache.fluss.security.auth.ServerAuthenticator;
+
+/** A connection-local SASL OAUTHBEARER server authenticator. */
+@Internal
+public final class OAuthBearerServerAuthenticator implements ServerAuthenticator {
+    private final OAuthBearerJwtValidator validator;
+
+    private FlussPrincipal principal;
+    private long expiresAtMs;
+
+    /** Creates a connection-local authenticator using the shared JWKS cache. */
+    public OAuthBearerServerAuthenticator(
+            Configuration configuration, OAuthBearerJwksResolver jwksResolver) {
+        validator = new OAuthBearerJwtValidator(configuration, jwksResolver);
+    }
+
+    @Override
+    public String protocol() {
+        return OAuthBearerClientAuthenticator.OAUTHBEARER_MECHANISM;
+    }
+
+    @Override
+    public byte[] evaluateResponse(byte[] tokenBytes) throws AuthenticationException {
+        String token = OAuthBearerSaslMessage.parseToken(tokenBytes);
+        OAuthBearerJwtValidator.ValidatedToken validatedToken = validator.validate(token);
+        principal = new FlussPrincipal(validatedToken.subject(), FlussPrincipal.USER_TYPE);
+        expiresAtMs = validatedToken.expiresAtMs();
+        return null;
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return principal != null;
+    }
+
+    @Override
+    public FlussPrincipal createPrincipal() {
+        if (principal == null) {
+            throw new AuthenticationException("SASL OAUTHBEARER authentication is not completed");
+        }
+        return principal;
+    }
+
+    @Override
+    public void validateSession() {
+        if (principal != null && System.currentTimeMillis() >= expiresAtMs) {
+            throw new AuthenticationException("JWT access token is expired");
+        }
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerUtils.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl.oauthbearer;
+
+import org.apache.fluss.exception.AuthenticationException;
+import org.apache.fluss.exception.RetriableAuthenticationException;
+import org.apache.fluss.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.fluss.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import static org.apache.fluss.utils.StringUtils.isNullOrWhitespaceOnly;
+
+/** Utilities shared by OAuth bearer client and server authentication. */
+final class OAuthBearerUtils {
+    static final int MAX_HTTP_RESPONSE_SIZE = 1024 * 1024;
+    static final int MAX_JWT_SIZE = 64 * 1024;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private OAuthBearerUtils() {}
+
+    static URI validateHttpEndpoint(String value, String key) {
+        if (isNullOrWhitespaceOnly(value)) {
+            throw new AuthenticationException("Configuration '" + key + "' must be set");
+        }
+        try {
+            URI uri = new URI(value);
+            if (!uri.isAbsolute()
+                    || (!("http".equalsIgnoreCase(uri.getScheme()))
+                            && !("https".equalsIgnoreCase(uri.getScheme())))) {
+                throw new AuthenticationException(
+                        "Configuration '" + key + "' must be an absolute HTTP(S) URI");
+            }
+            return uri;
+        } catch (URISyntaxException e) {
+            throw new AuthenticationException("Configuration '" + key + "' is not a valid URI", e);
+        }
+    }
+
+    static JsonNode execute(
+            URI endpoint, String method, int timeoutMs, String authorization, byte[] requestBody)
+            throws AuthenticationException {
+        HttpURLConnection connection = null;
+        try {
+            URL url = endpoint.toURL();
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setInstanceFollowRedirects(false);
+            connection.setConnectTimeout(timeoutMs);
+            connection.setReadTimeout(timeoutMs);
+            connection.setRequestMethod(method);
+            connection.setRequestProperty("Accept", "application/json");
+            if (authorization != null) {
+                connection.setRequestProperty("Authorization", authorization);
+            }
+            if (requestBody != null) {
+                connection.setDoOutput(true);
+                connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+                connection.setFixedLengthStreamingMode(requestBody.length);
+                try (OutputStream output = connection.getOutputStream()) {
+                    output.write(requestBody);
+                }
+            }
+
+            int status = connection.getResponseCode();
+            InputStream input =
+                    status >= 200 && status < 300
+                            ? connection.getInputStream()
+                            : connection.getErrorStream();
+            byte[] response = readLimited(input);
+            if (status < 200 || status >= 300) {
+                String message = "OAuth endpoint returned HTTP status " + status;
+                if (status == 429 || status >= 500) {
+                    throw new RetriableAuthenticationException(message);
+                }
+                throw new AuthenticationException(message);
+            }
+            try {
+                return OBJECT_MAPPER.readTree(response);
+            } catch (IOException e) {
+                throw new AuthenticationException("OAuth endpoint returned invalid JSON", e);
+            }
+        } catch (AuthenticationException e) {
+            throw e;
+        } catch (IOException e) {
+            RetriableAuthenticationException exception =
+                    new RetriableAuthenticationException("Failed to access OAuth endpoint");
+            exception.initCause(e);
+            throw exception;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private static byte[] readLimited(InputStream input) throws IOException {
+        if (input == null) {
+            return new byte[0];
+        }
+        try (InputStream in = input;
+                ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int total = 0;
+            int read;
+            while ((read = in.read(buffer)) >= 0) {
+                total += read;
+                if (total > MAX_HTTP_RESPONSE_SIZE) {
+                    throw new IOException("OAuth endpoint response exceeds size limit");
+                }
+                output.write(buffer, 0, read);
+            }
+            return output.toByteArray();
+        }
+    }
+}

--- a/fluss-common/src/test/java/org/apache/fluss/security/auth/sasl/SaslAuthenticatorFactoryTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/security/auth/sasl/SaslAuthenticatorFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl;
+
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.AuthenticationException;
+import org.apache.fluss.security.auth.ClientAuthenticator;
+import org.apache.fluss.security.auth.ServerAuthenticator;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SaslAuthenticatorFactory}. */
+class SaslAuthenticatorFactoryTest {
+
+    @Test
+    void testCreatesIndependentAuthenticators() {
+        Configuration configuration = new Configuration();
+        configuration.set(ConfigOptions.CLIENT_SASL_MECHANISM, "plain");
+
+        ClientAuthenticator firstClient =
+                SaslAuthenticatorFactory.createClientAuthenticator(configuration);
+        ClientAuthenticator secondClient =
+                SaslAuthenticatorFactory.createClientAuthenticator(configuration);
+        ServerAuthenticator firstServer =
+                SaslAuthenticatorFactory.createServerAuthenticator("plain", configuration);
+        ServerAuthenticator secondServer =
+                SaslAuthenticatorFactory.createServerAuthenticator("PLAIN", configuration);
+
+        Assertions.assertThat(firstClient).isNotSameAs(secondClient);
+        Assertions.assertThat(firstServer).isNotSameAs(secondServer);
+        Assertions.assertThat(firstServer.protocol()).isEqualTo("PLAIN");
+        Assertions.assertThatCode(() -> firstServer.matchProtocol("plain"))
+                .doesNotThrowAnyException();
+        Assertions.assertThat(SaslAuthenticatorFactory.supportsServerMechanism("plain")).isTrue();
+    }
+
+    @Test
+    void testRejectsUnsupportedMechanisms() {
+        Configuration configuration = new Configuration();
+        configuration.set(ConfigOptions.CLIENT_SASL_MECHANISM, "unknown");
+
+        Assertions.assertThatThrownBy(
+                        () -> SaslAuthenticatorFactory.createClientAuthenticator(configuration))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessage("Unable to find a matching SASL mechanism for UNKNOWN");
+        Assertions.assertThatThrownBy(
+                        () ->
+                                SaslAuthenticatorFactory.createServerAuthenticator(
+                                        "unknown", configuration))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessage("Unable to find a matching SASL mechanism for UNKNOWN");
+        Assertions.assertThat(SaslAuthenticatorFactory.supportsServerMechanism("unknown"))
+                .isFalse();
+    }
+}

--- a/fluss-common/src/test/java/org/apache/fluss/security/auth/sasl/SaslAuthenticatorFactoryTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/security/auth/sasl/SaslAuthenticatorFactoryTest.java
@@ -21,7 +21,6 @@ import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.AuthenticationException;
 import org.apache.fluss.security.auth.ClientAuthenticator;
-import org.apache.fluss.security.auth.ServerAuthenticator;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -30,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class SaslAuthenticatorFactoryTest {
 
     @Test
-    void testCreatesIndependentAuthenticators() {
+    void testCreatesIndependentClientAuthenticators() {
         Configuration configuration = new Configuration();
         configuration.set(ConfigOptions.CLIENT_SASL_MECHANISM, "plain");
 
@@ -38,21 +37,12 @@ class SaslAuthenticatorFactoryTest {
                 SaslAuthenticatorFactory.createClientAuthenticator(configuration);
         ClientAuthenticator secondClient =
                 SaslAuthenticatorFactory.createClientAuthenticator(configuration);
-        ServerAuthenticator firstServer =
-                SaslAuthenticatorFactory.createServerAuthenticator("plain", configuration);
-        ServerAuthenticator secondServer =
-                SaslAuthenticatorFactory.createServerAuthenticator("PLAIN", configuration);
 
         Assertions.assertThat(firstClient).isNotSameAs(secondClient);
-        Assertions.assertThat(firstServer).isNotSameAs(secondServer);
-        Assertions.assertThat(firstServer.protocol()).isEqualTo("PLAIN");
-        Assertions.assertThatCode(() -> firstServer.matchProtocol("plain"))
-                .doesNotThrowAnyException();
-        Assertions.assertThat(SaslAuthenticatorFactory.supportsServerMechanism("plain")).isTrue();
     }
 
     @Test
-    void testRejectsUnsupportedMechanisms() {
+    void testRejectsUnsupportedClientMechanism() {
         Configuration configuration = new Configuration();
         configuration.set(ConfigOptions.CLIENT_SASL_MECHANISM, "unknown");
 
@@ -60,13 +50,5 @@ class SaslAuthenticatorFactoryTest {
                         () -> SaslAuthenticatorFactory.createClientAuthenticator(configuration))
                 .isInstanceOf(AuthenticationException.class)
                 .hasMessage("Unable to find a matching SASL mechanism for UNKNOWN");
-        Assertions.assertThatThrownBy(
-                        () ->
-                                SaslAuthenticatorFactory.createServerAuthenticator(
-                                        "unknown", configuration))
-                .isInstanceOf(AuthenticationException.class)
-                .hasMessage("Unable to find a matching SASL mechanism for UNKNOWN");
-        Assertions.assertThat(SaslAuthenticatorFactory.supportsServerMechanism("unknown"))
-                .isFalse();
     }
 }

--- a/fluss-common/src/test/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerAuthenticationTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerAuthenticationTest.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.security.auth.sasl.oauthbearer;
+
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.Password;
+import org.apache.fluss.exception.AuthenticationException;
+import org.apache.fluss.exception.RetriableAuthenticationException;
+import org.apache.fluss.security.acl.FlussPrincipal;
+import org.apache.fluss.security.auth.AuthenticationFactory;
+import org.apache.fluss.security.auth.ClientAuthenticator;
+import org.apache.fluss.security.auth.ServerAuthenticator;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_ID;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_REQUEST_TIMEOUT;
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_TOKEN_ENDPOINT;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_ENABLED_MECHANISMS_CONFIG;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_EXPECTED_AUDIENCES;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_EXPECTED_ISSUER;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_ENDPOINT;
+import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_REFRESH_MIN_INTERVAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the OAuth bearer token and JWKS authentication path. */
+class OAuthBearerAuthenticationTest {
+    private final AtomicInteger tokenRequests = new AtomicInteger();
+    private final AtomicInteger jwksRequests = new AtomicInteger();
+    private final AtomicReference<Response> tokenResponse = new AtomicReference<>();
+    private final AtomicReference<Response> jwksResponse = new AtomicReference<>();
+
+    private HttpServer server;
+
+    @BeforeEach
+    void beforeEach() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                "/token",
+                exchange -> {
+                    tokenRequests.incrementAndGet();
+                    respond(exchange, tokenResponse.get());
+                });
+        server.createContext(
+                "/jwks",
+                exchange -> {
+                    jwksRequests.incrementAndGet();
+                    respond(exchange, jwksResponse.get());
+                });
+        server.start();
+    }
+
+    @AfterEach
+    void afterEach() {
+        server.stop(0);
+    }
+
+    @Test
+    void testClientAuthenticatorFetchesTokenForEachConnection() {
+        tokenResponse.set(
+                new Response(200, "{\"access_token\":\"token\",\"token_type\":\"Bearer\"}"));
+
+        OAuthBearerClientAuthenticator first =
+                new OAuthBearerClientAuthenticator(clientConfiguration());
+        OAuthBearerClientAuthenticator second =
+                new OAuthBearerClientAuthenticator(clientConfiguration());
+        first.initialize(null);
+        second.initialize(null);
+
+        byte[] firstResponse = first.authenticate(new byte[0]);
+        first.initialize(null);
+        assertThat(first.authenticate(new byte[0])).isEqualTo(firstResponse);
+        assertThat(second.authenticate(new byte[0])).isEqualTo(firstResponse);
+        assertThat(tokenRequests).hasValue(2);
+    }
+
+    @Test
+    void testTokenEndpointFailureFailsAuthentication() {
+        tokenResponse.set(new Response(503, "unavailable"));
+        OAuthBearerClientAuthenticator authenticator =
+                new OAuthBearerClientAuthenticator(clientConfiguration());
+        authenticator.initialize(null);
+
+        assertThatThrownBy(() -> authenticator.authenticate(new byte[0]))
+                .isInstanceOf(RetriableAuthenticationException.class);
+        assertThat(tokenRequests).hasValue(1);
+    }
+
+    @Test
+    void testJwtValidationAndJwksRotation() throws Exception {
+        long nowSeconds = System.currentTimeMillis() / 1000;
+        KeyPair firstKey = generateRsaKey();
+        KeyPair secondKey = generateRsaKey();
+        jwksResponse.set(new Response(200, jwks("first", firstKey)));
+        Configuration configuration = serverConfiguration();
+        configuration.set(SERVER_SASL_OAUTHBEARER_JWKS_REFRESH_MIN_INTERVAL, Duration.ZERO);
+        OAuthBearerJwksResolver resolver = new OAuthBearerJwksResolver(configuration);
+        OAuthBearerJwtValidator validator = new OAuthBearerJwtValidator(configuration, resolver);
+
+        String firstToken =
+                signedToken("first", firstKey, "subject", "issuer", "fluss", nowSeconds + 60);
+        OAuthBearerJwtValidator.ValidatedToken validated = validator.validate(firstToken);
+        assertThat(validated.subject()).isEqualTo("subject");
+        assertThat(jwksRequests).hasValue(1);
+        validator.validate(firstToken);
+        assertThat(jwksRequests).hasValue(1);
+
+        jwksResponse.set(new Response(200, jwks("second", secondKey)));
+        String secondToken =
+                signedToken("second", secondKey, "subject-2", "issuer", "fluss", nowSeconds + 60);
+        assertThat(validator.validate(secondToken).subject()).isEqualTo("subject-2");
+        assertThat(jwksRequests).hasValue(2);
+
+        String wrongAudience =
+                signedToken("second", secondKey, "subject-2", "issuer", "other", nowSeconds + 60);
+        assertThatThrownBy(() -> validator.validate(wrongAudience))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessageContaining("audience");
+
+        String expiredToken =
+                signedToken("second", secondKey, "subject-2", "issuer", "fluss", nowSeconds - 1);
+        assertThatThrownBy(() -> validator.validate(expiredToken))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessageContaining("expired");
+    }
+
+    @Test
+    void testClientAndServerAuthenticators() throws Exception {
+        KeyPair keyPair = generateRsaKey();
+        long expirationSeconds = System.currentTimeMillis() / 1000 + 60;
+        String token =
+                signedToken(
+                        "key", keyPair, "service-account", "issuer", "fluss", expirationSeconds);
+        tokenResponse.set(tokenResponse(token, 60));
+        jwksResponse.set(new Response(200, jwks("key", keyPair)));
+
+        OAuthBearerClientAuthenticator client =
+                new OAuthBearerClientAuthenticator(clientConfiguration());
+        OAuthBearerServerAuthenticator oauthServer =
+                new OAuthBearerServerAuthenticator(
+                        serverConfiguration(), new OAuthBearerJwksResolver(serverConfiguration()));
+
+        client.initialize(null);
+        byte[] initialResponse = client.authenticate(new byte[0]);
+        assertThat(client.isCompleted()).isTrue();
+        assertThat(oauthServer.evaluateResponse(initialResponse)).isNull();
+        assertThat(oauthServer.isCompleted()).isTrue();
+        assertThat(oauthServer.createPrincipal().getName()).isEqualTo("service-account");
+        assertThat(oauthServer.createPrincipal().getType()).isEqualTo(FlussPrincipal.USER_TYPE);
+    }
+
+    @Test
+    void testServerAuthenticatorBeforeAuthentication() {
+        Configuration configuration = serverConfiguration();
+        OAuthBearerServerAuthenticator oauthServer =
+                new OAuthBearerServerAuthenticator(
+                        configuration, new OAuthBearerJwksResolver(configuration));
+
+        assertThat(oauthServer.protocol()).isEqualTo("OAUTHBEARER");
+        assertThat(oauthServer.isCompleted()).isFalse();
+        oauthServer.validateSession();
+        assertThatThrownBy(oauthServer::createPrincipal)
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessage("SASL OAUTHBEARER authentication is not completed");
+    }
+
+    @Test
+    void testPluginFetchesTokenPerConnectionAndSharesJwksAcrossConnections() throws Exception {
+        KeyPair keyPair = generateRsaKey();
+        String token =
+                signedToken(
+                        "key",
+                        keyPair,
+                        "service-account",
+                        "issuer",
+                        "fluss",
+                        System.currentTimeMillis() / 1000 + 60);
+        tokenResponse.set(tokenResponse(token, 60));
+        jwksResponse.set(new Response(200, jwks("key", keyPair)));
+
+        Configuration clientConfiguration = clientConfiguration();
+        clientConfiguration.set(ConfigOptions.CLIENT_SECURITY_PROTOCOL, "SASL");
+        clientConfiguration.setString("client.security.sasl.mechanism", "OAUTHBEARER");
+        Supplier<ClientAuthenticator> clientSupplier =
+                AuthenticationFactory.loadClientAuthenticatorSupplier(clientConfiguration);
+        ClientAuthenticator firstClient = clientSupplier.get();
+        ClientAuthenticator secondClient = clientSupplier.get();
+        firstClient.initialize(null);
+        secondClient.initialize(null);
+        byte[] firstResponse = firstClient.authenticate(new byte[0]);
+        byte[] secondResponse = secondClient.authenticate(new byte[0]);
+        assertThat(firstResponse).isEqualTo(secondResponse);
+        assertThat(tokenRequests).hasValue(2);
+
+        Configuration serverConfiguration = serverConfiguration();
+        serverConfiguration.set(
+                SERVER_SASL_ENABLED_MECHANISMS_CONFIG, Collections.singletonList("OAUTHBEARER"));
+        serverConfiguration.setString(
+                ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP.key(), "CLIENT:SASL,INTERNAL:SASL");
+        Map<String, Supplier<ServerAuthenticator>> serverSuppliers =
+                AuthenticationFactory.loadServerAuthenticatorSuppliers(serverConfiguration);
+        ServerAuthenticator firstServer = serverSuppliers.get("CLIENT").get();
+        ServerAuthenticator secondServer = serverSuppliers.get("INTERNAL").get();
+        firstServer.initialize(authenticateContext("CLIENT"));
+        secondServer.initialize(authenticateContext("INTERNAL"));
+        firstServer.evaluateResponse(firstResponse);
+        secondServer.evaluateResponse(secondResponse);
+        assertThat(jwksRequests).hasValue(1);
+    }
+
+    @Test
+    void testJwksFailureFailsAuthentication() throws Exception {
+        jwksResponse.set(new Response(503, "unavailable"));
+        Configuration configuration = serverConfiguration();
+        OAuthBearerJwksResolver resolver = new OAuthBearerJwksResolver(configuration);
+        OAuthBearerJwtValidator validator = new OAuthBearerJwtValidator(configuration, resolver);
+        String token =
+                signedToken(
+                        "unknown",
+                        generateRsaKey(),
+                        "subject",
+                        "issuer",
+                        "fluss",
+                        System.currentTimeMillis() / 1000 + 60);
+
+        assertThatThrownBy(() -> validator.validate(token))
+                .isInstanceOf(AuthenticationException.class);
+        assertThat(jwksRequests).hasValue(1);
+
+        assertThatThrownBy(() -> validator.validate(token))
+                .isInstanceOf(AuthenticationException.class);
+        assertThat(jwksRequests).hasValue(2);
+    }
+
+    private Configuration clientConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.set(CLIENT_SASL_OAUTHBEARER_TOKEN_ENDPOINT, endpoint("/token"));
+        configuration.set(CLIENT_SASL_OAUTHBEARER_CLIENT_ID, "client");
+        configuration.set(CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET, new Password("secret"));
+        configuration.set(CLIENT_SASL_OAUTHBEARER_REQUEST_TIMEOUT, Duration.ofSeconds(5));
+        return configuration;
+    }
+
+    private Configuration serverConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.set(SERVER_SASL_OAUTHBEARER_JWKS_ENDPOINT, endpoint("/jwks"));
+        configuration.set(SERVER_SASL_OAUTHBEARER_EXPECTED_ISSUER, "issuer");
+        configuration.set(
+                SERVER_SASL_OAUTHBEARER_EXPECTED_AUDIENCES, Arrays.asList("fluss", "fluss-admin"));
+        return configuration;
+    }
+
+    private String endpoint(String path) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+    }
+
+    private static ServerAuthenticator.AuthenticateContext authenticateContext(
+            String listenerName) {
+        return new ServerAuthenticator.AuthenticateContext() {
+            @Override
+            public String ipAddress() {
+                return "127.0.0.1";
+            }
+
+            @Override
+            public String listenerName() {
+                return listenerName;
+            }
+
+            @Override
+            public String protocol() {
+                return "OAUTHBEARER";
+            }
+        };
+    }
+
+    private static Response tokenResponse(String token, long expiresIn) {
+        return new Response(
+                200,
+                "{\"access_token\":\""
+                        + token
+                        + "\",\"token_type\":\"Bearer\",\"expires_in\":"
+                        + expiresIn
+                        + "}");
+    }
+
+    private static String signedToken(
+            String keyId,
+            KeyPair keyPair,
+            String subject,
+            String issuer,
+            String audience,
+            long expirationSeconds)
+            throws Exception {
+        String unsigned =
+                encode("{\"alg\":\"RS256\",\"kid\":\"" + keyId + "\"}")
+                        + "."
+                        + encode(
+                                "{\"sub\":\""
+                                        + subject
+                                        + "\",\"iss\":\""
+                                        + issuer
+                                        + "\",\"aud\":\""
+                                        + audience
+                                        + "\",\"exp\":"
+                                        + expirationSeconds
+                                        + "}");
+        Signature signature = Signature.getInstance("SHA256withRSA");
+        signature.initSign(keyPair.getPrivate());
+        signature.update(unsigned.getBytes(StandardCharsets.US_ASCII));
+        return unsigned
+                + "."
+                + Base64.getUrlEncoder().withoutPadding().encodeToString(signature.sign());
+    }
+
+    private static String jwks(String keyId, KeyPair keyPair) {
+        RSAPublicKey key = (RSAPublicKey) keyPair.getPublic();
+        return "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\""
+                + keyId
+                + "\",\"use\":\"sig\",\"alg\":\"RS256\",\"n\":\""
+                + encodeUnsigned(key.getModulus())
+                + "\",\"e\":\""
+                + encodeUnsigned(key.getPublicExponent())
+                + "\"}]}";
+    }
+
+    private static KeyPair generateRsaKey() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    private static String encode(String value) {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String encodeUnsigned(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        if (bytes.length > 1 && bytes[0] == 0) {
+            bytes = Arrays.copyOfRange(bytes, 1, bytes.length);
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private static void respond(HttpExchange exchange, Response response) throws IOException {
+        byte[] body = response.body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(response.status, body.length);
+        try (OutputStream output = exchange.getResponseBody()) {
+            output.write(body);
+        }
+    }
+
+    private static final class Response {
+        private final int status;
+        private final String body;
+
+        private Response(int status, String body) {
+            this.status = status;
+            this.body = body;
+        }
+    }
+}

--- a/fluss-common/src/test/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerAuthenticationTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/security/auth/sasl/oauthbearer/OAuthBearerAuthenticationTest.java
@@ -51,6 +51,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_MECHANISM;
 import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_ID;
 import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET;
 import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_OAUTHBEARER_REQUEST_TIMEOUT;
@@ -60,6 +61,7 @@ import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_EXPE
 import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_EXPECTED_ISSUER;
 import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_ENDPOINT;
 import static org.apache.fluss.config.ConfigOptions.SERVER_SASL_OAUTHBEARER_JWKS_REFRESH_MIN_INTERVAL;
+import static org.apache.fluss.security.auth.sasl.oauthbearer.OAuthBearerClientAuthenticator.OAUTHBEARER_MECHANISM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -196,7 +198,7 @@ class OAuthBearerAuthenticationTest {
                 new OAuthBearerServerAuthenticator(
                         configuration, new OAuthBearerJwksResolver(configuration));
 
-        assertThat(oauthServer.protocol()).isEqualTo("OAUTHBEARER");
+        assertThat(oauthServer.protocol()).isEqualTo(OAUTHBEARER_MECHANISM);
         assertThat(oauthServer.isCompleted()).isFalse();
         oauthServer.validateSession();
         assertThatThrownBy(oauthServer::createPrincipal)
@@ -220,7 +222,7 @@ class OAuthBearerAuthenticationTest {
 
         Configuration clientConfiguration = clientConfiguration();
         clientConfiguration.set(ConfigOptions.CLIENT_SECURITY_PROTOCOL, "SASL");
-        clientConfiguration.setString("client.security.sasl.mechanism", "OAUTHBEARER");
+        clientConfiguration.set(CLIENT_SASL_MECHANISM, OAUTHBEARER_MECHANISM);
         Supplier<ClientAuthenticator> clientSupplier =
                 AuthenticationFactory.loadClientAuthenticatorSupplier(clientConfiguration);
         ClientAuthenticator firstClient = clientSupplier.get();
@@ -234,7 +236,8 @@ class OAuthBearerAuthenticationTest {
 
         Configuration serverConfiguration = serverConfiguration();
         serverConfiguration.set(
-                SERVER_SASL_ENABLED_MECHANISMS_CONFIG, Collections.singletonList("OAUTHBEARER"));
+                SERVER_SASL_ENABLED_MECHANISMS_CONFIG,
+                Collections.singletonList(OAUTHBEARER_MECHANISM));
         serverConfiguration.setString(
                 ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP.key(), "CLIENT:SASL,INTERNAL:SASL");
         Map<String, Supplier<ServerAuthenticator>> serverSuppliers =
@@ -309,7 +312,7 @@ class OAuthBearerAuthenticationTest {
 
             @Override
             public String protocol() {
-                return "OAUTHBEARER";
+                return OAUTHBEARER_MECHANISM;
             }
         };
     }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/FlinkConversions.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/utils/FlinkConversions.java
@@ -356,8 +356,11 @@ public class FlinkConversions {
                                     TimeUtils.formatWithHighestUnit(
                                             (Duration) flussOption.defaultValue()));
         } else if (clazz.equals(Password.class)) {
-            String defaultValue = ((Password) flussOption.defaultValue()).value();
-            option = builder.stringType().defaultValue(defaultValue);
+            Password defaultValue = (Password) flussOption.defaultValue();
+            option =
+                    defaultValue == null
+                            ? builder.stringType().noDefaultValue()
+                            : builder.stringType().defaultValue(defaultValue.value());
         } else if (clazz.equals(MemorySize.class)) {
             // use string type in Flink option instead to make convert back easier
             option = builder.stringType().defaultValue(flussOption.defaultValue().toString());

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/utils/FlinkConversionsTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/utils/FlinkConversionsTest.java
@@ -383,6 +383,18 @@ public class FlinkConversionsTest {
                                 .withDescription(
                                         ConfigOptions.CLIENT_WRITER_BUFFER_MEMORY_SIZE
                                                 .description()));
+
+        flinkOption =
+                FlinkConversions.toFlinkOption(ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET);
+        assertThat(flinkOption)
+                .isEqualTo(
+                        org.apache.flink.configuration.ConfigOptions.key(
+                                        ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET.key())
+                                .stringType()
+                                .noDefaultValue()
+                                .withDescription(
+                                        ConfigOptions.CLIENT_SASL_OAUTHBEARER_CLIENT_SECRET
+                                                .description()));
     }
 
     @Test

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/FlussProtocolPlugin.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/FlussProtocolPlugin.java
@@ -27,6 +27,7 @@ import org.apache.fluss.rpc.protocol.ApiManager;
 import org.apache.fluss.rpc.protocol.NetworkProtocolPlugin;
 import org.apache.fluss.security.auth.AuthenticationFactory;
 import org.apache.fluss.security.auth.PlainTextAuthenticationPlugin;
+import org.apache.fluss.security.auth.ServerAuthenticator;
 import org.apache.fluss.shaded.netty4.io.netty.channel.ChannelHandler;
 
 import java.util.LinkedHashMap;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -65,6 +67,7 @@ public class FlussProtocolPlugin implements NetworkProtocolPlugin, ServerReconfi
     private final List<String> listeners;
     private final RequestsMetrics requestsMetrics;
     private Configuration conf;
+    private Map<String, Supplier<ServerAuthenticator>> serverAuthenticatorSuppliers;
     /** Initial credentials from `security.sasl.plain.jaas.config`. */
     private Map<String, String> initialPlainCredentialsFromJaasConfig;
 
@@ -88,6 +91,8 @@ public class FlussProtocolPlugin implements NetworkProtocolPlugin, ServerReconfi
         this.conf = new Configuration(conf);
         this.initialPlainCredentialsFromJaasConfig = parseCredentialsFromJaasConfig(conf);
         enrichWithJaasConfig(conf);
+        this.serverAuthenticatorSuppliers =
+                AuthenticationFactory.loadServerAuthenticatorSuppliers(this.conf);
     }
 
     @Override
@@ -106,9 +111,7 @@ public class FlussProtocolPlugin implements NetworkProtocolPlugin, ServerReconfi
                 requestsMetrics,
                 conf.get(ConfigOptions.NETTY_CONNECTION_MAX_IDLE_TIME).getSeconds(),
                 (int) conf.get(ConfigOptions.NETTY_SERVER_MAX_REQUEST_SIZE).getBytes(),
-                Optional.ofNullable(
-                                AuthenticationFactory.loadServerAuthenticatorSuppliers(this.conf)
-                                        .get(listenerName))
+                Optional.ofNullable(serverAuthenticatorSuppliers.get(listenerName))
                         .orElse(PlainTextAuthenticationPlugin.PlainTextServerAuthenticator::new));
     }
 

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/NettyServerHandler.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/NettyServerHandler.java
@@ -119,6 +119,16 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
                 needRelease = true;
             }
 
+            if (authenticator.isCompleted()) {
+                try {
+                    authenticator.validateSession();
+                } catch (AuthenticationException e) {
+                    needRelease = true;
+                    closeWithAuthenticationError(ctx, requestId, e);
+                    return;
+                }
+            }
+
             FlussRequest request =
                     new FlussRequest(
                             apiKey,
@@ -219,6 +229,15 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
         switchState(ConnectionState.CLOSE);
         IOUtils.closeQuietly(authenticator);
         ctx.close();
+    }
+
+    private void closeWithAuthenticationError(
+            ChannelHandlerContext ctx, int requestId, AuthenticationException exception) {
+        switchState(ConnectionState.CLOSE);
+        IOUtils.closeQuietly(authenticator);
+        ByteBuf response =
+                encodeErrorResponse(ctx.alloc(), requestId, ApiError.fromThrowable(exception));
+        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
     }
 
     private void sendResponse(ChannelHandlerContext ctx, FlussRequest request) {

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/authenticate/SaslAuthenticationITCase.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/authenticate/SaslAuthenticationITCase.java
@@ -94,7 +94,6 @@ public class SaslAuthenticationITCase {
         clientConfig.setString("client.security.sasl.mechanism", "FAKE");
         clientConfig.setString("client.security.sasl.jaas.config", jaasClientInfo);
         assertThatThrownBy(() -> testAuthentication(clientConfig))
-                .cause()
                 .isExactlyInstanceOf(AuthenticationException.class)
                 .hasMessage("Unable to find a matching SASL mechanism for FAKE");
     }
@@ -105,7 +104,7 @@ public class SaslAuthenticationITCase {
                 "org.apache.fluss.security.auth.sasl.jaas.FakeLoginModule required username=\"admin\" password=\"wrong-secret\";";
         Configuration clientConfig = new Configuration();
         clientConfig.setString("client.security.protocol", "sasl");
-        clientConfig.setString("client.security.sasl.mechanism", "FAKE");
+        clientConfig.setString("client.security.sasl.mechanism", "PLAIN");
         clientConfig.setString("client.security.sasl.jaas.config", jaasClientInfo);
         assertThatThrownBy(() -> testAuthentication(clientConfig))
                 .isExactlyInstanceOf(AuthenticationException.class)
@@ -115,16 +114,17 @@ public class SaslAuthenticationITCase {
 
     @Test
     void testClientMechanismNotMatchServer() {
-        String jaasClientInfo =
-                " org.apache.fluss.security.auth.sasl.jaas.DigestLoginModule required username=\"admin\" password=\"wrong-secret\";";
         Configuration clientConfig = new Configuration();
         clientConfig.setString("client.security.protocol", "sasl");
-        clientConfig.setString("client.security.sasl.mechanism", "DIGEST-MD5");
-        clientConfig.setString("client.security.sasl.jaas.config", jaasClientInfo);
-        assertThatThrownBy(() -> testAuthentication(clientConfig))
+        clientConfig.setString("client.security.sasl.mechanism", "PLAIN");
+        clientConfig.setString("client.security.sasl.jaas.config", CLIENT_JAAS_INFO);
+        Configuration serverConfig = getDefaultServerConfig();
+        serverConfig.setString("security.sasl.enabled.mechanisms", "FAKE");
+        assertThatThrownBy(() -> testAuthentication(clientConfig, serverConfig))
+                .cause()
                 .isExactlyInstanceOf(AuthenticationException.class)
                 .hasMessageContaining(
-                        "Only 'org.apache.fluss.security.auth.sasl.plain.PlainLoginModule' is supported in 'client.security.sasl.jaas.config'.");
+                        "SASL server enables [FAKE] while protocol of client is 'PLAIN'");
     }
 
     @Test

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/server/NettyServerHandlerTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/server/NettyServerHandlerTest.java
@@ -18,6 +18,7 @@
 package org.apache.fluss.rpc.netty.server;
 
 import org.apache.fluss.cluster.ServerType;
+import org.apache.fluss.exception.AuthenticationException;
 import org.apache.fluss.metrics.groups.MetricGroup;
 import org.apache.fluss.metrics.util.NOPMetricsGroup;
 import org.apache.fluss.rpc.messages.ApiVersionsRequest;
@@ -32,9 +33,12 @@ import org.apache.fluss.rpc.protocol.ApiKeys;
 import org.apache.fluss.rpc.protocol.ApiManager;
 import org.apache.fluss.rpc.protocol.MessageCodec;
 import org.apache.fluss.security.auth.PlainTextAuthenticationPlugin;
+import org.apache.fluss.security.auth.ServerAuthenticator;
 import org.apache.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.fluss.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 import org.apache.fluss.shaded.netty4.io.netty.channel.Channel;
+import org.apache.fluss.shaded.netty4.io.netty.channel.ChannelFuture;
+import org.apache.fluss.shaded.netty4.io.netty.channel.ChannelFutureListener;
 import org.apache.fluss.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.fluss.shaded.netty4.io.netty.channel.ChannelId;
 import org.apache.fluss.shaded.netty4.io.netty.util.concurrent.DefaultEventExecutor;
@@ -48,10 +52,13 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Test for {@link NettyServerHandler}. */
@@ -201,6 +208,54 @@ final class NettyServerHandlerTest {
                 Duration.ofSeconds(20),
                 () -> assertThat(inflightLookupResponses.size()).isEqualTo(4));
         assertThat(inflightApiVersionResponses.size()).isEqualTo(5);
+    }
+
+    @Test
+    void testExpiredAuthenticatedSessionClosesConnectionBeforeDispatch() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean();
+        ServerAuthenticator expiredAuthenticator =
+                new PlainTextAuthenticationPlugin.PlainTextServerAuthenticator() {
+                    @Override
+                    public void validateSession() {
+                        throw new AuthenticationException("session expired");
+                    }
+
+                    @Override
+                    public void close() {
+                        closed.set(true);
+                    }
+                };
+        NettyServerHandler handler =
+                new NettyServerHandler(
+                        requestChannel,
+                        new ApiManager(ServerType.TABLET_SERVER),
+                        "FLUSS",
+                        true,
+                        RequestsMetrics.createCoordinatorServerRequestMetrics(
+                                NOPMetricsGroup.newInstance()),
+                        expiredAuthenticator);
+        ChannelFuture closeFuture = mock(ChannelFuture.class);
+        when(ctx.writeAndFlush(any())).thenReturn(closeFuture);
+        when(closeFuture.addListener(ChannelFutureListener.CLOSE)).thenReturn(closeFuture);
+        handler.channelActive(ctx);
+
+        ApiVersionsRequest request =
+                new ApiVersionsRequest()
+                        .setClientSoftwareName("test")
+                        .setClientSoftwareVersion("1.0.0");
+        ByteBuf byteBuf =
+                MessageCodec.encodeRequest(
+                        ByteBufAllocator.DEFAULT,
+                        ApiKeys.API_VERSIONS.id,
+                        ApiKeys.API_VERSIONS.highestSupportedVersion,
+                        1001,
+                        request);
+        handler.channelRead(ctx, byteBuf);
+
+        assertThat(requestChannel.requestsCount()).isZero();
+        assertThat(closed).isTrue();
+        verify(ctx).writeAndFlush(any(ByteBuf.class));
+        verify(closeFuture).addListener(ChannelFutureListener.CLOSE);
     }
 
     private static ChannelHandlerContext mockChannelHandlerContext() {

--- a/fluss-server/src/main/resources/META-INF/NOTICE
+++ b/fluss-server/src/main/resources/META-INF/NOTICE
@@ -13,6 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-cli:commons-cli:1.5.0
 - org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-math3:3.6.1
+- org.bitbucket.b_c:jose4j:0.9.6
 - org.roaringbitmap:RoaringBitmap:1.3.0
 - at.yawk.lz4:lz4-java:1.10.2
 - org.xerial.snappy:snappy-java:1.1.10.4
@@ -27,5 +28,4 @@ This project bundles the following dependencies under BSD License (https://opens
 See bundled license files for details.
 
 - com.github.luben:zstd-jni:1.5.7-6
-
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <log4j.version>2.25.4</log4j.version>
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <junit5.version>5.9.1</junit5.version>
+        <jose4j.version>0.9.6</jose4j.version>
         <mockito.version>3.4.6</mockito.version>
         <assertj.version>3.27.7</assertj.version>
 
@@ -427,6 +428,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.18.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>${jose4j.version}</version>
             </dependency>
 
             <dependency>

--- a/website/docs/security/authentication.md
+++ b/website/docs/security/authentication.md
@@ -10,7 +10,7 @@ Fluss provides a pluggable authentication mechanism, allowing users to configure
 ## Overview
 Authentication in Fluss is handled through listeners, where each connection triggers a specific authentication protocol based on the configuration. Supported mechanisms include:
 * **PLAINTEXT**: Default, no authentication.
-* **SASL**: This mechanism is based on SASL (Simple Authentication and Security Layer) authentication. Currently, only SASL/PLAIN is supported, which involves authentication using a username and password.
+* **SASL**: This mechanism is based on SASL (Simple Authentication and Security Layer) authentication. Fluss supports SASL/PLAIN and SASL/OAUTHBEARER.
 * **Custom plugins**: Extendable via interfaces for enterprise or third-party integrations.
 
 You can configure different authentication protocols per listener using the `security.protocol.map` property in `conf/server.yaml`.
@@ -24,12 +24,12 @@ The PLAINTEXT authentication method is the default used by Fluss. It does not pe
 No additional configuration is required for this mode.
 
 ## SASL
-This mechanism is based on SASL (Simple Authentication and Security Layer) authentication. Currently, only SASL/PLAIN is supported, which involves authentication using a username and password. It is recommended for production environments.
+This mechanism is based on SASL (Simple Authentication and Security Layer) authentication. Fluss supports PLAIN username/password authentication and OAUTHBEARER authentication with OAuth 2.0 client credentials and RS256 JWT access tokens.
 
 ### SASL Server-Side Configuration
 | Option                                                         | Type   | Default Value | Description                                                                                                                           |
 |----------------------------------------------------------------|--------|---------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| security.sasl.enabled.mechanisms                               | List   | PLAIN         | Comma-separated list of enabled SASL mechanisms. Only support PLAIN(which involves authentication using a username and password) now. |
+| security.sasl.enabled.mechanisms                               | List   | PLAIN         | Comma-separated list of enabled SASL mechanisms. Supported values are `PLAIN` and `OAUTHBEARER`.                                       |
 | `security.sasl.listener.name.{listenerName}.plain.jaas.config` | String | (none)        | JAAS configuration for a specific listener and PLAIN mechanism.                                                                       |
 | `security.sasl.plain.jaas.config`                              | String | (none)        | Global JAAS configuration for all listeners using the PLAIN mechanism.                                                                |
 
@@ -58,7 +58,7 @@ Clients must specify the appropriate security protocol and authentication mechan
 | Option                           | Type   | Default Value | Description                                                                                                                                                                                                                                                                               |
 |----------------------------------|--------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | client.security.protocol         | String | PLAINTEXT     | The security protocol used to communicate with brokers. Currently, only `PLAINTEXT` and `SASL` are supported, the configuration value is case insensitive.                                                                                                                                |
-| client.security.sasl.mechanism   | String | PLAIN         | The SASL mechanism used for authentication. Only support PLAIN now, but will support more mechanisms in the future.                                                                                                                                                                       |
+| client.security.sasl.mechanism   | String | PLAIN         | The SASL mechanism used for authentication. Supported values are `PLAIN` and `OAUTHBEARER`.                                                                                                                                                                                               |
 | client.security.sasl.username    | String | (none)        | The password to use for client-side SASL JAAS authentication. This is used when the client connects to the Fluss cluster with SASL authentication enabled. If not provided, the username will be read from the JAAS configuration string specified by `client.security.sasl.jaas.config`. |
 | client.security.sasl.password    | String | (none)        | The password to use for client-side SASL JAAS authentication. This is used when the client connects to the Fluss cluster with SASL authentication enabled. If not provided, the password will be read from the JAAS configuration string specified by `client.security.sasl.jaas.config`. |
 | client.security.sasl.jaas.config | String | (none)        | JAAS configuration for SASL. If not set, fallback to system property `-Djava.security.auth.login.config`.                                                                                                                                                                                 |
@@ -77,6 +77,56 @@ CREATE CATALOG fluss_catalog WITH (
   'client.security.sasl.password' = '<my-password>',
 );
 ```
+
+### SASL/OAUTHBEARER
+
+With OAUTHBEARER, the client synchronously obtains a JWT access token from an OAuth 2.0 token endpoint by using the client credentials grant. The server retrieves public keys from a JWKS endpoint, verifies the RS256 signature and JWT claims, and creates the authenticated principal as `User:<sub>`.
+
+#### OAUTHBEARER Client Configuration
+
+| Option | Type | Default Value | Description |
+| --- | --- | --- | --- |
+| `client.security.sasl.oauthbearer.token.endpoint` | String | (none) | Required absolute HTTP(S) OAuth 2.0 token endpoint. HTTPS is recommended. |
+| `client.security.sasl.oauthbearer.client-id` | String | (none) | Required OAuth 2.0 client ID. |
+| `client.security.sasl.oauthbearer.client-secret` | Password | (none) | Required OAuth 2.0 client secret. The value is redacted from configuration logs. |
+| `client.security.sasl.oauthbearer.scope` | String | (none) | Optional scope sent to the token endpoint. |
+| `client.security.sasl.oauthbearer.request-timeout` | Duration | 10 s | Timeout used for both connecting to and reading from the token endpoint. |
+
+Each new server connection synchronously requests its own access token. The token is retained only by that connection's authenticator for authentication retries. Fluss does not share or refresh client tokens and does not run a background refresh task. When a connection is re-established, the client requests a new token from the token endpoint. If the request fails, authentication for that connection fails.
+
+```yaml
+client.security.protocol: SASL
+client.security.sasl.mechanism: OAUTHBEARER
+client.security.sasl.oauthbearer.token.endpoint: https://idp.example.com/oauth2/token
+client.security.sasl.oauthbearer.client-id: fluss-client
+config.providers: env
+client.security.sasl.oauthbearer.client-secret: ${env:FLUSS_OAUTH_CLIENT_SECRET}
+client.security.sasl.oauthbearer.scope: fluss
+```
+
+Configuration provider markers such as `${env:FLUSS_OAUTH_CLIENT_SECRET}` are resolved by the existing [Secrets in Configuration](secrets.md) mechanism when the client is created through `ConnectionFactory`.
+
+#### OAUTHBEARER Server Configuration
+
+| Option | Type | Default Value | Description |
+| --- | --- | --- | --- |
+| `security.sasl.oauthbearer.jwks.endpoint` | String | (none) | Required absolute HTTP(S) JWKS endpoint. HTTPS is recommended. |
+| `security.sasl.oauthbearer.expected-issuer` | String | (none) | Required issuer that must exactly match the JWT `iss` claim. |
+| `security.sasl.oauthbearer.expected-audiences` | List | (none) | Required accepted audiences. At least one value must match the JWT `aud` claim. |
+| `security.sasl.oauthbearer.jwks.request-timeout` | Duration | 5 s | Timeout used for both connecting to and reading from the JWKS endpoint. |
+| `security.sasl.oauthbearer.jwks.refresh-min-interval` | Duration | 30 s | Minimum reprieve before refreshing non-empty cached JWKS keys again for an unknown JWT `kid`. |
+
+```yaml title="conf/server.yaml"
+bind.listeners: INTERNAL://localhost:9092, CLIENT://localhost:9093
+security.protocol.map: CLIENT:SASL, INTERNAL:PLAINTEXT
+internal.listener.name: INTERNAL
+security.sasl.enabled.mechanisms: OAUTHBEARER
+security.sasl.oauthbearer.jwks.endpoint: https://idp.example.com/.well-known/jwks.json
+security.sasl.oauthbearer.expected-issuer: https://idp.example.com/
+security.sasl.oauthbearer.expected-audiences: fluss
+```
+
+The server fetches JWKS lazily on a key miss and shares the cache within the server process. It does not preload keys or run a background refresh task. Each JWT is verified once during connection authentication. Subsequent RPCs use the principal stored on that connection and only compare the current time with the authenticated JWT `exp`; an expired connection is rejected and closed when its next RPC arrives. Idle expired connections remain subject to the normal connection idle timeout.
 
 
 ## Extending Authentication Methods (For Developers)


### PR DESCRIPTION
<!-- Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md) -->

### Purpose

Linked issue: close #3495

Depends on #3865, which makes the existing SASL layer mechanism-extensible while preserving SASL/PLAIN behavior.

This PR adds built-in SASL/OAUTHBEARER authentication to the native Fluss RPC layer. It allows clients to obtain JWT access tokens through the OAuth 2.0 Client Credentials grant, validates those tokens against server-side JWKS, issuer, audience, and lifetime requirements, maps the validated `sub` claim to `FlussPrincipal`, and reuses the existing ACL authorization flow.

### Brief change log

- Add an OAUTHBEARER client authenticator that obtains access tokens from a configured OAuth 2.0 token endpoint using the Client Credentials grant.
- Add server-side RS256 JWT validation, including JWKS resolution, signature verification, issuer/audience checks, token lifetime checks, and `sub` principal mapping.
- Share the JWKS resolver across server connections, refresh cached keys on an unknown `kid` with rate limiting, and reject an authenticated connection after its JWT expires.
- Support `PLAIN` and `OAUTHBEARER` through the same SASL plugin while keeping each connection's authenticator independent.
- Add client and server OAUTHBEARER configuration options, with client secrets represented as `Password` values and redacted from configuration logs.
- Add focused unit and integration coverage for token acquisition, JWT validation failures, JWKS refresh behavior, principal creation, session expiration, and existing SASL authentication behavior.
- Document the OAUTHBEARER client/server configuration and runtime lifecycle.

### Tests

- `./mvnw -q -pl fluss-common -Dtest=SaslAuthenticatorFactoryTest,OAuthBearerAuthenticationTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 8 tests passed.
- `./mvnw -q -pl fluss-rpc -am -Dtest=SaslAuthenticationITCase -Dsurefire.failIfNoSpecifiedTests=false -DskipITs test`
  - 12 tests passed.
- `git diff --check codex/fluss-3495-sasl-pr1..HEAD`

### API and Format

- Adds client and server configuration options for selecting OAUTHBEARER, retrieving access tokens, and validating JWTs through JWKS, issuer, and audience settings.
- Adds a backward-compatible default `ServerAuthenticator#validateSession()` hook so an authenticated connection can be rejected after its JWT expires.
- Adds the `jose4j` runtime dependency for JWT/JWKS processing.
- No protobuf, RPC wire format, or storage format changes.

### Documentation

Updated `website/docs/security/authentication.md` with OAUTHBEARER client and server configuration, Client Credentials behavior, JWKS caching/refresh behavior, token/session lifetime behavior, and configuration examples.
