### PR TITLE
[filesystem] Fix COS STS policy APPID and preserve session credentials

### DIFF
--- a/fluss-filesystems/fluss-fs-cos/pom.xml
+++ b/fluss-filesystems/fluss-fs-cos/pom.xml
@@ -31,7 +31,7 @@
     <name>Fluss : FileSystems : COS FS</name>
 
     <properties>
-        <fs.hadoop.cos.version>3.3.5</fs.hadoop.cos.version>
+        <fs.hadoop.cos.version>3.5.0</fs.hadoop.cos.version>
         <fs.cos.api.version>5.6.139</fs.cos.api.version>
         <fs.cos.sts.sdk.version>3.1.678</fs.cos.sts.sdk.version>
     </properties>

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
@@ -132,9 +132,8 @@ public class COSSecurityTokenProvider {
      * Builds a default STS policy that grants {@code name/cos:*} only on the bucket (and optional
      * key prefix) referenced by the given fsUri.
      *
-     * <p>COS resource format used here: {@code
-     * qcs::cos:<region>:uid/<appid>:<bucket>/<prefix>*}. The APPID is the numeric suffix of a COS
-     * bucket name.
+     * <p>COS resource format used here: {@code qcs::cos:<region>:uid/<appid>:<bucket>/<prefix>*}.
+     * The APPID is the numeric suffix of a COS bucket name.
      */
     static String buildBucketScopedPolicy(URI fsUri, String region) {
         String bucket = fsUri.getAuthority();
@@ -180,15 +179,7 @@ public class COSSecurityTokenProvider {
         }
 
         String resource =
-                "qcs::cos:"
-                        + region
-                        + ":uid/"
-                        + appId
-                        + ":"
-                        + bucket
-                        + "/"
-                        + prefix
-                        + "*";
+                "qcs::cos:" + region + ":uid/" + appId + ":" + bucket + "/" + prefix + "*";
         LOG.info("Using bucket-scoped STS policy with resource: {}", resource);
         return "{"
                 + "\"version\": \"2.0\","

--- a/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-cos/src/main/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProvider.java
@@ -132,11 +132,11 @@ public class COSSecurityTokenProvider {
      * Builds a default STS policy that grants {@code name/cos:*} only on the bucket (and optional
      * key prefix) referenced by the given fsUri.
      *
-     * <p>COS resource format used here: {@code qcs::cos:<region>:uid/*:<bucket>/<prefix>*}. The
-     * wildcard owner uid keeps the policy independent of the account uin while still restricting
-     * access to a specific bucket.
+     * <p>COS resource format used here: {@code
+     * qcs::cos:<region>:uid/<appid>:<bucket>/<prefix>*}. The APPID is the numeric suffix of a COS
+     * bucket name.
      */
-    private static String buildBucketScopedPolicy(URI fsUri, String region) {
+    static String buildBucketScopedPolicy(URI fsUri, String region) {
         String bucket = fsUri.getAuthority();
         if (bucket == null || bucket.isEmpty()) {
             // Fall back to all-resources policy if we cannot derive the bucket from fsUri.
@@ -156,6 +156,17 @@ public class COSSecurityTokenProvider {
                     + "}";
         }
 
+        int appIdSeparator = bucket.lastIndexOf('-');
+        String appId = appIdSeparator < 0 ? "" : bucket.substring(appIdSeparator + 1);
+        if (appId.isEmpty() || !appId.chars().allMatch(Character::isDigit)) {
+            throw new IllegalArgumentException(
+                    "Unable to derive COS APPID from bucket "
+                            + bucket
+                            + ". Expected a bucket name ending in '-<APPID>'; configure "
+                            + SECURITY_TOKEN_POLICY
+                            + " explicitly if a custom resource policy is required.");
+        }
+
         String path = fsUri.getPath();
         String prefix;
         if (path == null || path.isEmpty() || "/".equals(path)) {
@@ -168,7 +179,16 @@ public class COSSecurityTokenProvider {
             }
         }
 
-        String resource = "qcs::cos:" + region + ":uid/*:" + bucket + "/" + prefix + "*";
+        String resource =
+                "qcs::cos:"
+                        + region
+                        + ":uid/"
+                        + appId
+                        + ":"
+                        + bucket
+                        + "/"
+                        + prefix
+                        + "*";
         LOG.info("Using bucket-scoped STS policy with resource: {}", resource);
         return "{"
                 + "\"version\": \"2.0\","

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProviderTest.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/token/COSSecurityTokenProviderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos.token;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class COSSecurityTokenProviderTest {
+
+    @Test
+    void testBuildBucketScopedPolicyUsesBucketAppId() {
+        String policy =
+                COSSecurityTokenProvider.buildBucketScopedPolicy(
+                        URI.create("cosn://data-test-1370497452/fluss/remote-data"),
+                        "ap-guangzhou");
+
+        assertThat(policy)
+                .contains(
+                        "qcs::cos:ap-guangzhou:uid/1370497452:data-test-1370497452/fluss/remote-data/*")
+                .doesNotContain("uid/*");
+    }
+
+    @Test
+    void testBuildBucketScopedPolicyRejectsBucketWithoutAppId() {
+        assertThatThrownBy(
+                        () ->
+                                COSSecurityTokenProvider.buildBucketScopedPolicy(
+                                        URI.create("cosn://bucket/fluss/remote-data"),
+                                        "ap-guangzhou"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected a bucket name ending in '-<APPID>'");
+    }
+}

--- a/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/token/COSSessionCredentialsTest.java
+++ b/fluss-filesystems/fluss-fs-cos/src/test/java/org/apache/fluss/fs/cos/token/COSSessionCredentialsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.cos.token;
+
+import org.apache.fluss.fs.token.Credentials;
+import org.apache.fluss.fs.token.CredentialsJsonSerde;
+import org.apache.fluss.fs.token.ObtainedSecurityToken;
+
+import com.qcloud.cos.COSClient;
+import com.qcloud.cos.auth.COSCredentials;
+import com.qcloud.cos.auth.COSCredentialsProvider;
+import com.qcloud.cos.auth.COSSessionCredentials;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.cosn.CosNFileSystem;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class COSSessionCredentialsTest {
+
+    private static final String SESSION_TOKEN = "test-session-token";
+
+    @Test
+    void testCosNFileSystemPreservesSessionToken() throws Exception {
+        ObtainedSecurityToken token =
+                new ObtainedSecurityToken(
+                        "cosn",
+                        CredentialsJsonSerde.toJson(
+                                new Credentials(
+                                        "test-access-key", "test-secret-key", SESSION_TOKEN)),
+                        null,
+                        additionInfos());
+        new COSSecurityTokenReceiver().onNewTokensObtained(token);
+
+        Configuration configuration = new Configuration(false);
+        configuration.set(
+                "fs.cosn.credentials.provider", DynamicTemporaryCOSCredentialsProvider.NAME);
+        additionInfos().forEach(configuration::set);
+
+        try (CosNFileSystem fileSystem = new CosNFileSystem()) {
+            fileSystem.initialize(URI.create("cosn://test-bucket-1234567890"), configuration);
+
+            COSCredentials credentials = getCosClientCredentials(fileSystem);
+            assertThat(credentials).isInstanceOf(COSSessionCredentials.class);
+            assertThat(((COSSessionCredentials) credentials).getSessionToken())
+                    .isEqualTo(SESSION_TOKEN);
+        }
+    }
+
+    private static COSCredentials getCosClientCredentials(CosNFileSystem fileSystem)
+            throws Exception {
+        Object store = getField(CosNFileSystem.class, "store").get(fileSystem);
+        if (Proxy.isProxyClass(store.getClass())) {
+            InvocationHandler handler = Proxy.getInvocationHandler(store);
+            Object descriptor = getField(handler.getClass(), "proxyDescriptor").get(handler);
+            Object proxyInfo = getField(descriptor.getClass(), "proxyInfo").get(descriptor);
+            store = getField(proxyInfo.getClass(), "proxy").get(proxyInfo);
+        }
+        COSClient cosClient = (COSClient) getField(store.getClass(), "cosClient").get(store);
+        COSCredentialsProvider provider =
+                (COSCredentialsProvider) getField(COSClient.class, "credProvider").get(cosClient);
+        return provider.getCredentials();
+    }
+
+    private static Field getField(Class<?> type, String name) throws Exception {
+        for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+            try {
+                Field field = current.getDeclaredField(name);
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException ignored) {
+                // Continue with the superclass.
+            }
+        }
+        throw new NoSuchFieldException(type.getName() + "." + name);
+    }
+
+    private static Map<String, String> additionInfos() {
+        Map<String, String> additionInfos = new HashMap<>();
+        additionInfos.put("fs.cosn.userinfo.region", "ap-guangzhou");
+        additionInfos.put("fs.cosn.bucket.endpoint_suffix", "cos.ap-guangzhou.myqcloud.com");
+        return additionInfos;
+    }
+}


### PR DESCRIPTION
### Purpose

Linked issue: close #3983

The COS STS path had two independent causes of HTTP 403 failures:

1. The default Tencent Cloud COS policy used `uid/*` as the resource owner. COS requires the bucket APPID.
2. `hadoop-cos 3.3.5` converted temporary `COSSessionCredentials` to `BasicCOSCredentials`, dropping the session token before COS requests. This is fixed by Hadoop HADOOP-19648 in `hadoop-cos 3.5.0`.

### Brief change log

- derive the APPID from the numeric suffix of a standard COS bucket name
- use `uid/<appid>` in the bucket-scoped default policy
- fail with an actionable message when the APPID cannot be derived
- upgrade `hadoop-cos` from 3.3.5 to 3.5.0
- simplify the Fluss token provider to return session credentials directly
- add an integration-style unit test that initializes `CosNFileSystem` and verifies that the COS SDK still receives `COSSessionCredentials` through the Hadoop retry proxy

### Tests

- `mvn -s /tmp/fluss-maven-settings.xml -Dmaven.repo.local=/tmp/fluss-m2-cos-sts -pl fluss-filesystems/fluss-fs-cos -DskipITs -Dcheckstyle.skip -Drat.skip -Dspotless.check.skip test`
  - 3 tests passed
- `mvn -s /tmp/fluss-maven-settings.xml -Dmaven.repo.local=/tmp/fluss-m2-cos-sts -pl fluss-filesystems/fluss-fs-cos -am -DskipITs -Dcheckstyle.skip -Drat.skip -Dspotless.check.skip -DskipTests package`
- inspected the shaded JAR bytecode to confirm the credential adapter no longer creates `BasicCOSCredentials`
- deployed the shaded COS filesystem JAR to a Fluss main + Flink 2.2.1 + Paimon 2.0.0 test cluster

Live end-to-end validation on TKE:

- imported a 31-table MySQL snapshot through a DTS CDC sink into a fresh Fluss database
- the full snapshot completed with about 141 million rows
- MySQL CDC remained continuous after snapshot completion; the observed GTID checkpoint advanced and matched the current position
- observed 802 CDC records sinked after the full load at the final verification point
- all 31 Fluss tables used primary keys, 3 buckets, and `table.datalake.freshness=10min`
- Fluss lake tiering downloaded KV snapshots from COS with no real HTTP 403/Forbidden/AccessDenied response
- Paimon 2.0 committed `snapshot-1` and `LATEST` for the fresh database in COS
- verified non-empty snapshot metadata, including tables with 1,463 and 5,637,613 records
- Coordinator, Tablet, DTS, JobManager, and TaskManager remained Running with zero restarts during validation
- no `OutOfOrderSequenceException` was observed in DTS, Coordinator, or Tablet logs

### API and Format

No public API or storage format change.

### Documentation

No new user-facing feature. Users with a nonstandard bucket authority can continue to configure `fs.cosn.userinfo.security_token_policy` explicitly.

### Generative AI disclosure

- [ ] No generative AI tools used
- [x] Yes, OpenAI Codex was used to assist with investigation, implementation, test authoring, and live validation.

<!--
Generated-by: OpenAI Codex following the repository contribution guidelines.
-->
