### PR TITLE
[c++] Add bounded RecordBatch log reader APIs

### DIFF
--- a/fluss-rust/bindings/cpp/README.md
+++ b/fluss-rust/bindings/cpp/README.md
@@ -69,7 +69,9 @@ for (int32_t bucket_id : bucket_ids) {
 fluss::RecordBatchLogReader reader;
 table.NewScan().CreateRecordBatchLogReader(ranges, reader);
 
-while (true) {
+const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+bool finished = false;
+while (std::chrono::steady_clock::now() < deadline) {
     fluss::RecordBatchReadResult result;
     auto read_result = reader.NextBatch(1000, result);
     if (!read_result.Ok()) {
@@ -78,15 +80,19 @@ while (true) {
         if (!read_result.IsRetriable()) {
             throw std::runtime_error(read_result.error_message);
         }
-        continue;  // Retriable: check query cancellation before retrying.
+        continue;
     }
     if (result.status == fluss::BoundedReadStatus::TimedOut) {
-        continue;  // Check query cancellation before retrying.
+        continue;
     }
     if (result.status == fluss::BoundedReadStatus::Finished) {
+        finished = true;
         break;
     }
     process(result.batch->GetArrowRecordBatch());
+}
+if (!finished) {
+    throw std::runtime_error("Bounded read exceeded its execution deadline");
 }
 ```
 
@@ -101,14 +107,15 @@ table.NewScan().CreateRecordBatchLogReader(
 ```
 
 `CollectAllBatches(timeout_ms, out)` is available when materializing the complete bounded result
-is preferred. This operation is not atomic: it appends complete batches to `out` as they arrive,
-so `out` may contain a partial result when the supplied budget elapses. In that case it returns a
-retriable `REQUEST_TIME_OUT`; only an `Ok()` result means every stopping offset has been reached.
-The timeout never splits an individual Arrow batch, and calling the method again with the same
-reader and `out` resumes after the batches already returned. The timeout applies to one invocation
-only; callers that retry must enforce an overall query deadline or cancellation condition, since
-unconditional retries can continue forever. `NextBatch()` reports timeout separately from
-completion so engines can periodically check cancellation.
+is preferred. `timeout_ms` is the total execution budget for the whole call, so callers should
+normally pass the query's remaining execution time and call the method once. It appends complete
+batches to `out` as they arrive. If the budget expires before every stopping offset is reached, it
+stops collecting and returns a retriable `REQUEST_TIME_OUT`; `out` may contain a partial result,
+and only an `Ok()` result means the bounded result is complete. The timeout is checked between
+complete Arrow batches and never splits a batch already being returned. The reader remains valid
+after timeout if a caller has an explicit resume policy, but unconditional retry is not the
+intended usage. `NextBatch()` remains the per-poll API for engines that need to check cancellation
+between batches.
 
 ## TODO
 

--- a/fluss-rust/bindings/cpp/README.md
+++ b/fluss-rust/bindings/cpp/README.md
@@ -101,10 +101,14 @@ table.NewScan().CreateRecordBatchLogReader(
 ```
 
 `CollectAllBatches(timeout_ms, out)` is available when materializing the complete bounded result
-is preferred; it appends to `out` within the supplied budget, returning a retriable
-`REQUEST_TIME_OUT` `Result` if the budget elapses before every stopping offset is reached — call
-it again with the same `out` to resume. `NextBatch()` reports timeout separately from completion
-so engines can periodically check cancellation.
+is preferred. This operation is not atomic: it appends complete batches to `out` as they arrive,
+so `out` may contain a partial result when the supplied budget elapses. In that case it returns a
+retriable `REQUEST_TIME_OUT`; only an `Ok()` result means every stopping offset has been reached.
+The timeout never splits an individual Arrow batch, and calling the method again with the same
+reader and `out` resumes after the batches already returned. The timeout applies to one invocation
+only; callers that retry must enforce an overall query deadline or cancellation condition, since
+unconditional retries can continue forever. `NextBatch()` reports timeout separately from
+completion so engines can periodically check cancellation.
 
 ## TODO
 

--- a/fluss-rust/bindings/cpp/README.md
+++ b/fluss-rust/bindings/cpp/README.md
@@ -111,11 +111,12 @@ is preferred. `timeout_ms` is the total execution budget for the whole call, so 
 normally pass the query's remaining execution time and call the method once. It appends complete
 batches to `out` as they arrive. If the budget expires before every stopping offset is reached, it
 stops collecting and returns a retriable `REQUEST_TIME_OUT`; `out` may contain a partial result,
-and only an `Ok()` result means the bounded result is complete. The timeout is checked between
-complete Arrow batches and never splits a batch already being returned. The reader remains valid
-after timeout if a caller has an explicit resume policy, but unconditional retry is not the
-intended usage. `NextBatch()` remains the per-poll API for engines that need to check cancellation
-between batches.
+and only an `Ok()` result means the bounded result is complete. Once the budget is exhausted, the
+reader stops waiting for scanner data but still drains already-buffered batches and observes
+completion before reporting a timeout. This means an already-complete reader returns `Ok()` even
+with a non-positive timeout. The reader remains valid after timeout if a caller has an explicit
+resume policy, but unconditional retry is not the intended usage. `NextBatch()` remains the
+per-poll API for engines that need to check cancellation between batches.
 
 ## TODO
 

--- a/fluss-rust/bindings/cpp/README.md
+++ b/fluss-rust/bindings/cpp/README.md
@@ -33,10 +33,68 @@ bazel build //...
 `ci.sh` defaults to optimized builds via `-c opt` (override with `BAZEL_BUILD_FLAGS` if needed).
 See [ci.sh](ci.sh) for the CI build sequence.
 
+## Examples and Documentation
+
+- [examples/example.cpp](examples/example.cpp) demonstrates log-table writes, continuous scans,
+  bounded Arrow record-batch scans, projections, and offset queries.
+- [examples/admin_example.cpp](examples/admin_example.cpp) demonstrates database, table,
+  partition, and cluster administration.
+- [examples/kv_example.cpp](examples/kv_example.cpp) and
+  [examples/kv_changelog_example.cpp](examples/kv_changelog_example.cpp) demonstrate
+  primary-key table access.
+- The website documentation includes the
+  [C++ API reference](../../website/docs/user-guide/cpp/api-reference.md) and
+  [log-table examples](../../website/docs/user-guide/cpp/example/log-tables.md).
+
+For a bounded log scan, first subscribe the record-batch scanner at the desired starting
+offsets, then create a `RecordBatchLogReader` with either explicit stopping offsets or the
+latest offsets observed at reader creation:
+
+```cpp
+auto info = table.GetTableInfo();
+std::vector<int32_t> bucket_ids;
+for (int32_t bucket_id = 0; bucket_id < info.num_buckets; ++bucket_id) {
+    bucket_ids.push_back(bucket_id);
+}
+
+std::unordered_map<int32_t, int64_t> latest_offsets;
+admin.ListOffsets(table_path, bucket_ids, fluss::OffsetSpec::Latest(), latest_offsets);
+
+fluss::LogScanner scanner;
+table.NewScan().CreateRecordBatchLogScanner(scanner);
+
+std::vector<fluss::ReaderStopOffset> stopping_offsets;
+for (int32_t bucket_id : bucket_ids) {
+    scanner.Subscribe(bucket_id, 0);
+    stopping_offsets.push_back(
+        {fluss::TableBucket{info.table_id, bucket_id}, latest_offsets.at(bucket_id)});
+}
+
+fluss::RecordBatchLogReader reader;
+scanner.CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, reader);
+
+while (true) {
+    fluss::ArrowRecordBatches batches;
+    fluss::BoundedReadStatus status;
+    reader.NextBatch(1000, batches, status);
+    if (status == fluss::BoundedReadStatus::TimedOut) {
+        continue;  // Check query cancellation before retrying.
+    }
+    if (status == fluss::BoundedReadStatus::Finished) {
+        break;
+    }
+    for (const auto& batch : batches) {
+        process(batch->GetArrowRecordBatch());
+    }
+}
+```
+
+`CollectAllBatches()` is available when materializing the complete bounded result is
+preferred. `NextBatch()` reports timeout separately from completion so engines can periodically
+check cancellation. Use only one active reader or polling operation for a scanner at a time.
 
 ## TODO
 
-- [] How to introduce fluss-cpp in your own project, https://github.com/apache/opendal/blob/main/bindings/cpp/README.md is a good reference
+- [ ] How to introduce fluss-cpp in your own project, https://github.com/apache/opendal/blob/main/bindings/cpp/README.md is a good reference
 - [ ] Add CMake/Bazel install and packaging instructions.
-- [ ] Document API usage and minimal example in this README.
-- [ ] Add more C++ examples (log scan, upsert, etc.).
+- [ ] Add more C++ examples (upsert, partitioned bounded scans, etc.).

--- a/fluss-rust/bindings/cpp/README.md
+++ b/fluss-rust/bindings/cpp/README.md
@@ -96,8 +96,8 @@ if (!finished) {
 }
 ```
 
-Timestamp-bounded reads use the same iterator after resolving the timestamps independently for
-each bucket:
+Timestamp-bounded reads use the same iterator after resolving the half-open timestamp range
+independently for each bucket:
 
 ```cpp
 fluss::RecordBatchLogReader timestamp_reader;

--- a/fluss-rust/bindings/cpp/README.md
+++ b/fluss-rust/bindings/cpp/README.md
@@ -71,7 +71,15 @@ table.NewScan().CreateRecordBatchLogReader(ranges, reader);
 
 while (true) {
     fluss::RecordBatchReadResult result;
-    reader.NextBatch(1000, result);
+    auto read_result = reader.NextBatch(1000, result);
+    if (!read_result.Ok()) {
+        // Bail out on unretriable failures (auth, invalid table, ...); the
+        // reader's status field is only meaningful when `Ok()` is true.
+        if (!read_result.IsRetriable()) {
+            throw std::runtime_error(read_result.error_message);
+        }
+        continue;  // Retriable: check query cancellation before retrying.
+    }
     if (result.status == fluss::BoundedReadStatus::TimedOut) {
         continue;  // Check query cancellation before retrying.
     }
@@ -92,9 +100,11 @@ table.NewScan().CreateRecordBatchLogReader(
     fluss::TimestampRange{starting_timestamp_ms, stopping_timestamp_ms}, timestamp_reader);
 ```
 
-`CollectAllBatches()` is available when materializing the complete bounded result is
-preferred. `NextBatch()` reports timeout separately from completion so engines can periodically
-check cancellation.
+`CollectAllBatches(timeout_ms, out)` is available when materializing the complete bounded result
+is preferred; it appends to `out` within the supplied budget, returning a retriable
+`REQUEST_TIME_OUT` `Result` if the budget elapses before every stopping offset is reached — call
+it again with the same `out` to resume. `NextBatch()` reports timeout separately from completion
+so engines can periodically check cancellation.
 
 ## TODO
 

--- a/fluss-rust/bindings/cpp/README.md
+++ b/fluss-rust/bindings/cpp/README.md
@@ -46,9 +46,9 @@ See [ci.sh](ci.sh) for the CI build sequence.
   [C++ API reference](../../website/docs/user-guide/cpp/api-reference.md) and
   [log-table examples](../../website/docs/user-guide/cpp/example/log-tables.md).
 
-For a bounded log scan, first subscribe the record-batch scanner at the desired starting
-offsets, then create a `RecordBatchLogReader` with either explicit stopping offsets or the
-latest offsets observed at reader creation:
+For a bounded log scan, pass the per-bucket offset ranges directly to `TableScan`. The returned
+reader yields one Arrow batch at a time until every `[starting_offset, stopping_offset)` range
+is complete:
 
 ```cpp
 auto info = table.GetTableInfo();
@@ -60,38 +60,41 @@ for (int32_t bucket_id = 0; bucket_id < info.num_buckets; ++bucket_id) {
 std::unordered_map<int32_t, int64_t> latest_offsets;
 admin.ListOffsets(table_path, bucket_ids, fluss::OffsetSpec::Latest(), latest_offsets);
 
-fluss::LogScanner scanner;
-table.NewScan().CreateRecordBatchLogScanner(scanner);
-
-std::vector<fluss::ReaderStopOffset> stopping_offsets;
+std::vector<fluss::RecordBatchLogReadRange> ranges;
 for (int32_t bucket_id : bucket_ids) {
-    scanner.Subscribe(bucket_id, 0);
-    stopping_offsets.push_back(
-        {fluss::TableBucket{info.table_id, bucket_id}, latest_offsets.at(bucket_id)});
+    ranges.push_back(
+        {fluss::TableBucket{info.table_id, bucket_id}, 0, latest_offsets.at(bucket_id)});
 }
 
 fluss::RecordBatchLogReader reader;
-scanner.CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, reader);
+table.NewScan().CreateRecordBatchLogReader(ranges, reader);
 
 while (true) {
-    fluss::ArrowRecordBatches batches;
-    fluss::BoundedReadStatus status;
-    reader.NextBatch(1000, batches, status);
-    if (status == fluss::BoundedReadStatus::TimedOut) {
+    fluss::RecordBatchReadResult result;
+    reader.NextBatch(1000, result);
+    if (result.status == fluss::BoundedReadStatus::TimedOut) {
         continue;  // Check query cancellation before retrying.
     }
-    if (status == fluss::BoundedReadStatus::Finished) {
+    if (result.status == fluss::BoundedReadStatus::Finished) {
         break;
     }
-    for (const auto& batch : batches) {
-        process(batch->GetArrowRecordBatch());
-    }
+    process(result.batch->GetArrowRecordBatch());
 }
+```
+
+Timestamp-bounded reads use the same iterator after resolving the timestamps independently for
+each bucket:
+
+```cpp
+fluss::RecordBatchLogReader timestamp_reader;
+table.NewScan().CreateRecordBatchLogReader(
+    admin, table_buckets,
+    fluss::TimestampRange{starting_timestamp_ms, stopping_timestamp_ms}, timestamp_reader);
 ```
 
 `CollectAllBatches()` is available when materializing the complete bounded result is
 preferred. `NextBatch()` reports timeout separately from completion so engines can periodically
-check cancellation. Use only one active reader or polling operation for a scanner at a time.
+check cancellation.
 
 ## TODO
 

--- a/fluss-rust/bindings/cpp/examples/example.cpp
+++ b/fluss-rust/bindings/cpp/examples/example.cpp
@@ -371,6 +371,7 @@ int main() {
 
     // 8.1) Bounded Arrow record batch scan with explicit stopping offsets
     std::cout << "\n=== Bounded Arrow Record Batch Scan ===" << std::endl;
+    constexpr int64_t kBoundedReadTimeoutMs = 30000;
     std::vector<fluss::RecordBatchLogReadRange> bounded_ranges;
     for (int32_t bucket_id : all_bucket_ids) {
         const int64_t starting_offset = earliest_offsets.at(bucket_id);
@@ -384,21 +385,24 @@ int main() {
         check("create_bounded_reader",
               table.NewScan().CreateRecordBatchLogReader(bounded_ranges, bounded_reader));
 
+        fluss::ArrowRecordBatches bounded_batches;
+        auto collect_result =
+            bounded_reader.CollectAllBatches(kBoundedReadTimeoutMs, bounded_batches);
+        if (!collect_result.Ok()) {
+            std::cerr << "collect_bounded_batches failed after collecting "
+                      << bounded_batches.Size()
+                      << " partial batches: code=" << collect_result.error_code
+                      << " msg=" << collect_result.error_message << std::endl;
+            return 1;
+        }
+
         int64_t bounded_row_count = 0;
-        while (true) {
-            fluss::RecordBatchReadResult result;
-            check("bounded_next_batch", bounded_reader.NextBatch(1000, result));
-            if (result.status == fluss::BoundedReadStatus::TimedOut) {
-                continue;
-            }
-            if (result.status == fluss::BoundedReadStatus::Finished) {
-                break;
-            }
-            bounded_row_count += result.batch->NumRows();
-            std::cout << "  bucket=" << result.batch->GetBucketId()
-                      << " base_offset=" << result.batch->GetBaseOffset()
-                      << " last_offset=" << result.batch->GetLastOffset()
-                      << " rows=" << result.batch->NumRows() << std::endl;
+        for (const auto& batch : bounded_batches) {
+            bounded_row_count += batch->NumRows();
+            std::cout << "  bucket=" << batch->GetBucketId()
+                      << " base_offset=" << batch->GetBaseOffset()
+                      << " last_offset=" << batch->GetLastOffset()
+                      << " rows=" << batch->NumRows() << std::endl;
         }
         std::cout << "Bounded scan completed with " << bounded_row_count << " rows" << std::endl;
     }
@@ -431,17 +435,19 @@ int main() {
           table.NewScan().CreateRecordBatchLogReader(
               admin, table_buckets, fluss::TimestampRange{timestamp_ms, now_ms}, timestamp_reader));
 
-    while (true) {
-        fluss::RecordBatchReadResult result;
-        check("timestamp_next_batch", timestamp_reader.NextBatch(1000, result));
-        if (result.status == fluss::BoundedReadStatus::TimedOut) {
-            continue;
-        }
-        if (result.status == fluss::BoundedReadStatus::Finished) {
-            break;
-        }
-        std::cout << "Timestamp range batch: bucket=" << result.batch->GetBucketId()
-                  << " rows=" << result.batch->NumRows() << std::endl;
+    fluss::ArrowRecordBatches timestamp_batches;
+    auto timestamp_collect_result =
+        timestamp_reader.CollectAllBatches(kBoundedReadTimeoutMs, timestamp_batches);
+    if (!timestamp_collect_result.Ok()) {
+        std::cerr << "collect_timestamp_batches failed after collecting "
+                  << timestamp_batches.Size()
+                  << " partial batches: code=" << timestamp_collect_result.error_code
+                  << " msg=" << timestamp_collect_result.error_message << std::endl;
+        return 1;
+    }
+    for (const auto& batch : timestamp_batches) {
+        std::cout << "Timestamp range batch: bucket=" << batch->GetBucketId()
+                  << " rows=" << batch->NumRows() << std::endl;
     }
 
     // 9) Batch subscribe

--- a/fluss-rust/bindings/cpp/examples/example.cpp
+++ b/fluss-rust/bindings/cpp/examples/example.cpp
@@ -371,44 +371,34 @@ int main() {
 
     // 8.1) Bounded Arrow record batch scan with explicit stopping offsets
     std::cout << "\n=== Bounded Arrow Record Batch Scan ===" << std::endl;
-    fluss::LogScanner bounded_scanner;
-    check("new_bounded_record_batch_scanner",
-          table.NewScan().CreateRecordBatchLogScanner(bounded_scanner));
-
-    std::vector<fluss::ReaderStopOffset> stopping_offsets;
+    std::vector<fluss::RecordBatchLogReadRange> bounded_ranges;
     for (int32_t bucket_id : all_bucket_ids) {
         const int64_t starting_offset = earliest_offsets.at(bucket_id);
         const int64_t stopping_offset = latest_offsets.at(bucket_id);
-        if (starting_offset >= stopping_offset) {
-            continue;
-        }
-        check("subscribe_bounded", bounded_scanner.Subscribe(bucket_id, starting_offset));
-        stopping_offsets.push_back({fluss::TableBucket{info.table_id, bucket_id}, stopping_offset});
+        bounded_ranges.push_back(
+            {fluss::TableBucket{info.table_id, bucket_id}, starting_offset, stopping_offset});
     }
 
-    if (!stopping_offsets.empty()) {
+    if (!bounded_ranges.empty()) {
         fluss::RecordBatchLogReader bounded_reader;
-        check("create_bounded_reader", bounded_scanner.CreateRecordBatchLogReaderUntilOffsets(
-                                           stopping_offsets, bounded_reader));
+        check("create_bounded_reader",
+              table.NewScan().CreateRecordBatchLogReader(bounded_ranges, bounded_reader));
 
         int64_t bounded_row_count = 0;
         while (true) {
-            fluss::ArrowRecordBatches bounded_batches;
-            fluss::BoundedReadStatus status;
-            check("bounded_next_batch", bounded_reader.NextBatch(1000, bounded_batches, status));
-            if (status == fluss::BoundedReadStatus::TimedOut) {
+            fluss::RecordBatchReadResult result;
+            check("bounded_next_batch", bounded_reader.NextBatch(1000, result));
+            if (result.status == fluss::BoundedReadStatus::TimedOut) {
                 continue;
             }
-            if (status == fluss::BoundedReadStatus::Finished) {
+            if (result.status == fluss::BoundedReadStatus::Finished) {
                 break;
             }
-            for (const auto& bounded_batch : bounded_batches) {
-                bounded_row_count += bounded_batch->NumRows();
-                std::cout << "  bucket=" << bounded_batch->GetBucketId()
-                          << " base_offset=" << bounded_batch->GetBaseOffset()
-                          << " last_offset=" << bounded_batch->GetLastOffset()
-                          << " rows=" << bounded_batch->NumRows() << std::endl;
-            }
+            bounded_row_count += result.batch->NumRows();
+            std::cout << "  bucket=" << result.batch->GetBucketId()
+                      << " base_offset=" << result.batch->GetBaseOffset()
+                      << " last_offset=" << result.batch->GetLastOffset()
+                      << " rows=" << result.batch->NumRows() << std::endl;
         }
         std::cout << "Bounded scan completed with " << bounded_row_count << " rows" << std::endl;
     }
@@ -418,6 +408,8 @@ int main() {
     auto timestamp_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(one_hour_ago.time_since_epoch())
             .count();
+    auto now_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
 
     std::unordered_map<int32_t, int64_t> timestamp_offsets;
     check("list_timestamp_offsets",
@@ -426,6 +418,30 @@ int main() {
     std::cout << "Offsets for timestamp " << timestamp_ms << " (1 hour ago):" << std::endl;
     for (const auto& [bucket_id, offset] : timestamp_offsets) {
         std::cout << "  Bucket " << bucket_id << ": offset=" << offset << std::endl;
+    }
+
+    // 8.2) Bounded Arrow record batch scan by timestamp range
+    std::vector<fluss::TableBucket> table_buckets;
+    for (int32_t bucket_id : all_bucket_ids) {
+        table_buckets.push_back({info.table_id, bucket_id});
+    }
+
+    fluss::RecordBatchLogReader timestamp_reader;
+    check("create_timestamp_reader",
+          table.NewScan().CreateRecordBatchLogReader(
+              admin, table_buckets, fluss::TimestampRange{timestamp_ms, now_ms}, timestamp_reader));
+
+    while (true) {
+        fluss::RecordBatchReadResult result;
+        check("timestamp_next_batch", timestamp_reader.NextBatch(1000, result));
+        if (result.status == fluss::BoundedReadStatus::TimedOut) {
+            continue;
+        }
+        if (result.status == fluss::BoundedReadStatus::Finished) {
+            break;
+        }
+        std::cout << "Timestamp range batch: bucket=" << result.batch->GetBucketId()
+                  << " rows=" << result.batch->NumRows() << std::endl;
     }
 
     // 9) Batch subscribe
@@ -471,7 +487,7 @@ int main() {
     // 10) Arrow record batch polling
     std::cout << "\n=== Testing Arrow Record Batch Polling ===" << std::endl;
 
-    fluss::LogScanner arrow_scanner;
+    fluss::RecordBatchLogScanner arrow_scanner;
     check("new_record_batch_log_scanner",
           table.NewScan().CreateRecordBatchLogScanner(arrow_scanner));
 
@@ -480,7 +496,7 @@ int main() {
     }
 
     fluss::ArrowRecordBatches arrow_batches;
-    check("poll_record_batch", arrow_scanner.PollRecordBatch(5000, arrow_batches));
+    check("poll_record_batch", arrow_scanner.Poll(5000, arrow_batches));
 
     std::cout << "Polled " << arrow_batches.Size() << " Arrow record batches" << std::endl;
     for (size_t i = 0; i < arrow_batches.Size(); ++i) {
@@ -496,7 +512,7 @@ int main() {
     // 11) Arrow record batch polling with projection
     std::cout << "\n=== Testing Arrow Record Batch Polling with Projection ===" << std::endl;
 
-    fluss::LogScanner projected_arrow_scanner;
+    fluss::RecordBatchLogScanner projected_arrow_scanner;
     check("new_record_batch_log_scanner_with_projection",
           table.NewScan()
               .ProjectByIndex(projected_columns)
@@ -508,7 +524,7 @@ int main() {
 
     fluss::ArrowRecordBatches projected_arrow_batches;
     check("poll_projected_record_batch",
-          projected_arrow_scanner.PollRecordBatch(5000, projected_arrow_batches));
+          projected_arrow_scanner.Poll(5000, projected_arrow_batches));
 
     std::cout << "Polled " << projected_arrow_batches.Size() << " projected Arrow record batches"
               << std::endl;

--- a/fluss-rust/bindings/cpp/examples/example.cpp
+++ b/fluss-rust/bindings/cpp/examples/example.cpp
@@ -369,6 +369,50 @@ int main() {
         std::cout << "  Bucket " << bucket_id << ": offset=" << offset << std::endl;
     }
 
+    // 8.1) Bounded Arrow record batch scan with explicit stopping offsets
+    std::cout << "\n=== Bounded Arrow Record Batch Scan ===" << std::endl;
+    fluss::LogScanner bounded_scanner;
+    check("new_bounded_record_batch_scanner",
+          table.NewScan().CreateRecordBatchLogScanner(bounded_scanner));
+
+    std::vector<fluss::ReaderStopOffset> stopping_offsets;
+    for (int32_t bucket_id : all_bucket_ids) {
+        const int64_t starting_offset = earliest_offsets.at(bucket_id);
+        const int64_t stopping_offset = latest_offsets.at(bucket_id);
+        if (starting_offset >= stopping_offset) {
+            continue;
+        }
+        check("subscribe_bounded", bounded_scanner.Subscribe(bucket_id, starting_offset));
+        stopping_offsets.push_back({fluss::TableBucket{info.table_id, bucket_id}, stopping_offset});
+    }
+
+    if (!stopping_offsets.empty()) {
+        fluss::RecordBatchLogReader bounded_reader;
+        check("create_bounded_reader", bounded_scanner.CreateRecordBatchLogReaderUntilOffsets(
+                                           stopping_offsets, bounded_reader));
+
+        int64_t bounded_row_count = 0;
+        while (true) {
+            fluss::ArrowRecordBatches bounded_batches;
+            fluss::BoundedReadStatus status;
+            check("bounded_next_batch", bounded_reader.NextBatch(1000, bounded_batches, status));
+            if (status == fluss::BoundedReadStatus::TimedOut) {
+                continue;
+            }
+            if (status == fluss::BoundedReadStatus::Finished) {
+                break;
+            }
+            for (const auto& bounded_batch : bounded_batches) {
+                bounded_row_count += bounded_batch->NumRows();
+                std::cout << "  bucket=" << bounded_batch->GetBucketId()
+                          << " base_offset=" << bounded_batch->GetBaseOffset()
+                          << " last_offset=" << bounded_batch->GetLastOffset()
+                          << " rows=" << bounded_batch->NumRows() << std::endl;
+            }
+        }
+        std::cout << "Bounded scan completed with " << bounded_row_count << " rows" << std::endl;
+    }
+
     auto now = std::chrono::system_clock::now();
     auto one_hour_ago = now - std::chrono::hours(1);
     auto timestamp_ms =

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -1930,7 +1930,8 @@ class RecordBatchLogReader {
 
     bool Available() const;
 
-    /// Waits up to timeout_ms for the next batch.
+    /// Waits up to timeout_ms for the next batch. A non-positive timeout_ms
+    /// polls without waiting.
     /// Read `out.status` only when the returned `Result` is `Ok()`.
     /// TimedOut leaves the reader valid for a later retry; Finished means every
     /// subscribed bucket reached its stopping offset.
@@ -1944,7 +1945,8 @@ class RecordBatchLogReader {
     /// retriable REQUEST_TIME_OUT; `out` may then contain a partial set of
     /// complete batches. Only an `Ok()` result means the bounded result is
     /// complete. The timeout is checked between complete Arrow batches and never
-    /// splits a batch already being returned.
+    /// splits a batch already being returned. A non-positive timeout_ms returns
+    /// REQUEST_TIME_OUT without attempting a read.
     /// The reader remains valid after timeout, but retrying is an explicit caller
     /// policy rather than part of this operation; callers should not retry
     /// indefinitely.

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -1701,9 +1701,6 @@ class TableScan {
 
     std::vector<size_t> ResolveNameProjection() const;
     Result DoCreateScanner(LogScanner& out, bool is_record_batch);
-    Result ResolveTimestampRanges(Admin& admin, const std::vector<TableBucket>& buckets,
-                                  const TimestampRange& range,
-                                  std::vector<RecordBatchLogReadRange>& out) const;
 
     ffi::Table* table_{nullptr};
     std::vector<size_t> projection_;
@@ -1874,6 +1871,18 @@ class LogScanner {
     Result CreateRecordBatchLogReaderUntilOffsets(const std::vector<ReaderStopOffset>& offsets,
                                                   RecordBatchLogReader& out);
 
+    /// Creates a bounded reader from per-bucket offset ranges, subscribing
+    /// every non-empty range. Range validation happens in the SDK.
+    Result CreateRecordBatchLogReaderFromRanges(const std::vector<RecordBatchLogReadRange>& ranges,
+                                                RecordBatchLogReader& out);
+
+    /// Creates a bounded reader for a timestamp range over the given buckets.
+    /// The SDK resolves both timestamps to per-bucket offsets.
+    Result CreateRecordBatchLogReaderBetweenTimestamps(const Admin& admin,
+                                                       const std::vector<TableBucket>& buckets,
+                                                       const TimestampRange& range,
+                                                       RecordBatchLogReader& out);
+
     ffi::LogScanner* scanner_{nullptr};
 };
 
@@ -1912,6 +1921,19 @@ class RecordBatchLogScanner {
    private:
     friend class TableScan;
     explicit RecordBatchLogScanner(ffi::LogScanner* scanner) noexcept;
+
+    /// Transfers this scanner into a reader bounded by per-bucket offset ranges,
+    /// subscribing every non-empty range. The scanner becomes unavailable on
+    /// success.
+    Result CreateRecordBatchLogReaderFromRanges(const std::vector<RecordBatchLogReadRange>& ranges,
+                                                RecordBatchLogReader& out) &&;
+
+    /// Transfers this scanner into a reader bounded by a timestamp range over
+    /// the given buckets. The scanner becomes unavailable on success.
+    Result CreateRecordBatchLogReaderBetweenTimestamps(const Admin& admin,
+                                                       const std::vector<TableBucket>& buckets,
+                                                       const TimestampRange& range,
+                                                       RecordBatchLogReader& out) &&;
 
     LogScanner scanner_;
 };

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -1936,16 +1936,18 @@ class RecordBatchLogReader {
     /// subscribed bucket reached its stopping offset.
     Result NextBatch(int64_t timeout_ms, RecordBatchReadResult& out);
 
-    /// Drains remaining batches until every stopping offset is reached or the
-    /// total budget of timeout_ms elapses. Batches are *appended* to `out`, so a
-    /// timed-out call can be resumed by calling again with the same `out`.
-    /// This operation is not atomic: on timeout, `out` may contain a partial set
-    /// of complete batches. Only an `Ok()` result means every stopping offset has
-    /// been reached. The timeout never splits a returned Arrow batch; the reader
-    /// stays valid and a retry continues after the batches already appended.
-    /// The timeout result is a retriable REQUEST_TIME_OUT. `timeout_ms` bounds
-    /// one invocation only; callers that retry must enforce their own overall
-    /// deadline or cancellation condition to avoid retrying indefinitely.
+    /// Drains remaining batches using timeout_ms as the total execution budget
+    /// for this invocation. Callers should normally pass the query's remaining
+    /// execution time and invoke this method once.
+    /// Batches are *appended* to `out`. If the budget expires before every
+    /// stopping offset is reached, the method stops collecting and returns a
+    /// retriable REQUEST_TIME_OUT; `out` may then contain a partial set of
+    /// complete batches. Only an `Ok()` result means the bounded result is
+    /// complete. The timeout is checked between complete Arrow batches and never
+    /// splits a batch already being returned.
+    /// The reader remains valid after timeout, but retrying is an explicit caller
+    /// policy rather than part of this operation; callers should not retry
+    /// indefinitely.
     Result CollectAllBatches(int64_t timeout_ms, ArrowRecordBatches& out);
 
    private:

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -1264,8 +1264,12 @@ enum class BoundedReadStatus {
     Finished = 2,
 };
 
+/// Outcome of one bounded record-batch read. Meaningful only when the
+/// accompanying `Result` is `Ok()`; on a non-Ok `Result` the status is reset to
+/// `Finished` so callers that skip the error check terminate instead of
+/// retrying a failed read forever.
 struct RecordBatchReadResult {
-    BoundedReadStatus status{BoundedReadStatus::TimedOut};
+    BoundedReadStatus status{BoundedReadStatus::Finished};
     std::unique_ptr<ArrowRecordBatch> batch;
 };
 
@@ -1927,12 +1931,17 @@ class RecordBatchLogReader {
     bool Available() const;
 
     /// Waits up to timeout_ms for the next batch.
+    /// Read `out.status` only when the returned `Result` is `Ok()`.
     /// TimedOut leaves the reader valid for a later retry; Finished means every
     /// subscribed bucket reached its stopping offset.
     Result NextBatch(int64_t timeout_ms, RecordBatchReadResult& out);
 
-    /// Drains all remaining batches until every stopping offset is reached.
-    Result CollectAllBatches(ArrowRecordBatches& out);
+    /// Drains remaining batches until every stopping offset is reached or the
+    /// total budget of timeout_ms elapses. Batches are *appended* to `out`, so a
+    /// timed-out call can be resumed by calling again with the same `out`.
+    /// On timeout the reader stays valid and the returned `Result` is a
+    /// retriable REQUEST_TIME_OUT, so callers can resume or cancel.
+    Result CollectAllBatches(int64_t timeout_ms, ArrowRecordBatches& out);
 
    private:
     friend class LogScanner;

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -1242,11 +1242,31 @@ struct ReaderStopOffset {
     int64_t offset;
 };
 
+/// One bounded log range. Records are returned for
+/// [starting_offset, stopping_offset).
+struct RecordBatchLogReadRange {
+    TableBucket bucket;
+    int64_t starting_offset;
+    int64_t stopping_offset;
+};
+
+/// A log timestamp range in epoch milliseconds. Each requested bucket resolves
+/// the two timestamps to offsets before the reader is created.
+struct TimestampRange {
+    int64_t starting_timestamp_ms;
+    int64_t stopping_timestamp_ms;
+};
+
 /// Outcome of a bounded record-batch read.
 enum class BoundedReadStatus {
     BatchAvailable = 0,
     TimedOut = 1,
     Finished = 2,
+};
+
+struct RecordBatchReadResult {
+    BoundedReadStatus status{BoundedReadStatus::TimedOut};
+    std::unique_ptr<ArrowRecordBatch> batch;
 };
 
 struct LakeSnapshot {
@@ -1352,6 +1372,7 @@ class Lookuper;
 class PrefixLookuper;
 class WriteResult;
 class LogScanner;
+class RecordBatchLogScanner;
 class RecordBatchLogReader;
 class BatchScanner;
 class Admin;
@@ -1648,7 +1669,25 @@ class TableScan {
     /// path carries no per-record change types; read a primary-key table's
     /// changelog with `CreateLogScanner()` instead. Requires the ARROW log
     /// format.
+    Result CreateRecordBatchLogScanner(RecordBatchLogScanner& out);
+
+    /// Legacy overload. Prefer the strongly typed RecordBatchLogScanner.
     Result CreateRecordBatchLogScanner(LogScanner& out);
+
+    /// Creates a bounded reader directly from per-bucket offset ranges.
+    ///
+    /// This is the preferred API for query engines: it subscribes every bucket
+    /// at its starting offset, installs the corresponding stopping offset, and
+    /// transfers scanner ownership to the returned reader.
+    Result CreateRecordBatchLogReader(const std::vector<RecordBatchLogReadRange>& ranges,
+                                      RecordBatchLogReader& out);
+
+    /// Creates a bounded reader for a timestamp range over requested buckets.
+    ///
+    /// The timestamps are resolved independently for every requested bucket,
+    /// then read with [starting_offset, stopping_offset) semantics.
+    Result CreateRecordBatchLogReader(Admin& admin, const std::vector<TableBucket>& buckets,
+                                      const TimestampRange& range, RecordBatchLogReader& out);
 
     Result CreateBucketBatchScanner(const TableBucket& bucket, BatchScanner& out);
 
@@ -1658,6 +1697,9 @@ class TableScan {
 
     std::vector<size_t> ResolveNameProjection() const;
     Result DoCreateScanner(LogScanner& out, bool is_record_batch);
+    Result ResolveTimestampRanges(Admin& admin, const std::vector<TableBucket>& buckets,
+                                  const TimestampRange& range,
+                                  std::vector<RecordBatchLogReadRange>& out) const;
 
     ffi::Table* table_{nullptr};
     std::vector<size_t> projection_;
@@ -1809,6 +1851,14 @@ class LogScanner {
     Result Poll(int64_t timeout_ms, ScanRecords& out);
     Result PollRecordBatch(int64_t timeout_ms, ArrowRecordBatches& out);
 
+   private:
+    friend class Table;
+    friend class TableScan;
+    friend class RecordBatchLogScanner;
+    LogScanner(ffi::LogScanner* scanner) noexcept;
+
+    void Destroy() noexcept;
+
     /// Creates a bounded reader using the latest offsets observed during this call.
     /// Subscribe the record-batch scanner at the desired starting offsets before
     /// calling this method.
@@ -1820,13 +1870,46 @@ class LogScanner {
     Result CreateRecordBatchLogReaderUntilOffsets(const std::vector<ReaderStopOffset>& offsets,
                                                   RecordBatchLogReader& out);
 
-   private:
-    friend class Table;
-    friend class TableScan;
-    LogScanner(ffi::LogScanner* scanner) noexcept;
-
-    void Destroy() noexcept;
     ffi::LogScanner* scanner_{nullptr};
+};
+
+/// Strongly typed Arrow record-batch log scanner.
+///
+/// Use this type for unbounded batch polling, or move it into a bounded reader.
+class RecordBatchLogScanner {
+   public:
+    RecordBatchLogScanner() noexcept;
+    ~RecordBatchLogScanner() noexcept;
+
+    RecordBatchLogScanner(const RecordBatchLogScanner&) = delete;
+    RecordBatchLogScanner& operator=(const RecordBatchLogScanner&) = delete;
+    RecordBatchLogScanner(RecordBatchLogScanner&& other) noexcept;
+    RecordBatchLogScanner& operator=(RecordBatchLogScanner&& other) noexcept;
+
+    bool Available() const;
+
+    Result Subscribe(int32_t bucket_id, int64_t start_offset);
+    Result Subscribe(const std::vector<BucketSubscription>& bucket_offsets);
+    Result SubscribePartitionBuckets(int64_t partition_id, int32_t bucket_id, int64_t start_offset);
+    Result SubscribePartitionBuckets(const std::vector<PartitionBucketSubscription>& subscriptions);
+    Result Unsubscribe(int32_t bucket_id);
+    Result UnsubscribePartition(int64_t partition_id, int32_t bucket_id);
+    Result Poll(int64_t timeout_ms, ArrowRecordBatches& out);
+
+    /// Transfers this scanner into a reader bounded by the latest offsets
+    /// observed during the call. The scanner becomes unavailable on success.
+    Result CreateRecordBatchLogReaderUntilLatest(const Admin& admin, RecordBatchLogReader& out) &&;
+
+    /// Transfers this scanner into a reader with explicit stopping offsets.
+    /// The scanner becomes unavailable on success.
+    Result CreateRecordBatchLogReaderUntilOffsets(const std::vector<ReaderStopOffset>& offsets,
+                                                  RecordBatchLogReader& out) &&;
+
+   private:
+    friend class TableScan;
+    explicit RecordBatchLogScanner(ffi::LogScanner* scanner) noexcept;
+
+    LogScanner scanner_;
 };
 
 /// Bounded Arrow batch reader created from a subscribed record-batch log scanner.
@@ -1846,13 +1929,15 @@ class RecordBatchLogReader {
     /// Waits up to timeout_ms for the next batch.
     /// TimedOut leaves the reader valid for a later retry; Finished means every
     /// subscribed bucket reached its stopping offset.
-    Result NextBatch(int64_t timeout_ms, ArrowRecordBatches& out, BoundedReadStatus& status);
+    Result NextBatch(int64_t timeout_ms, RecordBatchReadResult& out);
 
     /// Drains all remaining batches until every stopping offset is reached.
     Result CollectAllBatches(ArrowRecordBatches& out);
 
    private:
     friend class LogScanner;
+    friend class RecordBatchLogScanner;
+    friend class TableScan;
     explicit RecordBatchLogReader(ffi::RecordBatchLogReader* reader) noexcept;
 
     void Destroy() noexcept;

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -1952,8 +1952,10 @@ class RecordBatchLogReader {
 
     bool Available() const;
 
-    /// Waits up to timeout_ms for the next batch. A non-positive timeout_ms
-    /// polls without waiting.
+    /// Waits up to timeout_ms for the next batch. With a non-positive
+    /// timeout_ms, the method returns a buffered batch or reports Finished if
+    /// already complete; otherwise it reports TimedOut without polling the
+    /// scanner.
     /// Read `out.status` only when the returned `Result` is `Ok()`.
     /// TimedOut leaves the reader valid for a later retry; Finished means every
     /// subscribed bucket reached its stopping offset.
@@ -1966,9 +1968,11 @@ class RecordBatchLogReader {
     /// stopping offset is reached, the method stops collecting and returns a
     /// retriable REQUEST_TIME_OUT; `out` may then contain a partial set of
     /// complete batches. Only an `Ok()` result means the bounded result is
-    /// complete. The timeout is checked between complete Arrow batches and never
-    /// splits a batch already being returned. A non-positive timeout_ms returns
-    /// REQUEST_TIME_OUT without attempting a read.
+    /// complete. Once the budget is exhausted, the reader does not wait for
+    /// additional scanner data, but it still returns buffered batches and
+    /// observes completion before reporting REQUEST_TIME_OUT. Consequently, a
+    /// non-positive timeout_ms returns Ok for an already-complete reader and
+    /// REQUEST_TIME_OUT when unread work remains.
     /// The reader remains valid after timeout, but retrying is an explicit caller
     /// policy rather than part of this operation; callers should not retry
     /// indefinitely.

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -1939,8 +1939,13 @@ class RecordBatchLogReader {
     /// Drains remaining batches until every stopping offset is reached or the
     /// total budget of timeout_ms elapses. Batches are *appended* to `out`, so a
     /// timed-out call can be resumed by calling again with the same `out`.
-    /// On timeout the reader stays valid and the returned `Result` is a
-    /// retriable REQUEST_TIME_OUT, so callers can resume or cancel.
+    /// This operation is not atomic: on timeout, `out` may contain a partial set
+    /// of complete batches. Only an `Ok()` result means every stopping offset has
+    /// been reached. The timeout never splits a returned Arrow batch; the reader
+    /// stays valid and a retry continues after the batches already appended.
+    /// The timeout result is a retriable REQUEST_TIME_OUT. `timeout_ms` bounds
+    /// one invocation only; callers that retry must enforce their own overall
+    /// deadline or cancellation condition to avoid retrying indefinitely.
     Result CollectAllBatches(int64_t timeout_ms, ArrowRecordBatches& out);
 
    private:

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -1243,16 +1243,18 @@ struct ReaderStopOffset {
 };
 
 /// One bounded log range. Records are returned for
-/// [starting_offset, stopping_offset). The bucket id must be within the table's
-/// configured bucket count.
+/// [starting_offset, stopping_offset). `stopping_offset` must be non-negative,
+/// `starting_offset` must be non-negative or `EARLIEST_OFFSET`, and the bucket
+/// id must be within the table's configured bucket count.
 struct RecordBatchLogReadRange {
     TableBucket bucket;
     int64_t starting_offset;
     int64_t stopping_offset;
 };
 
-/// A log timestamp range in epoch milliseconds. Each requested bucket resolves
-/// the two timestamps to offsets before the reader is created.
+/// A half-open log timestamp range [starting_timestamp_ms,
+/// stopping_timestamp_ms) in epoch milliseconds. Each requested bucket
+/// resolves the two timestamps to offsets before the reader is created.
 struct TimestampRange {
     int64_t starting_timestamp_ms;
     int64_t stopping_timestamp_ms;

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -47,6 +47,7 @@ struct Table;
 struct AppendWriter;
 struct WriteResult;
 struct LogScanner;
+struct RecordBatchLogReader;
 struct BatchScanner;
 struct UpsertWriter;
 struct Lookuper;
@@ -1235,6 +1236,19 @@ struct PartitionBucketSubscription {
     int64_t offset;
 };
 
+/// Stopping offset for one bucket subscribed on a record-batch log scanner.
+struct ReaderStopOffset {
+    TableBucket bucket;
+    int64_t offset;
+};
+
+/// Outcome of a bounded record-batch read.
+enum class BoundedReadStatus {
+    BatchAvailable = 0,
+    TimedOut = 1,
+    Finished = 2,
+};
+
 struct LakeSnapshot {
     int64_t snapshot_id;
     std::vector<BucketOffset> bucket_offsets;
@@ -1338,6 +1352,7 @@ class Lookuper;
 class PrefixLookuper;
 class WriteResult;
 class LogScanner;
+class RecordBatchLogReader;
 class BatchScanner;
 class Admin;
 class Table;
@@ -1502,6 +1517,7 @@ class Admin {
                          const std::string* partition_name = nullptr);
 
     friend class Connection;
+    friend class LogScanner;
     Admin(ffi::Admin* admin) noexcept;
 
     void Destroy() noexcept;
@@ -1793,6 +1809,17 @@ class LogScanner {
     Result Poll(int64_t timeout_ms, ScanRecords& out);
     Result PollRecordBatch(int64_t timeout_ms, ArrowRecordBatches& out);
 
+    /// Creates a bounded reader using the latest offsets observed during this call.
+    /// Subscribe the record-batch scanner at the desired starting offsets before
+    /// calling this method.
+    Result CreateRecordBatchLogReaderUntilLatest(const Admin& admin, RecordBatchLogReader& out);
+
+    /// Creates a bounded reader using explicit stopping offsets.
+    /// Starting offsets come from the scanner subscriptions. Every stopping
+    /// offset must correspond to a bucket already subscribed on this scanner.
+    Result CreateRecordBatchLogReaderUntilOffsets(const std::vector<ReaderStopOffset>& offsets,
+                                                  RecordBatchLogReader& out);
+
    private:
     friend class Table;
     friend class TableScan;
@@ -1800,6 +1827,36 @@ class LogScanner {
 
     void Destroy() noexcept;
     ffi::LogScanner* scanner_{nullptr};
+};
+
+/// Bounded Arrow batch reader created from a subscribed record-batch log scanner.
+/// Only one reader or polling operation may consume the scanner at a time.
+class RecordBatchLogReader {
+   public:
+    RecordBatchLogReader() noexcept;
+    ~RecordBatchLogReader() noexcept;
+
+    RecordBatchLogReader(const RecordBatchLogReader&) = delete;
+    RecordBatchLogReader& operator=(const RecordBatchLogReader&) = delete;
+    RecordBatchLogReader(RecordBatchLogReader&& other) noexcept;
+    RecordBatchLogReader& operator=(RecordBatchLogReader&& other) noexcept;
+
+    bool Available() const;
+
+    /// Waits up to timeout_ms for the next batch.
+    /// TimedOut leaves the reader valid for a later retry; Finished means every
+    /// subscribed bucket reached its stopping offset.
+    Result NextBatch(int64_t timeout_ms, ArrowRecordBatches& out, BoundedReadStatus& status);
+
+    /// Drains all remaining batches until every stopping offset is reached.
+    Result CollectAllBatches(ArrowRecordBatches& out);
+
+   private:
+    friend class LogScanner;
+    explicit RecordBatchLogReader(ffi::RecordBatchLogReader* reader) noexcept;
+
+    void Destroy() noexcept;
+    ffi::RecordBatchLogReader* reader_{nullptr};
 };
 
 // One-shot bounded scan of a single bucket, from TableScan::CreateBucketBatchScanner.

--- a/fluss-rust/bindings/cpp/include/fluss.hpp
+++ b/fluss-rust/bindings/cpp/include/fluss.hpp
@@ -1243,7 +1243,8 @@ struct ReaderStopOffset {
 };
 
 /// One bounded log range. Records are returned for
-/// [starting_offset, stopping_offset).
+/// [starting_offset, stopping_offset). The bucket id must be within the table's
+/// configured bucket count.
 struct RecordBatchLogReadRange {
     TableBucket bucket;
     int64_t starting_offset;

--- a/fluss-rust/bindings/cpp/src/lib.rs
+++ b/fluss-rust/bindings/cpp/src/lib.rs
@@ -730,9 +730,6 @@ mod ffi {
             self: &RecordBatchLogReader,
             timeout_ms: i64,
         ) -> FfiBoundedReadResult;
-        fn record_batch_log_reader_collect_all_batches(
-            self: &RecordBatchLogReader,
-        ) -> FfiArrowRecordBatchesResult;
 
         // BatchScanner
         unsafe fn delete_batch_scanner(scanner: *mut BatchScanner);
@@ -2333,14 +2330,6 @@ impl RecordBatchLogReader {
                 empty_bounded_read_result(ok_result(), FINISHED)
             }
             Err(e) => empty_bounded_read_result(err_from_core_error(&e), FINISHED),
-        }
-    }
-
-    fn record_batch_log_reader_collect_all_batches(&self) -> ffi::FfiArrowRecordBatchesResult {
-        let mut reader = self.inner.lock().unwrap();
-        match RUNTIME.block_on(reader.collect_all_batches()) {
-            Ok(batches) => arrow_batches_result(types::core_scan_batches_to_ffi(&batches)),
-            Err(e) => empty_arrow_batches_result(err_from_core_error(&e)),
         }
     }
 }

--- a/fluss-rust/bindings/cpp/src/lib.rs
+++ b/fluss-rust/bindings/cpp/src/lib.rs
@@ -2274,18 +2274,20 @@ impl LogScanner {
             return client_err_ptr("Batch-based scanner not available".to_string());
         };
 
-        let stopping_offsets = offsets
-            .into_iter()
-            .map(|offset| {
-                let partition_id = offset.has_partition_id.then_some(offset.partition_id);
-                let bucket = fcore::metadata::TableBucket::new_with_partition(
-                    offset.table_id,
-                    partition_id,
-                    offset.bucket_id,
+        let mut stopping_offsets = HashMap::with_capacity(offsets.len());
+        for offset in offsets {
+            let partition_id = offset.has_partition_id.then_some(offset.partition_id);
+            let bucket = fcore::metadata::TableBucket::new_with_partition(
+                offset.table_id,
+                partition_id,
+                offset.bucket_id,
+            );
+            if stopping_offsets.insert(bucket, offset.offset).is_some() {
+                return client_err_ptr(
+                    "Duplicate bucket in bounded reader stopping offsets".to_string(),
                 );
-                (bucket, offset.offset)
-            })
-            .collect();
+            }
+        }
 
         match fcore::client::RecordBatchLogReader::new_until_offsets(
             scanner.new_shared_handle(),

--- a/fluss-rust/bindings/cpp/src/lib.rs
+++ b/fluss-rust/bindings/cpp/src/lib.rs
@@ -188,6 +188,22 @@ mod ffi {
         offset: i64,
     }
 
+    struct FfiReaderBucket {
+        table_id: i64,
+        has_partition_id: bool,
+        partition_id: i64,
+        bucket_id: i32,
+    }
+
+    struct FfiBoundedLogReadRange {
+        table_id: i64,
+        has_partition_id: bool,
+        partition_id: i64,
+        bucket_id: i32,
+        starting_offset: i64,
+        stopping_offset: i64,
+    }
+
     struct FfiLakeSnapshot {
         snapshot_id: i64,
         bucket_offsets: Vec<FfiBucketOffset>,
@@ -722,11 +738,26 @@ mod ffi {
             self: &LogScanner,
             offsets: Vec<FfiReaderStopOffset>,
         ) -> FfiPtrResult;
+        fn create_record_batch_log_reader_from_ranges(
+            self: &LogScanner,
+            ranges: Vec<FfiBoundedLogReadRange>,
+        ) -> FfiPtrResult;
+        fn create_record_batch_log_reader_between_timestamps(
+            self: &LogScanner,
+            admin: &Admin,
+            buckets: Vec<FfiReaderBucket>,
+            starting_timestamp_ms: i64,
+            stopping_timestamp_ms: i64,
+        ) -> FfiPtrResult;
         fn free_arrow_ffi_structures(array_ptr: usize, schema_ptr: usize);
 
         // RecordBatchLogReader
         unsafe fn delete_record_batch_log_reader(reader: *mut RecordBatchLogReader);
         fn record_batch_log_reader_next_batch(
+            self: &RecordBatchLogReader,
+            timeout_ms: i64,
+        ) -> FfiBoundedReadResult;
+        fn record_batch_log_reader_collect_all_batches(
             self: &RecordBatchLogReader,
             timeout_ms: i64,
         ) -> FfiBoundedReadResult;
@@ -2299,9 +2330,109 @@ impl LogScanner {
             Err(e) => err_ptr_from_core(&e),
         }
     }
+
+    fn create_record_batch_log_reader_from_ranges(
+        &self,
+        ranges: Vec<ffi::FfiBoundedLogReadRange>,
+    ) -> ffi::FfiPtrResult {
+        let ScannerKind::Batch(ref scanner) = self.scanner else {
+            return client_err_ptr("Batch-based scanner not available".to_string());
+        };
+
+        let ranges: Vec<fcore::client::BoundedLogReadRange> = ranges
+            .into_iter()
+            .map(|range| fcore::client::BoundedLogReadRange {
+                bucket: reader_bucket_to_core(
+                    range.table_id,
+                    range.has_partition_id,
+                    range.partition_id,
+                    range.bucket_id,
+                ),
+                starting_offset: range.starting_offset,
+                stopping_offset: range.stopping_offset,
+            })
+            .collect();
+
+        let reader_result = RUNTIME.block_on(fcore::client::RecordBatchLogReader::new_from_ranges(
+            scanner.new_shared_handle(),
+            ranges,
+        ));
+
+        match reader_result {
+            Ok(reader) => {
+                let ptr = Box::into_raw(Box::new(RecordBatchLogReader {
+                    inner: Mutex::new(reader),
+                }));
+                ok_ptr(ptr as usize)
+            }
+            Err(e) => err_ptr_from_core(&e),
+        }
+    }
+
+    fn create_record_batch_log_reader_between_timestamps(
+        &self,
+        admin: &Admin,
+        buckets: Vec<ffi::FfiReaderBucket>,
+        starting_timestamp_ms: i64,
+        stopping_timestamp_ms: i64,
+    ) -> ffi::FfiPtrResult {
+        let ScannerKind::Batch(ref scanner) = self.scanner else {
+            return client_err_ptr("Batch-based scanner not available".to_string());
+        };
+
+        let buckets: Vec<fcore::metadata::TableBucket> = buckets
+            .into_iter()
+            .map(|bucket| {
+                reader_bucket_to_core(
+                    bucket.table_id,
+                    bucket.has_partition_id,
+                    bucket.partition_id,
+                    bucket.bucket_id,
+                )
+            })
+            .collect();
+
+        let reader_result =
+            RUNTIME.block_on(fcore::client::RecordBatchLogReader::new_between_timestamps(
+                scanner.new_shared_handle(),
+                admin.inner.as_ref(),
+                &buckets,
+                starting_timestamp_ms,
+                stopping_timestamp_ms,
+            ));
+
+        match reader_result {
+            Ok(reader) => {
+                let ptr = Box::into_raw(Box::new(RecordBatchLogReader {
+                    inner: Mutex::new(reader),
+                }));
+                ok_ptr(ptr as usize)
+            }
+            Err(e) => err_ptr_from_core(&e),
+        }
+    }
+}
+
+fn reader_bucket_to_core(
+    table_id: i64,
+    has_partition_id: bool,
+    partition_id: i64,
+    bucket_id: i32,
+) -> fcore::metadata::TableBucket {
+    fcore::metadata::TableBucket::new_with_partition(
+        table_id,
+        has_partition_id.then_some(partition_id),
+        bucket_id,
+    )
 }
 
 // RecordBatchLogReader implementation
+
+/// Bounded read statuses shared with the C++ `BoundedReadStatus` enum.
+const BATCH_AVAILABLE: i32 = 0;
+const TIMED_OUT: i32 = 1;
+const FINISHED: i32 = 2;
+
 unsafe fn delete_record_batch_log_reader(reader: *mut RecordBatchLogReader) {
     if !reader.is_null() {
         unsafe {
@@ -2312,10 +2443,6 @@ unsafe fn delete_record_batch_log_reader(reader: *mut RecordBatchLogReader) {
 
 impl RecordBatchLogReader {
     fn record_batch_log_reader_next_batch(&self, timeout_ms: i64) -> ffi::FfiBoundedReadResult {
-        const BATCH_AVAILABLE: i32 = 0;
-        const TIMED_OUT: i32 = 1;
-        const FINISHED: i32 = 2;
-
         let mut reader = self.inner.lock().unwrap();
         let timeout = Duration::from_millis(timeout_ms.max(0) as u64);
         match RUNTIME.block_on(reader.next_batch_with_timeout(timeout)) {
@@ -2329,6 +2456,28 @@ impl RecordBatchLogReader {
             Ok(fcore::client::RecordBatchReadOutcome::Finished) => {
                 empty_bounded_read_result(ok_result(), FINISHED)
             }
+            Err(e) => empty_bounded_read_result(err_from_core_error(&e), FINISHED),
+        }
+    }
+
+    /// Drains the reader under a total time budget. `FINISHED` means the whole
+    /// bounded result was collected; `TIMED_OUT` means the budget expired and
+    /// the returned batches are a partial result.
+    fn record_batch_log_reader_collect_all_batches(
+        &self,
+        timeout_ms: i64,
+    ) -> ffi::FfiBoundedReadResult {
+        let mut reader = self.inner.lock().unwrap();
+        let timeout = Duration::from_millis(timeout_ms.max(0) as u64);
+        match RUNTIME.block_on(reader.collect_all_batches_with_timeout(timeout)) {
+            Ok(outcome) => bounded_read_result(
+                types::core_scan_batches_to_ffi(&outcome.batches),
+                if outcome.complete {
+                    FINISHED
+                } else {
+                    TIMED_OUT
+                },
+            ),
             Err(e) => empty_bounded_read_result(err_from_core_error(&e), FINISHED),
         }
     }

--- a/fluss-rust/bindings/cpp/src/lib.rs
+++ b/fluss-rust/bindings/cpp/src/lib.rs
@@ -174,6 +174,20 @@ mod ffi {
         arrow_batches: FfiArrowRecordBatches,
     }
 
+    struct FfiBoundedReadResult {
+        result: FfiResult,
+        arrow_batches: FfiArrowRecordBatches,
+        status: i32,
+    }
+
+    struct FfiReaderStopOffset {
+        table_id: i64,
+        has_partition_id: bool,
+        partition_id: i64,
+        bucket_id: i32,
+        offset: i64,
+    }
+
     struct FfiLakeSnapshot {
         snapshot_id: i64,
         bucket_offsets: Vec<FfiBucketOffset>,
@@ -300,6 +314,7 @@ mod ffi {
         type AppendWriter;
         type WriteResult;
         type LogScanner;
+        type RecordBatchLogReader;
         type BatchScanner;
         type UpsertWriter;
         type Lookuper;
@@ -699,7 +714,25 @@ mod ffi {
         -> FfiResult;
         fn poll(self: &LogScanner, timeout_ms: i64) -> Box<ScanResultInner>;
         fn poll_record_batch(self: &LogScanner, timeout_ms: i64) -> FfiArrowRecordBatchesResult;
+        fn create_record_batch_log_reader_until_latest(
+            self: &LogScanner,
+            admin: &Admin,
+        ) -> FfiPtrResult;
+        fn create_record_batch_log_reader_until_offsets(
+            self: &LogScanner,
+            offsets: Vec<FfiReaderStopOffset>,
+        ) -> FfiPtrResult;
         fn free_arrow_ffi_structures(array_ptr: usize, schema_ptr: usize);
+
+        // RecordBatchLogReader
+        unsafe fn delete_record_batch_log_reader(reader: *mut RecordBatchLogReader);
+        fn record_batch_log_reader_next_batch(
+            self: &RecordBatchLogReader,
+            timeout_ms: i64,
+        ) -> FfiBoundedReadResult;
+        fn record_batch_log_reader_collect_all_batches(
+            self: &RecordBatchLogReader,
+        ) -> FfiArrowRecordBatchesResult;
 
         // BatchScanner
         unsafe fn delete_batch_scanner(scanner: *mut BatchScanner);
@@ -844,6 +877,10 @@ pub struct LogScanner {
     projected_columns: Vec<fcore::metadata::Column>,
 }
 
+pub struct RecordBatchLogReader {
+    inner: Mutex<fcore::client::RecordBatchLogReader>,
+}
+
 pub struct BatchScanner {
     inner: Mutex<fcore::client::LimitBatchScanner>,
 }
@@ -940,6 +977,32 @@ fn arrow_batches_result(
             arrow_batches,
         },
         Err(e) => empty_arrow_batches_result(client_err(e)),
+    }
+}
+
+fn bounded_read_result(
+    converted: Result<ffi::FfiArrowRecordBatches, String>,
+    status: i32,
+) -> ffi::FfiBoundedReadResult {
+    match converted {
+        Ok(arrow_batches) => ffi::FfiBoundedReadResult {
+            result: ok_result(),
+            arrow_batches,
+            status,
+        },
+        Err(e) => ffi::FfiBoundedReadResult {
+            result: client_err(e),
+            arrow_batches: ffi::FfiArrowRecordBatches { batches: vec![] },
+            status,
+        },
+    }
+}
+
+fn empty_bounded_read_result(result: ffi::FfiResult, status: i32) -> ffi::FfiBoundedReadResult {
+    ffi::FfiBoundedReadResult {
+        result,
+        arrow_batches: ffi::FfiArrowRecordBatches { batches: vec![] },
+        status,
     }
 }
 
@@ -2174,6 +2237,106 @@ impl LogScanner {
         let result = RUNTIME.block_on(async { inner_batch.poll(timeout).await });
 
         match result {
+            Ok(batches) => arrow_batches_result(types::core_scan_batches_to_ffi(&batches)),
+            Err(e) => empty_arrow_batches_result(err_from_core_error(&e)),
+        }
+    }
+
+    fn create_record_batch_log_reader_until_latest(&self, admin: &Admin) -> ffi::FfiPtrResult {
+        let ScannerKind::Batch(ref scanner) = self.scanner else {
+            return client_err_ptr("Batch-based scanner not available".to_string());
+        };
+
+        let reader_result = RUNTIME.block_on(async {
+            fcore::client::RecordBatchLogReader::new_until_latest(
+                scanner.new_shared_handle(),
+                admin.inner.as_ref(),
+            )
+            .await
+        });
+
+        match reader_result {
+            Ok(reader) => {
+                let ptr = Box::into_raw(Box::new(RecordBatchLogReader {
+                    inner: Mutex::new(reader),
+                }));
+                ok_ptr(ptr as usize)
+            }
+            Err(e) => err_ptr_from_core(&e),
+        }
+    }
+
+    fn create_record_batch_log_reader_until_offsets(
+        &self,
+        offsets: Vec<ffi::FfiReaderStopOffset>,
+    ) -> ffi::FfiPtrResult {
+        let ScannerKind::Batch(ref scanner) = self.scanner else {
+            return client_err_ptr("Batch-based scanner not available".to_string());
+        };
+
+        let stopping_offsets = offsets
+            .into_iter()
+            .map(|offset| {
+                let partition_id = offset.has_partition_id.then_some(offset.partition_id);
+                let bucket = fcore::metadata::TableBucket::new_with_partition(
+                    offset.table_id,
+                    partition_id,
+                    offset.bucket_id,
+                );
+                (bucket, offset.offset)
+            })
+            .collect();
+
+        match fcore::client::RecordBatchLogReader::new_until_offsets(
+            scanner.new_shared_handle(),
+            stopping_offsets,
+        ) {
+            Ok(reader) => {
+                let ptr = Box::into_raw(Box::new(RecordBatchLogReader {
+                    inner: Mutex::new(reader),
+                }));
+                ok_ptr(ptr as usize)
+            }
+            Err(e) => err_ptr_from_core(&e),
+        }
+    }
+}
+
+// RecordBatchLogReader implementation
+unsafe fn delete_record_batch_log_reader(reader: *mut RecordBatchLogReader) {
+    if !reader.is_null() {
+        unsafe {
+            drop(Box::from_raw(reader));
+        }
+    }
+}
+
+impl RecordBatchLogReader {
+    fn record_batch_log_reader_next_batch(&self, timeout_ms: i64) -> ffi::FfiBoundedReadResult {
+        const BATCH_AVAILABLE: i32 = 0;
+        const TIMED_OUT: i32 = 1;
+        const FINISHED: i32 = 2;
+
+        let mut reader = self.inner.lock().unwrap();
+        let timeout = Duration::from_millis(timeout_ms.max(0) as u64);
+        match RUNTIME.block_on(reader.next_batch_with_timeout(timeout)) {
+            Ok(fcore::client::RecordBatchReadOutcome::Batch(batch)) => bounded_read_result(
+                types::core_scan_batches_to_ffi(std::slice::from_ref(&batch)),
+                BATCH_AVAILABLE,
+            ),
+            Ok(fcore::client::RecordBatchReadOutcome::TimedOut) => {
+                empty_bounded_read_result(ok_result(), TIMED_OUT)
+            }
+            Ok(fcore::client::RecordBatchReadOutcome::Finished) => {
+                empty_bounded_read_result(ok_result(), FINISHED)
+            }
+            Err(e) => empty_bounded_read_result(err_from_core_error(&e), FINISHED),
+        }
+    }
+
+    fn record_batch_log_reader_collect_all_batches(&self) -> ffi::FfiArrowRecordBatchesResult {
+        let mut reader = self.inner.lock().unwrap();
+        match RUNTIME.block_on(reader.collect_all_batches()) {
             Ok(batches) => arrow_batches_result(types::core_scan_batches_to_ffi(&batches)),
             Err(e) => empty_arrow_batches_result(err_from_core_error(&e)),
         }

--- a/fluss-rust/bindings/cpp/src/table.cpp
+++ b/fluss-rust/bindings/cpp/src/table.cpp
@@ -20,6 +20,7 @@
 #include <arrow/c/bridge.h>
 
 #include <cassert>
+#include <chrono>
 #include <ctime>
 #include <map>
 #include <set>
@@ -2234,55 +2235,87 @@ RecordBatchLogReader& RecordBatchLogReader::operator=(RecordBatchLogReader&& oth
 bool RecordBatchLogReader::Available() const { return reader_ != nullptr; }
 
 Result RecordBatchLogReader::NextBatch(int64_t timeout_ms, RecordBatchReadResult& out) {
+    // Default to Finished so that a caller which ignores the returned Result
+    // and only inspects out.status still terminates instead of spinning on a
+    // stale TimedOut value. Only a fully successful call writes the real
+    // terminal status back to `out`.
+    out.status = BoundedReadStatus::Finished;
+    out.batch.reset();
+
     if (!Available()) {
         return utils::make_client_error("RecordBatchLogReader not available");
     }
 
-    out.status = BoundedReadStatus::TimedOut;
-    out.batch.reset();
     auto ffi_result = reader_->record_batch_log_reader_next_batch(timeout_ms);
     auto result = utils::from_ffi_result(ffi_result.result);
     if (!result.Ok()) {
         return result;
     }
+    BoundedReadStatus status;
     switch (ffi_result.status) {
         case 0:
-            out.status = BoundedReadStatus::BatchAvailable;
+            status = BoundedReadStatus::BatchAvailable;
             break;
         case 1:
-            out.status = BoundedReadStatus::TimedOut;
+            status = BoundedReadStatus::TimedOut;
             break;
         case 2:
-            out.status = BoundedReadStatus::Finished;
+            status = BoundedReadStatus::Finished;
             break;
         default:
             return utils::make_client_error("Unknown bounded read status: " +
                                             std::to_string(ffi_result.status));
     }
-    result = detail::ArrowBatchImporter::ImportOne(ffi_result.arrow_batches, out.batch);
+    std::unique_ptr<ArrowRecordBatch> batch;
+    result = detail::ArrowBatchImporter::ImportOne(ffi_result.arrow_batches, batch);
     if (!result.Ok()) {
         return result;
     }
-    if (out.status == BoundedReadStatus::BatchAvailable && !out.batch) {
+    if (status == BoundedReadStatus::BatchAvailable && !batch) {
         return utils::make_client_error("Bounded reader reported a batch without returning one");
     }
-    if (out.status != BoundedReadStatus::BatchAvailable && out.batch) {
+    if (status != BoundedReadStatus::BatchAvailable && batch) {
         return utils::make_client_error("Bounded reader returned a batch for a terminal status");
     }
+    out.status = status;
+    out.batch = std::move(batch);
     return utils::make_ok();
 }
 
-Result RecordBatchLogReader::CollectAllBatches(ArrowRecordBatches& out) {
+Result RecordBatchLogReader::CollectAllBatches(int64_t timeout_ms, ArrowRecordBatches& out) {
     if (!Available()) {
         return utils::make_client_error("RecordBatchLogReader not available");
     }
 
-    auto ffi_result = reader_->record_batch_log_reader_collect_all_batches();
-    auto result = utils::from_ffi_result(ffi_result.result);
-    if (!result.Ok()) {
-        return result;
+    const auto timeout = std::chrono::milliseconds(timeout_ms > 0 ? timeout_ms : 0);
+    const auto start = std::chrono::steady_clock::now();
+    while (true) {
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        int64_t remaining_ms = 0;
+        if (elapsed < timeout) {
+            remaining_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(timeout - elapsed).count();
+        }
+        RecordBatchReadResult step;
+        auto result = NextBatch(remaining_ms, step);
+        if (!result.Ok()) {
+            return result;
+        }
+        if (step.status == BoundedReadStatus::Finished) {
+            return utils::make_ok();
+        }
+        if (step.status == BoundedReadStatus::TimedOut) {
+            // Budget exhausted before completion. Already-collected batches
+            // remain in `out`; the reader stays valid so callers can resume.
+            return utils::make_error(ErrorCode::REQUEST_TIME_OUT,
+                                     "CollectAllBatches timed out before every stopping offset was "
+                                     "reached");
+        }
+        // BatchAvailable
+        if (step.batch) {
+            out.batches.push_back(std::move(step.batch));
+        }
     }
-    return detail::ArrowBatchImporter::Import(ffi_result.arrow_batches, out);
 }
 
 // ============================================================================

--- a/fluss-rust/bindings/cpp/src/table.cpp
+++ b/fluss-rust/bindings/cpp/src/table.cpp
@@ -1858,6 +1858,126 @@ Result LogScanner::PollRecordBatch(int64_t timeout_ms, ArrowRecordBatches& out) 
 }
 
 // ============================================================================
+// RecordBatchLogReader
+// ============================================================================
+
+Result LogScanner::CreateRecordBatchLogReaderUntilLatest(const Admin& admin,
+                                                         RecordBatchLogReader& out) {
+    if (!Available()) {
+        return utils::make_client_error("LogScanner not available");
+    }
+    if (!admin.Available()) {
+        return utils::make_client_error("Admin not available");
+    }
+
+    auto ffi_result = scanner_->create_record_batch_log_reader_until_latest(*admin.admin_);
+    auto result = utils::from_ffi_result(ffi_result.result);
+    if (result.Ok()) {
+        out.Destroy();
+        out.reader_ = utils::ptr_from_ffi<ffi::RecordBatchLogReader>(ffi_result);
+    }
+    return result;
+}
+
+Result LogScanner::CreateRecordBatchLogReaderUntilOffsets(
+    const std::vector<ReaderStopOffset>& offsets, RecordBatchLogReader& out) {
+    if (!Available()) {
+        return utils::make_client_error("LogScanner not available");
+    }
+
+    rust::Vec<ffi::FfiReaderStopOffset> ffi_offsets;
+    for (const auto& offset : offsets) {
+        ffi::FfiReaderStopOffset ffi_offset;
+        ffi_offset.table_id = offset.bucket.table_id;
+        ffi_offset.has_partition_id = offset.bucket.partition_id.has_value();
+        ffi_offset.partition_id = offset.bucket.partition_id.value_or(0);
+        ffi_offset.bucket_id = offset.bucket.bucket_id;
+        ffi_offset.offset = offset.offset;
+        ffi_offsets.push_back(ffi_offset);
+    }
+
+    auto ffi_result =
+        scanner_->create_record_batch_log_reader_until_offsets(std::move(ffi_offsets));
+    auto result = utils::from_ffi_result(ffi_result.result);
+    if (result.Ok()) {
+        out.Destroy();
+        out.reader_ = utils::ptr_from_ffi<ffi::RecordBatchLogReader>(ffi_result);
+    }
+    return result;
+}
+
+RecordBatchLogReader::RecordBatchLogReader() noexcept = default;
+
+RecordBatchLogReader::RecordBatchLogReader(ffi::RecordBatchLogReader* reader) noexcept
+    : reader_(reader) {}
+
+RecordBatchLogReader::~RecordBatchLogReader() noexcept { Destroy(); }
+
+void RecordBatchLogReader::Destroy() noexcept {
+    if (reader_) {
+        ffi::delete_record_batch_log_reader(reader_);
+        reader_ = nullptr;
+    }
+}
+
+RecordBatchLogReader::RecordBatchLogReader(RecordBatchLogReader&& other) noexcept
+    : reader_(other.reader_) {
+    other.reader_ = nullptr;
+}
+
+RecordBatchLogReader& RecordBatchLogReader::operator=(RecordBatchLogReader&& other) noexcept {
+    if (this != &other) {
+        Destroy();
+        reader_ = other.reader_;
+        other.reader_ = nullptr;
+    }
+    return *this;
+}
+
+bool RecordBatchLogReader::Available() const { return reader_ != nullptr; }
+
+Result RecordBatchLogReader::NextBatch(int64_t timeout_ms, ArrowRecordBatches& out,
+                                       BoundedReadStatus& status) {
+    if (!Available()) {
+        return utils::make_client_error("RecordBatchLogReader not available");
+    }
+
+    auto ffi_result = reader_->record_batch_log_reader_next_batch(timeout_ms);
+    auto result = utils::from_ffi_result(ffi_result.result);
+    if (!result.Ok()) {
+        return result;
+    }
+    switch (ffi_result.status) {
+        case 0:
+            status = BoundedReadStatus::BatchAvailable;
+            break;
+        case 1:
+            status = BoundedReadStatus::TimedOut;
+            break;
+        case 2:
+            status = BoundedReadStatus::Finished;
+            break;
+        default:
+            return utils::make_client_error("Unknown bounded read status: " +
+                                            std::to_string(ffi_result.status));
+    }
+    return detail::ArrowBatchImporter::Import(ffi_result.arrow_batches, out);
+}
+
+Result RecordBatchLogReader::CollectAllBatches(ArrowRecordBatches& out) {
+    if (!Available()) {
+        return utils::make_client_error("RecordBatchLogReader not available");
+    }
+
+    auto ffi_result = reader_->record_batch_log_reader_collect_all_batches();
+    auto result = utils::from_ffi_result(ffi_result.result);
+    if (!result.Ok()) {
+        return result;
+    }
+    return detail::ArrowBatchImporter::Import(ffi_result.arrow_batches, out);
+}
+
+// ============================================================================
 // BatchScanner
 // ============================================================================
 

--- a/fluss-rust/bindings/cpp/src/table.cpp
+++ b/fluss-rust/bindings/cpp/src/table.cpp
@@ -21,6 +21,9 @@
 
 #include <cassert>
 #include <ctime>
+#include <map>
+#include <set>
+#include <tuple>
 
 #include "ffi_converter.hpp"
 #include "fluss.hpp"
@@ -1245,6 +1248,16 @@ std::vector<size_t> TableScan::ResolveNameProjection() const {
 
 Result TableScan::CreateLogScanner(LogScanner& out) { return DoCreateScanner(out, false); }
 
+Result TableScan::CreateRecordBatchLogScanner(RecordBatchLogScanner& out) {
+    LogScanner scanner;
+    auto result = DoCreateScanner(scanner, true);
+    if (result.Ok()) {
+        out = RecordBatchLogScanner(scanner.scanner_);
+        scanner.scanner_ = nullptr;
+    }
+    return result;
+}
+
 Result TableScan::CreateRecordBatchLogScanner(LogScanner& out) {
     return DoCreateScanner(out, true);
 }
@@ -1274,6 +1287,210 @@ Result TableScan::DoCreateScanner(LogScanner& out, bool is_record_batch) {
         // ResolveNameProjection() may throw
         return utils::make_client_error(e.what());
     }
+}
+
+Result TableScan::CreateRecordBatchLogReader(const std::vector<RecordBatchLogReadRange>& ranges,
+                                             RecordBatchLogReader& out) {
+    if (table_ == nullptr) {
+        return utils::make_client_error("Table not available");
+    }
+
+    auto info = utils::from_ffi_table_info(table_->get_table_info_from_table());
+    std::vector<BucketSubscription> bucket_subscriptions;
+    std::vector<PartitionBucketSubscription> partition_subscriptions;
+    std::vector<ReaderStopOffset> stopping_offsets;
+    std::set<std::tuple<int64_t, int64_t, int32_t>> seen_buckets;
+
+    for (const auto& range : ranges) {
+        if (range.bucket.table_id != info.table_id) {
+            return utils::make_client_error("Read range table_id does not match the scanned table");
+        }
+        if (range.starting_offset > range.stopping_offset) {
+            return utils::make_client_error(
+                "Read range starting_offset must not exceed stopping_offset");
+        }
+
+        const int64_t partition_id = range.bucket.partition_id.value_or(-1);
+        if (!seen_buckets.emplace(range.bucket.table_id, partition_id, range.bucket.bucket_id)
+                 .second) {
+            return utils::make_client_error("Duplicate bucket in bounded read ranges");
+        }
+        if (info.is_partitioned != range.bucket.partition_id.has_value()) {
+            return utils::make_client_error(
+                info.is_partitioned
+                    ? "Partitioned table read ranges must include partition_id"
+                    : "Non-partitioned table read ranges must not include partition_id");
+        }
+
+        // Empty ranges complete immediately and do not need a subscription.
+        if (range.starting_offset == range.stopping_offset) {
+            continue;
+        }
+
+        if (info.is_partitioned) {
+            partition_subscriptions.push_back(
+                {*range.bucket.partition_id, range.bucket.bucket_id, range.starting_offset});
+        } else {
+            bucket_subscriptions.push_back({range.bucket.bucket_id, range.starting_offset});
+        }
+        stopping_offsets.push_back({range.bucket, range.stopping_offset});
+    }
+
+    RecordBatchLogScanner scanner;
+    auto result = CreateRecordBatchLogScanner(scanner);
+    if (!result.Ok()) {
+        return result;
+    }
+
+    if (!partition_subscriptions.empty()) {
+        result = scanner.SubscribePartitionBuckets(partition_subscriptions);
+    } else if (!bucket_subscriptions.empty()) {
+        result = scanner.Subscribe(bucket_subscriptions);
+    }
+    if (!result.Ok()) {
+        return result;
+    }
+
+    return std::move(scanner).CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, out);
+}
+
+Result TableScan::ResolveTimestampRanges(Admin& admin, const std::vector<TableBucket>& buckets,
+                                         const TimestampRange& range,
+                                         std::vector<RecordBatchLogReadRange>& out) const {
+    if (table_ == nullptr) {
+        return utils::make_client_error("Table not available");
+    }
+    if (!admin.Available()) {
+        return utils::make_client_error("Admin not available");
+    }
+    if (range.starting_timestamp_ms > range.stopping_timestamp_ms) {
+        return utils::make_client_error(
+            "starting_timestamp_ms must not exceed stopping_timestamp_ms");
+    }
+
+    auto info = utils::from_ffi_table_info(table_->get_table_info_from_table());
+    auto ffi_path = table_->get_table_path();
+    TablePath table_path(std::string(ffi_path.database_name), std::string(ffi_path.table_name));
+    std::set<std::tuple<int64_t, int64_t, int32_t>> seen_buckets;
+    out.clear();
+    if (buckets.empty()) {
+        return utils::make_ok();
+    }
+
+    if (!info.is_partitioned) {
+        std::vector<int32_t> bucket_ids;
+        for (const auto& bucket : buckets) {
+            if (bucket.table_id != info.table_id || bucket.partition_id.has_value()) {
+                return utils::make_client_error(
+                    "Timestamp range contains a bucket from another table or partition mode");
+            }
+            if (!seen_buckets.emplace(bucket.table_id, -1, bucket.bucket_id).second) {
+                return utils::make_client_error("Duplicate bucket in timestamp read range");
+            }
+            bucket_ids.push_back(bucket.bucket_id);
+        }
+
+        std::unordered_map<int32_t, int64_t> starting_offsets;
+        std::unordered_map<int32_t, int64_t> stopping_offsets;
+        auto result =
+            admin.ListOffsets(table_path, bucket_ids,
+                              OffsetSpec::Timestamp(range.starting_timestamp_ms), starting_offsets);
+        if (!result.Ok()) {
+            return result;
+        }
+        result =
+            admin.ListOffsets(table_path, bucket_ids,
+                              OffsetSpec::Timestamp(range.stopping_timestamp_ms), stopping_offsets);
+        if (!result.Ok()) {
+            return result;
+        }
+
+        for (const auto& bucket : buckets) {
+            auto start = starting_offsets.find(bucket.bucket_id);
+            auto stop = stopping_offsets.find(bucket.bucket_id);
+            if (start == starting_offsets.end() || stop == stopping_offsets.end()) {
+                return utils::make_client_error(
+                    "Timestamp offset lookup did not return every requested bucket");
+            }
+            out.push_back({bucket, start->second, stop->second});
+        }
+        return utils::make_ok();
+    }
+
+    std::vector<PartitionInfo> partition_infos;
+    auto result = admin.ListPartitionInfos(table_path, partition_infos);
+    if (!result.Ok()) {
+        return result;
+    }
+    std::unordered_map<int64_t, std::string> partition_names;
+    for (const auto& partition : partition_infos) {
+        partition_names.emplace(partition.partition_id, partition.partition_name);
+    }
+
+    std::map<int64_t, std::vector<int32_t>> bucket_ids_by_partition;
+    for (const auto& bucket : buckets) {
+        if (bucket.table_id != info.table_id || !bucket.partition_id.has_value()) {
+            return utils::make_client_error(
+                "Timestamp range contains a bucket from another table or partition mode");
+        }
+        if (!seen_buckets.emplace(bucket.table_id, *bucket.partition_id, bucket.bucket_id).second) {
+            return utils::make_client_error("Duplicate bucket in timestamp read range");
+        }
+        bucket_ids_by_partition[*bucket.partition_id].push_back(bucket.bucket_id);
+    }
+
+    std::map<std::pair<int64_t, int32_t>, int64_t> starting_offsets;
+    std::map<std::pair<int64_t, int32_t>, int64_t> stopping_offsets;
+    for (const auto& entry : bucket_ids_by_partition) {
+        const int64_t partition_id = entry.first;
+        const auto& bucket_ids = entry.second;
+        auto partition_name = partition_names.find(partition_id);
+        if (partition_name == partition_names.end()) {
+            return utils::make_client_error("Unknown partition_id in timestamp read range");
+        }
+
+        std::unordered_map<int32_t, int64_t> partition_starts;
+        std::unordered_map<int32_t, int64_t> partition_stops;
+        result = admin.ListPartitionOffsets(table_path, partition_name->second, bucket_ids,
+                                            OffsetSpec::Timestamp(range.starting_timestamp_ms),
+                                            partition_starts);
+        if (!result.Ok()) {
+            return result;
+        }
+        result = admin.ListPartitionOffsets(table_path, partition_name->second, bucket_ids,
+                                            OffsetSpec::Timestamp(range.stopping_timestamp_ms),
+                                            partition_stops);
+        if (!result.Ok()) {
+            return result;
+        }
+        for (int32_t bucket_id : bucket_ids) {
+            auto start = partition_starts.find(bucket_id);
+            auto stop = partition_stops.find(bucket_id);
+            if (start == partition_starts.end() || stop == partition_stops.end()) {
+                return utils::make_client_error(
+                    "Timestamp offset lookup did not return every requested partition bucket");
+            }
+            starting_offsets[{partition_id, bucket_id}] = start->second;
+            stopping_offsets[{partition_id, bucket_id}] = stop->second;
+        }
+    }
+
+    for (const auto& bucket : buckets) {
+        const auto key = std::make_pair(*bucket.partition_id, bucket.bucket_id);
+        out.push_back({bucket, starting_offsets.at(key), stopping_offsets.at(key)});
+    }
+    return utils::make_ok();
+}
+
+Result TableScan::CreateRecordBatchLogReader(Admin& admin, const std::vector<TableBucket>& buckets,
+                                             const TimestampRange& range,
+                                             RecordBatchLogReader& out) {
+    std::vector<RecordBatchLogReadRange> ranges;
+    auto result = ResolveTimestampRanges(admin, buckets, range, ranges);
+    if (!result.Ok()) {
+        return result;
+    }
+    return CreateRecordBatchLogReader(ranges, out);
 }
 
 TableScan& TableScan::Limit(int32_t row_number) {
@@ -1841,6 +2058,20 @@ struct ArrowBatchImporter {
         }
         return utils::make_ok();
     }
+
+    static Result ImportOne(ffi::FfiArrowRecordBatches& src,
+                            std::unique_ptr<ArrowRecordBatch>& out) {
+        ArrowRecordBatches batches;
+        auto result = Import(src, batches);
+        if (!result.Ok()) {
+            return result;
+        }
+        if (batches.Size() > 1) {
+            return utils::make_client_error("Bounded reader returned more than one record batch");
+        }
+        out = batches.Empty() ? nullptr : std::move(batches.batches.front());
+        return utils::make_ok();
+    }
 };
 }  // namespace detail
 
@@ -1855,6 +2086,72 @@ Result LogScanner::PollRecordBatch(int64_t timeout_ms, ArrowRecordBatches& out) 
         return result;
     }
     return detail::ArrowBatchImporter::Import(ffi_result.arrow_batches, out);
+}
+
+// ============================================================================
+// RecordBatchLogScanner
+// ============================================================================
+
+RecordBatchLogScanner::RecordBatchLogScanner() noexcept = default;
+
+RecordBatchLogScanner::RecordBatchLogScanner(ffi::LogScanner* scanner) noexcept
+    : scanner_(scanner) {}
+
+RecordBatchLogScanner::~RecordBatchLogScanner() noexcept = default;
+
+RecordBatchLogScanner::RecordBatchLogScanner(RecordBatchLogScanner&& other) noexcept = default;
+
+RecordBatchLogScanner& RecordBatchLogScanner::operator=(RecordBatchLogScanner&& other) noexcept =
+    default;
+
+bool RecordBatchLogScanner::Available() const { return scanner_.Available(); }
+
+Result RecordBatchLogScanner::Subscribe(int32_t bucket_id, int64_t start_offset) {
+    return scanner_.Subscribe(bucket_id, start_offset);
+}
+
+Result RecordBatchLogScanner::Subscribe(const std::vector<BucketSubscription>& bucket_offsets) {
+    return scanner_.Subscribe(bucket_offsets);
+}
+
+Result RecordBatchLogScanner::SubscribePartitionBuckets(int64_t partition_id, int32_t bucket_id,
+                                                        int64_t start_offset) {
+    return scanner_.SubscribePartitionBuckets(partition_id, bucket_id, start_offset);
+}
+
+Result RecordBatchLogScanner::SubscribePartitionBuckets(
+    const std::vector<PartitionBucketSubscription>& subscriptions) {
+    return scanner_.SubscribePartitionBuckets(subscriptions);
+}
+
+Result RecordBatchLogScanner::Unsubscribe(int32_t bucket_id) {
+    return scanner_.Unsubscribe(bucket_id);
+}
+
+Result RecordBatchLogScanner::UnsubscribePartition(int64_t partition_id, int32_t bucket_id) {
+    return scanner_.UnsubscribePartition(partition_id, bucket_id);
+}
+
+Result RecordBatchLogScanner::Poll(int64_t timeout_ms, ArrowRecordBatches& out) {
+    return scanner_.PollRecordBatch(timeout_ms, out);
+}
+
+Result RecordBatchLogScanner::CreateRecordBatchLogReaderUntilLatest(const Admin& admin,
+                                                                    RecordBatchLogReader& out) && {
+    auto result = scanner_.CreateRecordBatchLogReaderUntilLatest(admin, out);
+    if (result.Ok()) {
+        scanner_ = LogScanner();
+    }
+    return result;
+}
+
+Result RecordBatchLogScanner::CreateRecordBatchLogReaderUntilOffsets(
+    const std::vector<ReaderStopOffset>& offsets, RecordBatchLogReader& out) && {
+    auto result = scanner_.CreateRecordBatchLogReaderUntilOffsets(offsets, out);
+    if (result.Ok()) {
+        scanner_ = LogScanner();
+    }
+    return result;
 }
 
 // ============================================================================
@@ -1936,12 +2233,13 @@ RecordBatchLogReader& RecordBatchLogReader::operator=(RecordBatchLogReader&& oth
 
 bool RecordBatchLogReader::Available() const { return reader_ != nullptr; }
 
-Result RecordBatchLogReader::NextBatch(int64_t timeout_ms, ArrowRecordBatches& out,
-                                       BoundedReadStatus& status) {
+Result RecordBatchLogReader::NextBatch(int64_t timeout_ms, RecordBatchReadResult& out) {
     if (!Available()) {
         return utils::make_client_error("RecordBatchLogReader not available");
     }
 
+    out.status = BoundedReadStatus::TimedOut;
+    out.batch.reset();
     auto ffi_result = reader_->record_batch_log_reader_next_batch(timeout_ms);
     auto result = utils::from_ffi_result(ffi_result.result);
     if (!result.Ok()) {
@@ -1949,19 +2247,29 @@ Result RecordBatchLogReader::NextBatch(int64_t timeout_ms, ArrowRecordBatches& o
     }
     switch (ffi_result.status) {
         case 0:
-            status = BoundedReadStatus::BatchAvailable;
+            out.status = BoundedReadStatus::BatchAvailable;
             break;
         case 1:
-            status = BoundedReadStatus::TimedOut;
+            out.status = BoundedReadStatus::TimedOut;
             break;
         case 2:
-            status = BoundedReadStatus::Finished;
+            out.status = BoundedReadStatus::Finished;
             break;
         default:
             return utils::make_client_error("Unknown bounded read status: " +
                                             std::to_string(ffi_result.status));
     }
-    return detail::ArrowBatchImporter::Import(ffi_result.arrow_batches, out);
+    result = detail::ArrowBatchImporter::ImportOne(ffi_result.arrow_batches, out.batch);
+    if (!result.Ok()) {
+        return result;
+    }
+    if (out.status == BoundedReadStatus::BatchAvailable && !out.batch) {
+        return utils::make_client_error("Bounded reader reported a batch without returning one");
+    }
+    if (out.status != BoundedReadStatus::BatchAvailable && out.batch) {
+        return utils::make_client_error("Bounded reader returned a batch for a terminal status");
+    }
+    return utils::make_ok();
 }
 
 Result RecordBatchLogReader::CollectAllBatches(ArrowRecordBatches& out) {

--- a/fluss-rust/bindings/cpp/src/table.cpp
+++ b/fluss-rust/bindings/cpp/src/table.cpp
@@ -2289,31 +2289,39 @@ Result RecordBatchLogReader::CollectAllBatches(int64_t timeout_ms, ArrowRecordBa
 
     const auto timeout = std::chrono::milliseconds(timeout_ms > 0 ? timeout_ms : 0);
     const auto start = std::chrono::steady_clock::now();
+    const auto timeout_result = [] {
+        return utils::make_error(
+            ErrorCode::REQUEST_TIME_OUT,
+            "CollectAllBatches timed out before every stopping offset was reached");
+    };
     while (true) {
         const auto elapsed = std::chrono::steady_clock::now() - start;
-        int64_t remaining_ms = 0;
-        if (elapsed < timeout) {
-            remaining_ms =
-                std::chrono::duration_cast<std::chrono::milliseconds>(timeout - elapsed).count();
+        if (elapsed >= timeout) {
+            return timeout_result();
         }
+
+        const int64_t remaining_ms =
+            std::chrono::ceil<std::chrono::milliseconds>(timeout - elapsed).count();
         RecordBatchReadResult step;
         auto result = NextBatch(remaining_ms, step);
         if (!result.Ok()) {
             return result;
         }
         if (step.status == BoundedReadStatus::Finished) {
+            if (std::chrono::steady_clock::now() - start >= timeout) {
+                return timeout_result();
+            }
             return utils::make_ok();
         }
         if (step.status == BoundedReadStatus::TimedOut) {
-            // Budget exhausted before completion. Already-collected batches
-            // remain in `out`; the reader stays valid so callers can resume.
-            return utils::make_error(ErrorCode::REQUEST_TIME_OUT,
-                                     "CollectAllBatches timed out before every stopping offset was "
-                                     "reached");
+            return timeout_result();
         }
         // BatchAvailable
         if (step.batch) {
             out.batches.push_back(std::move(step.batch));
+        }
+        if (std::chrono::steady_clock::now() - start >= timeout) {
+            return timeout_result();
         }
     }
 }

--- a/fluss-rust/bindings/cpp/src/table.cpp
+++ b/fluss-rust/bindings/cpp/src/table.cpp
@@ -2307,21 +2307,19 @@ Result RecordBatchLogReader::CollectAllBatches(int64_t timeout_ms, ArrowRecordBa
         if (!result.Ok()) {
             return result;
         }
+        // Finished means every stopping offset was reached, so the collected
+        // result is complete. Report success even when the budget expired in
+        // the meantime; a complete result must never surface as a timeout.
         if (step.status == BoundedReadStatus::Finished) {
-            if (std::chrono::steady_clock::now() - start >= timeout) {
-                return timeout_result();
-            }
             return utils::make_ok();
         }
         if (step.status == BoundedReadStatus::TimedOut) {
             return timeout_result();
         }
-        // BatchAvailable
+        // BatchAvailable: keep the batch and let the next iteration re-check
+        // the remaining budget.
         if (step.batch) {
             out.batches.push_back(std::move(step.batch));
-        }
-        if (std::chrono::steady_clock::now() - start >= timeout) {
-            return timeout_result();
         }
     }
 }

--- a/fluss-rust/bindings/cpp/src/table.cpp
+++ b/fluss-rust/bindings/cpp/src/table.cpp
@@ -20,11 +20,7 @@
 #include <arrow/c/bridge.h>
 
 #include <cassert>
-#include <chrono>
 #include <ctime>
-#include <map>
-#include <set>
-#include <tuple>
 
 #include "ffi_converter.hpp"
 #include "fluss.hpp"
@@ -1292,206 +1288,24 @@ Result TableScan::DoCreateScanner(LogScanner& out, bool is_record_batch) {
 
 Result TableScan::CreateRecordBatchLogReader(const std::vector<RecordBatchLogReadRange>& ranges,
                                              RecordBatchLogReader& out) {
-    if (table_ == nullptr) {
-        return utils::make_client_error("Table not available");
-    }
-
-    auto info = utils::from_ffi_table_info(table_->get_table_info_from_table());
-    std::vector<BucketSubscription> bucket_subscriptions;
-    std::vector<PartitionBucketSubscription> partition_subscriptions;
-    std::vector<ReaderStopOffset> stopping_offsets;
-    std::set<std::tuple<int64_t, int64_t, int32_t>> seen_buckets;
-
-    for (const auto& range : ranges) {
-        if (range.bucket.table_id != info.table_id) {
-            return utils::make_client_error("Read range table_id does not match the scanned table");
-        }
-        if (range.starting_offset > range.stopping_offset) {
-            return utils::make_client_error(
-                "Read range starting_offset must not exceed stopping_offset");
-        }
-
-        const int64_t partition_id = range.bucket.partition_id.value_or(-1);
-        if (!seen_buckets.emplace(range.bucket.table_id, partition_id, range.bucket.bucket_id)
-                 .second) {
-            return utils::make_client_error("Duplicate bucket in bounded read ranges");
-        }
-        if (info.is_partitioned != range.bucket.partition_id.has_value()) {
-            return utils::make_client_error(
-                info.is_partitioned
-                    ? "Partitioned table read ranges must include partition_id"
-                    : "Non-partitioned table read ranges must not include partition_id");
-        }
-
-        // Empty ranges complete immediately and do not need a subscription.
-        if (range.starting_offset == range.stopping_offset) {
-            continue;
-        }
-
-        if (info.is_partitioned) {
-            partition_subscriptions.push_back(
-                {*range.bucket.partition_id, range.bucket.bucket_id, range.starting_offset});
-        } else {
-            bucket_subscriptions.push_back({range.bucket.bucket_id, range.starting_offset});
-        }
-        stopping_offsets.push_back({range.bucket, range.stopping_offset});
-    }
-
     RecordBatchLogScanner scanner;
     auto result = CreateRecordBatchLogScanner(scanner);
     if (!result.Ok()) {
         return result;
     }
-
-    if (!partition_subscriptions.empty()) {
-        result = scanner.SubscribePartitionBuckets(partition_subscriptions);
-    } else if (!bucket_subscriptions.empty()) {
-        result = scanner.Subscribe(bucket_subscriptions);
-    }
-    if (!result.Ok()) {
-        return result;
-    }
-
-    return std::move(scanner).CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, out);
-}
-
-Result TableScan::ResolveTimestampRanges(Admin& admin, const std::vector<TableBucket>& buckets,
-                                         const TimestampRange& range,
-                                         std::vector<RecordBatchLogReadRange>& out) const {
-    if (table_ == nullptr) {
-        return utils::make_client_error("Table not available");
-    }
-    if (!admin.Available()) {
-        return utils::make_client_error("Admin not available");
-    }
-    if (range.starting_timestamp_ms > range.stopping_timestamp_ms) {
-        return utils::make_client_error(
-            "starting_timestamp_ms must not exceed stopping_timestamp_ms");
-    }
-
-    auto info = utils::from_ffi_table_info(table_->get_table_info_from_table());
-    auto ffi_path = table_->get_table_path();
-    TablePath table_path(std::string(ffi_path.database_name), std::string(ffi_path.table_name));
-    std::set<std::tuple<int64_t, int64_t, int32_t>> seen_buckets;
-    out.clear();
-    if (buckets.empty()) {
-        return utils::make_ok();
-    }
-
-    if (!info.is_partitioned) {
-        std::vector<int32_t> bucket_ids;
-        for (const auto& bucket : buckets) {
-            if (bucket.table_id != info.table_id || bucket.partition_id.has_value()) {
-                return utils::make_client_error(
-                    "Timestamp range contains a bucket from another table or partition mode");
-            }
-            if (!seen_buckets.emplace(bucket.table_id, -1, bucket.bucket_id).second) {
-                return utils::make_client_error("Duplicate bucket in timestamp read range");
-            }
-            bucket_ids.push_back(bucket.bucket_id);
-        }
-
-        std::unordered_map<int32_t, int64_t> starting_offsets;
-        std::unordered_map<int32_t, int64_t> stopping_offsets;
-        auto result =
-            admin.ListOffsets(table_path, bucket_ids,
-                              OffsetSpec::Timestamp(range.starting_timestamp_ms), starting_offsets);
-        if (!result.Ok()) {
-            return result;
-        }
-        result =
-            admin.ListOffsets(table_path, bucket_ids,
-                              OffsetSpec::Timestamp(range.stopping_timestamp_ms), stopping_offsets);
-        if (!result.Ok()) {
-            return result;
-        }
-
-        for (const auto& bucket : buckets) {
-            auto start = starting_offsets.find(bucket.bucket_id);
-            auto stop = stopping_offsets.find(bucket.bucket_id);
-            if (start == starting_offsets.end() || stop == stopping_offsets.end()) {
-                return utils::make_client_error(
-                    "Timestamp offset lookup did not return every requested bucket");
-            }
-            out.push_back({bucket, start->second, stop->second});
-        }
-        return utils::make_ok();
-    }
-
-    std::vector<PartitionInfo> partition_infos;
-    auto result = admin.ListPartitionInfos(table_path, partition_infos);
-    if (!result.Ok()) {
-        return result;
-    }
-    std::unordered_map<int64_t, std::string> partition_names;
-    for (const auto& partition : partition_infos) {
-        partition_names.emplace(partition.partition_id, partition.partition_name);
-    }
-
-    std::map<int64_t, std::vector<int32_t>> bucket_ids_by_partition;
-    for (const auto& bucket : buckets) {
-        if (bucket.table_id != info.table_id || !bucket.partition_id.has_value()) {
-            return utils::make_client_error(
-                "Timestamp range contains a bucket from another table or partition mode");
-        }
-        if (!seen_buckets.emplace(bucket.table_id, *bucket.partition_id, bucket.bucket_id).second) {
-            return utils::make_client_error("Duplicate bucket in timestamp read range");
-        }
-        bucket_ids_by_partition[*bucket.partition_id].push_back(bucket.bucket_id);
-    }
-
-    std::map<std::pair<int64_t, int32_t>, int64_t> starting_offsets;
-    std::map<std::pair<int64_t, int32_t>, int64_t> stopping_offsets;
-    for (const auto& entry : bucket_ids_by_partition) {
-        const int64_t partition_id = entry.first;
-        const auto& bucket_ids = entry.second;
-        auto partition_name = partition_names.find(partition_id);
-        if (partition_name == partition_names.end()) {
-            return utils::make_client_error("Unknown partition_id in timestamp read range");
-        }
-
-        std::unordered_map<int32_t, int64_t> partition_starts;
-        std::unordered_map<int32_t, int64_t> partition_stops;
-        result = admin.ListPartitionOffsets(table_path, partition_name->second, bucket_ids,
-                                            OffsetSpec::Timestamp(range.starting_timestamp_ms),
-                                            partition_starts);
-        if (!result.Ok()) {
-            return result;
-        }
-        result = admin.ListPartitionOffsets(table_path, partition_name->second, bucket_ids,
-                                            OffsetSpec::Timestamp(range.stopping_timestamp_ms),
-                                            partition_stops);
-        if (!result.Ok()) {
-            return result;
-        }
-        for (int32_t bucket_id : bucket_ids) {
-            auto start = partition_starts.find(bucket_id);
-            auto stop = partition_stops.find(bucket_id);
-            if (start == partition_starts.end() || stop == partition_stops.end()) {
-                return utils::make_client_error(
-                    "Timestamp offset lookup did not return every requested partition bucket");
-            }
-            starting_offsets[{partition_id, bucket_id}] = start->second;
-            stopping_offsets[{partition_id, bucket_id}] = stop->second;
-        }
-    }
-
-    for (const auto& bucket : buckets) {
-        const auto key = std::make_pair(*bucket.partition_id, bucket.bucket_id);
-        out.push_back({bucket, starting_offsets.at(key), stopping_offsets.at(key)});
-    }
-    return utils::make_ok();
+    return std::move(scanner).CreateRecordBatchLogReaderFromRanges(ranges, out);
 }
 
 Result TableScan::CreateRecordBatchLogReader(Admin& admin, const std::vector<TableBucket>& buckets,
                                              const TimestampRange& range,
                                              RecordBatchLogReader& out) {
-    std::vector<RecordBatchLogReadRange> ranges;
-    auto result = ResolveTimestampRanges(admin, buckets, range, ranges);
+    RecordBatchLogScanner scanner;
+    auto result = CreateRecordBatchLogScanner(scanner);
     if (!result.Ok()) {
         return result;
     }
-    return CreateRecordBatchLogReader(ranges, out);
+    return std::move(scanner).CreateRecordBatchLogReaderBetweenTimestamps(admin, buckets, range,
+                                                                          out);
 }
 
 TableScan& TableScan::Limit(int32_t row_number) {
@@ -2041,6 +1855,10 @@ namespace detail {
 struct ArrowBatchImporter {
     static Result Import(ffi::FfiArrowRecordBatches& src, ArrowRecordBatches& out) {
         out.batches.clear();
+        return ImportAppend(src, out);
+    }
+
+    static Result ImportAppend(ffi::FfiArrowRecordBatches& src, ArrowRecordBatches& out) {
         for (const auto& ffi_batch : src.batches) {
             auto* c_array = reinterpret_cast<struct ArrowArray*>(ffi_batch.array_ptr);
             auto* c_schema = reinterpret_cast<struct ArrowSchema*>(ffi_batch.schema_ptr);
@@ -2155,6 +1973,26 @@ Result RecordBatchLogScanner::CreateRecordBatchLogReaderUntilOffsets(
     return result;
 }
 
+Result RecordBatchLogScanner::CreateRecordBatchLogReaderFromRanges(
+    const std::vector<RecordBatchLogReadRange>& ranges, RecordBatchLogReader& out) && {
+    auto result = scanner_.CreateRecordBatchLogReaderFromRanges(ranges, out);
+    if (result.Ok()) {
+        scanner_ = LogScanner();
+    }
+    return result;
+}
+
+Result RecordBatchLogScanner::CreateRecordBatchLogReaderBetweenTimestamps(
+    const Admin& admin, const std::vector<TableBucket>& buckets, const TimestampRange& range,
+    RecordBatchLogReader& out) && {
+    auto result =
+        scanner_.CreateRecordBatchLogReaderBetweenTimestamps(admin, buckets, range, out);
+    if (result.Ok()) {
+        scanner_ = LogScanner();
+    }
+    return result;
+}
+
 // ============================================================================
 // RecordBatchLogReader
 // ============================================================================
@@ -2196,6 +2034,64 @@ Result LogScanner::CreateRecordBatchLogReaderUntilOffsets(
 
     auto ffi_result =
         scanner_->create_record_batch_log_reader_until_offsets(std::move(ffi_offsets));
+    auto result = utils::from_ffi_result(ffi_result.result);
+    if (result.Ok()) {
+        out.Destroy();
+        out.reader_ = utils::ptr_from_ffi<ffi::RecordBatchLogReader>(ffi_result);
+    }
+    return result;
+}
+
+Result LogScanner::CreateRecordBatchLogReaderFromRanges(
+    const std::vector<RecordBatchLogReadRange>& ranges, RecordBatchLogReader& out) {
+    if (!Available()) {
+        return utils::make_client_error("LogScanner not available");
+    }
+
+    rust::Vec<ffi::FfiBoundedLogReadRange> ffi_ranges;
+    for (const auto& range : ranges) {
+        ffi::FfiBoundedLogReadRange ffi_range;
+        ffi_range.table_id = range.bucket.table_id;
+        ffi_range.has_partition_id = range.bucket.partition_id.has_value();
+        ffi_range.partition_id = range.bucket.partition_id.value_or(0);
+        ffi_range.bucket_id = range.bucket.bucket_id;
+        ffi_range.starting_offset = range.starting_offset;
+        ffi_range.stopping_offset = range.stopping_offset;
+        ffi_ranges.push_back(ffi_range);
+    }
+
+    auto ffi_result = scanner_->create_record_batch_log_reader_from_ranges(std::move(ffi_ranges));
+    auto result = utils::from_ffi_result(ffi_result.result);
+    if (result.Ok()) {
+        out.Destroy();
+        out.reader_ = utils::ptr_from_ffi<ffi::RecordBatchLogReader>(ffi_result);
+    }
+    return result;
+}
+
+Result LogScanner::CreateRecordBatchLogReaderBetweenTimestamps(
+    const Admin& admin, const std::vector<TableBucket>& buckets, const TimestampRange& range,
+    RecordBatchLogReader& out) {
+    if (!Available()) {
+        return utils::make_client_error("LogScanner not available");
+    }
+    if (!admin.Available()) {
+        return utils::make_client_error("Admin not available");
+    }
+
+    rust::Vec<ffi::FfiReaderBucket> ffi_buckets;
+    for (const auto& bucket : buckets) {
+        ffi::FfiReaderBucket ffi_bucket;
+        ffi_bucket.table_id = bucket.table_id;
+        ffi_bucket.has_partition_id = bucket.partition_id.has_value();
+        ffi_bucket.partition_id = bucket.partition_id.value_or(0);
+        ffi_bucket.bucket_id = bucket.bucket_id;
+        ffi_buckets.push_back(ffi_bucket);
+    }
+
+    auto ffi_result = scanner_->create_record_batch_log_reader_between_timestamps(
+        *admin.admin_, std::move(ffi_buckets), range.starting_timestamp_ms,
+        range.stopping_timestamp_ms);
     auto result = utils::from_ffi_result(ffi_result.result);
     if (result.Ok()) {
         out.Destroy();
@@ -2287,40 +2183,27 @@ Result RecordBatchLogReader::CollectAllBatches(int64_t timeout_ms, ArrowRecordBa
         return utils::make_client_error("RecordBatchLogReader not available");
     }
 
-    const auto timeout = std::chrono::milliseconds(timeout_ms > 0 ? timeout_ms : 0);
-    const auto start = std::chrono::steady_clock::now();
-    const auto timeout_result = [] {
-        return utils::make_error(
-            ErrorCode::REQUEST_TIME_OUT,
-            "CollectAllBatches timed out before every stopping offset was reached");
-    };
-    while (true) {
-        const auto elapsed = std::chrono::steady_clock::now() - start;
-        if (elapsed >= timeout) {
-            return timeout_result();
-        }
-
-        const int64_t remaining_ms =
-            std::chrono::ceil<std::chrono::milliseconds>(timeout - elapsed).count();
-        RecordBatchReadResult step;
-        auto result = NextBatch(remaining_ms, step);
-        if (!result.Ok()) {
-            return result;
-        }
-        // Finished means every stopping offset was reached, so the collected
-        // result is complete. Report success even when the budget expired in
-        // the meantime; a complete result must never surface as a timeout.
-        if (step.status == BoundedReadStatus::Finished) {
+    auto ffi_result = reader_->record_batch_log_reader_collect_all_batches(timeout_ms);
+    auto result = utils::from_ffi_result(ffi_result.result);
+    if (!result.Ok()) {
+        return result;
+    }
+    // Batches collected before the budget expired are part of the result, so
+    // they are appended even when the collection is incomplete.
+    result = detail::ArrowBatchImporter::ImportAppend(ffi_result.arrow_batches, out);
+    if (!result.Ok()) {
+        return result;
+    }
+    switch (ffi_result.status) {
+        case static_cast<int32_t>(BoundedReadStatus::Finished):
             return utils::make_ok();
-        }
-        if (step.status == BoundedReadStatus::TimedOut) {
-            return timeout_result();
-        }
-        // BatchAvailable: keep the batch and let the next iteration re-check
-        // the remaining budget.
-        if (step.batch) {
-            out.batches.push_back(std::move(step.batch));
-        }
+        case static_cast<int32_t>(BoundedReadStatus::TimedOut):
+            return utils::make_error(
+                ErrorCode::REQUEST_TIME_OUT,
+                "CollectAllBatches timed out before every stopping offset was reached");
+        default:
+            return utils::make_client_error("Unknown bounded read status: " +
+                                           std::to_string(ffi_result.status));
     }
 }
 

--- a/fluss-rust/bindings/cpp/test/test_log_table.cpp
+++ b/fluss-rust/bindings/cpp/test/test_log_table.cpp
@@ -276,6 +276,51 @@ TEST_F(LogTableTest, RecordBatchLogReaderUntilOffsets) {
         ASSERT_OK(waiting_reader.NextBatch(100, timeout_result));
         EXPECT_EQ(timeout_result.batch, nullptr);
         EXPECT_EQ(timeout_result.status, fluss::BoundedReadStatus::TimedOut);
+
+        // CollectAllBatches must honour its budget instead of blocking until the
+        // stopping offset becomes reachable, which may never happen (e.g. a
+        // tablet server outage).
+        fluss::ArrowRecordBatches partial;
+        auto collect_result = waiting_reader.CollectAllBatches(200, partial);
+        EXPECT_FALSE(collect_result.Ok());
+        EXPECT_EQ(collect_result.error_code, fluss::ErrorCode::REQUEST_TIME_OUT);
+        EXPECT_TRUE(collect_result.IsRetriable());
+        // The reader survives the timeout, so callers may resume or cancel.
+        EXPECT_TRUE(waiting_reader.Available());
+    }
+
+    // An unavailable reader must not report TimedOut: callers that only inspect
+    // the status would otherwise retry an unretriable failure forever.
+    {
+        fluss::RecordBatchLogReader unavailable_reader;
+        ASSERT_FALSE(unavailable_reader.Available());
+
+        fluss::RecordBatchReadResult result;
+        result.status = fluss::BoundedReadStatus::BatchAvailable;
+        auto next_result = unavailable_reader.NextBatch(100, result);
+        EXPECT_FALSE(next_result.Ok());
+        EXPECT_EQ(result.status, fluss::BoundedReadStatus::Finished);
+        EXPECT_EQ(result.batch, nullptr);
+    }
+
+    // CollectAllBatches appends to the output, preserving previously collected
+    // batches when a caller resumes after a timeout.
+    {
+        const std::vector<fluss::RecordBatchLogReadRange> bucket_range = {
+            {fluss::TableBucket{table_id, 0}, 1, latest_offsets.at(0)}};
+
+        fluss::ArrowRecordBatches accumulated;
+        fluss::RecordBatchLogReader first_reader;
+        ASSERT_OK(table.NewScan().CreateRecordBatchLogReader(bucket_range, first_reader));
+        ASSERT_OK(first_reader.CollectAllBatches(30000, accumulated));
+        const size_t after_first = accumulated.Size();
+        ASSERT_GT(after_first, 0u);
+
+        fluss::RecordBatchLogReader second_reader;
+        ASSERT_OK(table.NewScan().CreateRecordBatchLogReader(bucket_range, second_reader));
+        ASSERT_OK(second_reader.CollectAllBatches(30000, accumulated));
+        EXPECT_GT(accumulated.Size(), after_first)
+            << "CollectAllBatches must append to out, not overwrite it";
     }
 
     ASSERT_OK(adm.DropTable(table_path, false));
@@ -1242,7 +1287,7 @@ TEST_F(LogTableTest, PartitionedTableAppendScan) {
         ASSERT_OK(bounded_table.NewScan().CreateRecordBatchLogReader(ranges, reader));
 
         fluss::ArrowRecordBatches batches;
-        ASSERT_OK(reader.CollectAllBatches(batches));
+        ASSERT_OK(reader.CollectAllBatches(30000, batches));
 
         std::vector<int32_t> ids;
         for (const auto& bounded_batch : batches) {
@@ -1272,7 +1317,7 @@ TEST_F(LogTableTest, PartitionedTableAppendScan) {
             reader));
 
         fluss::ArrowRecordBatches batches;
-        ASSERT_OK(reader.CollectAllBatches(batches));
+        ASSERT_OK(reader.CollectAllBatches(30000, batches));
 
         std::vector<int32_t> ids;
         for (const auto& bounded_batch : batches) {

--- a/fluss-rust/bindings/cpp/test/test_log_table.cpp
+++ b/fluss-rust/bindings/cpp/test/test_log_table.cpp
@@ -173,6 +173,169 @@ TEST_F(LogTableTest, AppendRecordBatchAndScan) {
     ASSERT_OK(adm.DropTable(table_path, false));
 }
 
+TEST_F(LogTableTest, RecordBatchLogReaderUntilOffsets) {
+    auto& adm = admin();
+    auto& conn = connection();
+
+    constexpr int32_t kNumBuckets = 3;
+    fluss::TablePath table_path("fluss", "test_record_batch_log_reader_offsets_cpp");
+    auto schema = fluss::Schema::NewBuilder()
+                      .AddColumn("c1", DataType::Int())
+                      .AddColumn("c2", DataType::String())
+                      .Build();
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetBucketCount(kNumBuckets)
+                                .SetBucketKeys({"c1"})
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+    auto table_append = table.NewAppend();
+    fluss::AppendWriter append_writer;
+    ASSERT_OK(table_append.CreateWriter(append_writer));
+
+    auto c1 = arrow::Int32Builder();
+    auto c2 = arrow::StringBuilder();
+    for (int32_t value = 1; value <= 60; ++value) {
+        ASSERT_TRUE(c1.Append(value).ok());
+        ASSERT_TRUE(c2.Append("v" + std::to_string(value)).ok());
+    }
+    auto batch = arrow::RecordBatch::Make(
+        arrow::schema({arrow::field("c1", arrow::int32()), arrow::field("c2", arrow::utf8())}), 60,
+        {c1.Finish().ValueOrDie(), c2.Finish().ValueOrDie()});
+    ASSERT_OK(append_writer.AppendArrowBatch(batch));
+    ASSERT_OK(append_writer.Flush());
+
+    fluss::LogScanner scanner;
+    ASSERT_OK(table.NewScan().CreateRecordBatchLogScanner(scanner));
+
+    const int64_t table_id = table.GetTableInfo().table_id;
+    std::vector<int32_t> bucket_ids;
+    for (int32_t bucket_id = 0; bucket_id < kNumBuckets; ++bucket_id) {
+        bucket_ids.push_back(bucket_id);
+    }
+
+    std::unordered_map<int32_t, int64_t> latest_offsets;
+    ASSERT_OK(adm.ListOffsets(table_path, bucket_ids, fluss::OffsetSpec::Latest(), latest_offsets));
+    ASSERT_EQ(latest_offsets.size(), bucket_ids.size());
+
+    std::vector<fluss::ReaderStopOffset> stopping_offsets;
+    std::vector<int64_t> expected_rows_by_bucket(kNumBuckets);
+    for (int32_t bucket_id : bucket_ids) {
+        const int64_t stopping_offset = latest_offsets.at(bucket_id);
+        ASSERT_GT(stopping_offset, 1)
+            << "Bucket " << bucket_id << " should contain rows after starting offset 1";
+        ASSERT_OK(scanner.Subscribe(bucket_id, 1));
+        stopping_offsets.push_back({fluss::TableBucket{table_id, bucket_id}, stopping_offset});
+        expected_rows_by_bucket[bucket_id] = stopping_offset - 1;
+    }
+
+    fluss::RecordBatchLogReader reader;
+    ASSERT_OK(scanner.CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, reader));
+
+    fluss::ArrowRecordBatches batches;
+    ASSERT_OK(reader.CollectAllBatches(batches));
+
+    std::vector<int64_t> actual_rows_by_bucket(kNumBuckets);
+    for (const auto& bounded_batch : batches) {
+        const int32_t bucket_id = bounded_batch->GetBucketId();
+        ASSERT_GE(bucket_id, 0);
+        ASSERT_LT(bucket_id, kNumBuckets);
+        EXPECT_GE(bounded_batch->GetBaseOffset(), 1);
+        EXPECT_LT(bounded_batch->GetLastOffset(), latest_offsets.at(bucket_id));
+        actual_rows_by_bucket[bucket_id] += bounded_batch->NumRows();
+    }
+    for (int32_t bucket_id : bucket_ids) {
+        EXPECT_EQ(actual_rows_by_bucket[bucket_id], expected_rows_by_bucket[bucket_id])
+            << "Unexpected row count for bucket " << bucket_id;
+    }
+
+    fluss::ArrowRecordBatches eof_batches;
+    fluss::BoundedReadStatus eof_status = fluss::BoundedReadStatus::BatchAvailable;
+    ASSERT_OK(reader.NextBatch(1000, eof_batches, eof_status));
+    EXPECT_TRUE(eof_batches.Empty());
+    EXPECT_EQ(eof_status, fluss::BoundedReadStatus::Finished);
+
+    // A bounded reader whose stopping offset is not available yet should return
+    // TimedOut without becoming exhausted, so query engines can check cancellation
+    // and retry.
+    {
+        fluss::LogScanner waiting_scanner;
+        ASSERT_OK(table.NewScan().CreateRecordBatchLogScanner(waiting_scanner));
+        const int64_t start_offset = latest_offsets.at(0);
+        ASSERT_OK(waiting_scanner.Subscribe(0, start_offset));
+
+        fluss::RecordBatchLogReader waiting_reader;
+        ASSERT_OK(waiting_scanner.CreateRecordBatchLogReaderUntilOffsets(
+            {{fluss::TableBucket{table_id, 0}, start_offset + 1}}, waiting_reader));
+
+        fluss::ArrowRecordBatches timeout_batches;
+        fluss::BoundedReadStatus timeout_status = fluss::BoundedReadStatus::Finished;
+        ASSERT_OK(waiting_reader.NextBatch(100, timeout_batches, timeout_status));
+        EXPECT_TRUE(timeout_batches.Empty());
+        EXPECT_EQ(timeout_status, fluss::BoundedReadStatus::TimedOut);
+    }
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}
+
+TEST_F(LogTableTest, RecordBatchLogReaderUntilLatest) {
+    auto& adm = admin();
+    auto& conn = connection();
+
+    fluss::TablePath table_path("fluss", "test_record_batch_log_reader_latest_cpp");
+    auto schema = fluss::Schema::NewBuilder().AddColumn("c1", DataType::Int()).Build();
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetBucketCount(1)
+                                .SetBucketKeys({"c1"})
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+    auto table_append = table.NewAppend();
+    fluss::AppendWriter append_writer;
+    ASSERT_OK(table_append.CreateWriter(append_writer));
+
+    auto c1 = arrow::Int32Builder();
+    ASSERT_TRUE(c1.AppendValues({1, 2, 3}).ok());
+    auto batch = arrow::RecordBatch::Make(arrow::schema({arrow::field("c1", arrow::int32())}), 3,
+                                          {c1.Finish().ValueOrDie()});
+    ASSERT_OK(append_writer.AppendArrowBatch(batch));
+    ASSERT_OK(append_writer.Flush());
+
+    fluss::LogScanner scanner;
+    ASSERT_OK(table.NewScan().CreateRecordBatchLogScanner(scanner));
+    ASSERT_OK(scanner.Subscribe(0, 0));
+
+    fluss::RecordBatchLogReader reader;
+    ASSERT_OK(scanner.CreateRecordBatchLogReaderUntilLatest(adm, reader));
+
+    fluss::ArrowRecordBatches batches;
+    fluss::BoundedReadStatus status = fluss::BoundedReadStatus::TimedOut;
+    ASSERT_OK(reader.NextBatch(5000, batches, status));
+    ASSERT_EQ(status, fluss::BoundedReadStatus::BatchAvailable);
+    ASSERT_EQ(batches.Size(), 1);
+    auto ids =
+        std::static_pointer_cast<arrow::Int32Array>(batches[0]->GetArrowRecordBatch()->column(0));
+    ASSERT_EQ(ids->length(), 3);
+    EXPECT_EQ(ids->Value(0), 1);
+    EXPECT_EQ(ids->Value(1), 2);
+    EXPECT_EQ(ids->Value(2), 3);
+
+    fluss::ArrowRecordBatches eof_batches;
+    ASSERT_OK(reader.NextBatch(1000, eof_batches, status));
+    EXPECT_TRUE(eof_batches.Empty());
+    EXPECT_EQ(status, fluss::BoundedReadStatus::Finished);
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}
+
 TEST_F(LogTableTest, LimitScan) {
     auto& adm = admin();
     auto& conn = connection();
@@ -987,6 +1150,40 @@ TEST_F(LogTableTest, PartitionedTableAppendScan) {
                                     {4, "EU", 400},  {5, "US", 500},  {6, "US", 600},
                                     {7, "EU", 700},  {8, "EU", 800}};
     EXPECT_EQ(collected, expected);
+
+    // Test bounded record-batch reading across partition buckets.
+    {
+        fluss::Table bounded_table;
+        ASSERT_OK(conn.GetTable(table_path, bounded_table));
+        fluss::LogScanner bounded_scanner;
+        ASSERT_OK(bounded_table.NewScan().CreateRecordBatchLogScanner(bounded_scanner));
+
+        std::vector<fluss::PartitionBucketSubscription> subscriptions;
+        std::vector<fluss::ReaderStopOffset> stopping_offsets;
+        for (const auto& pi : partition_infos) {
+            subscriptions.push_back({pi.partition_id, 0, 1});
+            stopping_offsets.push_back(
+                {fluss::TableBucket{bounded_table.GetTableInfo().table_id, 0, pi.partition_id}, 3});
+        }
+        ASSERT_OK(bounded_scanner.SubscribePartitionBuckets(subscriptions));
+
+        fluss::RecordBatchLogReader reader;
+        ASSERT_OK(bounded_scanner.CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, reader));
+
+        fluss::ArrowRecordBatches batches;
+        ASSERT_OK(reader.CollectAllBatches(batches));
+
+        std::vector<int32_t> ids;
+        for (const auto& bounded_batch : batches) {
+            auto id_array = std::static_pointer_cast<arrow::Int32Array>(
+                bounded_batch->GetArrowRecordBatch()->column(0));
+            for (int64_t row = 0; row < id_array->length(); ++row) {
+                ids.push_back(id_array->Value(row));
+            }
+        }
+        std::sort(ids.begin(), ids.end());
+        EXPECT_EQ(ids, std::vector<int32_t>({2, 4, 5, 7}));
+    }
 
     // Test unsubscribe_partition: unsubscribe EU, should only get US data
     {

--- a/fluss-rust/bindings/cpp/test/test_log_table.cpp
+++ b/fluss-rust/bindings/cpp/test/test_log_table.cpp
@@ -209,9 +209,6 @@ TEST_F(LogTableTest, RecordBatchLogReaderUntilOffsets) {
     ASSERT_OK(append_writer.AppendArrowBatch(batch));
     ASSERT_OK(append_writer.Flush());
 
-    fluss::LogScanner scanner;
-    ASSERT_OK(table.NewScan().CreateRecordBatchLogScanner(scanner));
-
     const int64_t table_id = table.GetTableInfo().table_id;
     std::vector<int32_t> bucket_ids;
     for (int32_t bucket_id = 0; bucket_id < kNumBuckets; ++bucket_id) {
@@ -222,61 +219,63 @@ TEST_F(LogTableTest, RecordBatchLogReaderUntilOffsets) {
     ASSERT_OK(adm.ListOffsets(table_path, bucket_ids, fluss::OffsetSpec::Latest(), latest_offsets));
     ASSERT_EQ(latest_offsets.size(), bucket_ids.size());
 
-    std::vector<fluss::ReaderStopOffset> stopping_offsets;
+    std::vector<fluss::RecordBatchLogReadRange> ranges;
     std::vector<int64_t> expected_rows_by_bucket(kNumBuckets);
     for (int32_t bucket_id : bucket_ids) {
         const int64_t stopping_offset = latest_offsets.at(bucket_id);
         ASSERT_GT(stopping_offset, 1)
             << "Bucket " << bucket_id << " should contain rows after starting offset 1";
-        ASSERT_OK(scanner.Subscribe(bucket_id, 1));
-        stopping_offsets.push_back({fluss::TableBucket{table_id, bucket_id}, stopping_offset});
+        ranges.push_back({fluss::TableBucket{table_id, bucket_id}, 1, stopping_offset});
         expected_rows_by_bucket[bucket_id] = stopping_offset - 1;
     }
 
     fluss::RecordBatchLogReader reader;
-    ASSERT_OK(scanner.CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, reader));
-
-    fluss::ArrowRecordBatches batches;
-    ASSERT_OK(reader.CollectAllBatches(batches));
+    ASSERT_OK(table.NewScan().CreateRecordBatchLogReader(ranges, reader));
 
     std::vector<int64_t> actual_rows_by_bucket(kNumBuckets);
-    for (const auto& bounded_batch : batches) {
-        const int32_t bucket_id = bounded_batch->GetBucketId();
+    int timeout_count = 0;
+    while (true) {
+        fluss::RecordBatchReadResult result;
+        ASSERT_OK(reader.NextBatch(1000, result));
+        if (result.status == fluss::BoundedReadStatus::TimedOut) {
+            ASSERT_LT(++timeout_count, 10);
+            continue;
+        }
+        if (result.status == fluss::BoundedReadStatus::Finished) {
+            break;
+        }
+
+        ASSERT_NE(result.batch, nullptr);
+        const int32_t bucket_id = result.batch->GetBucketId();
         ASSERT_GE(bucket_id, 0);
         ASSERT_LT(bucket_id, kNumBuckets);
-        EXPECT_GE(bounded_batch->GetBaseOffset(), 1);
-        EXPECT_LT(bounded_batch->GetLastOffset(), latest_offsets.at(bucket_id));
-        actual_rows_by_bucket[bucket_id] += bounded_batch->NumRows();
+        EXPECT_GE(result.batch->GetBaseOffset(), 1);
+        EXPECT_LT(result.batch->GetLastOffset(), latest_offsets.at(bucket_id));
+        actual_rows_by_bucket[bucket_id] += result.batch->NumRows();
     }
     for (int32_t bucket_id : bucket_ids) {
         EXPECT_EQ(actual_rows_by_bucket[bucket_id], expected_rows_by_bucket[bucket_id])
             << "Unexpected row count for bucket " << bucket_id;
     }
 
-    fluss::ArrowRecordBatches eof_batches;
-    fluss::BoundedReadStatus eof_status = fluss::BoundedReadStatus::BatchAvailable;
-    ASSERT_OK(reader.NextBatch(1000, eof_batches, eof_status));
-    EXPECT_TRUE(eof_batches.Empty());
-    EXPECT_EQ(eof_status, fluss::BoundedReadStatus::Finished);
+    fluss::RecordBatchReadResult eof_result;
+    ASSERT_OK(reader.NextBatch(1000, eof_result));
+    EXPECT_EQ(eof_result.batch, nullptr);
+    EXPECT_EQ(eof_result.status, fluss::BoundedReadStatus::Finished);
 
     // A bounded reader whose stopping offset is not available yet should return
     // TimedOut without becoming exhausted, so query engines can check cancellation
     // and retry.
     {
-        fluss::LogScanner waiting_scanner;
-        ASSERT_OK(table.NewScan().CreateRecordBatchLogScanner(waiting_scanner));
         const int64_t start_offset = latest_offsets.at(0);
-        ASSERT_OK(waiting_scanner.Subscribe(0, start_offset));
-
         fluss::RecordBatchLogReader waiting_reader;
-        ASSERT_OK(waiting_scanner.CreateRecordBatchLogReaderUntilOffsets(
-            {{fluss::TableBucket{table_id, 0}, start_offset + 1}}, waiting_reader));
+        ASSERT_OK(table.NewScan().CreateRecordBatchLogReader(
+            {{fluss::TableBucket{table_id, 0}, start_offset, start_offset + 1}}, waiting_reader));
 
-        fluss::ArrowRecordBatches timeout_batches;
-        fluss::BoundedReadStatus timeout_status = fluss::BoundedReadStatus::Finished;
-        ASSERT_OK(waiting_reader.NextBatch(100, timeout_batches, timeout_status));
-        EXPECT_TRUE(timeout_batches.Empty());
-        EXPECT_EQ(timeout_status, fluss::BoundedReadStatus::TimedOut);
+        fluss::RecordBatchReadResult timeout_result;
+        ASSERT_OK(waiting_reader.NextBatch(100, timeout_result));
+        EXPECT_EQ(timeout_result.batch, nullptr);
+        EXPECT_EQ(timeout_result.status, fluss::BoundedReadStatus::TimedOut);
     }
 
     ASSERT_OK(adm.DropTable(table_path, false));
@@ -309,29 +308,96 @@ TEST_F(LogTableTest, RecordBatchLogReaderUntilLatest) {
     ASSERT_OK(append_writer.AppendArrowBatch(batch));
     ASSERT_OK(append_writer.Flush());
 
-    fluss::LogScanner scanner;
+    fluss::RecordBatchLogScanner scanner;
     ASSERT_OK(table.NewScan().CreateRecordBatchLogScanner(scanner));
     ASSERT_OK(scanner.Subscribe(0, 0));
 
     fluss::RecordBatchLogReader reader;
-    ASSERT_OK(scanner.CreateRecordBatchLogReaderUntilLatest(adm, reader));
+    ASSERT_OK(std::move(scanner).CreateRecordBatchLogReaderUntilLatest(adm, reader));
+    EXPECT_FALSE(scanner.Available());
 
-    fluss::ArrowRecordBatches batches;
-    fluss::BoundedReadStatus status = fluss::BoundedReadStatus::TimedOut;
-    ASSERT_OK(reader.NextBatch(5000, batches, status));
-    ASSERT_EQ(status, fluss::BoundedReadStatus::BatchAvailable);
-    ASSERT_EQ(batches.Size(), 1);
-    auto ids =
-        std::static_pointer_cast<arrow::Int32Array>(batches[0]->GetArrowRecordBatch()->column(0));
+    fluss::RecordBatchReadResult read_result;
+    ASSERT_OK(reader.NextBatch(5000, read_result));
+    ASSERT_EQ(read_result.status, fluss::BoundedReadStatus::BatchAvailable);
+    ASSERT_NE(read_result.batch, nullptr);
+    auto ids = std::static_pointer_cast<arrow::Int32Array>(
+        read_result.batch->GetArrowRecordBatch()->column(0));
     ASSERT_EQ(ids->length(), 3);
     EXPECT_EQ(ids->Value(0), 1);
     EXPECT_EQ(ids->Value(1), 2);
     EXPECT_EQ(ids->Value(2), 3);
 
-    fluss::ArrowRecordBatches eof_batches;
-    ASSERT_OK(reader.NextBatch(1000, eof_batches, status));
-    EXPECT_TRUE(eof_batches.Empty());
-    EXPECT_EQ(status, fluss::BoundedReadStatus::Finished);
+    fluss::RecordBatchReadResult eof_result;
+    ASSERT_OK(reader.NextBatch(1000, eof_result));
+    EXPECT_EQ(eof_result.batch, nullptr);
+    EXPECT_EQ(eof_result.status, fluss::BoundedReadStatus::Finished);
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}
+
+TEST_F(LogTableTest, RecordBatchLogReaderTimestampRange) {
+    auto& adm = admin();
+    auto& conn = connection();
+
+    fluss::TablePath table_path("fluss", "test_record_batch_log_reader_timestamp_cpp");
+    auto schema = fluss::Schema::NewBuilder().AddColumn("c1", DataType::Int()).Build();
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetBucketCount(1)
+                                .SetBucketKeys({"c1"})
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+    fluss::AppendWriter writer;
+    ASSERT_OK(table.NewAppend().CreateWriter(writer));
+
+    const auto starting_timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                           std::chrono::system_clock::now().time_since_epoch())
+                                           .count();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    auto c1 = arrow::Int32Builder();
+    ASSERT_TRUE(c1.AppendValues({1, 2, 3}).ok());
+    auto batch = arrow::RecordBatch::Make(arrow::schema({arrow::field("c1", arrow::int32())}), 3,
+                                          {c1.Finish().ValueOrDie()});
+    ASSERT_OK(writer.AppendArrowBatch(batch));
+    ASSERT_OK(writer.Flush());
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    const auto stopping_timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                           std::chrono::system_clock::now().time_since_epoch())
+                                           .count();
+
+    const auto info = table.GetTableInfo();
+    fluss::RecordBatchLogReader timestamp_reader;
+    ASSERT_OK(table.NewScan().CreateRecordBatchLogReader(
+        adm, {fluss::TableBucket{info.table_id, 0}},
+        fluss::TimestampRange{starting_timestamp_ms, stopping_timestamp_ms}, timestamp_reader));
+
+    std::vector<int32_t> ids;
+    int timeout_count = 0;
+    while (true) {
+        fluss::RecordBatchReadResult result;
+        ASSERT_OK(timestamp_reader.NextBatch(1000, result));
+        if (result.status == fluss::BoundedReadStatus::TimedOut) {
+            ASSERT_LT(++timeout_count, 10);
+            continue;
+        }
+        if (result.status == fluss::BoundedReadStatus::Finished) {
+            break;
+        }
+
+        ASSERT_NE(result.batch, nullptr);
+        auto id_array = std::static_pointer_cast<arrow::Int32Array>(
+            result.batch->GetArrowRecordBatch()->column(0));
+        for (int64_t i = 0; i < id_array->length(); ++i) {
+            ids.push_back(id_array->Value(i));
+        }
+    }
+    EXPECT_EQ(ids, std::vector<int32_t>({1, 2, 3}));
 
     ASSERT_OK(adm.DropTable(table_path, false));
 }
@@ -1053,6 +1119,11 @@ TEST_F(LogTableTest, PartitionedTableAppendScan) {
     fluss::AppendWriter append_writer;
     ASSERT_OK(table_append.CreateWriter(append_writer));
 
+    const auto starting_timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                           std::chrono::system_clock::now().time_since_epoch())
+                                           .count();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
     // Append rows
     struct TestData {
         int32_t id;
@@ -1110,6 +1181,11 @@ TEST_F(LogTableTest, PartitionedTableAppendScan) {
     }
     ASSERT_OK(append_writer.Flush());
 
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    const auto stopping_timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                           std::chrono::system_clock::now().time_since_epoch())
+                                           .count();
+
     // Test list partition offsets
     std::unordered_map<int32_t, int64_t> us_offsets;
     ASSERT_OK(adm.ListPartitionOffsets(table_path, "US", {0}, fluss::OffsetSpec::Latest(),
@@ -1155,20 +1231,15 @@ TEST_F(LogTableTest, PartitionedTableAppendScan) {
     {
         fluss::Table bounded_table;
         ASSERT_OK(conn.GetTable(table_path, bounded_table));
-        fluss::LogScanner bounded_scanner;
-        ASSERT_OK(bounded_table.NewScan().CreateRecordBatchLogScanner(bounded_scanner));
-
-        std::vector<fluss::PartitionBucketSubscription> subscriptions;
-        std::vector<fluss::ReaderStopOffset> stopping_offsets;
+        std::vector<fluss::RecordBatchLogReadRange> ranges;
         for (const auto& pi : partition_infos) {
-            subscriptions.push_back({pi.partition_id, 0, 1});
-            stopping_offsets.push_back(
-                {fluss::TableBucket{bounded_table.GetTableInfo().table_id, 0, pi.partition_id}, 3});
+            ranges.push_back(
+                {fluss::TableBucket{bounded_table.GetTableInfo().table_id, 0, pi.partition_id}, 1,
+                 3});
         }
-        ASSERT_OK(bounded_scanner.SubscribePartitionBuckets(subscriptions));
 
         fluss::RecordBatchLogReader reader;
-        ASSERT_OK(bounded_scanner.CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, reader));
+        ASSERT_OK(bounded_table.NewScan().CreateRecordBatchLogReader(ranges, reader));
 
         fluss::ArrowRecordBatches batches;
         ASSERT_OK(reader.CollectAllBatches(batches));
@@ -1183,6 +1254,36 @@ TEST_F(LogTableTest, PartitionedTableAppendScan) {
         }
         std::sort(ids.begin(), ids.end());
         EXPECT_EQ(ids, std::vector<int32_t>({2, 4, 5, 7}));
+    }
+
+    // Test timestamp-bounded reading across partition buckets.
+    {
+        fluss::Table timestamp_table;
+        ASSERT_OK(conn.GetTable(table_path, timestamp_table));
+
+        std::vector<fluss::TableBucket> buckets;
+        for (const auto& pi : partition_infos) {
+            buckets.push_back({timestamp_table.GetTableInfo().table_id, 0, pi.partition_id});
+        }
+
+        fluss::RecordBatchLogReader reader;
+        ASSERT_OK(timestamp_table.NewScan().CreateRecordBatchLogReader(
+            adm, buckets, fluss::TimestampRange{starting_timestamp_ms, stopping_timestamp_ms},
+            reader));
+
+        fluss::ArrowRecordBatches batches;
+        ASSERT_OK(reader.CollectAllBatches(batches));
+
+        std::vector<int32_t> ids;
+        for (const auto& bounded_batch : batches) {
+            auto id_array = std::static_pointer_cast<arrow::Int32Array>(
+                bounded_batch->GetArrowRecordBatch()->column(0));
+            for (int64_t row = 0; row < id_array->length(); ++row) {
+                ids.push_back(id_array->Value(row));
+            }
+        }
+        std::sort(ids.begin(), ids.end());
+        EXPECT_EQ(ids, std::vector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8}));
     }
 
     // Test unsubscribe_partition: unsubscribe EU, should only get US data

--- a/fluss-rust/bindings/cpp/test/test_log_table.cpp
+++ b/fluss-rust/bindings/cpp/test/test_log_table.cpp
@@ -306,6 +306,17 @@ TEST_F(LogTableTest, RecordBatchLogReaderUntilOffsets) {
         EXPECT_EQ(result.batch, nullptr);
     }
 
+    // Completion takes precedence over timeout. An empty bounded range is
+    // already complete, so a zero budget must return Ok without polling.
+    {
+        fluss::RecordBatchLogReader complete_reader;
+        ASSERT_OK(table.NewScan().CreateRecordBatchLogReader({}, complete_reader));
+
+        fluss::ArrowRecordBatches complete;
+        ASSERT_OK(complete_reader.CollectAllBatches(0, complete));
+        EXPECT_TRUE(complete.Empty());
+    }
+
     // CollectAllBatches appends to the output instead of clearing batches that
     // the caller collected earlier.
     {

--- a/fluss-rust/bindings/cpp/test/test_log_table.cpp
+++ b/fluss-rust/bindings/cpp/test/test_log_table.cpp
@@ -178,6 +178,7 @@ TEST_F(LogTableTest, RecordBatchLogReaderUntilOffsets) {
     auto& conn = connection();
 
     constexpr int32_t kNumBuckets = 3;
+    constexpr int64_t kCollectAllTimeoutMs = 200;
     fluss::TablePath table_path("fluss", "test_record_batch_log_reader_offsets_cpp");
     auto schema = fluss::Schema::NewBuilder()
                       .AddColumn("c1", DataType::Int())
@@ -277,11 +278,11 @@ TEST_F(LogTableTest, RecordBatchLogReaderUntilOffsets) {
         EXPECT_EQ(timeout_result.batch, nullptr);
         EXPECT_EQ(timeout_result.status, fluss::BoundedReadStatus::TimedOut);
 
-        // CollectAllBatches must honour its budget instead of blocking until the
-        // stopping offset becomes reachable, which may never happen (e.g. a
-        // tablet server outage).
+        // The stopping offset cannot be reached without another append.
+        // CollectAllBatches must return when its timeout budget expires.
         fluss::ArrowRecordBatches partial;
-        auto collect_result = waiting_reader.CollectAllBatches(200, partial);
+        auto collect_result =
+            waiting_reader.CollectAllBatches(kCollectAllTimeoutMs, partial);
         EXPECT_FALSE(collect_result.Ok());
         EXPECT_EQ(collect_result.error_code, fluss::ErrorCode::REQUEST_TIME_OUT);
         EXPECT_TRUE(collect_result.IsRetriable());

--- a/fluss-rust/bindings/cpp/test/test_log_table.cpp
+++ b/fluss-rust/bindings/cpp/test/test_log_table.cpp
@@ -178,6 +178,8 @@ TEST_F(LogTableTest, RecordBatchLogReaderUntilOffsets) {
     auto& conn = connection();
 
     constexpr int32_t kNumBuckets = 3;
+    // The stopping offset below is deliberately unreachable, so this only
+    // controls how quickly the timeout path is exercised.
     constexpr int64_t kCollectAllTimeoutMs = 200;
     fluss::TablePath table_path("fluss", "test_record_batch_log_reader_offsets_cpp");
     auto schema = fluss::Schema::NewBuilder()
@@ -304,8 +306,8 @@ TEST_F(LogTableTest, RecordBatchLogReaderUntilOffsets) {
         EXPECT_EQ(result.batch, nullptr);
     }
 
-    // CollectAllBatches appends to the output, preserving previously collected
-    // batches when a caller resumes after a timeout.
+    // CollectAllBatches appends to the output instead of clearing batches that
+    // the caller collected earlier.
     {
         const std::vector<fluss::RecordBatchLogReadRange> bucket_range = {
             {fluss::TableBucket{table_id, 0}, 1, latest_offsets.at(0)}};

--- a/fluss-rust/crates/fluss/src/client/table/mod.rs
+++ b/fluss-rust/crates/fluss/src/client/table/mod.rs
@@ -39,7 +39,7 @@ mod upsert;
 pub use append::{AppendWriter, TableAppend};
 pub use batch_scanner::LimitBatchScanner;
 pub use lookup::{LookupResult, Lookuper, PrefixKeyLookuper, TableLookup, TablePrefixLookup};
-pub use reader::{RecordBatchLogReader, SyncRecordBatchLogReader};
+pub use reader::{RecordBatchLogReader, RecordBatchReadOutcome, SyncRecordBatchLogReader};
 pub use remote_log::{
     DEFAULT_REMOTE_FILE_DOWNLOAD_THREAD_NUM, DEFAULT_SCANNER_REMOTE_LOG_PREFETCH_NUM,
 };

--- a/fluss-rust/crates/fluss/src/client/table/mod.rs
+++ b/fluss-rust/crates/fluss/src/client/table/mod.rs
@@ -39,7 +39,10 @@ mod upsert;
 pub use append::{AppendWriter, TableAppend};
 pub use batch_scanner::LimitBatchScanner;
 pub use lookup::{LookupResult, Lookuper, PrefixKeyLookuper, TableLookup, TablePrefixLookup};
-pub use reader::{RecordBatchLogReader, RecordBatchReadOutcome, SyncRecordBatchLogReader};
+pub use reader::{
+    BoundedCollectOutcome, BoundedLogReadRange, RecordBatchLogReader, RecordBatchReadOutcome,
+    SyncRecordBatchLogReader,
+};
 pub use remote_log::{
     DEFAULT_REMOTE_FILE_DOWNLOAD_THREAD_NUM, DEFAULT_SCANNER_REMOTE_LOG_PREFETCH_NUM,
 };

--- a/fluss-rust/crates/fluss/src/client/table/reader.rs
+++ b/fluss-rust/crates/fluss/src/client/table/reader.rs
@@ -33,14 +33,15 @@
 use crate::client::admin::FlussAdmin;
 use crate::client::table::RecordBatchLogScanner;
 use crate::error::{Error, Result};
-use crate::metadata::TableBucket;
+use crate::metadata::{TableBucket, TablePath};
 use crate::record::ScanBatch;
 use crate::rpc::message::OffsetSpec;
+use crate::{PartitionId, TableId};
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
 use futures::Stream;
 use log::warn;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
 const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_millis(500);
@@ -56,6 +57,34 @@ pub enum RecordBatchReadOutcome {
     Finished,
 }
 
+/// A `[starting_offset, stopping_offset)` read range for a single bucket.
+///
+/// Query engines that already know the offsets to read describe the whole scan
+/// as a list of these ranges and hand it to
+/// [`RecordBatchLogReader::new_from_ranges`], which subscribes the buckets and
+/// installs the stopping offsets in one step.
+#[derive(Debug, Clone)]
+pub struct BoundedLogReadRange {
+    /// Bucket to read. Its partition mode must match the scanned table.
+    pub bucket: TableBucket,
+    /// First offset to read, inclusive.
+    pub starting_offset: i64,
+    /// Offset to stop at, exclusive. Must not be below `starting_offset`;
+    /// an equal value is an empty range that completes immediately.
+    pub stopping_offset: i64,
+}
+
+/// Outcome of draining a bounded reader under a total time budget.
+#[derive(Debug)]
+pub struct BoundedCollectOutcome {
+    /// Complete batches collected before the budget was exhausted.
+    pub batches: Vec<ScanBatch>,
+    /// `true` when every stopping offset was reached, so `batches` holds the
+    /// whole bounded result. `false` when the budget expired first and
+    /// `batches` is a partial result.
+    pub complete: bool,
+}
+
 /// Bounded log reader that consumes log data up to specified stopping offsets.
 ///
 /// This type wraps a [`RecordBatchLogScanner`] and adds stopping semantics:
@@ -68,8 +97,11 @@ pub enum RecordBatchReadOutcome {
 /// # Construction
 ///
 /// Use [`RecordBatchLogReader::new_until_latest`] for the common case of
-/// reading all currently-available data, or [`RecordBatchLogReader::new_until_offsets`]
-/// for custom stopping offsets.
+/// reading all currently-available data, [`RecordBatchLogReader::new_from_ranges`]
+/// or [`RecordBatchLogReader::new_between_timestamps`] to describe the whole
+/// scan (starting offsets included) up front, or
+/// [`RecordBatchLogReader::new_until_offsets`] to bound a scanner that is
+/// already subscribed.
 ///
 /// # Async iteration
 ///
@@ -165,9 +197,154 @@ impl RecordBatchLogReader {
         })
     }
 
+    /// Create a reader from explicit `[starting_offset, stopping_offset)`
+    /// ranges, subscribing every non-empty range on the way.
+    ///
+    /// This is the entry point for callers that already know the offsets to
+    /// read (query engines planning a bounded scan, bindings receiving ranges
+    /// from a foreign language). Ranges are validated against the scanned
+    /// table before anything is subscribed: every bucket must belong to the
+    /// table, match its partition mode, appear once, and have
+    /// `starting_offset <= stopping_offset`. Empty ranges need no subscription
+    /// and complete immediately.
+    pub async fn new_from_ranges(
+        scanner: RecordBatchLogScanner,
+        ranges: Vec<BoundedLogReadRange>,
+    ) -> Result<Self> {
+        validate_read_ranges(scanner.table_id(), scanner.is_partitioned(), &ranges)?;
+
+        let mut stopping_offsets = HashMap::with_capacity(ranges.len());
+        let mut bucket_offsets: HashMap<i32, i64> = HashMap::new();
+        let mut partition_bucket_offsets: HashMap<(PartitionId, i32), i64> = HashMap::new();
+        for range in ranges {
+            if range.starting_offset == range.stopping_offset {
+                continue;
+            }
+            match range.bucket.partition_id() {
+                Some(partition_id) => {
+                    partition_bucket_offsets.insert(
+                        (partition_id, range.bucket.bucket_id()),
+                        range.starting_offset,
+                    );
+                }
+                None => {
+                    bucket_offsets.insert(range.bucket.bucket_id(), range.starting_offset);
+                }
+            }
+            stopping_offsets.insert(range.bucket, range.stopping_offset);
+        }
+
+        if !bucket_offsets.is_empty() {
+            scanner.subscribe_buckets(&bucket_offsets).await?;
+        }
+        if !partition_bucket_offsets.is_empty() {
+            scanner
+                .subscribe_partition_buckets(&partition_bucket_offsets)
+                .await?;
+        }
+
+        Self::new_until_offsets(scanner, stopping_offsets)
+    }
+
+    /// Create a reader for a `[starting_timestamp_ms, stopping_timestamp_ms]`
+    /// window over the requested buckets.
+    ///
+    /// Both timestamps are resolved to offsets per bucket, then read with
+    /// `[starting_offset, stopping_offset)` semantics. Partition metadata and
+    /// offsets are queried once during construction.
+    pub async fn new_between_timestamps(
+        scanner: RecordBatchLogScanner,
+        admin: &FlussAdmin,
+        buckets: &[TableBucket],
+        starting_timestamp_ms: i64,
+        stopping_timestamp_ms: i64,
+    ) -> Result<Self> {
+        if starting_timestamp_ms > stopping_timestamp_ms {
+            return Err(Error::IllegalArgument {
+                message: "starting_timestamp_ms must not exceed stopping_timestamp_ms.".to_string(),
+            });
+        }
+
+        validate_read_buckets(scanner.table_id(), scanner.is_partitioned(), buckets)?;
+        if buckets.is_empty() {
+            // Nothing to resolve, so skip the offset lookups entirely.
+            return Self::new_from_ranges(scanner, Vec::new()).await;
+        }
+
+        let resolver = OffsetResolver::new(admin, &scanner).await?;
+        let starting_offsets = resolver
+            .resolve(buckets, OffsetSpec::Timestamp(starting_timestamp_ms))
+            .await?;
+        let stopping_offsets = resolver
+            .resolve(buckets, OffsetSpec::Timestamp(stopping_timestamp_ms))
+            .await?;
+
+        let mut ranges = Vec::with_capacity(buckets.len());
+        for bucket in buckets {
+            let (Some(&starting_offset), Some(&stopping_offset)) =
+                (starting_offsets.get(bucket), stopping_offsets.get(bucket))
+            else {
+                return Err(Error::UnexpectedError {
+                    message: format!(
+                        "Timestamp offset lookup did not return an offset for {bucket:?}."
+                    ),
+                    source: None,
+                });
+            };
+            ranges.push(BoundedLogReadRange {
+                bucket: bucket.clone(),
+                starting_offset,
+                stopping_offset,
+            });
+        }
+
+        Self::new_from_ranges(scanner, ranges).await
+    }
+
     /// Returns the Arrow schema for batches produced by this reader.
     pub fn schema(&self) -> SchemaRef {
         self.schema.clone()
+    }
+
+    /// Drain all remaining batches, waiting at most `timeout` for the whole
+    /// operation.
+    ///
+    /// The timeout is a budget for this call rather than a per-poll timeout, so
+    /// a stalled bucket cannot keep the caller blocked forever. It is checked
+    /// between complete batches and never splits a batch. When the budget
+    /// expires first, the batches collected so far are returned with
+    /// [`BoundedCollectOutcome::complete`] set to `false`; the reader stays
+    /// valid, so resuming is an explicit caller policy.
+    pub async fn collect_all_batches_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<BoundedCollectOutcome> {
+        let start = Instant::now();
+        let mut batches = Vec::new();
+        loop {
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
+                return Ok(BoundedCollectOutcome {
+                    batches,
+                    complete: false,
+                });
+            }
+            match self.next_batch_with_timeout(timeout - elapsed).await? {
+                RecordBatchReadOutcome::Batch(batch) => batches.push(batch),
+                RecordBatchReadOutcome::TimedOut => {
+                    return Ok(BoundedCollectOutcome {
+                        batches,
+                        complete: false,
+                    });
+                }
+                RecordBatchReadOutcome::Finished => {
+                    return Ok(BoundedCollectOutcome {
+                        batches,
+                        complete: true,
+                    });
+                }
+            }
+        }
     }
 
     /// Drain all remaining batches until stopping offsets are satisfied.
@@ -366,6 +543,65 @@ impl arrow::record_batch::RecordBatchReader for SyncRecordBatchLogReader {
     }
 }
 
+/// Validate that every bucket in a bounded read belongs to the scanned table
+/// and appears exactly once.
+fn validate_read_buckets<'a>(
+    table_id: TableId,
+    is_partitioned: bool,
+    buckets: impl IntoIterator<Item = &'a TableBucket>,
+) -> Result<()> {
+    let mut seen = HashSet::new();
+    for bucket in buckets {
+        if bucket.table_id() != table_id {
+            return Err(Error::IllegalArgument {
+                message: format!("Bounded read bucket {bucket:?} is not part of table {table_id}."),
+            });
+        }
+        if bucket.partition_id().is_some() != is_partitioned {
+            return Err(Error::IllegalArgument {
+                message: if is_partitioned {
+                    format!("Bounded read bucket {bucket:?} is missing a partition id.")
+                } else {
+                    format!(
+                        "Bounded read bucket {bucket:?} carries a partition id for a non-partitioned table."
+                    )
+                },
+            });
+        }
+        if !seen.insert(bucket) {
+            return Err(Error::IllegalArgument {
+                message: format!("Duplicate bucket {bucket:?} in a bounded read."),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Validate read ranges against the scanned table before any subscription
+/// happens.
+fn validate_read_ranges(
+    table_id: TableId,
+    is_partitioned: bool,
+    ranges: &[BoundedLogReadRange],
+) -> Result<()> {
+    validate_read_buckets(
+        table_id,
+        is_partitioned,
+        ranges.iter().map(|range| &range.bucket),
+    )?;
+    for range in ranges {
+        if range.starting_offset > range.stopping_offset {
+            return Err(Error::IllegalArgument {
+                message: format!(
+                    "Read range for {:?} has starting offset {} above stopping offset {}.",
+                    range.bucket, range.starting_offset, range.stopping_offset
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn validate_stopping_offsets(
     subscriptions: Vec<(TableBucket, i64)>,
     stopping_offsets: &mut HashMap<TableBucket, i64>,
@@ -394,6 +630,97 @@ fn validate_stopping_offsets(
     Ok(())
 }
 
+/// Resolves an [`OffsetSpec`] into per-bucket offsets, hiding the partitioned
+/// and non-partitioned lookup paths from callers.
+///
+/// Partition metadata is fetched once per resolver, so a construction that
+/// resolves several specs (a timestamp range resolves two) still issues a
+/// single `list_partition_infos` call. The resolver is not cached across
+/// readers since each [`RecordBatchLogReader`] is typically short-lived.
+struct OffsetResolver<'a> {
+    admin: &'a FlussAdmin,
+    table_path: &'a TablePath,
+    table_id: TableId,
+    /// Partition names by id, or `None` for a non-partitioned table.
+    partition_names: Option<HashMap<PartitionId, String>>,
+}
+
+impl<'a> OffsetResolver<'a> {
+    async fn new(admin: &'a FlussAdmin, scanner: &'a RecordBatchLogScanner) -> Result<Self> {
+        let partition_names = if scanner.is_partitioned() {
+            let partition_infos = admin.list_partition_infos(scanner.table_path()).await?;
+            Some(
+                partition_infos
+                    .into_iter()
+                    .map(|info| (info.get_partition_id(), info.get_partition_name()))
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
+        Ok(Self {
+            admin,
+            table_path: scanner.table_path(),
+            table_id: scanner.table_id(),
+            partition_names,
+        })
+    }
+
+    /// Resolve `spec` for `buckets`. Buckets the server does not report are
+    /// absent from the result.
+    async fn resolve(
+        &self,
+        buckets: &[TableBucket],
+        spec: OffsetSpec,
+    ) -> Result<HashMap<TableBucket, i64>> {
+        let Some(partition_names) = self.partition_names.as_ref() else {
+            let bucket_ids: Vec<i32> = buckets.iter().map(|tb| tb.bucket_id()).collect();
+            let offsets = self
+                .admin
+                .list_offsets(self.table_path, &bucket_ids, spec)
+                .await?;
+            return Ok(offsets
+                .into_iter()
+                .map(|(bucket_id, offset)| (TableBucket::new(self.table_id, bucket_id), offset))
+                .collect());
+        };
+
+        let mut bucket_ids_by_partition: HashMap<PartitionId, Vec<i32>> = HashMap::new();
+        for bucket in buckets {
+            if let Some(partition_id) = bucket.partition_id() {
+                bucket_ids_by_partition
+                    .entry(partition_id)
+                    .or_default()
+                    .push(bucket.bucket_id());
+            }
+        }
+
+        let mut resolved: HashMap<TableBucket, i64> = HashMap::new();
+        for (partition_id, bucket_ids) in bucket_ids_by_partition {
+            let partition_name =
+                partition_names
+                    .get(&partition_id)
+                    .ok_or_else(|| Error::UnexpectedError {
+                        message: format!("Unknown partition_id: {partition_id}"),
+                        source: None,
+                    })?;
+
+            let offsets = self
+                .admin
+                .list_partition_offsets(self.table_path, partition_name, &bucket_ids, spec.clone())
+                .await?;
+            for (bucket_id, offset) in offsets {
+                let bucket =
+                    TableBucket::new_with_partition(self.table_id, Some(partition_id), bucket_id);
+                resolved.insert(bucket, offset);
+            }
+        }
+
+        Ok(resolved)
+    }
+}
+
 /// Query latest offsets for all subscribed buckets, handling both partitioned
 /// and non-partitioned tables.
 ///
@@ -407,112 +734,33 @@ async fn query_latest_offsets(
     scanner: &RecordBatchLogScanner,
     subscribed: &[(TableBucket, i64)],
 ) -> Result<HashMap<TableBucket, i64>> {
-    let table_path = scanner.table_path();
-
-    if !scanner.is_partitioned() {
-        let bucket_ids: Vec<i32> = subscribed.iter().map(|(tb, _)| tb.bucket_id()).collect();
-
-        let offsets = admin
-            .list_offsets(table_path, &bucket_ids, OffsetSpec::Latest)
-            .await?;
-
-        let subscribed_offset_by_bucket: HashMap<i32, i64> = subscribed
-            .iter()
-            .map(|(tb, off)| (tb.bucket_id(), *off))
-            .collect();
-
-        let table_id = scanner.table_id();
-        Ok(offsets
-            .into_iter()
-            .filter(|(bucket_id, latest_offset)| {
-                if *latest_offset < 0 {
-                    warn!(
-                        "Server returned negative latest offset {latest_offset} for bucket {bucket_id} of table {table_id}; skipping bucket."
-                    );
-                    return false;
-                }
-                if *latest_offset == 0 {
-                    return false;
-                }
-                let Some(&subscribed_offset) = subscribed_offset_by_bucket.get(bucket_id)
-                else {
-                    return false;
-                };
-                subscribed_offset < *latest_offset
-            })
-            .map(|(bucket_id, offset)| (TableBucket::new(table_id, bucket_id), offset))
-            .collect())
-    } else {
-        query_partitioned_offsets(admin, scanner, subscribed).await
-    }
-}
-
-/// Query offsets for partitioned table subscriptions.
-///
-/// Partition metadata is fetched once per reader construction (not cached),
-/// since each [`RecordBatchLogReader`] is typically short-lived and consumed.
-async fn query_partitioned_offsets(
-    admin: &FlussAdmin,
-    scanner: &RecordBatchLogScanner,
-    subscribed: &[(TableBucket, i64)],
-) -> Result<HashMap<TableBucket, i64>> {
-    let table_path = scanner.table_path();
     let table_id = scanner.table_id();
+    let buckets: Vec<TableBucket> = subscribed.iter().map(|(tb, _)| tb.clone()).collect();
+    let latest_offsets = OffsetResolver::new(admin, scanner)
+        .await?
+        .resolve(&buckets, OffsetSpec::Latest)
+        .await?;
 
-    let partition_infos = admin.list_partition_infos(table_path).await?;
-    let partition_id_to_name: HashMap<i64, String> = partition_infos
-        .into_iter()
-        .map(|info| (info.get_partition_id(), info.get_partition_name()))
-        .collect();
-
-    let subscribed_offset_map: HashMap<TableBucket, i64> = subscribed.iter().cloned().collect();
-
-    let mut by_partition: HashMap<i64, Vec<i32>> = HashMap::new();
-    for (tb, _) in subscribed {
-        if let Some(partition_id) = tb.partition_id() {
-            by_partition
-                .entry(partition_id)
-                .or_default()
-                .push(tb.bucket_id());
+    let mut stopping_offsets = HashMap::with_capacity(latest_offsets.len());
+    for (bucket, subscribed_offset) in subscribed {
+        let Some(&latest_offset) = latest_offsets.get(bucket) else {
+            continue;
+        };
+        if latest_offset < 0 {
+            warn!(
+                "Server returned negative latest offset {latest_offset} for {bucket:?} of table {table_id}; skipping bucket."
+            );
+            continue;
+        }
+        if latest_offset == 0 {
+            continue;
+        }
+        if *subscribed_offset < latest_offset {
+            stopping_offsets.insert(bucket.clone(), latest_offset);
         }
     }
 
-    let mut result: HashMap<TableBucket, i64> = HashMap::new();
-
-    for (partition_id, bucket_ids) in by_partition {
-        let partition_name =
-            partition_id_to_name
-                .get(&partition_id)
-                .ok_or_else(|| Error::UnexpectedError {
-                    message: format!("Unknown partition_id: {partition_id}"),
-                    source: None,
-                })?;
-
-        let offsets = admin
-            .list_partition_offsets(table_path, partition_name, &bucket_ids, OffsetSpec::Latest)
-            .await?;
-
-        for (bucket_id, latest_offset) in offsets {
-            if latest_offset < 0 {
-                warn!(
-                    "Server returned negative latest offset {latest_offset} for bucket {bucket_id} of partition {partition_id} (table {table_id}); skipping bucket."
-                );
-                continue;
-            }
-            if latest_offset == 0 {
-                continue;
-            }
-            let tb = TableBucket::new_with_partition(table_id, Some(partition_id), bucket_id);
-            let Some(&subscribed_offset) = subscribed_offset_map.get(&tb) else {
-                continue;
-            };
-            if subscribed_offset < latest_offset {
-                result.insert(tb, latest_offset);
-            }
-        }
-    }
-
-    Ok(result)
+    Ok(stopping_offsets)
 }
 
 /// Filter and slice scan batches against per-bucket stopping offsets.
@@ -608,6 +856,67 @@ mod tests {
     fn validate_stopping_offsets_rejects_unsubscribed_bucket() {
         let mut offsets = HashMap::from([(bucket(1), 10)]);
         let result = validate_stopping_offsets(vec![(bucket(0), 0)], &mut offsets);
+
+        assert!(matches!(result, Err(Error::IllegalArgument { .. })));
+    }
+
+    fn range(
+        bucket: TableBucket,
+        starting_offset: i64,
+        stopping_offset: i64,
+    ) -> BoundedLogReadRange {
+        BoundedLogReadRange {
+            bucket,
+            starting_offset,
+            stopping_offset,
+        }
+    }
+
+    #[test]
+    fn validate_read_ranges_accepts_empty_and_non_empty_ranges() {
+        let ranges = vec![range(bucket(0), 5, 5), range(bucket(1), 0, 10)];
+
+        validate_read_ranges(1, false, &ranges).unwrap();
+    }
+
+    #[test]
+    fn validate_read_ranges_rejects_bucket_of_another_table() {
+        let ranges = vec![range(TableBucket::new(2, 0), 0, 10)];
+
+        let result = validate_read_ranges(1, false, &ranges);
+
+        assert!(matches!(result, Err(Error::IllegalArgument { .. })));
+    }
+
+    #[test]
+    fn validate_read_ranges_rejects_partition_mode_mismatch() {
+        let unpartitioned = vec![range(bucket(0), 0, 10)];
+        let partitioned = vec![range(TableBucket::new_with_partition(1, Some(7), 0), 0, 10)];
+
+        assert!(matches!(
+            validate_read_ranges(1, true, &unpartitioned),
+            Err(Error::IllegalArgument { .. })
+        ));
+        assert!(matches!(
+            validate_read_ranges(1, false, &partitioned),
+            Err(Error::IllegalArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_read_ranges_rejects_duplicate_bucket() {
+        let ranges = vec![range(bucket(0), 0, 10), range(bucket(0), 10, 20)];
+
+        let result = validate_read_ranges(1, false, &ranges);
+
+        assert!(matches!(result, Err(Error::IllegalArgument { .. })));
+    }
+
+    #[test]
+    fn validate_read_ranges_rejects_inverted_range() {
+        let ranges = vec![range(bucket(0), 20, 10)];
+
+        let result = validate_read_ranges(1, false, &ranges);
 
         assert!(matches!(result, Err(Error::IllegalArgument { .. })));
     }

--- a/fluss-rust/crates/fluss/src/client/table/reader.rs
+++ b/fluss-rust/crates/fluss/src/client/table/reader.rs
@@ -310,11 +310,12 @@ impl RecordBatchLogReader {
     /// operation.
     ///
     /// The timeout is a budget for this call rather than a per-poll timeout, so
-    /// a stalled bucket cannot keep the caller blocked forever. It is checked
-    /// between complete batches and never splits a batch. When the budget
-    /// expires first, the batches collected so far are returned with
-    /// [`BoundedCollectOutcome::complete`] set to `false`; the reader stays
-    /// valid, so resuming is an explicit caller policy.
+    /// a stalled bucket cannot keep the caller blocked forever. Once the budget
+    /// is exhausted, the reader no longer waits for scanner data, but it still
+    /// drains already-buffered batches and observes completion before reporting
+    /// a timeout. When unread work remains, the batches collected so far are
+    /// returned with [`BoundedCollectOutcome::complete`] set to `false`; the
+    /// reader stays valid, so resuming is an explicit caller policy.
     pub async fn collect_all_batches_with_timeout(
         &mut self,
         timeout: Duration,
@@ -322,14 +323,12 @@ impl RecordBatchLogReader {
         let start = Instant::now();
         let mut batches = Vec::new();
         loop {
-            let elapsed = start.elapsed();
-            if elapsed >= timeout {
-                return Ok(BoundedCollectOutcome {
-                    batches,
-                    complete: false,
-                });
-            }
-            match self.next_batch_with_timeout(timeout - elapsed).await? {
+            // next_batch_with_timeout checks buffered batches and completion
+            // before checking its timeout. Passing a zero remaining duration
+            // therefore stops network waiting without misreporting a complete
+            // result as timed out.
+            let remaining = timeout.saturating_sub(start.elapsed());
+            match self.next_batch_with_timeout(remaining).await? {
                 RecordBatchReadOutcome::Batch(batch) => batches.push(batch),
                 RecordBatchReadOutcome::TimedOut => {
                     return Ok(BoundedCollectOutcome {

--- a/fluss-rust/crates/fluss/src/client/table/reader.rs
+++ b/fluss-rust/crates/fluss/src/client/table/reader.rs
@@ -136,18 +136,26 @@ impl RecordBatchLogReader {
     /// Create a reader with explicit stopping offsets per bucket.
     ///
     /// # NOTE: Every key in `stopping_offsets` **must** correspond to a bucket that is
-    /// currently subscribed on the `scanner`. If a stopping offset refers to a
-    /// bucket that will never appear in polled batches, the reader will loop
-    /// indefinitely waiting for data that never arrives.
+    /// currently subscribed on the `scanner`; construction fails otherwise.
+    /// Concrete subscriptions that already meet their stop point are treated
+    /// as empty ranges and complete immediately.
     ///
     /// Use [`new_until_latest`](Self::new_until_latest) for the common case;
     /// it queries the server and builds a validated stopping-offset map
     /// automatically.
     pub fn new_until_offsets(
         scanner: RecordBatchLogScanner,
-        stopping_offsets: HashMap<TableBucket, i64>,
+        mut stopping_offsets: HashMap<TableBucket, i64>,
     ) -> Result<Self> {
         scanner.try_set_reader_active()?;
+
+        if let Err(error) =
+            validate_stopping_offsets(scanner.get_subscribed_buckets(), &mut stopping_offsets)
+        {
+            scanner.clear_reader_active();
+            return Err(error);
+        }
+
         let schema = scanner.schema();
         Ok(Self {
             scanner,
@@ -358,6 +366,34 @@ impl arrow::record_batch::RecordBatchReader for SyncRecordBatchLogReader {
     }
 }
 
+fn validate_stopping_offsets(
+    subscriptions: Vec<(TableBucket, i64)>,
+    stopping_offsets: &mut HashMap<TableBucket, i64>,
+) -> Result<()> {
+    let subscribed: HashMap<TableBucket, i64> = subscriptions.into_iter().collect();
+    for bucket in stopping_offsets.keys() {
+        if !subscribed.contains_key(bucket) {
+            return Err(Error::IllegalArgument {
+                message: format!(
+                    "Stopping offset for {bucket:?} has no matching scanner subscription."
+                ),
+            });
+        }
+    }
+
+    // A concrete subscription that already meets the stop point is an empty
+    // range. Remove it up front so the reader can finish without waiting for a
+    // server batch that may never arrive. Negative offsets are symbolic values
+    // such as EARLIEST_OFFSET and cannot be compared until the server resolves
+    // them.
+    stopping_offsets.retain(|bucket, stop| {
+        subscribed
+            .get(bucket)
+            .is_none_or(|start| *start < 0 || start < stop)
+    });
+    Ok(())
+}
+
 /// Query latest offsets for all subscribed buckets, handling both partitioned
 /// and non-partitioned tables.
 ///
@@ -566,6 +602,35 @@ mod tests {
 
     fn bucket(id: i32) -> TableBucket {
         TableBucket::new(1, id)
+    }
+
+    #[test]
+    fn validate_stopping_offsets_rejects_unsubscribed_bucket() {
+        let mut offsets = HashMap::from([(bucket(1), 10)]);
+        let result = validate_stopping_offsets(vec![(bucket(0), 0)], &mut offsets);
+
+        assert!(matches!(result, Err(Error::IllegalArgument { .. })));
+    }
+
+    #[test]
+    fn validate_stopping_offsets_prunes_completed_range() {
+        let mut offsets = HashMap::from([(bucket(0), 10), (bucket(1), 20)]);
+        validate_stopping_offsets(vec![(bucket(0), 10), (bucket(1), 15)], &mut offsets).unwrap();
+
+        assert!(!offsets.contains_key(&bucket(0)));
+        assert_eq!(offsets.get(&bucket(1)), Some(&20));
+    }
+
+    #[test]
+    fn validate_stopping_offsets_keeps_symbolic_start() {
+        let mut offsets = HashMap::from([(bucket(0), 0)]);
+        validate_stopping_offsets(
+            vec![(bucket(0), crate::client::EARLIEST_OFFSET)],
+            &mut offsets,
+        )
+        .unwrap();
+
+        assert_eq!(offsets.get(&bucket(0)), Some(&0));
     }
 
     #[test]

--- a/fluss-rust/crates/fluss/src/client/table/reader.rs
+++ b/fluss-rust/crates/fluss/src/client/table/reader.rs
@@ -209,8 +209,9 @@ impl RecordBatchLogReader {
     ///
     /// # NOTE: Every key in `stopping_offsets` **must** correspond to a bucket
     /// currently subscribed on the `scanner`, every subscribed bucket must
-    /// have a stopping offset, and every stopping offset must be non-negative;
-    /// construction fails otherwise.
+    /// have a stopping offset, every subscribed starting offset must be
+    /// non-negative or [`crate::client::EARLIEST_OFFSET`], and every stopping
+    /// offset must be non-negative; construction fails otherwise.
     /// Concrete subscriptions that already meet their stop point are treated
     /// as empty ranges and complete immediately.
     ///

--- a/fluss-rust/crates/fluss/src/client/table/reader.rs
+++ b/fluss-rust/crates/fluss/src/client/table/reader.rs
@@ -39,7 +39,7 @@ use crate::rpc::message::OffsetSpec;
 use crate::{PartitionId, TableId};
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
-use futures::Stream;
+use futures::{Stream, future::try_join_all};
 use log::warn;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
@@ -121,6 +121,38 @@ pub struct RecordBatchLogReader {
     schema: SchemaRef,
 }
 
+/// Clears the scanner's active-reader flag if reader construction exits early.
+///
+/// This makes async constructors cancellation-safe: dropping a constructor
+/// future while it is awaiting metadata or offsets must not leave a shared
+/// binding-layer scanner permanently locked.
+struct ReaderActivationGuard<'a> {
+    scanner: &'a RecordBatchLogScanner,
+    clear_on_drop: bool,
+}
+
+impl<'a> ReaderActivationGuard<'a> {
+    fn acquire(scanner: &'a RecordBatchLogScanner) -> Result<Self> {
+        scanner.try_set_reader_active()?;
+        Ok(Self {
+            scanner,
+            clear_on_drop: true,
+        })
+    }
+
+    fn keep_active(mut self) {
+        self.clear_on_drop = false;
+    }
+}
+
+impl Drop for ReaderActivationGuard<'_> {
+    fn drop(&mut self) {
+        if self.clear_on_drop {
+            self.scanner.clear_reader_active();
+        }
+    }
+}
+
 impl RecordBatchLogReader {
     /// Create a reader that reads until the latest offsets at the time of creation.
     ///
@@ -137,25 +169,25 @@ impl RecordBatchLogReader {
     ) -> Result<Self> {
         // Acquire the guard first so no concurrent unsubscribe can mutate
         // state between reading subscriptions and using them.
-        scanner.try_set_reader_active()?;
+        let activation = ReaderActivationGuard::acquire(&scanner)?;
 
         let subscribed = scanner.get_subscribed_buckets();
         if subscribed.is_empty() {
-            scanner.clear_reader_active();
             return Err(Error::IllegalArgument {
                 message: "No buckets subscribed. Call subscribe() before creating a reader."
                     .to_string(),
             });
         }
+        validate_read_buckets(
+            scanner.table_id(),
+            scanner.is_partitioned(),
+            scanner.num_buckets(),
+            subscribed.iter().map(|(bucket, _)| bucket),
+        )?;
 
-        let stopping_offsets = match query_latest_offsets(admin, &scanner, &subscribed).await {
-            Ok(o) => o,
-            Err(e) => {
-                scanner.clear_reader_active();
-                return Err(e);
-            }
-        };
+        let stopping_offsets = query_latest_offsets(admin, &scanner, &subscribed).await?;
         let schema = scanner.schema();
+        activation.keep_active();
 
         Ok(Self {
             scanner,
@@ -179,16 +211,18 @@ impl RecordBatchLogReader {
         scanner: RecordBatchLogScanner,
         mut stopping_offsets: HashMap<TableBucket, i64>,
     ) -> Result<Self> {
-        scanner.try_set_reader_active()?;
+        let activation = ReaderActivationGuard::acquire(&scanner)?;
 
-        if let Err(error) =
-            validate_stopping_offsets(scanner.get_subscribed_buckets(), &mut stopping_offsets)
-        {
-            scanner.clear_reader_active();
-            return Err(error);
-        }
+        validate_read_buckets(
+            scanner.table_id(),
+            scanner.is_partitioned(),
+            scanner.num_buckets(),
+            stopping_offsets.keys(),
+        )?;
+        validate_stopping_offsets(scanner.get_subscribed_buckets(), &mut stopping_offsets)?;
 
         let schema = scanner.schema();
+        activation.keep_active();
         Ok(Self {
             scanner,
             stopping_offsets,
@@ -205,13 +239,30 @@ impl RecordBatchLogReader {
     /// from a foreign language). Ranges are validated against the scanned
     /// table before anything is subscribed: every bucket must belong to the
     /// table, match its partition mode, appear once, and have
-    /// `starting_offset <= stopping_offset`. Empty ranges need no subscription
+    /// a valid bucket id and `starting_offset <= stopping_offset`. The scanner
+    /// must not have existing subscriptions. Empty ranges need no subscription
     /// and complete immediately.
     pub async fn new_from_ranges(
         scanner: RecordBatchLogScanner,
         ranges: Vec<BoundedLogReadRange>,
     ) -> Result<Self> {
-        validate_read_ranges(scanner.table_id(), scanner.is_partitioned(), &ranges)?;
+        // Acquire the guard before inspecting or changing subscriptions. The
+        // internal subscribe helpers below require this guard and bypass the
+        // public subscription check that intentionally rejects active readers.
+        let activation = ReaderActivationGuard::acquire(&scanner)?;
+
+        validate_read_ranges(
+            scanner.table_id(),
+            scanner.is_partitioned(),
+            scanner.num_buckets(),
+            &ranges,
+        )?;
+        if !scanner.get_subscribed_buckets().is_empty() {
+            return Err(Error::IllegalArgument {
+                message: "new_from_ranges requires a scanner without existing subscriptions."
+                    .to_string(),
+            });
+        }
 
         let mut stopping_offsets = HashMap::with_capacity(ranges.len());
         let mut bucket_offsets: HashMap<i32, i64> = HashMap::new();
@@ -235,23 +286,32 @@ impl RecordBatchLogReader {
         }
 
         if !bucket_offsets.is_empty() {
-            scanner.subscribe_buckets(&bucket_offsets).await?;
+            scanner
+                .subscribe_buckets_for_reader(&bucket_offsets)
+                .await?;
         }
         if !partition_bucket_offsets.is_empty() {
             scanner
-                .subscribe_partition_buckets(&partition_bucket_offsets)
+                .subscribe_partition_buckets_for_reader(&partition_bucket_offsets)
                 .await?;
         }
 
-        Self::new_until_offsets(scanner, stopping_offsets)
+        let schema = scanner.schema();
+        activation.keep_active();
+        Ok(Self {
+            scanner,
+            stopping_offsets,
+            buffer: VecDeque::new(),
+            schema,
+        })
     }
 
     /// Create a reader for a `[starting_timestamp_ms, stopping_timestamp_ms]`
     /// window over the requested buckets.
     ///
     /// Both timestamps are resolved to offsets per bucket, then read with
-    /// `[starting_offset, stopping_offset)` semantics. Partition metadata and
-    /// offsets are queried once during construction.
+    /// `[starting_offset, stopping_offset)` semantics. Partition metadata is
+    /// fetched once, and independent partition lookups are issued concurrently.
     pub async fn new_between_timestamps(
         scanner: RecordBatchLogScanner,
         admin: &FlussAdmin,
@@ -265,7 +325,12 @@ impl RecordBatchLogReader {
             });
         }
 
-        validate_read_buckets(scanner.table_id(), scanner.is_partitioned(), buckets)?;
+        validate_read_buckets(
+            scanner.table_id(),
+            scanner.is_partitioned(),
+            scanner.num_buckets(),
+            buckets,
+        )?;
         if buckets.is_empty() {
             // Nothing to resolve, so skip the offset lookups entirely.
             return Self::new_from_ranges(scanner, Vec::new()).await;
@@ -547,6 +612,7 @@ impl arrow::record_batch::RecordBatchReader for SyncRecordBatchLogReader {
 fn validate_read_buckets<'a>(
     table_id: TableId,
     is_partitioned: bool,
+    num_buckets: i32,
     buckets: impl IntoIterator<Item = &'a TableBucket>,
 ) -> Result<()> {
     let mut seen = HashSet::new();
@@ -567,6 +633,14 @@ fn validate_read_buckets<'a>(
                 },
             });
         }
+        if bucket.bucket_id() < 0 || bucket.bucket_id() >= num_buckets {
+            return Err(Error::IllegalArgument {
+                message: format!(
+                    "Bounded read bucket id {} is out of range for a table with {num_buckets} buckets.",
+                    bucket.bucket_id()
+                ),
+            });
+        }
         if !seen.insert(bucket) {
             return Err(Error::IllegalArgument {
                 message: format!("Duplicate bucket {bucket:?} in a bounded read."),
@@ -581,11 +655,13 @@ fn validate_read_buckets<'a>(
 fn validate_read_ranges(
     table_id: TableId,
     is_partitioned: bool,
+    num_buckets: i32,
     ranges: &[BoundedLogReadRange],
 ) -> Result<()> {
     validate_read_buckets(
         table_id,
         is_partitioned,
+        num_buckets,
         ranges.iter().map(|range| &range.bucket),
     )?;
     for range in ranges {
@@ -695,20 +771,27 @@ impl<'a> OffsetResolver<'a> {
             }
         }
 
-        let mut resolved: HashMap<TableBucket, i64> = HashMap::new();
-        for (partition_id, bucket_ids) in bucket_ids_by_partition {
-            let partition_name =
-                partition_names
-                    .get(&partition_id)
-                    .ok_or_else(|| Error::UnexpectedError {
-                        message: format!("Unknown partition_id: {partition_id}"),
-                        source: None,
+        let fetches = bucket_ids_by_partition
+            .into_iter()
+            .map(|(partition_id, bucket_ids)| {
+                let spec = spec.clone();
+                async move {
+                    let partition_name = partition_names.get(&partition_id).ok_or_else(|| {
+                        Error::UnexpectedError {
+                            message: format!("Unknown partition_id: {partition_id}"),
+                            source: None,
+                        }
                     })?;
+                    let offsets = self
+                        .admin
+                        .list_partition_offsets(self.table_path, partition_name, &bucket_ids, spec)
+                        .await?;
+                    Ok::<_, Error>((partition_id, offsets))
+                }
+            });
 
-            let offsets = self
-                .admin
-                .list_partition_offsets(self.table_path, partition_name, &bucket_ids, spec.clone())
-                .await?;
+        let mut resolved: HashMap<TableBucket, i64> = HashMap::new();
+        for (partition_id, offsets) in try_join_all(fetches).await? {
             for (bucket_id, offset) in offsets {
                 let bucket =
                     TableBucket::new_with_partition(self.table_id, Some(partition_id), bucket_id);
@@ -875,14 +958,14 @@ mod tests {
     fn validate_read_ranges_accepts_empty_and_non_empty_ranges() {
         let ranges = vec![range(bucket(0), 5, 5), range(bucket(1), 0, 10)];
 
-        validate_read_ranges(1, false, &ranges).unwrap();
+        validate_read_ranges(1, false, 2, &ranges).unwrap();
     }
 
     #[test]
     fn validate_read_ranges_rejects_bucket_of_another_table() {
         let ranges = vec![range(TableBucket::new(2, 0), 0, 10)];
 
-        let result = validate_read_ranges(1, false, &ranges);
+        let result = validate_read_ranges(1, false, 1, &ranges);
 
         assert!(matches!(result, Err(Error::IllegalArgument { .. })));
     }
@@ -893,20 +976,29 @@ mod tests {
         let partitioned = vec![range(TableBucket::new_with_partition(1, Some(7), 0), 0, 10)];
 
         assert!(matches!(
-            validate_read_ranges(1, true, &unpartitioned),
+            validate_read_ranges(1, true, 1, &unpartitioned),
             Err(Error::IllegalArgument { .. })
         ));
         assert!(matches!(
-            validate_read_ranges(1, false, &partitioned),
+            validate_read_ranges(1, false, 1, &partitioned),
             Err(Error::IllegalArgument { .. })
         ));
+    }
+
+    #[test]
+    fn validate_read_ranges_rejects_out_of_range_bucket() {
+        let ranges = vec![range(bucket(2), 0, 10)];
+
+        let result = validate_read_ranges(1, false, 2, &ranges);
+
+        assert!(matches!(result, Err(Error::IllegalArgument { .. })));
     }
 
     #[test]
     fn validate_read_ranges_rejects_duplicate_bucket() {
         let ranges = vec![range(bucket(0), 0, 10), range(bucket(0), 10, 20)];
 
-        let result = validate_read_ranges(1, false, &ranges);
+        let result = validate_read_ranges(1, false, 1, &ranges);
 
         assert!(matches!(result, Err(Error::IllegalArgument { .. })));
     }
@@ -915,7 +1007,7 @@ mod tests {
     fn validate_read_ranges_rejects_inverted_range() {
         let ranges = vec![range(bucket(0), 20, 10)];
 
-        let result = validate_read_ranges(1, false, &ranges);
+        let result = validate_read_ranges(1, false, 1, &ranges);
 
         assert!(matches!(result, Err(Error::IllegalArgument { .. })));
     }

--- a/fluss-rust/crates/fluss/src/client/table/reader.rs
+++ b/fluss-rust/crates/fluss/src/client/table/reader.rs
@@ -40,7 +40,6 @@ use crate::{PartitionId, TableId};
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
 use futures::{Stream, future::try_join_all};
-use log::warn;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
@@ -67,10 +66,12 @@ pub enum RecordBatchReadOutcome {
 pub struct BoundedLogReadRange {
     /// Bucket to read. Its partition mode must match the scanned table.
     pub bucket: TableBucket,
-    /// First offset to read, inclusive.
+    /// First offset to read, inclusive. Must be non-negative or
+    /// [`crate::client::EARLIEST_OFFSET`].
     pub starting_offset: i64,
-    /// Offset to stop at, exclusive. Must not be below `starting_offset`;
-    /// an equal value is an empty range that completes immediately.
+    /// Non-negative offset to stop at, exclusive. Must not be below
+    /// `starting_offset`; an equal value is an empty range that completes
+    /// immediately.
     pub stopping_offset: i64,
 }
 
@@ -186,6 +187,13 @@ impl RecordBatchLogReader {
         )?;
 
         let stopping_offsets = query_latest_offsets(admin, &scanner, &subscribed).await?;
+        unsubscribe_completed_buckets(
+            &scanner,
+            subscribed
+                .iter()
+                .map(|(bucket, _)| bucket)
+                .filter(|bucket| !stopping_offsets.contains_key(*bucket)),
+        );
         let schema = scanner.schema();
         activation.keep_active();
 
@@ -199,8 +207,10 @@ impl RecordBatchLogReader {
 
     /// Create a reader with explicit stopping offsets per bucket.
     ///
-    /// # NOTE: Every key in `stopping_offsets` **must** correspond to a bucket that is
-    /// currently subscribed on the `scanner`; construction fails otherwise.
+    /// # NOTE: Every key in `stopping_offsets` **must** correspond to a bucket
+    /// currently subscribed on the `scanner`, every subscribed bucket must
+    /// have a stopping offset, and every stopping offset must be non-negative;
+    /// construction fails otherwise.
     /// Concrete subscriptions that already meet their stop point are treated
     /// as empty ranges and complete immediately.
     ///
@@ -219,7 +229,9 @@ impl RecordBatchLogReader {
             scanner.num_buckets(),
             stopping_offsets.keys(),
         )?;
-        validate_stopping_offsets(scanner.get_subscribed_buckets(), &mut stopping_offsets)?;
+        let completed =
+            validate_stopping_offsets(scanner.get_subscribed_buckets(), &mut stopping_offsets)?;
+        unsubscribe_completed_buckets(&scanner, &completed);
 
         let schema = scanner.schema();
         activation.keep_active();
@@ -239,9 +251,10 @@ impl RecordBatchLogReader {
     /// from a foreign language). Ranges are validated against the scanned
     /// table before anything is subscribed: every bucket must belong to the
     /// table, match its partition mode, appear once, and have
-    /// a valid bucket id and `starting_offset <= stopping_offset`. The scanner
-    /// must not have existing subscriptions. Empty ranges need no subscription
-    /// and complete immediately.
+    /// a valid bucket id, `starting_offset <= stopping_offset`, and a
+    /// non-negative stopping offset. The scanner must not have existing
+    /// subscriptions. Empty ranges need no subscription and complete
+    /// immediately.
     pub async fn new_from_ranges(
         scanner: RecordBatchLogScanner,
         ranges: Vec<BoundedLogReadRange>,
@@ -268,7 +281,7 @@ impl RecordBatchLogReader {
         let mut bucket_offsets: HashMap<i32, i64> = HashMap::new();
         let mut partition_bucket_offsets: HashMap<(PartitionId, i32), i64> = HashMap::new();
         for range in ranges {
-            if range.starting_offset == range.stopping_offset {
+            if range.stopping_offset == 0 || range.starting_offset == range.stopping_offset {
                 continue;
             }
             match range.bucket.partition_id() {
@@ -306,7 +319,7 @@ impl RecordBatchLogReader {
         })
     }
 
-    /// Create a reader for a `[starting_timestamp_ms, stopping_timestamp_ms]`
+    /// Create a reader for a `[starting_timestamp_ms, stopping_timestamp_ms)`
     /// window over the requested buckets.
     ///
     /// Both timestamps are resolved to offsets per bucket, then read with
@@ -665,6 +678,22 @@ fn validate_read_ranges(
         ranges.iter().map(|range| &range.bucket),
     )?;
     for range in ranges {
+        if range.starting_offset < 0 && range.starting_offset != crate::client::EARLIEST_OFFSET {
+            return Err(Error::IllegalArgument {
+                message: format!(
+                    "Read range for {:?} has unsupported negative starting offset {}.",
+                    range.bucket, range.starting_offset
+                ),
+            });
+        }
+        if range.stopping_offset < 0 {
+            return Err(Error::IllegalArgument {
+                message: format!(
+                    "Read range for {:?} has negative stopping offset {}.",
+                    range.bucket, range.stopping_offset
+                ),
+            });
+        }
         if range.starting_offset > range.stopping_offset {
             return Err(Error::IllegalArgument {
                 message: format!(
@@ -680,8 +709,17 @@ fn validate_read_ranges(
 fn validate_stopping_offsets(
     subscriptions: Vec<(TableBucket, i64)>,
     stopping_offsets: &mut HashMap<TableBucket, i64>,
-) -> Result<()> {
+) -> Result<Vec<TableBucket>> {
     let subscribed: HashMap<TableBucket, i64> = subscriptions.into_iter().collect();
+    for (bucket, start) in &subscribed {
+        if *start < 0 && *start != crate::client::EARLIEST_OFFSET {
+            return Err(Error::IllegalArgument {
+                message: format!(
+                    "Scanner subscription for {bucket:?} has unsupported negative starting offset {start}."
+                ),
+            });
+        }
+    }
     for bucket in stopping_offsets.keys() {
         if !subscribed.contains_key(bucket) {
             return Err(Error::IllegalArgument {
@@ -691,18 +729,54 @@ fn validate_stopping_offsets(
             });
         }
     }
+    for bucket in subscribed.keys() {
+        if !stopping_offsets.contains_key(bucket) {
+            return Err(Error::IllegalArgument {
+                message: format!(
+                    "Scanner subscription for {bucket:?} has no matching stopping offset."
+                ),
+            });
+        }
+    }
+    for (bucket, stop) in stopping_offsets.iter() {
+        if *stop < 0 {
+            return Err(Error::IllegalArgument {
+                message: format!("Stopping offset for {bucket:?} must not be negative."),
+            });
+        }
+    }
 
-    // A concrete subscription that already meets the stop point is an empty
-    // range. Remove it up front so the reader can finish without waiting for a
-    // server batch that may never arrive. Negative offsets are symbolic values
-    // such as EARLIEST_OFFSET and cannot be compared until the server resolves
-    // them.
+    // A stop at offset 0 is always empty because log offsets are non-negative.
+    // Otherwise, a concrete subscription that already meets the stop point is
+    // also empty. Remove both up front so the reader can finish without waiting
+    // for a server batch that may never arrive. Negative starting offsets are
+    // symbolic values such as EARLIEST_OFFSET and cannot otherwise be compared
+    // until the server resolves them.
+    let mut completed = Vec::new();
     stopping_offsets.retain(|bucket, stop| {
-        subscribed
-            .get(bucket)
-            .is_none_or(|start| *start < 0 || start < stop)
+        let should_read = *stop > 0
+            && subscribed
+                .get(bucket)
+                .is_none_or(|start| *start < 0 || start < stop);
+        if !should_read {
+            completed.push(bucket.clone());
+        }
+        should_read
     });
-    Ok(())
+    Ok(completed)
+}
+
+fn unsubscribe_completed_buckets<'a>(
+    scanner: &RecordBatchLogScanner,
+    buckets: impl IntoIterator<Item = &'a TableBucket>,
+) {
+    for bucket in buckets {
+        if let Some(partition_id) = bucket.partition_id() {
+            scanner.unsubscribe_partition_sync(partition_id, bucket.bucket_id());
+        } else {
+            scanner.unsubscribe_sync(bucket.bucket_id());
+        }
+    }
 }
 
 /// Resolves an [`OffsetSpec`] into per-bucket offsets, hiding the partitioned
@@ -808,9 +882,9 @@ impl<'a> OffsetResolver<'a> {
 ///
 /// Buckets whose subscribed offset already meets or exceeds the latest offset
 /// are excluded from the result (there is nothing to read). A `latest_offset`
-/// of `0` means the bucket is empty and is silently skipped; a negative value
-/// is unexpected from the server and is logged as a warning before being
-/// skipped.
+/// of `0` means the bucket is empty. Missing or negative offsets are treated as
+/// errors rather than silently reporting a potentially incomplete read as
+/// finished.
 async fn query_latest_offsets(
     admin: &FlussAdmin,
     scanner: &RecordBatchLogScanner,
@@ -825,14 +899,23 @@ async fn query_latest_offsets(
 
     let mut stopping_offsets = HashMap::with_capacity(latest_offsets.len());
     for (bucket, subscribed_offset) in subscribed {
-        let Some(&latest_offset) = latest_offsets.get(bucket) else {
-            continue;
-        };
+        let latest_offset =
+            latest_offsets
+                .get(bucket)
+                .copied()
+                .ok_or_else(|| Error::UnexpectedError {
+                    message: format!(
+                        "Latest offset lookup did not return an offset for {bucket:?}."
+                    ),
+                    source: None,
+                })?;
         if latest_offset < 0 {
-            warn!(
-                "Server returned negative latest offset {latest_offset} for {bucket:?} of table {table_id}; skipping bucket."
-            );
-            continue;
+            return Err(Error::UnexpectedError {
+                message: format!(
+                    "Server returned negative latest offset {latest_offset} for {bucket:?} of table {table_id}."
+                ),
+                source: None,
+            });
         }
         if latest_offset == 0 {
             continue;
@@ -1013,24 +1096,55 @@ mod tests {
     }
 
     #[test]
-    fn validate_stopping_offsets_prunes_completed_range() {
-        let mut offsets = HashMap::from([(bucket(0), 10), (bucket(1), 20)]);
-        validate_stopping_offsets(vec![(bucket(0), 10), (bucket(1), 15)], &mut offsets).unwrap();
+    fn validate_read_ranges_rejects_negative_stopping_offset() {
+        let ranges = vec![range(bucket(0), crate::client::EARLIEST_OFFSET, -1)];
 
-        assert!(!offsets.contains_key(&bucket(0)));
-        assert_eq!(offsets.get(&bucket(1)), Some(&20));
+        let result = validate_read_ranges(1, false, 1, &ranges);
+
+        assert!(matches!(result, Err(Error::IllegalArgument { .. })));
     }
 
     #[test]
-    fn validate_stopping_offsets_keeps_symbolic_start() {
+    fn validate_read_ranges_rejects_unknown_negative_starting_offset() {
+        let ranges = vec![range(bucket(0), -1, 10)];
+
+        let result = validate_read_ranges(1, false, 1, &ranges);
+
+        assert!(matches!(result, Err(Error::IllegalArgument { .. })));
+    }
+
+    #[test]
+    fn validate_stopping_offsets_prunes_completed_range() {
+        let mut offsets = HashMap::from([(bucket(0), 10), (bucket(1), 20)]);
+        let completed =
+            validate_stopping_offsets(vec![(bucket(0), 10), (bucket(1), 15)], &mut offsets)
+                .unwrap();
+
+        assert!(!offsets.contains_key(&bucket(0)));
+        assert_eq!(offsets.get(&bucket(1)), Some(&20));
+        assert_eq!(completed, vec![bucket(0)]);
+    }
+
+    #[test]
+    fn validate_stopping_offsets_prunes_zero_stop_with_symbolic_start() {
         let mut offsets = HashMap::from([(bucket(0), 0)]);
-        validate_stopping_offsets(
+        let completed = validate_stopping_offsets(
             vec![(bucket(0), crate::client::EARLIEST_OFFSET)],
             &mut offsets,
         )
         .unwrap();
 
-        assert_eq!(offsets.get(&bucket(0)), Some(&0));
+        assert!(!offsets.contains_key(&bucket(0)));
+        assert_eq!(completed, vec![bucket(0)]);
+    }
+
+    #[test]
+    fn validate_stopping_offsets_rejects_subscription_without_stop() {
+        let mut offsets = HashMap::from([(bucket(0), 10)]);
+
+        let result = validate_stopping_offsets(vec![(bucket(0), 0), (bucket(1), 0)], &mut offsets);
+
+        assert!(matches!(result, Err(Error::IllegalArgument { .. })));
     }
 
     #[test]

--- a/fluss-rust/crates/fluss/src/client/table/reader.rs
+++ b/fluss-rust/crates/fluss/src/client/table/reader.rs
@@ -41,9 +41,20 @@ use arrow_schema::SchemaRef;
 use futures::Stream;
 use log::warn;
 use std::collections::{HashMap, VecDeque};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Outcome of a bounded record-batch read with a caller-supplied timeout.
+#[derive(Debug)]
+pub enum RecordBatchReadOutcome {
+    /// A batch is available.
+    Batch(ScanBatch),
+    /// No batch became available before the timeout elapsed.
+    TimedOut,
+    /// Every subscribed bucket reached its stopping offset.
+    Finished,
+}
 
 /// Bounded log reader that consumes log data up to specified stopping offsets.
 ///
@@ -174,18 +185,42 @@ impl RecordBatchLogReader {
     /// network traffic on data the reader will discard.
     pub async fn next_batch(&mut self) -> Result<Option<ScanBatch>> {
         loop {
+            match self.next_batch_with_timeout(DEFAULT_POLL_TIMEOUT).await? {
+                RecordBatchReadOutcome::Batch(batch) => return Ok(Some(batch)),
+                RecordBatchReadOutcome::TimedOut => continue,
+                RecordBatchReadOutcome::Finished => return Ok(None),
+            }
+        }
+    }
+
+    /// Fetch the next [`ScanBatch`] while waiting for at most `timeout`.
+    ///
+    /// Unlike [`next_batch`](Self::next_batch), this method returns
+    /// [`RecordBatchReadOutcome::TimedOut`] when no data becomes available
+    /// before the timeout. The reader remains valid and the caller may retry.
+    pub async fn next_batch_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<RecordBatchReadOutcome> {
+        let start = Instant::now();
+        loop {
             if let Some(batch) = self.buffer.pop_front() {
-                return Ok(Some(batch));
+                return Ok(RecordBatchReadOutcome::Batch(batch));
             }
 
             if self.stopping_offsets.is_empty() {
-                return Ok(None);
+                return Ok(RecordBatchReadOutcome::Finished);
             }
 
-            let scan_batches = self.scanner.poll(DEFAULT_POLL_TIMEOUT).await?;
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
+                return Ok(RecordBatchReadOutcome::TimedOut);
+            }
+
+            let scan_batches = self.scanner.poll(timeout - elapsed).await?;
 
             if scan_batches.is_empty() {
-                continue;
+                return Ok(RecordBatchReadOutcome::TimedOut);
             }
 
             let completed =

--- a/fluss-rust/crates/fluss/src/client/table/scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/scanner.rs
@@ -417,6 +417,12 @@ struct LogScannerInner {
     /// Guards against subscription changes while a
     /// [`crate::client::RecordBatchLogReader`] is iterating.
     reader_active: std::sync::atomic::AtomicBool,
+    /// Serializes the active-reader transition with subscription mutations.
+    ///
+    /// Public subscribe methods await metadata before changing the status map.
+    /// Without this lock, a subscribe call that passed the initial
+    /// `reader_active` check could finish after a bounded reader became active.
+    subscription_lock: Mutex<()>,
     /// Holds the snapshot fields used by [`PollGuard`] to derive the
     /// scanner poll-timing metrics. The mutex makes the state updates
     /// in `record_poll_start` / `record_poll_end` atomic; metric
@@ -615,6 +621,7 @@ impl LogScannerInner {
             )?,
             arrow_schema,
             reader_active: std::sync::atomic::AtomicBool::new(false),
+            subscription_lock: Mutex::new(()),
             poll_state: Mutex::new(PollState::default()),
             metrics,
             last_poll_unix_ms,
@@ -791,6 +798,8 @@ impl LogScannerInner {
         self.metadata
             .check_and_update_table_metadata(from_ref(&self.table_path))
             .await?;
+        let _subscription_guard = self.subscription_lock.lock();
+        self.check_no_active_reader()?;
         self.log_scanner_status
             .assign_scan_bucket(table_bucket, offset);
         Ok(())
@@ -850,6 +859,8 @@ impl LogScannerInner {
         self.metadata
             .check_and_update_table_metadata(from_ref(&self.table_path))
             .await?;
+        let _subscription_guard = self.subscription_lock.lock();
+        self.check_no_active_reader()?;
         self.log_scanner_status
             .assign_scan_bucket(table_bucket, offset);
         Ok(())
@@ -914,6 +925,7 @@ impl LogScannerInner {
             .check_and_update_table_metadata(from_ref(&self.table_path))
             .await?;
 
+        let _subscription_guard = self.subscription_lock.lock();
         if reader_is_active {
             debug_assert!(
                 self.reader_active
@@ -928,6 +940,7 @@ impl LogScannerInner {
     }
 
     async fn unsubscribe(&self, bucket: i32) -> Result<()> {
+        let _subscription_guard = self.subscription_lock.lock();
         self.check_no_active_reader()?;
         if self.is_partitioned_table {
             return Err(Error::UnsupportedOperation {
@@ -944,6 +957,7 @@ impl LogScannerInner {
     }
 
     async fn unsubscribe_partition(&self, partition_id: PartitionId, bucket: i32) -> Result<()> {
+        let _subscription_guard = self.subscription_lock.lock();
         self.check_no_active_reader()?;
         if !self.is_partitioned_table {
             return Err(Error::UnsupportedOperation {
@@ -1178,6 +1192,7 @@ impl RecordBatchLogScanner {
     /// `LogScannerImpl.acquire()` single-consumer guard.
     pub(crate) fn try_set_reader_active(&self) -> Result<()> {
         use std::sync::atomic::Ordering;
+        let _subscription_guard = self.inner.subscription_lock.lock();
         self.inner
             .reader_active
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -1191,6 +1206,7 @@ impl RecordBatchLogScanner {
 
     /// Clears the active-reader guard, re-enabling subscription changes.
     pub(crate) fn clear_reader_active(&self) {
+        let _subscription_guard = self.inner.subscription_lock.lock();
         self.inner
             .reader_active
             .store(false, std::sync::atomic::Ordering::Release);
@@ -1208,6 +1224,7 @@ impl RecordBatchLogScanner {
     ///
     /// **Not intended for general use** — prefer the async [`unsubscribe`].
     pub(crate) fn unsubscribe_sync(&self, bucket: i32) {
+        let _subscription_guard = self.inner.subscription_lock.lock();
         if self.inner.is_partitioned_table {
             return;
         }
@@ -1221,6 +1238,7 @@ impl RecordBatchLogScanner {
     /// [`unsubscribe_partition`](Self::unsubscribe_partition). See
     /// [`unsubscribe_sync`](Self::unsubscribe_sync) for rationale.
     pub(crate) fn unsubscribe_partition_sync(&self, partition_id: PartitionId, bucket: i32) {
+        let _subscription_guard = self.inner.subscription_lock.lock();
         if !self.inner.is_partitioned_table {
             return;
         }

--- a/fluss-rust/crates/fluss/src/client/table/scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/scanner.rs
@@ -408,6 +408,7 @@ pub struct RecordBatchLogScanner {
 struct LogScannerInner {
     table_path: TablePath,
     table_id: TableId,
+    num_buckets: i32,
     metadata: Arc<Metadata>,
     log_scanner_status: Arc<LogScannerStatus>,
     log_fetcher: LogFetcher,
@@ -597,6 +598,7 @@ impl LogScannerInner {
         Ok(Self {
             table_path: table_info.table_path.clone(),
             table_id: table_info.table_id,
+            num_buckets: table_info.get_num_buckets(),
             is_partitioned_table: table_info.is_partitioned(),
             metadata: metadata.clone(),
             log_scanner_status: log_scanner_status.clone(),
@@ -809,7 +811,24 @@ impl LogScannerInner {
             let table_bucket = TableBucket::new(self.table_id, *bucket_id);
             scan_bucket_offsets.insert(table_bucket, *offset);
         }
-        self.do_subscribe_buckets(scan_bucket_offsets).await
+        self.do_subscribe_buckets(scan_bucket_offsets, false).await
+    }
+
+    async fn subscribe_buckets_for_reader(&self, bucket_offsets: &HashMap<i32, i64>) -> Result<()> {
+        if self.is_partitioned_table {
+            return Err(Error::UnsupportedOperation {
+                message:
+                    "The table is a partitioned table, please use \"subscribe_partition_buckets\" instead."
+                        .to_string(),
+            });
+        }
+
+        let mut scan_bucket_offsets = HashMap::new();
+        for (bucket_id, offset) in bucket_offsets {
+            let table_bucket = TableBucket::new(self.table_id, *bucket_id);
+            scan_bucket_offsets.insert(table_bucket, *offset);
+        }
+        self.do_subscribe_buckets(scan_bucket_offsets, true).await
     }
 
     async fn subscribe_partition(
@@ -855,10 +874,35 @@ impl LogScannerInner {
                 TableBucket::new_with_partition(self.table_id, Some(partition_id), bucket_id);
             scan_bucket_offsets.insert(table_bucket, offset);
         }
-        self.do_subscribe_buckets(scan_bucket_offsets).await
+        self.do_subscribe_buckets(scan_bucket_offsets, false).await
     }
 
-    async fn do_subscribe_buckets(&self, bucket_offsets: HashMap<TableBucket, i64>) -> Result<()> {
+    async fn subscribe_partition_buckets_for_reader(
+        &self,
+        partition_bucket_offsets: &HashMap<(PartitionId, i32), i64>,
+    ) -> Result<()> {
+        if !self.is_partitioned_table {
+            return Err(UnsupportedOperation {
+                message: "The table is not a partitioned table, please use \"subscribe_buckets\" \
+                    to subscribe to non-partitioned buckets instead."
+                    .to_string(),
+            });
+        }
+
+        let mut scan_bucket_offsets = HashMap::new();
+        for (&(partition_id, bucket_id), &offset) in partition_bucket_offsets {
+            let table_bucket =
+                TableBucket::new_with_partition(self.table_id, Some(partition_id), bucket_id);
+            scan_bucket_offsets.insert(table_bucket, offset);
+        }
+        self.do_subscribe_buckets(scan_bucket_offsets, true).await
+    }
+
+    async fn do_subscribe_buckets(
+        &self,
+        bucket_offsets: HashMap<TableBucket, i64>,
+        reader_is_active: bool,
+    ) -> Result<()> {
         if bucket_offsets.is_empty() {
             return Err(Error::UnexpectedError {
                 message: "Bucket offsets are empty.".to_string(),
@@ -870,6 +914,15 @@ impl LogScannerInner {
             .check_and_update_table_metadata(from_ref(&self.table_path))
             .await?;
 
+        if reader_is_active {
+            debug_assert!(
+                self.reader_active
+                    .load(std::sync::atomic::Ordering::Acquire),
+                "reader-only subscription helper called without an active reader"
+            );
+        } else {
+            self.check_no_active_reader()?;
+        }
         self.log_scanner_status.assign_scan_buckets(bucket_offsets);
         Ok(())
     }
@@ -1074,6 +1127,32 @@ impl RecordBatchLogScanner {
 
     pub fn table_id(&self) -> TableId {
         self.inner.table_id
+    }
+
+    pub(crate) fn num_buckets(&self) -> i32 {
+        self.inner.num_buckets
+    }
+
+    /// Subscribes non-partitioned ranges while the caller holds the active
+    /// reader guard.
+    pub(crate) async fn subscribe_buckets_for_reader(
+        &self,
+        bucket_offsets: &HashMap<i32, i64>,
+    ) -> Result<()> {
+        self.inner
+            .subscribe_buckets_for_reader(bucket_offsets)
+            .await
+    }
+
+    /// Subscribes partitioned ranges while the caller holds the active reader
+    /// guard.
+    pub(crate) async fn subscribe_partition_buckets_for_reader(
+        &self,
+        partition_bucket_offsets: &HashMap<(PartitionId, i32), i64>,
+    ) -> Result<()> {
+        self.inner
+            .subscribe_partition_buckets_for_reader(partition_bucket_offsets)
+            .await
     }
 
     /// Creates a new handle to the same underlying scanner state.

--- a/fluss-rust/crates/fluss/src/client/table/scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/scanner.rs
@@ -806,24 +806,24 @@ impl LogScannerInner {
     }
 
     async fn subscribe_buckets(&self, bucket_offsets: &HashMap<i32, i64>) -> Result<()> {
-        self.check_no_active_reader()?;
-        if self.is_partitioned_table {
-            return Err(Error::UnsupportedOperation {
-                message:
-                    "The table is a partitioned table, please use \"subscribe_partition_buckets\" instead."
-                        .to_string(),
-            });
-        }
-
-        let mut scan_bucket_offsets = HashMap::new();
-        for (bucket_id, offset) in bucket_offsets {
-            let table_bucket = TableBucket::new(self.table_id, *bucket_id);
-            scan_bucket_offsets.insert(table_bucket, *offset);
-        }
-        self.do_subscribe_buckets(scan_bucket_offsets, false).await
+        self.subscribe_buckets_internal(bucket_offsets, false).await
     }
 
     async fn subscribe_buckets_for_reader(&self, bucket_offsets: &HashMap<i32, i64>) -> Result<()> {
+        self.subscribe_buckets_internal(bucket_offsets, true).await
+    }
+
+    /// `reader_is_active` is `false` for subscriptions initiated through the
+    /// scanner API, which must reject an active reader, and `true` during reader
+    /// construction, which already holds the active-reader guard.
+    async fn subscribe_buckets_internal(
+        &self,
+        bucket_offsets: &HashMap<i32, i64>,
+        reader_is_active: bool,
+    ) -> Result<()> {
+        if !reader_is_active {
+            self.check_no_active_reader()?;
+        }
         if self.is_partitioned_table {
             return Err(Error::UnsupportedOperation {
                 message:
@@ -837,7 +837,8 @@ impl LogScannerInner {
             let table_bucket = TableBucket::new(self.table_id, *bucket_id);
             scan_bucket_offsets.insert(table_bucket, *offset);
         }
-        self.do_subscribe_buckets(scan_bucket_offsets, true).await
+        self.do_subscribe_buckets(scan_bucket_offsets, reader_is_active)
+            .await
     }
 
     async fn subscribe_partition(
@@ -870,28 +871,29 @@ impl LogScannerInner {
         &self,
         partition_bucket_offsets: &HashMap<(PartitionId, i32), i64>,
     ) -> Result<()> {
-        self.check_no_active_reader()?;
-        if !self.is_partitioned_table {
-            return Err(UnsupportedOperation {
-                message: "The table is not a partitioned table, please use \"subscribe_buckets\" \
-                    to subscribe to non-partitioned buckets instead."
-                    .to_string(),
-            });
-        }
-
-        let mut scan_bucket_offsets = HashMap::new();
-        for (&(partition_id, bucket_id), &offset) in partition_bucket_offsets {
-            let table_bucket =
-                TableBucket::new_with_partition(self.table_id, Some(partition_id), bucket_id);
-            scan_bucket_offsets.insert(table_bucket, offset);
-        }
-        self.do_subscribe_buckets(scan_bucket_offsets, false).await
+        self.subscribe_partition_buckets_internal(partition_bucket_offsets, false)
+            .await
     }
 
     async fn subscribe_partition_buckets_for_reader(
         &self,
         partition_bucket_offsets: &HashMap<(PartitionId, i32), i64>,
     ) -> Result<()> {
+        self.subscribe_partition_buckets_internal(partition_bucket_offsets, true)
+            .await
+    }
+
+    /// `reader_is_active` is `false` for subscriptions initiated through the
+    /// scanner API, which must reject an active reader, and `true` during reader
+    /// construction, which already holds the active-reader guard.
+    async fn subscribe_partition_buckets_internal(
+        &self,
+        partition_bucket_offsets: &HashMap<(PartitionId, i32), i64>,
+        reader_is_active: bool,
+    ) -> Result<()> {
+        if !reader_is_active {
+            self.check_no_active_reader()?;
+        }
         if !self.is_partitioned_table {
             return Err(UnsupportedOperation {
                 message: "The table is not a partitioned table, please use \"subscribe_buckets\" \
@@ -906,7 +908,8 @@ impl LogScannerInner {
                 TableBucket::new_with_partition(self.table_id, Some(partition_id), bucket_id);
             scan_bucket_offsets.insert(table_bucket, offset);
         }
-        self.do_subscribe_buckets(scan_bucket_offsets, true).await
+        self.do_subscribe_buckets(scan_bucket_offsets, reader_is_active)
+            .await
     }
 
     async fn do_subscribe_buckets(

--- a/fluss-rust/crates/fluss/tests/integration/record_batch_log_reader.rs
+++ b/fluss-rust/crates/fluss/tests/integration/record_batch_log_reader.rs
@@ -152,10 +152,14 @@ mod reader_test {
 
         let table_id = table.get_table_info().table_id;
         let mut reader = RecordBatchLogReader::new_until_offsets(
-            scanner,
+            scanner.new_shared_handle(),
             HashMap::from([(TableBucket::new(table_id, 0), 1)]),
         )
         .expect("Failed to create record batch reader");
+        assert!(
+            scanner.get_subscribed_buckets().is_empty(),
+            "an empty range should be unsubscribed as soon as the reader is created"
+        );
 
         let batches = tokio::time::timeout(Duration::from_secs(10), reader.collect_all_batches())
             .await

--- a/fluss-rust/crates/fluss/tests/integration/record_batch_log_reader.rs
+++ b/fluss-rust/crates/fluss/tests/integration/record_batch_log_reader.rs
@@ -172,6 +172,55 @@ mod reader_test {
     }
 
     #[tokio::test]
+    async fn collect_with_expired_budget_reports_already_complete_reader() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("Failed to get admin");
+
+        let table_path = TablePath::new("fluss", "test_reader_collect_already_complete");
+        let table_descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("id", DataTypes::int())
+                    .build()
+                    .expect("Failed to build schema"),
+            )
+            .build()
+            .expect("Failed to build table");
+        create_table(&admin, &table_path, &table_descriptor).await;
+
+        let table = connection
+            .get_table(&table_path)
+            .await
+            .expect("Failed to get table");
+        let scanner = table
+            .new_scan()
+            .create_record_batch_log_scanner()
+            .expect("Failed to create record batch scanner");
+        let mut reader = RecordBatchLogReader::new_until_offsets(scanner, HashMap::new())
+            .expect("Failed to create already-complete reader");
+
+        let outcome = reader
+            .collect_all_batches_with_timeout(Duration::ZERO)
+            .await
+            .expect("Failed to collect already-complete reader");
+
+        assert!(
+            outcome.complete,
+            "an already-complete reader must not be reported as timed out"
+        );
+        assert!(
+            outcome.batches.is_empty(),
+            "an already-complete reader should not return any batches"
+        );
+
+        admin
+            .drop_table(&table_path, false)
+            .await
+            .expect("Failed to drop table");
+    }
+
+    #[tokio::test]
     async fn until_offsets_past_end_of_log() {
         let cluster = get_shared_cluster();
         let connection = cluster.get_fluss_connection().await;

--- a/fluss-rust/crates/fluss/tests/integration/record_batch_log_reader.rs
+++ b/fluss-rust/crates/fluss/tests/integration/record_batch_log_reader.rs
@@ -21,10 +21,12 @@
 mod reader_test {
     use crate::integration::utils::{
         create_partitions, create_table, extract_ids_from_batches, get_shared_cluster,
-        wait_for_partitions_ready,
+        poll_until_count, wait_for_partitions_ready,
     };
     use arrow::array::record_batch;
-    use fluss::client::{EARLIEST_OFFSET, FlussConnection, RecordBatchLogReader};
+    use fluss::client::{
+        BoundedLogReadRange, EARLIEST_OFFSET, FlussConnection, RecordBatchLogReader,
+    };
     use fluss::config::{Config, NoKeyAssigner};
     use fluss::metadata::{DataTypes, Schema, TableBucket, TableDescriptor, TablePath};
     use fluss::rpc::message::OffsetSpec;
@@ -213,6 +215,62 @@ mod reader_test {
             outcome.batches.is_empty(),
             "an already-complete reader should not return any batches"
         );
+
+        admin
+            .drop_table(&table_path, false)
+            .await
+            .expect("Failed to drop table");
+    }
+
+    #[tokio::test]
+    async fn failed_range_construction_releases_reader_guard() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("Failed to get admin");
+
+        let table_path = TablePath::new("fluss", "test_reader_guard_release");
+        let table_descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("id", DataTypes::int())
+                    .build()
+                    .expect("Failed to build schema"),
+            )
+            .build()
+            .expect("Failed to build table");
+        create_table(&admin, &table_path, &table_descriptor).await;
+
+        let table = connection
+            .get_table(&table_path)
+            .await
+            .expect("Failed to get table");
+        let table_id = table.get_table_info().table_id;
+        let scanner = table
+            .new_scan()
+            .create_record_batch_log_scanner()
+            .expect("Failed to create record batch scanner");
+        scanner
+            .subscribe(0, EARLIEST_OFFSET)
+            .await
+            .expect("Failed to create the existing subscription");
+
+        let result = RecordBatchLogReader::new_from_ranges(
+            scanner.new_shared_handle(),
+            vec![BoundedLogReadRange {
+                bucket: TableBucket::new(table_id, 0),
+                starting_offset: 0,
+                stopping_offset: 1,
+            }],
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "range construction must reject a scanner with existing subscriptions"
+        );
+        scanner
+            .unsubscribe(0)
+            .await
+            .expect("failed construction must release the reader guard");
 
         admin
             .drop_table(&table_path, false)
@@ -564,6 +622,144 @@ mod reader_test {
             ids,
             vec![1, 2, 3, 4],
             "latest-offset reader should read all records present in subscribed partitions"
+        );
+
+        admin
+            .drop_table(&table_path, false)
+            .await
+            .expect("Failed to drop table");
+    }
+
+    #[tokio::test]
+    async fn between_timestamps_reads_partitioned_table() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("Failed to get admin");
+
+        let table_path = TablePath::new("fluss", "test_reader_partitioned_timestamp_range");
+        let table_descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("id", DataTypes::int())
+                    .column("region", DataTypes::string())
+                    .column("value", DataTypes::bigint())
+                    .build()
+                    .expect("Failed to build schema"),
+            )
+            .partitioned_by(vec!["region"])
+            .build()
+            .expect("Failed to build table");
+
+        create_table(&admin, &table_path, &table_descriptor).await;
+        create_partitions(&admin, &table_path, "region", &["US", "EU"]).await;
+        wait_for_partitions_ready(&admin, &table_path, &["US", "EU"]).await;
+
+        let table = connection
+            .get_table(&table_path)
+            .await
+            .expect("Failed to get table");
+        let writer = table
+            .new_append()
+            .expect("Failed to create append")
+            .create_writer()
+            .expect("Failed to create writer");
+        writer
+            .append_arrow_batch(
+                record_batch!(
+                    ("id", Int32, [1, 2]),
+                    ("region", Utf8, ["US", "US"]),
+                    ("value", Int64, [100, 200])
+                )
+                .unwrap(),
+            )
+            .expect("Failed to append US batch");
+        writer
+            .append_arrow_batch(
+                record_batch!(
+                    ("id", Int32, [3, 4]),
+                    ("region", Utf8, ["EU", "EU"]),
+                    ("value", Int64, [300, 400])
+                )
+                .unwrap(),
+            )
+            .expect("Failed to append EU batch");
+        writer.flush().await.expect("Failed to flush");
+
+        let table_id = table.get_table_info().table_id;
+        let partition_infos = admin
+            .list_partition_infos(&table_path)
+            .await
+            .expect("Failed to list partition infos");
+        let buckets: Vec<TableBucket> = partition_infos
+            .iter()
+            .map(|partition| {
+                TableBucket::new_with_partition(table_id, Some(partition.get_partition_id()), 0)
+            })
+            .collect();
+
+        // Read the server-assigned timestamps first, avoiding assumptions
+        // about clock synchronization between the test and the cluster.
+        let timestamp_scanner = table
+            .new_scan()
+            .create_log_scanner()
+            .expect("Failed to create timestamp scanner");
+        for bucket in &buckets {
+            timestamp_scanner
+                .subscribe_partition(
+                    bucket
+                        .partition_id()
+                        .expect("Partition id should be present"),
+                    bucket.bucket_id(),
+                    EARLIEST_OFFSET,
+                )
+                .await
+                .expect("Failed to subscribe timestamp scanner");
+        }
+        let timestamps = poll_until_count(
+            4,
+            Duration::from_secs(10),
+            Duration::from_millis(500),
+            async |timeout| {
+                timestamp_scanner
+                    .poll(timeout)
+                    .await
+                    .expect("Failed to poll timestamps")
+                    .into_records_by_buckets()
+                    .into_values()
+                    .flatten()
+                    .map(|record| record.timestamp())
+                    .collect()
+            },
+        )
+        .await;
+        assert_eq!(timestamps.len(), 4, "Expected four server timestamps");
+        let starting_timestamp_ms = timestamps.iter().min().copied().unwrap() - 1;
+        let stopping_timestamp_ms = timestamps.iter().max().copied().unwrap() + 1;
+
+        let scanner = table
+            .new_scan()
+            .create_record_batch_log_scanner()
+            .expect("Failed to create record batch scanner");
+        let mut reader = RecordBatchLogReader::new_between_timestamps(
+            scanner,
+            &admin,
+            &buckets,
+            starting_timestamp_ms,
+            stopping_timestamp_ms,
+        )
+        .await
+        .expect("Failed to create timestamp-range reader");
+        let batches = tokio::time::timeout(Duration::from_secs(10), reader.collect_all_batches())
+            .await
+            .expect("Timed out collecting timestamp-range batches")
+            .expect("Failed to collect timestamp-range batches");
+
+        let mut ids = extract_ids_from_batches(&batches);
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec![1, 2, 3, 4],
+            "timestamp-range reader should resolve and read both partitions"
         );
 
         admin

--- a/fluss-rust/website/docs/user-guide/cpp/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/cpp/api-reference.md
@@ -263,7 +263,7 @@ offset, and returns one batch per successful `NextBatch()` call.
 |---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
 | `Available() -> bool`                                                                                         | Check whether the reader is valid                              |
 | `NextBatch(int64_t timeout_ms, RecordBatchReadResult& out) -> Result` | Wait up to the timeout for one batch, timeout, or completion   |
-| `CollectAllBatches(int64_t timeout_ms, ArrowRecordBatches& out) -> Result`                | Drain batches until every stopping offset is reached or the budget elapses |
+| `CollectAllBatches(int64_t timeout_ms, ArrowRecordBatches& out) -> Result`                | Drain batches using one whole-operation timeout budget       |
 
 `BoundedReadStatus` is `BatchAvailable`, `TimedOut`, or `Finished`. Inspect `out.status` only
 when the returned `Result` is `Ok()`; on a non-Ok `Result` the status is reset to `Finished`,
@@ -273,16 +273,17 @@ forever. A timeout does not exhaust the reader; callers may check cancellation a
 
 :::caution Partial results on timeout
 
-`CollectAllBatches()` is not atomic. It takes a total timeout budget and appends complete batches
-to `out` as they arrive. If the budget elapses, `out` may therefore contain only part of the
-bounded result and the method returns a retriable `REQUEST_TIME_OUT`. Only an `Ok()` result means
-every stopping offset has been reached.
+`CollectAllBatches()` uses `timeout_ms` as the total execution budget for the whole invocation.
+Callers should normally pass the query's remaining execution time and invoke the method once. It
+appends complete batches to `out` as they arrive. If the budget expires, collection stops,
+`out` may contain only part of the bounded result, and the method returns a retriable
+`REQUEST_TIME_OUT`. Only an `Ok()` result means every stopping offset has been reached.
 
-The timeout never splits an individual Arrow batch. The reader remains valid, and calling the
-method again with the same reader and `out` continues after the batches already returned instead
-of reading them again. The timeout budget applies to one invocation only. Retrying is optional;
-callers that retry must enforce an overall query deadline or cancellation condition because an
-unconditional retry loop can run forever if the stopping offsets remain unreachable.
+The timeout is checked between complete Arrow batches and never splits a batch already being
+returned. The method does not internally retry after the budget is exhausted. The reader remains
+valid, so an application may explicitly resume with the same reader and `out`, but the normal
+whole-query behavior is to propagate the timeout/incomplete result rather than start an
+unconditional retry loop.
 
 :::
 

--- a/fluss-rust/website/docs/user-guide/cpp/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/cpp/api-reference.md
@@ -230,15 +230,15 @@ useful when subscriptions need to be configured incrementally.
 | Field             | Type          | Description                         |
 |-------------------|---------------|-------------------------------------|
 | `bucket`          | `TableBucket` | Bucket assigned to this reader      |
-| `starting_offset` | `int64_t`     | Inclusive starting offset           |
-| `stopping_offset` | `int64_t`     | Exclusive stopping offset           |
+| `starting_offset` | `int64_t`     | Inclusive non-negative offset or `EARLIEST_OFFSET` |
+| `stopping_offset` | `int64_t`     | Non-negative exclusive stopping offset |
 
 ## `TimestampRange`
 
 | Field                     | Type      | Description                                  |
 |---------------------------|-----------|----------------------------------------------|
-| `starting_timestamp_ms`   | `int64_t` | Starting log timestamp in epoch milliseconds |
-| `stopping_timestamp_ms`   | `int64_t` | Stopping log timestamp in epoch milliseconds |
+| `starting_timestamp_ms`   | `int64_t` | Inclusive starting timestamp in epoch milliseconds |
+| `stopping_timestamp_ms`   | `int64_t` | Exclusive stopping timestamp in epoch milliseconds |
 
 ## `RecordBatchReadResult`
 
@@ -295,9 +295,9 @@ than start an unconditional retry loop.
 
 `TableScan::CreateRecordBatchLogReader()` accepts resolved per-bucket ranges, which is useful when
 a coordinator has selected globally consistent offsets for multiple workers. Each bucket id is
-validated against the table's configured bucket count. The timestamp overload resolves both
-timestamps with `OffsetSpec::Timestamp` for every requested bucket before reading; independent
-partition lookups are issued concurrently.
+validated against the table's configured bucket count, and stopping offsets must be non-negative.
+The timestamp overload resolves both timestamps with `OffsetSpec::Timestamp` for every requested
+bucket before reading; independent partition lookups are issued concurrently.
 
 ## `BatchScanner`
 

--- a/fluss-rust/website/docs/user-guide/cpp/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/cpp/api-reference.md
@@ -271,10 +271,20 @@ so a caller that skips the error check terminates instead of retrying a failed r
 forever. A timeout does not exhaust the reader; callers may check cancellation and invoke
 `NextBatch()` again.
 
-`CollectAllBatches()` takes a total budget and *appends* to `out`. If the budget elapses before
-completion, the reader stays valid and it returns a retriable `REQUEST_TIME_OUT` `Result`, so
-calling it again with the same `out` resumes the drain instead of blocking forever on an
-unreachable stopping offset (e.g. during a tablet server outage).
+:::caution Partial results on timeout
+
+`CollectAllBatches()` is not atomic. It takes a total timeout budget and appends complete batches
+to `out` as they arrive. If the budget elapses, `out` may therefore contain only part of the
+bounded result and the method returns a retriable `REQUEST_TIME_OUT`. Only an `Ok()` result means
+every stopping offset has been reached.
+
+The timeout never splits an individual Arrow batch. The reader remains valid, and calling the
+method again with the same reader and `out` continues after the batches already returned instead
+of reading them again. The timeout budget applies to one invocation only. Retrying is optional;
+callers that retry must enforce an overall query deadline or cancellation condition because an
+unconditional retry loop can run forever if the stopping offsets remain unreachable.
+
+:::
 
 `RecordBatchReadResult::batch` is non-null only when `status` is `BatchAvailable`.
 

--- a/fluss-rust/website/docs/user-guide/cpp/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/cpp/api-reference.md
@@ -205,6 +205,37 @@ Performs prefix (bucket-key) lookups, returning all rows whose primary key start
 | `UnsubscribePartition(int64_t partition_id, int32_t bucket_id) -> Result`                            | Unsubscribe from a partition bucket       |
 | `Poll(int64_t timeout_ms, ScanRecords& out) -> Result`                                               | Poll individual records                   |
 | `PollRecordBatch(int64_t timeout_ms, ArrowRecordBatches& out) -> Result`                             | Poll Arrow RecordBatches                  |
+| `CreateRecordBatchLogReaderUntilLatest(const Admin& admin, RecordBatchLogReader& out) -> Result`     | Create a bounded reader using the latest offsets observed during the call |
+| `CreateRecordBatchLogReaderUntilOffsets(const std::vector<ReaderStopOffset>& offsets, RecordBatchLogReader& out) -> Result` | Create a bounded reader using explicit stopping offsets |
+
+The reader methods require a scanner created by
+`TableScan::CreateRecordBatchLogScanner()`. Subscribe every bucket assigned to this reader first;
+subscriptions provide the starting offsets, while `ReaderStopOffset` provides the stopping offset
+for each bucket. Only one reader or polling operation may consume a scanner at a time.
+
+## `ReaderStopOffset`
+
+| Field    | Type          | Description                                      |
+|----------|---------------|--------------------------------------------------|
+| `bucket` | `TableBucket` | A bucket already subscribed on the log scanner   |
+| `offset` | `int64_t`     | Offset at which the bounded reader stops          |
+
+## `RecordBatchLogReader`
+
+Bounded Arrow record-batch reader created from a subscribed `LogScanner`.
+
+| Method                                                                                             | Description                                                    |
+|----------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `Available() -> bool`                                                                              | Check whether the reader is valid                              |
+| `NextBatch(int64_t timeout_ms, ArrowRecordBatches& out, BoundedReadStatus& status) -> Result`       | Wait up to the timeout for a batch, timeout, or completion     |
+| `CollectAllBatches(ArrowRecordBatches& out) -> Result`                                             | Drain all batches until every stopping offset has been reached |
+
+`BoundedReadStatus` is `BatchAvailable`, `TimedOut`, or `Finished`. A timeout does not exhaust
+the reader; callers may check cancellation and invoke `NextBatch()` again.
+
+`CreateRecordBatchLogReaderUntilLatest()` queries the latest offset of every subscribed bucket
+when the reader is created. `CreateRecordBatchLogReaderUntilOffsets()` is useful when a
+coordinator has already selected offsets and needs multiple workers to use the same boundary.
 
 ## `BatchScanner`
 

--- a/fluss-rust/website/docs/user-guide/cpp/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/cpp/api-reference.md
@@ -277,7 +277,10 @@ forever. A timeout does not exhaust the reader; callers may check cancellation a
 Callers should normally pass the query's remaining execution time and invoke the method once. It
 appends complete batches to `out` as they arrive. If the budget expires, collection stops,
 `out` may contain only part of the bounded result, and the method returns a retriable
-`REQUEST_TIME_OUT`. Only an `Ok()` result means every stopping offset has been reached.
+`REQUEST_TIME_OUT`. Only an `Ok()` result means every stopping offset has been reached. Reaching
+every stopping offset always reports `Ok()`, even when the budget expired in the meantime, so a
+complete result never surfaces as a timeout. A non-positive `timeout_ms` returns
+`REQUEST_TIME_OUT` without attempting a read.
 
 The timeout is checked between complete Arrow batches and never splits a batch already being
 returned. The method does not internally retry after the budget is exhausted. The reader remains

--- a/fluss-rust/website/docs/user-guide/cpp/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/cpp/api-reference.md
@@ -279,14 +279,15 @@ appends complete batches to `out` as they arrive. If the budget expires, collect
 `out` may contain only part of the bounded result, and the method returns a retriable
 `REQUEST_TIME_OUT`. Only an `Ok()` result means every stopping offset has been reached. Reaching
 every stopping offset always reports `Ok()`, even when the budget expired in the meantime, so a
-complete result never surfaces as a timeout. A non-positive `timeout_ms` returns
-`REQUEST_TIME_OUT` without attempting a read.
+complete result never surfaces as a timeout. Once the budget is exhausted, the reader does not wait
+for additional scanner data, but it still returns already-buffered batches and observes an
+already-complete reader. Consequently, a non-positive `timeout_ms` returns `Ok()` when the reader
+is already complete and `REQUEST_TIME_OUT` when unread work remains.
 
-The timeout is checked between complete Arrow batches and never splits a batch already being
-returned. The method does not internally retry after the budget is exhausted. The reader remains
-valid, so an application may explicitly resume with the same reader and `out`, but the normal
-whole-query behavior is to propagate the timeout/incomplete result rather than start an
-unconditional retry loop.
+The method does not internally retry or perform another blocking poll after the budget is
+exhausted. The reader remains valid, so an application may explicitly resume with the same reader
+and `out`, but the normal whole-query behavior is to propagate the timeout/incomplete result rather
+than start an unconditional retry loop.
 
 :::
 

--- a/fluss-rust/website/docs/user-guide/cpp/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/cpp/api-reference.md
@@ -263,10 +263,18 @@ offset, and returns one batch per successful `NextBatch()` call.
 |---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
 | `Available() -> bool`                                                                                         | Check whether the reader is valid                              |
 | `NextBatch(int64_t timeout_ms, RecordBatchReadResult& out) -> Result` | Wait up to the timeout for one batch, timeout, or completion   |
-| `CollectAllBatches(ArrowRecordBatches& out) -> Result`                | Drain all batches until every stopping offset has been reached |
+| `CollectAllBatches(int64_t timeout_ms, ArrowRecordBatches& out) -> Result`                | Drain batches until every stopping offset is reached or the budget elapses |
 
-`BoundedReadStatus` is `BatchAvailable`, `TimedOut`, or `Finished`. A timeout does not exhaust
-the reader; callers may check cancellation and invoke `NextBatch()` again.
+`BoundedReadStatus` is `BatchAvailable`, `TimedOut`, or `Finished`. Inspect `out.status` only
+when the returned `Result` is `Ok()`; on a non-Ok `Result` the status is reset to `Finished`,
+so a caller that skips the error check terminates instead of retrying a failed read
+forever. A timeout does not exhaust the reader; callers may check cancellation and invoke
+`NextBatch()` again.
+
+`CollectAllBatches()` takes a total budget and *appends* to `out`. If the budget elapses before
+completion, the reader stays valid and it returns a retriable `REQUEST_TIME_OUT` `Result`, so
+calling it again with the same `out` resumes the drain instead of blocking forever on an
+unreachable stopping offset (e.g. during a tablet server outage).
 
 `RecordBatchReadResult::batch` is non-null only when `status` is `BatchAvailable`.
 

--- a/fluss-rust/website/docs/user-guide/cpp/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/cpp/api-reference.md
@@ -152,7 +152,9 @@ Complete API reference for the Fluss C++ client.
 | `ProjectByName(std::vector<std::string> column_names) -> TableScan&` | Project columns by name                       |
 | `Limit(int32_t row_number) -> TableScan&`                            | Set a positive row limit (enables `CreateBucketBatchScanner`; rejected by log scanners) |
 | `CreateLogScanner(LogScanner& out) -> Result`                        | Create a record-based log scanner; on a primary-key table, subscribes to its CDC changelog (per-record `change_type`) |
-| `CreateRecordBatchLogScanner(LogScanner& out) -> Result`             | Create an Arrow RecordBatch-based log scanner (log tables only — no per-record change types) |
+| `CreateRecordBatchLogScanner(RecordBatchLogScanner& out) -> Result`  | Create a strongly typed Arrow RecordBatch scanner |
+| `CreateRecordBatchLogReader(const std::vector<RecordBatchLogReadRange>& ranges, RecordBatchLogReader& out) -> Result` | Create a bounded reader directly from per-bucket offset ranges |
+| `CreateRecordBatchLogReader(Admin& admin, const std::vector<TableBucket>& buckets, const TimestampRange& range, RecordBatchLogReader& out) -> Result` | Resolve a timestamp range per bucket and create a bounded reader |
 | `CreateBucketBatchScanner(const TableBucket& bucket, BatchScanner& out) -> Result` | Bounded scan of one bucket (requires `Limit`) |
 
 ## `AppendWriter`
@@ -204,14 +206,46 @@ Performs prefix (bucket-key) lookups, returning all rows whose primary key start
 | `Unsubscribe(int32_t bucket_id) -> Result`                                                           | Unsubscribe from a non-partitioned bucket |
 | `UnsubscribePartition(int64_t partition_id, int32_t bucket_id) -> Result`                            | Unsubscribe from a partition bucket       |
 | `Poll(int64_t timeout_ms, ScanRecords& out) -> Result`                                               | Poll individual records                   |
-| `PollRecordBatch(int64_t timeout_ms, ArrowRecordBatches& out) -> Result`                             | Poll Arrow RecordBatches                  |
-| `CreateRecordBatchLogReaderUntilLatest(const Admin& admin, RecordBatchLogReader& out) -> Result`     | Create a bounded reader using the latest offsets observed during the call |
-| `CreateRecordBatchLogReaderUntilOffsets(const std::vector<ReaderStopOffset>& offsets, RecordBatchLogReader& out) -> Result` | Create a bounded reader using explicit stopping offsets |
+| `PollRecordBatch(int64_t timeout_ms, ArrowRecordBatches& out) -> Result`                             | Legacy Arrow RecordBatch polling API      |
 
-The reader methods require a scanner created by
-`TableScan::CreateRecordBatchLogScanner()`. Subscribe every bucket assigned to this reader first;
-subscriptions provide the starting offsets, while `ReaderStopOffset` provides the stopping offset
-for each bucket. Only one reader or polling operation may consume a scanner at a time.
+## `RecordBatchLogScanner`
+
+Strongly typed unbounded Arrow RecordBatch scanner. Its subscribe and unsubscribe methods mirror
+`LogScanner`; `Poll()` returns Arrow batches.
+
+| Method                                                                                               | Description                              |
+|------------------------------------------------------------------------------------------------------|------------------------------------------|
+| `Subscribe(int32_t bucket_id, int64_t offset) -> Result`                                             | Subscribe to a single bucket             |
+| `Subscribe(const std::vector<BucketSubscription>& bucket_offsets) -> Result`                         | Subscribe to multiple buckets            |
+| `SubscribePartitionBuckets(const std::vector<PartitionBucketSubscription>& subscriptions) -> Result` | Subscribe to multiple partition buckets |
+| `Poll(int64_t timeout_ms, ArrowRecordBatches& out) -> Result`                                        | Poll Arrow RecordBatches                 |
+| `CreateRecordBatchLogReaderUntilLatest(const Admin& admin, RecordBatchLogReader& out) && -> Result`  | Move the scanner into a reader bounded by current latest offsets |
+| `CreateRecordBatchLogReaderUntilOffsets(const std::vector<ReaderStopOffset>& offsets, RecordBatchLogReader& out) && -> Result` | Move the scanner into a reader using explicit stops |
+
+Prefer `TableScan::CreateRecordBatchLogReader()` for query engines. The scanner-level methods are
+useful when subscriptions need to be configured incrementally.
+
+## `RecordBatchLogReadRange`
+
+| Field             | Type          | Description                         |
+|-------------------|---------------|-------------------------------------|
+| `bucket`          | `TableBucket` | Bucket assigned to this reader      |
+| `starting_offset` | `int64_t`     | Inclusive starting offset           |
+| `stopping_offset` | `int64_t`     | Exclusive stopping offset           |
+
+## `TimestampRange`
+
+| Field                     | Type      | Description                                  |
+|---------------------------|-----------|----------------------------------------------|
+| `starting_timestamp_ms`   | `int64_t` | Starting log timestamp in epoch milliseconds |
+| `stopping_timestamp_ms`   | `int64_t` | Stopping log timestamp in epoch milliseconds |
+
+## `RecordBatchReadResult`
+
+| Field    | Type                                | Description                                      |
+|----------|-------------------------------------|--------------------------------------------------|
+| `status` | `BoundedReadStatus`                 | Batch available, timed out, or finished          |
+| `batch`  | `std::unique_ptr<ArrowRecordBatch>` | Present only when `status` is `BatchAvailable`   |
 
 ## `ReaderStopOffset`
 
@@ -222,20 +256,24 @@ for each bucket. Only one reader or polling operation may consume a scanner at a
 
 ## `RecordBatchLogReader`
 
-Bounded Arrow record-batch reader created from a subscribed `LogScanner`.
+Bounded Arrow record-batch reader. It can manage multiple buckets, each with its own stopping
+offset, and returns one batch per successful `NextBatch()` call.
 
-| Method                                                                                             | Description                                                    |
-|----------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
-| `Available() -> bool`                                                                              | Check whether the reader is valid                              |
-| `NextBatch(int64_t timeout_ms, ArrowRecordBatches& out, BoundedReadStatus& status) -> Result`       | Wait up to the timeout for a batch, timeout, or completion     |
-| `CollectAllBatches(ArrowRecordBatches& out) -> Result`                                             | Drain all batches until every stopping offset has been reached |
+| Method                                                                                                        | Description                                                    |
+|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `Available() -> bool`                                                                                         | Check whether the reader is valid                              |
+| `NextBatch(int64_t timeout_ms, RecordBatchReadResult& out) -> Result` | Wait up to the timeout for one batch, timeout, or completion   |
+| `CollectAllBatches(ArrowRecordBatches& out) -> Result`                | Drain all batches until every stopping offset has been reached |
 
 `BoundedReadStatus` is `BatchAvailable`, `TimedOut`, or `Finished`. A timeout does not exhaust
 the reader; callers may check cancellation and invoke `NextBatch()` again.
 
-`CreateRecordBatchLogReaderUntilLatest()` queries the latest offset of every subscribed bucket
-when the reader is created. `CreateRecordBatchLogReaderUntilOffsets()` is useful when a
-coordinator has already selected offsets and needs multiple workers to use the same boundary.
+`RecordBatchReadResult::batch` is non-null only when `status` is `BatchAvailable`.
+
+`TableScan::CreateRecordBatchLogReader()` accepts resolved per-bucket ranges, which is useful when
+a coordinator has selected globally consistent offsets for multiple workers. The timestamp
+overload resolves both timestamps with `OffsetSpec::Timestamp` for every requested bucket before
+reading.
 
 ## `BatchScanner`
 

--- a/fluss-rust/website/docs/user-guide/cpp/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/cpp/api-reference.md
@@ -294,9 +294,10 @@ than start an unconditional retry loop.
 `RecordBatchReadResult::batch` is non-null only when `status` is `BatchAvailable`.
 
 `TableScan::CreateRecordBatchLogReader()` accepts resolved per-bucket ranges, which is useful when
-a coordinator has selected globally consistent offsets for multiple workers. The timestamp
-overload resolves both timestamps with `OffsetSpec::Timestamp` for every requested bucket before
-reading.
+a coordinator has selected globally consistent offsets for multiple workers. Each bucket id is
+validated against the table's configured bucket count. The timestamp overload resolves both
+timestamps with `OffsetSpec::Timestamp` for every requested bucket before reading; independent
+partition lookups are issued concurrently.
 
 ## `BatchScanner`
 

--- a/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
+++ b/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
@@ -169,19 +169,22 @@ for (int32_t bucket_id : bucket_ids) {
 fluss::RecordBatchLogReader reader;
 table.NewScan().CreateRecordBatchLogReader(ranges, reader);
 
-while (true) {
+const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+bool finished = false;
+while (std::chrono::steady_clock::now() < deadline) {
     fluss::RecordBatchReadResult result;
     auto read_result = reader.NextBatch(1000, result);
     if (!read_result.Ok()) {
         if (!read_result.IsRetriable()) {
             throw std::runtime_error(read_result.error_message);
         }
-        continue;  // Retriable: check query cancellation before retrying.
+        continue;
     }
     if (result.status == fluss::BoundedReadStatus::TimedOut) {
-        continue;  // Check query cancellation before retrying.
+        continue;
     }
     if (result.status == fluss::BoundedReadStatus::Finished) {
+        finished = true;
         break;
     }
 
@@ -189,6 +192,9 @@ while (true) {
               << " base_offset=" << result.batch->GetBaseOffset()
               << " last_offset=" << result.batch->GetLastOffset()
               << " rows=" << result.batch->NumRows() << std::endl;
+}
+if (!finished) {
+    throw std::runtime_error("Bounded read exceeded its execution deadline");
 }
 ```
 
@@ -205,7 +211,9 @@ table.NewScan().CreateRecordBatchLogReader(
     admin, assigned_buckets,
     fluss::TimestampRange{starting_timestamp_ms, stopping_timestamp_ms}, reader);
 
-while (true) {
+const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+bool finished = false;
+while (std::chrono::steady_clock::now() < deadline) {
     fluss::RecordBatchReadResult result;
     auto read_result = reader.NextBatch(1000, result);
     if (!read_result.Ok()) {
@@ -218,9 +226,13 @@ while (true) {
         continue;
     }
     if (result.status == fluss::BoundedReadStatus::Finished) {
+        finished = true;
         break;
     }
     process(result.batch->GetArrowRecordBatch());
+}
+if (!finished) {
+    throw std::runtime_error("Bounded read exceeded its execution deadline");
 }
 ```
 
@@ -238,21 +250,12 @@ fluss::RecordBatchLogReader latest_reader;
 std::move(latest_scanner).CreateRecordBatchLogReaderUntilLatest(admin, latest_reader);
 
 fluss::ArrowRecordBatches batches;
-const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
-bool completed = false;
-while (!query_cancelled() && std::chrono::steady_clock::now() < deadline) {
-    auto collect_result = latest_reader.CollectAllBatches(1000, batches);
-    if (collect_result.Ok()) {
-        completed = true;
-        break;
-    }
-    if (collect_result.error_code != fluss::ErrorCode::REQUEST_TIME_OUT) {
-        throw std::runtime_error(collect_result.error_message);
-    }
-    // The per-call timeout returned control; the next iteration may resume.
-}
-if (!completed) {
-    throw std::runtime_error("Bounded read cancelled or exceeded its overall deadline");
+// Use the remaining query execution time as the budget for the whole collection.
+auto collect_result = latest_reader.CollectAllBatches(30000, batches);
+if (!collect_result.Ok()) {
+    // `batches` may be partial. Propagate the timeout/error instead of treating
+    // it as a complete bounded result or retrying unconditionally.
+    throw std::runtime_error(collect_result.error_message);
 }
 ```
 
@@ -263,10 +266,15 @@ unavailable after it is moved into the reader.
 
 `CollectAllBatches()` is not all-or-nothing. It appends complete batches to its output while
 reading, so a `REQUEST_TIME_OUT` result may leave `batches` partially populated. Only an `Ok()`
-result means all stopping offsets have been reached. The timeout never splits an individual Arrow
-batch, and retrying with the same reader and output continues after the batches already returned.
-The timeout applies to one `CollectAllBatches()` invocation, not the whole retry loop, so every
-retry loop must have an overall deadline or cancellation condition.
+result means all stopping offsets have been reached.
+
+The supplied timeout is the total execution budget for the whole `CollectAllBatches()` call, not a
+per-batch polling timeout. Once the budget expires, the method stops collecting and returns
+`REQUEST_TIME_OUT`; it does not internally retry with a fresh budget. The timeout is checked
+between complete Arrow batches and never splits a batch already being returned. The reader remains
+valid after timeout, but applications should normally propagate the incomplete result. Resuming
+with the same reader and output should only be done as an explicit higher-level policy with its own
+deadline.
 
 :::
 

--- a/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
+++ b/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
@@ -144,6 +144,80 @@ for (size_t i = 0; i < batches.Size(); ++i) {
 }
 ```
 
+## Bounded Arrow RecordBatch Reading
+
+Use `RecordBatchLogReader` when the scan should finish after reaching a fixed offset for every
+bucket. Starting offsets are configured by subscribing the scanner. Stopping offsets can be
+queried once and passed explicitly:
+
+```cpp
+auto info = table.GetTableInfo();
+
+std::vector<int32_t> bucket_ids;
+for (int32_t bucket_id = 0; bucket_id < info.num_buckets; ++bucket_id) {
+    bucket_ids.push_back(bucket_id);
+}
+
+std::unordered_map<int32_t, int64_t> latest_offsets;
+admin.ListOffsets(table_path, bucket_ids, fluss::OffsetSpec::Latest(), latest_offsets);
+
+fluss::LogScanner scanner;
+table.NewScan().CreateRecordBatchLogScanner(scanner);
+
+std::vector<fluss::ReaderStopOffset> stopping_offsets;
+for (int32_t bucket_id : bucket_ids) {
+    scanner.Subscribe(bucket_id, 0);
+    stopping_offsets.push_back(
+        {fluss::TableBucket{info.table_id, bucket_id}, latest_offsets.at(bucket_id)});
+}
+
+fluss::RecordBatchLogReader reader;
+scanner.CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, reader);
+
+while (true) {
+    fluss::ArrowRecordBatches batches;
+    fluss::BoundedReadStatus status;
+    reader.NextBatch(1000, batches, status);
+    if (status == fluss::BoundedReadStatus::TimedOut) {
+        continue;  // Check query cancellation before retrying.
+    }
+    if (status == fluss::BoundedReadStatus::Finished) {
+        break;
+    }
+
+    for (const auto& batch : batches) {
+        std::cout << "bucket=" << batch->GetBucketId()
+                  << " base_offset=" << batch->GetBaseOffset()
+                  << " last_offset=" << batch->GetLastOffset()
+                  << " rows=" << batch->NumRows() << std::endl;
+    }
+}
+```
+
+`TimedOut` does not exhaust the reader. It lets a query engine periodically check cancellation
+or deadlines before retrying. `Finished` means all stopping offsets have been reached.
+
+For the common case where the client should read everything currently available, let the
+reader query the latest offsets:
+
+```cpp
+fluss::LogScanner latest_scanner;
+table.NewScan().CreateRecordBatchLogScanner(latest_scanner);
+for (int32_t bucket_id : bucket_ids) {
+    latest_scanner.Subscribe(bucket_id, 0);
+}
+
+fluss::RecordBatchLogReader latest_reader;
+latest_scanner.CreateRecordBatchLogReaderUntilLatest(admin, latest_reader);
+
+fluss::ArrowRecordBatches batches;
+latest_reader.CollectAllBatches(batches);
+```
+
+Subscribe every bucket assigned to the reader before creating it. Do not call `PollRecordBatch()`
+or create a second reader concurrently on the same scanner. Destroy the reader before reusing
+that scanner.
+
 ## Column Projection
 
 ```cpp

--- a/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
+++ b/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
@@ -171,7 +171,13 @@ table.NewScan().CreateRecordBatchLogReader(ranges, reader);
 
 while (true) {
     fluss::RecordBatchReadResult result;
-    reader.NextBatch(1000, result);
+    auto read_result = reader.NextBatch(1000, result);
+    if (!read_result.Ok()) {
+        if (!read_result.IsRetriable()) {
+            throw std::runtime_error(read_result.error_message);
+        }
+        continue;  // Retriable: check query cancellation before retrying.
+    }
     if (result.status == fluss::BoundedReadStatus::TimedOut) {
         continue;  // Check query cancellation before retrying.
     }
@@ -186,8 +192,9 @@ while (true) {
 }
 ```
 
-`TimedOut` does not exhaust the reader. It lets a query engine periodically check cancellation
-or deadlines before retrying. `Finished` means all stopping offsets have been reached.
+Inspect `result.status` only when `NextBatch()` returns an `Ok()` result. `TimedOut` does not
+exhaust the reader; it lets a query engine periodically check cancellation or deadlines before
+retrying. `Finished` means all stopping offsets have been reached.
 
 To read a log timestamp range, pass the assigned buckets and timestamps. Fluss resolves both
 timestamps with `OffsetSpec::Timestamp` for every bucket, then uses the same bounded offset reader:
@@ -200,7 +207,13 @@ table.NewScan().CreateRecordBatchLogReader(
 
 while (true) {
     fluss::RecordBatchReadResult result;
-    reader.NextBatch(1000, result);
+    auto read_result = reader.NextBatch(1000, result);
+    if (!read_result.Ok()) {
+        if (!read_result.IsRetriable()) {
+            throw std::runtime_error(read_result.error_message);
+        }
+        continue;
+    }
     if (result.status == fluss::BoundedReadStatus::TimedOut) {
         continue;
     }
@@ -225,11 +238,22 @@ fluss::RecordBatchLogReader latest_reader;
 std::move(latest_scanner).CreateRecordBatchLogReaderUntilLatest(admin, latest_reader);
 
 fluss::ArrowRecordBatches batches;
-latest_reader.CollectAllBatches(batches);
+while (true) {
+    auto collect_result = latest_reader.CollectAllBatches(30000, batches);
+    if (collect_result.Ok()) {
+        break;
+    }
+    if (!collect_result.IsRetriable()) {
+        throw std::runtime_error(collect_result.error_message);
+    }
+    // Check query cancellation, then call again with the same `batches` to resume.
+}
 ```
 
 The scanner-level creation methods transfer ownership on success, so the scanner becomes
-unavailable after it is moved into the reader.
+unavailable after it is moved into the reader. `CollectAllBatches()` uses a total timeout budget
+and appends to its output, so it cannot block forever on an unreachable stopping offset and can
+resume without losing batches already returned.
 
 ## Column Projection
 

--- a/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
+++ b/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
@@ -238,22 +238,37 @@ fluss::RecordBatchLogReader latest_reader;
 std::move(latest_scanner).CreateRecordBatchLogReaderUntilLatest(admin, latest_reader);
 
 fluss::ArrowRecordBatches batches;
-while (true) {
-    auto collect_result = latest_reader.CollectAllBatches(30000, batches);
+const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+bool completed = false;
+while (!query_cancelled() && std::chrono::steady_clock::now() < deadline) {
+    auto collect_result = latest_reader.CollectAllBatches(1000, batches);
     if (collect_result.Ok()) {
+        completed = true;
         break;
     }
-    if (!collect_result.IsRetriable()) {
+    if (collect_result.error_code != fluss::ErrorCode::REQUEST_TIME_OUT) {
         throw std::runtime_error(collect_result.error_message);
     }
-    // Check query cancellation, then call again with the same `batches` to resume.
+    // The per-call timeout returned control; the next iteration may resume.
+}
+if (!completed) {
+    throw std::runtime_error("Bounded read cancelled or exceeded its overall deadline");
 }
 ```
 
 The scanner-level creation methods transfer ownership on success, so the scanner becomes
-unavailable after it is moved into the reader. `CollectAllBatches()` uses a total timeout budget
-and appends to its output, so it cannot block forever on an unreachable stopping offset and can
-resume without losing batches already returned.
+unavailable after it is moved into the reader.
+
+:::caution Partial results on timeout
+
+`CollectAllBatches()` is not all-or-nothing. It appends complete batches to its output while
+reading, so a `REQUEST_TIME_OUT` result may leave `batches` partially populated. Only an `Ok()`
+result means all stopping offsets have been reached. The timeout never splits an individual Arrow
+batch, and retrying with the same reader and output continues after the batches already returned.
+The timeout applies to one `CollectAllBatches()` invocation, not the whole retry loop, so every
+retry loop must have an overall deadline or cancellation condition.
+
+:::
 
 ## Column Projection
 

--- a/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
+++ b/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
@@ -123,7 +123,7 @@ scanner.Unsubscribe(1);
 ```cpp
 #include <arrow/record_batch.h>
 
-fluss::LogScanner arrow_scanner;
+fluss::RecordBatchLogScanner arrow_scanner;
 table.NewScan().CreateRecordBatchLogScanner(arrow_scanner);
 
 for (int b = 0; b < info.num_buckets; ++b) {
@@ -131,7 +131,7 @@ for (int b = 0; b < info.num_buckets; ++b) {
 }
 
 fluss::ArrowRecordBatches batches;
-arrow_scanner.PollRecordBatch(5000, batches);
+arrow_scanner.Poll(5000, batches);
 
 for (size_t i = 0; i < batches.Size(); ++i) {
     const auto& batch = batches[i];
@@ -147,8 +147,7 @@ for (size_t i = 0; i < batches.Size(); ++i) {
 ## Bounded Arrow RecordBatch Reading
 
 Use `RecordBatchLogReader` when the scan should finish after reaching a fixed offset for every
-bucket. Starting offsets are configured by subscribing the scanner. Stopping offsets can be
-queried once and passed explicitly:
+bucket. Query engines can pass the complete per-bucket ranges directly:
 
 ```cpp
 auto info = table.GetTableInfo();
@@ -161,62 +160,76 @@ for (int32_t bucket_id = 0; bucket_id < info.num_buckets; ++bucket_id) {
 std::unordered_map<int32_t, int64_t> latest_offsets;
 admin.ListOffsets(table_path, bucket_ids, fluss::OffsetSpec::Latest(), latest_offsets);
 
-fluss::LogScanner scanner;
-table.NewScan().CreateRecordBatchLogScanner(scanner);
-
-std::vector<fluss::ReaderStopOffset> stopping_offsets;
+std::vector<fluss::RecordBatchLogReadRange> ranges;
 for (int32_t bucket_id : bucket_ids) {
-    scanner.Subscribe(bucket_id, 0);
-    stopping_offsets.push_back(
-        {fluss::TableBucket{info.table_id, bucket_id}, latest_offsets.at(bucket_id)});
+    ranges.push_back(
+        {fluss::TableBucket{info.table_id, bucket_id}, 0, latest_offsets.at(bucket_id)});
 }
 
 fluss::RecordBatchLogReader reader;
-scanner.CreateRecordBatchLogReaderUntilOffsets(stopping_offsets, reader);
+table.NewScan().CreateRecordBatchLogReader(ranges, reader);
 
 while (true) {
-    fluss::ArrowRecordBatches batches;
-    fluss::BoundedReadStatus status;
-    reader.NextBatch(1000, batches, status);
-    if (status == fluss::BoundedReadStatus::TimedOut) {
+    fluss::RecordBatchReadResult result;
+    reader.NextBatch(1000, result);
+    if (result.status == fluss::BoundedReadStatus::TimedOut) {
         continue;  // Check query cancellation before retrying.
     }
-    if (status == fluss::BoundedReadStatus::Finished) {
+    if (result.status == fluss::BoundedReadStatus::Finished) {
         break;
     }
 
-    for (const auto& batch : batches) {
-        std::cout << "bucket=" << batch->GetBucketId()
-                  << " base_offset=" << batch->GetBaseOffset()
-                  << " last_offset=" << batch->GetLastOffset()
-                  << " rows=" << batch->NumRows() << std::endl;
-    }
+    std::cout << "bucket=" << result.batch->GetBucketId()
+              << " base_offset=" << result.batch->GetBaseOffset()
+              << " last_offset=" << result.batch->GetLastOffset()
+              << " rows=" << result.batch->NumRows() << std::endl;
 }
 ```
 
 `TimedOut` does not exhaust the reader. It lets a query engine periodically check cancellation
 or deadlines before retrying. `Finished` means all stopping offsets have been reached.
 
+To read a log timestamp range, pass the assigned buckets and timestamps. Fluss resolves both
+timestamps with `OffsetSpec::Timestamp` for every bucket, then uses the same bounded offset reader:
+
+```cpp
+fluss::RecordBatchLogReader reader;
+table.NewScan().CreateRecordBatchLogReader(
+    admin, assigned_buckets,
+    fluss::TimestampRange{starting_timestamp_ms, stopping_timestamp_ms}, reader);
+
+while (true) {
+    fluss::RecordBatchReadResult result;
+    reader.NextBatch(1000, result);
+    if (result.status == fluss::BoundedReadStatus::TimedOut) {
+        continue;
+    }
+    if (result.status == fluss::BoundedReadStatus::Finished) {
+        break;
+    }
+    process(result.batch->GetArrowRecordBatch());
+}
+```
+
 For the common case where the client should read everything currently available, let the
 reader query the latest offsets:
 
 ```cpp
-fluss::LogScanner latest_scanner;
+fluss::RecordBatchLogScanner latest_scanner;
 table.NewScan().CreateRecordBatchLogScanner(latest_scanner);
 for (int32_t bucket_id : bucket_ids) {
     latest_scanner.Subscribe(bucket_id, 0);
 }
 
 fluss::RecordBatchLogReader latest_reader;
-latest_scanner.CreateRecordBatchLogReaderUntilLatest(admin, latest_reader);
+std::move(latest_scanner).CreateRecordBatchLogReaderUntilLatest(admin, latest_reader);
 
 fluss::ArrowRecordBatches batches;
 latest_reader.CollectAllBatches(batches);
 ```
 
-Subscribe every bucket assigned to the reader before creating it. Do not call `PollRecordBatch()`
-or create a second reader concurrently on the same scanner. Destroy the reader before reusing
-that scanner.
+The scanner-level creation methods transfer ownership on success, so the scanner becomes
+unavailable after it is moved into the reader.
 
 ## Column Projection
 

--- a/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
+++ b/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
@@ -202,8 +202,9 @@ Inspect `result.status` only when `NextBatch()` returns an `Ok()` result. `Timed
 exhaust the reader; it lets a query engine periodically check cancellation or deadlines before
 retrying. `Finished` means all stopping offsets have been reached.
 
-To read a log timestamp range, pass the assigned buckets and timestamps. Fluss resolves both
-timestamps with `OffsetSpec::Timestamp` for every bucket, then uses the same bounded offset reader:
+To read a half-open log timestamp range `[starting_timestamp_ms, stopping_timestamp_ms)`, pass the
+assigned buckets and timestamps. Fluss resolves both timestamps with `OffsetSpec::Timestamp` for
+every bucket, then uses the same bounded offset reader:
 
 ```cpp
 fluss::RecordBatchLogReader reader;

--- a/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
+++ b/fluss-rust/website/docs/user-guide/cpp/example/log-tables.md
@@ -270,11 +270,11 @@ result means all stopping offsets have been reached.
 
 The supplied timeout is the total execution budget for the whole `CollectAllBatches()` call, not a
 per-batch polling timeout. Once the budget expires, the method stops collecting and returns
-`REQUEST_TIME_OUT`; it does not internally retry with a fresh budget. The timeout is checked
-between complete Arrow batches and never splits a batch already being returned. The reader remains
-valid after timeout, but applications should normally propagate the incomplete result. Resuming
-with the same reader and output should only be done as an explicit higher-level policy with its own
-deadline.
+`REQUEST_TIME_OUT` if unread work remains; it does not internally retry with a fresh budget. It
+does not wait for more scanner data after the deadline, but it still drains already-buffered
+batches and reports `Ok()` if every stopping offset has been reached. The reader remains valid
+after timeout, but applications should normally propagate the incomplete result. Resuming with the
+same reader and output should only be done as an explicit higher-level policy with its own deadline.
 
 :::
 

--- a/fluss-rust/website/docs/user-guide/rust/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/rust/api-reference.md
@@ -203,8 +203,9 @@ Unlike `RecordBatchLogScanner` which polls indefinitely, this reader stops autom
 | `fn to_record_batch_reader(self, handle: tokio::runtime::Handle) -> SyncRecordBatchLogReader`                | Sync adapter implementing `arrow::RecordBatchReader` (see below) |
 
 `new_from_ranges` requires a scanner without existing subscriptions. It validates table identity,
-partition mode, duplicate and out-of-range bucket ids, and range ordering before subscribing.
-Timestamp offset lookups for independent partitions are issued concurrently.
+partition mode, duplicate and out-of-range bucket ids, range ordering, and non-negative stopping
+offsets before subscribing. `new_until_offsets` requires one stopping offset for every scanner
+subscription. Timestamp offset lookups for independent partitions are issued concurrently.
 
 `collect_all_batches_with_timeout` returns batches collected before the budget expires and sets
 `BoundedCollectOutcome::complete` to indicate whether every stopping offset was reached. Once the

--- a/fluss-rust/website/docs/user-guide/rust/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/rust/api-reference.md
@@ -193,10 +193,20 @@ Unlike `RecordBatchLogScanner` which polls indefinitely, this reader stops autom
 |-------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
 | `async fn new_until_latest(scanner: RecordBatchLogScanner, admin: &FlussAdmin) -> Result<Self>`              | Read until the latest offsets at time of creation         |
 | `fn new_until_offsets(scanner: RecordBatchLogScanner, stopping_offsets: HashMap<TableBucket, i64>) -> Result<Self>` | Read until custom stopping offsets per bucket             |
+| `async fn new_from_ranges(scanner: RecordBatchLogScanner, ranges: Vec<BoundedLogReadRange>) -> Result<Self>` | Subscribe and read explicit per-bucket offset ranges |
+| `async fn new_between_timestamps(scanner: RecordBatchLogScanner, admin: &FlussAdmin, buckets: &[TableBucket], starting_timestamp_ms: i64, stopping_timestamp_ms: i64) -> Result<Self>` | Resolve and read a timestamp range per bucket |
 | `async fn next_batch(&mut self) -> Result<Option<ScanBatch>>`                                                | Get the next batch with bucket/offset metadata, or `None` when all buckets caught up |
+| `async fn next_batch_with_timeout(&mut self, timeout: Duration) -> Result<RecordBatchReadOutcome>`           | Get a batch, timeout, or completion without exhausting the reader |
 | `async fn collect_all_batches(&mut self) -> Result<Vec<ScanBatch>>`                                          | Drain all batches (with metadata) until stopping offsets are satisfied |
+| `async fn collect_all_batches_with_timeout(&mut self, timeout: Duration) -> Result<BoundedCollectOutcome>`   | Drain batches using one whole-operation timeout budget |
 | `fn schema(&self) -> SchemaRef`                                                                              | Arrow schema for produced batches                        |
 | `fn to_record_batch_reader(self, handle: tokio::runtime::Handle) -> SyncRecordBatchLogReader`                | Sync adapter implementing `arrow::RecordBatchReader` (see below) |
+
+`collect_all_batches_with_timeout` returns batches collected before the budget expires and sets
+`BoundedCollectOutcome::complete` to indicate whether every stopping offset was reached. Once the
+budget is exhausted, it does not wait for additional scanner data, but it still drains buffered
+batches and observes completion before reporting an incomplete result. An already-complete reader
+therefore returns `complete = true` even with a zero timeout.
 
 ## `SyncRecordBatchLogReader`
 

--- a/fluss-rust/website/docs/user-guide/rust/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/rust/api-reference.md
@@ -202,6 +202,10 @@ Unlike `RecordBatchLogScanner` which polls indefinitely, this reader stops autom
 | `fn schema(&self) -> SchemaRef`                                                                              | Arrow schema for produced batches                        |
 | `fn to_record_batch_reader(self, handle: tokio::runtime::Handle) -> SyncRecordBatchLogReader`                | Sync adapter implementing `arrow::RecordBatchReader` (see below) |
 
+`new_from_ranges` requires a scanner without existing subscriptions. It validates table identity,
+partition mode, duplicate and out-of-range bucket ids, and range ordering before subscribing.
+Timestamp offset lookups for independent partitions are issued concurrently.
+
 `collect_all_batches_with_timeout` returns batches collected before the budget expires and sets
 `BoundedCollectOutcome::complete` to indicate whether every stopping offset was reached. Once the
 budget is exhausted, it does not wait for additional scanner data, but it still drains buffered

--- a/fluss-rust/website/docs/user-guide/rust/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/rust/api-reference.md
@@ -205,7 +205,8 @@ Unlike `RecordBatchLogScanner` which polls indefinitely, this reader stops autom
 `new_from_ranges` requires a scanner without existing subscriptions. It validates table identity,
 partition mode, duplicate and out-of-range bucket ids, range ordering, and non-negative stopping
 offsets before subscribing. `new_until_offsets` requires one stopping offset for every scanner
-subscription. Timestamp offset lookups for independent partitions are issued concurrently.
+subscription; starting offsets must be non-negative or `EARLIEST_OFFSET`. Timestamp offset lookups
+for independent partitions are issued concurrently.
 
 `collect_all_batches_with_timeout` returns batches collected before the budget expires and sets
 `BoundedCollectOutcome::complete` to indicate whether every stopping offset was reached. Once the


### PR DESCRIPTION
### Purpose

Linked issue: close #3987

Expose bounded `RecordBatchLogReader` APIs through the C++ binding.

### API example

```cpp
fluss::RecordBatchLogReader reader;
check("create_bounded_reader",
      table.NewScan().CreateRecordBatchLogReader(
          admin,
          assigned_buckets,
          fluss::TimestampRange{
              starting_timestamp_ms,
              stopping_timestamp_ms,
          },
          reader));

while (true) {
    fluss::RecordBatchReadResult result;
    check("next_batch", reader.NextBatch(1000, result));

    if (result.status == fluss::BoundedReadStatus::TimedOut) {
        continue;
    }
    if (result.status == fluss::BoundedReadStatus::Finished) {
        break;
    }

    process(result.batch->GetArrowRecordBatch());
}
```

The API also supports:

- explicit starting and stopping offsets for each bucket;
- starting offsets configured through scanner subscriptions;
- stopping at explicit or latest offsets;
- partitioned and non-partitioned tables.

`TimedOut` allows callers to check cancellation or deadlines before retrying. `Finished` means all assigned buckets have reached their stopping offsets.

### Tests

- `cargo test -p fluss-rs --lib client::table::reader`
- `cargo test -p fluss-cpp --lib`
- `cargo clippy -p fluss-rs -p fluss-cpp --lib -- -D warnings`
- `cargo fmt --check`
- CMake C++ build
- Docker-backed C++ integration tests for explicit offsets, latest offsets,
  timestamp ranges, and partitioned tables

### API and Format

This PR adds backward-compatible public C++ APIs.

### Documentation

Updated the C++ README, API reference, log table guide, and example program.