### PR TITLE
[server] Parallelize replica leader transitions

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -649,6 +649,14 @@ public class ConfigOptions {
                             "The rack for the tabletServer. This will be used in rack aware bucket assignment "
                                     + "for fault tolerance. Examples: `RACK1`, `cn-hangzhou-server10`");
 
+    public static final ConfigOption<Integer> TABLET_SERVER_REPLICA_TRANSITION_THREAD_NUM =
+            key("tablet-server.replica-transition-thread-num")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "The maximum number of replica role transitions that can run "
+                                    + "concurrently in a TabletServer.");
+
     public static final ConfigOption<Double> TABLET_SERVER_ADVERTISED_RESOURCE_CPU_CORES =
             key("tablet-server.advertised-resource.cpu-cores")
                     .doubleType()

--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -405,7 +405,7 @@ public class ConfigOptions {
     public static final ConfigOption<Integer> SERVER_IO_POOL_SIZE =
             key("server.io-pool.size")
                     .intType()
-                    .defaultValue(10)
+                    .defaultValue(2)
                     .withDescription(
                             "The size of the IO thread pool to run blocking operations for both coordinator and tablet servers. "
                                     + "This includes discard unnecessary snapshot files, transfer kv snapshot files, "

--- a/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/FlussConfigUtils.java
@@ -134,6 +134,7 @@ public class FlussConfigUtils {
                             "Configuration %s must be set.", ConfigOptions.TABLET_SERVER_ID.key()));
         }
         validMinValue(ConfigOptions.TABLET_SERVER_ID, serverId.get(), 0);
+        validMinValue(conf, ConfigOptions.TABLET_SERVER_REPLICA_TRANSITION_THREAD_NUM, 1);
     }
 
     public static void validateRemoteDataDirs(Configuration conf) {

--- a/fluss-common/src/test/java/org/apache/fluss/config/FlussConfigUtilsTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/config/FlussConfigUtilsTest.java
@@ -189,6 +189,14 @@ class FlussConfigUtilsTest {
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining(ConfigOptions.TABLET_SERVER_ID.key())
                 .hasMessageContaining("it must be greater than or equal 0");
+
+        conf.set(ConfigOptions.TABLET_SERVER_ID, 0);
+        conf.set(ConfigOptions.TABLET_SERVER_REPLICA_TRANSITION_THREAD_NUM, 0);
+        assertThatThrownBy(() -> validateTabletConfigs(conf))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining(
+                        ConfigOptions.TABLET_SERVER_REPLICA_TRANSITION_THREAD_NUM.key())
+                .hasMessageContaining("must be greater than or equal 1");
     }
 
     @Test

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -123,9 +123,11 @@ import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.server.zk.data.lake.LakeTableSnapshot;
 import org.apache.fluss.utils.ByteArraySlice;
+import org.apache.fluss.utils.ExecutorUtils;
 import org.apache.fluss.utils.FileUtils;
 import org.apache.fluss.utils.FlussPaths;
 import org.apache.fluss.utils.clock.Clock;
+import org.apache.fluss.utils.concurrent.ExecutorThreadFactory;
 import org.apache.fluss.utils.concurrent.Scheduler;
 
 import org.slf4j.Logger;
@@ -152,6 +154,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
@@ -196,6 +200,7 @@ public class ReplicaManager implements ServerReconfigurable {
 
     private final TabletServerMetadataCache metadataCache;
     private final ExecutorService ioExecutor;
+    private final ExecutorService replicaTransitionExecutor;
     private final ProjectionPushdownCache projectionsCache = new ProjectionPushdownCache();
     private final Lock replicaStateChangeLock = new ReentrantLock();
 
@@ -361,6 +366,10 @@ public class ReplicaManager implements ServerReconfigurable {
         this.userMetrics = userMetrics;
         this.clock = clock;
         this.ioExecutor = ioExecutor;
+        this.replicaTransitionExecutor =
+                Executors.newFixedThreadPool(
+                        conf.get(ConfigOptions.TABLET_SERVER_REPLICA_TRANSITION_THREAD_NUM),
+                        new ExecutorThreadFactory("tablet-server-replica-transition-" + serverId));
         this.minInSyncReplicas = conf.get(ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER);
         this.scannerManager = checkNotNull(scannerManager, "scannerManager");
         // Historical lookup cache capacity currently uses only the first data volume.
@@ -1389,29 +1398,49 @@ public class ReplicaManager implements ServerReconfigurable {
                         .map(NotifyLeaderAndIsrData::getTableBucket)
                         .collect(Collectors.toSet()));
 
+        List<CompletableFuture<NotifyLeaderAndIsrResultForBucket>> makeLeaderFutures =
+                new ArrayList<>(replicasToBeLeader.size());
         for (NotifyLeaderAndIsrData data : replicasToBeLeader) {
             TableBucket tb = data.getTableBucket();
             try {
                 Replica replica = getReplicaOrException(tb);
-                // register replica to remote log manager first.
-                remoteLogManager.registerReplica(replica);
-
-                // Load the latest lake progress before leader activation. Historical KV recovery
-                // requires its lake log end offset, while failures remain best effort for normal
-                // replicas.
-                if (replica.isDataLakeEnabled()) {
-                    updateWithLakeTableSnapshot(replica);
-                }
-                replica.makeLeader(data);
-
-                // start the remote log tiering tasks for leaders
-                remoteLogManager.startLogTiering(replica);
-                result.put(tb, new NotifyLeaderAndIsrResultForBucket(tb));
+                makeLeaderFutures.add(
+                        CompletableFuture.supplyAsync(
+                                () -> makeLeader(replica, data), replicaTransitionExecutor));
             } catch (Exception e) {
                 LOG.error("Error make replica {} to leader", tb, e);
                 result.put(
                         tb, new NotifyLeaderAndIsrResultForBucket(tb, ApiError.fromThrowable(e)));
             }
+        }
+
+        for (CompletableFuture<NotifyLeaderAndIsrResultForBucket> future : makeLeaderFutures) {
+            NotifyLeaderAndIsrResultForBucket leaderResult = future.join();
+            result.put(leaderResult.getTableBucket(), leaderResult);
+        }
+    }
+
+    @VisibleForTesting
+    NotifyLeaderAndIsrResultForBucket makeLeader(Replica replica, NotifyLeaderAndIsrData data) {
+        TableBucket tb = data.getTableBucket();
+        try {
+            // register replica to remote log manager first.
+            remoteLogManager.registerReplica(replica);
+
+            // Load the latest lake progress before leader activation. Historical KV recovery
+            // requires its lake log end offset, while failures remain best effort for normal
+            // replicas.
+            if (replica.isDataLakeEnabled()) {
+                updateWithLakeTableSnapshot(replica);
+            }
+            replica.makeLeader(data);
+
+            // start the remote log tiering tasks for leaders
+            remoteLogManager.startLogTiering(replica);
+            return new NotifyLeaderAndIsrResultForBucket(tb);
+        } catch (Exception e) {
+            LOG.error("Error make replica {} to leader", tb, e);
+            return new NotifyLeaderAndIsrResultForBucket(tb, ApiError.fromThrowable(e));
         }
     }
 
@@ -2549,6 +2578,7 @@ public class ReplicaManager implements ServerReconfigurable {
     public static final class OfflineReplica implements HostedReplica {}
 
     public void shutdown() throws InterruptedException {
+        ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaTransitionExecutor);
         // Close the resources for snapshot kv
         kvSnapshotResource.close();
         historicalPartitionManager.close();

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -123,11 +123,9 @@ import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.data.LeaderAndIsr;
 import org.apache.fluss.server.zk.data.lake.LakeTableSnapshot;
 import org.apache.fluss.utils.ByteArraySlice;
-import org.apache.fluss.utils.ExecutorUtils;
 import org.apache.fluss.utils.FileUtils;
 import org.apache.fluss.utils.FlussPaths;
 import org.apache.fluss.utils.clock.Clock;
-import org.apache.fluss.utils.concurrent.ExecutorThreadFactory;
 import org.apache.fluss.utils.concurrent.Scheduler;
 
 import org.slf4j.Logger;
@@ -154,8 +152,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
@@ -264,6 +260,7 @@ public class ReplicaManager implements ServerReconfigurable {
             ScannerManager scannerManager,
             Clock clock,
             ExecutorService ioExecutor,
+            ExecutorService replicaTransitionExecutor,
             LocalDiskManager localDiskManager,
             @Nullable PluginManager pluginManager)
             throws IOException {
@@ -292,6 +289,7 @@ public class ReplicaManager implements ServerReconfigurable {
                 scannerManager,
                 clock,
                 ioExecutor,
+                replicaTransitionExecutor,
                 localDiskManager,
                 pluginManager);
     }
@@ -315,6 +313,7 @@ public class ReplicaManager implements ServerReconfigurable {
             ScannerManager scannerManager,
             Clock clock,
             ExecutorService ioExecutor,
+            ExecutorService replicaTransitionExecutor,
             LocalDiskManager localDiskManager,
             @Nullable PluginManager pluginManager)
             throws IOException {
@@ -366,10 +365,7 @@ public class ReplicaManager implements ServerReconfigurable {
         this.userMetrics = userMetrics;
         this.clock = clock;
         this.ioExecutor = ioExecutor;
-        this.replicaTransitionExecutor =
-                Executors.newFixedThreadPool(
-                        conf.get(ConfigOptions.TABLET_SERVER_REPLICA_TRANSITION_THREAD_NUM),
-                        new ExecutorThreadFactory("tablet-server-replica-transition-" + serverId));
+        this.replicaTransitionExecutor = replicaTransitionExecutor;
         this.minInSyncReplicas = conf.get(ConfigOptions.LOG_REPLICA_MIN_IN_SYNC_REPLICAS_NUMBER);
         this.scannerManager = checkNotNull(scannerManager, "scannerManager");
         // Historical lookup cache capacity currently uses only the first data volume.
@@ -2582,7 +2578,6 @@ public class ReplicaManager implements ServerReconfigurable {
     public static final class OfflineReplica implements HostedReplica {}
 
     public void shutdown() throws InterruptedException {
-        ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaTransitionExecutor);
         // Close the resources for snapshot kv
         kvSnapshotResource.close();
         historicalPartitionManager.close();

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1414,6 +1414,10 @@ public class ReplicaManager implements ServerReconfigurable {
             }
         }
 
+        CompletableFuture.allOf(
+                        makeLeaderFutures.toArray(
+                                new CompletableFuture<?>[makeLeaderFutures.size()]))
+                .join();
         for (CompletableFuture<NotifyLeaderAndIsrResultForBucket> future : makeLeaderFutures) {
             NotifyLeaderAndIsrResultForBucket leaderResult = future.join();
             result.put(leaderResult.getTableBucket(), leaderResult);

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -151,7 +151,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1417,10 +1419,18 @@ public class ReplicaManager implements ServerReconfigurable {
             }
         }
 
-        CompletableFuture.allOf(
-                        makeLeaderFutures.toArray(
-                                new CompletableFuture<?>[makeLeaderFutures.size()]))
-                .join();
+        try {
+            CompletableFuture.allOf(
+                            makeLeaderFutures.toArray(
+                                    new CompletableFuture<?>[makeLeaderFutures.size()]))
+                    .get();
+        } catch (InterruptedException e) {
+            makeLeaderFutures.forEach(future -> future.cancel(false));
+            Thread.currentThread().interrupt();
+            throw new CompletionException(e);
+        } catch (ExecutionException e) {
+            throw new CompletionException(e.getCause());
+        }
         for (CompletableFuture<NotifyLeaderAndIsrResultForBucket> future : makeLeaderFutures) {
             NotifyLeaderAndIsrResultForBucket leaderResult = future.join();
             result.put(leaderResult.getTableBucket(), leaderResult);

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1427,8 +1427,8 @@ public class ReplicaManager implements ServerReconfigurable {
         }
     }
 
-    @VisibleForTesting
-    NotifyLeaderAndIsrResultForBucket makeLeader(Replica replica, NotifyLeaderAndIsrData data) {
+    private NotifyLeaderAndIsrResultForBucket makeLeader(
+            Replica replica, NotifyLeaderAndIsrData data) {
         TableBucket tb = data.getTableBucket();
         try {
             // register replica to remote log manager first.

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -145,6 +145,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -572,12 +573,18 @@ public class ReplicaManager implements ServerReconfigurable {
         inLock(
                 replicaStateChangeLock,
                 () -> {
+                    Map<TableBucket, NotifyLeaderAndIsrData> dataByTableBucket =
+                            new LinkedHashMap<>();
+                    for (NotifyLeaderAndIsrData data : notifyLeaderAndIsrDataList) {
+                        dataByTableBucket.put(data.getTableBucket(), data);
+                    }
+
                     // check or apply coordinator epoch.
                     validateAndApplyCoordinatorEpoch(requestCoordinatorEpoch, "notifyLeaderAndIsr");
 
                     List<NotifyLeaderAndIsrData> replicasToBeLeader = new ArrayList<>();
                     List<NotifyLeaderAndIsrData> replicasToBeFollower = new ArrayList<>();
-                    for (NotifyLeaderAndIsrData data : notifyLeaderAndIsrDataList) {
+                    for (NotifyLeaderAndIsrData data : dataByTableBucket.values()) {
                         LOG.info(
                                 "Try to become leaderAndFollower for {} with isr {}, replicas: {}",
                                 data.getTableBucket(),

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
@@ -488,16 +488,16 @@ public class TabletServer extends ServerBase {
             }
 
             try {
-                if (replicaStateChangeExecutor != null) {
-                    ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaStateChangeExecutor);
+                if (replicaTransitionExecutor != null) {
+                    ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaTransitionExecutor);
                 }
             } catch (Throwable t) {
                 exception = ExceptionUtils.firstOrSuppressed(t, exception);
             }
 
             try {
-                if (replicaTransitionExecutor != null) {
-                    ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaTransitionExecutor);
+                if (replicaStateChangeExecutor != null) {
+                    ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaStateChangeExecutor);
                 }
             } catch (Throwable t) {
                 exception = ExceptionUtils.firstOrSuppressed(t, exception);

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
@@ -189,6 +189,9 @@ public class TabletServer extends ServerBase {
     @GuardedBy("lock")
     private ExecutorService replicaStateChangeExecutor;
 
+    @GuardedBy("lock")
+    private ExecutorService replicaTransitionExecutor;
+
     public TabletServer(Configuration conf) {
         this(conf, SystemClock.getInstance());
     }
@@ -285,6 +288,11 @@ public class TabletServer extends ServerBase {
             this.replicaStateChangeExecutor =
                     Executors.newSingleThreadExecutor(
                             new ExecutorThreadFactory("tablet-server-replica-state-change"));
+            this.replicaTransitionExecutor =
+                    Executors.newFixedThreadPool(
+                            conf.get(ConfigOptions.TABLET_SERVER_REPLICA_TRANSITION_THREAD_NUM),
+                            new ExecutorThreadFactory(
+                                    "tablet-server-replica-transition-" + serverId));
 
             this.scannerManager = new ScannerManager(conf, scheduler);
 
@@ -307,6 +315,7 @@ public class TabletServer extends ServerBase {
                             scannerManager,
                             clock,
                             ioExecutor,
+                            replicaTransitionExecutor,
                             localDiskManager,
                             pluginManager);
             replicaManager.startup();
@@ -481,6 +490,14 @@ public class TabletServer extends ServerBase {
             try {
                 if (replicaStateChangeExecutor != null) {
                     ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaStateChangeExecutor);
+                }
+            } catch (Throwable t) {
+                exception = ExceptionUtils.firstOrSuppressed(t, exception);
+            }
+
+            try {
+                if (replicaTransitionExecutor != null) {
+                    ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaTransitionExecutor);
                 }
             } catch (Throwable t) {
                 exception = ExceptionUtils.firstOrSuppressed(t, exception);

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -1800,7 +1800,26 @@ class ReplicaManagerTest extends ReplicaTestBase {
     }
 
     @Test
-    void testMakeLeadersInParallel() throws Exception {
+    void testMakeLeadersInParallelWithPartialFailure() throws Exception {
+        TableBucket firstBucket = new TableBucket(DATA1_TABLE_ID, 1);
+        TableBucket secondBucket = new TableBucket(DATA1_TABLE_ID, 2);
+        List<Integer> replicas = Arrays.asList(1, 2, 3);
+        makeLogTableAsLeader(firstBucket.getBucket());
+        replicaManager
+                .getReplicaOrException(firstBucket)
+                .makeLeader(
+                        new NotifyLeaderAndIsrData(
+                                PhysicalTablePath.of(DATA1_TABLE_PATH),
+                                firstBucket,
+                                replicas,
+                                new LeaderAndIsr(
+                                        TABLET_SERVER_ID,
+                                        INITIAL_LEADER_EPOCH,
+                                        replicas,
+                                        Collections.emptyList(),
+                                        INITIAL_COORDINATOR_EPOCH,
+                                        INITIAL_BUCKET_EPOCH + 1)));
+
         ReplicaManager spyingReplicaManager = spy(replicaManager);
         replicaManager = spyingReplicaManager;
 
@@ -1817,8 +1836,6 @@ class ReplicaManagerTest extends ReplicaTestBase {
                 .when(spyingReplicaManager)
                 .makeLeader(any(Replica.class), any(NotifyLeaderAndIsrData.class));
 
-        TableBucket firstBucket = new TableBucket(DATA1_TABLE_ID, 1);
-        TableBucket secondBucket = new TableBucket(DATA1_TABLE_ID, 2);
         CompletableFuture<List<NotifyLeaderAndIsrResultForBucket>> future =
                 new CompletableFuture<>();
         spyingReplicaManager.becomeLeaderOrFollower(
@@ -1827,22 +1844,22 @@ class ReplicaManagerTest extends ReplicaTestBase {
                         new NotifyLeaderAndIsrData(
                                 PhysicalTablePath.of(DATA1_TABLE_PATH),
                                 firstBucket,
-                                Arrays.asList(1, 2, 3),
+                                replicas,
                                 new LeaderAndIsr(
                                         TABLET_SERVER_ID,
                                         INITIAL_LEADER_EPOCH,
-                                        Arrays.asList(1, 2, 3),
+                                        replicas,
                                         Collections.emptyList(),
                                         INITIAL_COORDINATOR_EPOCH,
                                         INITIAL_BUCKET_EPOCH)),
                         new NotifyLeaderAndIsrData(
                                 PhysicalTablePath.of(DATA1_TABLE_PATH),
                                 secondBucket,
-                                Arrays.asList(1, 2, 3),
+                                replicas,
                                 new LeaderAndIsr(
                                         TABLET_SERVER_ID,
                                         INITIAL_LEADER_EPOCH,
-                                        Arrays.asList(1, 2, 3),
+                                        replicas,
                                         Collections.emptyList(),
                                         INITIAL_COORDINATOR_EPOCH,
                                         INITIAL_BUCKET_EPOCH))),
@@ -1850,10 +1867,27 @@ class ReplicaManagerTest extends ReplicaTestBase {
 
         assertThat(future.get())
                 .containsExactlyInAnyOrder(
-                        new NotifyLeaderAndIsrResultForBucket(firstBucket),
+                        new NotifyLeaderAndIsrResultForBucket(
+                                firstBucket,
+                                new ApiError(
+                                        Errors.INVALID_UPDATE_VERSION_EXCEPTION,
+                                        String.format(
+                                                "Skipped the become-leader state change for %s with a lower bucket epoch %s"
+                                                        + " since the leader is already at a newer bucket epoch %s",
+                                                firstBucket,
+                                                INITIAL_BUCKET_EPOCH,
+                                                INITIAL_BUCKET_EPOCH + 1))),
                         new NotifyLeaderAndIsrResultForBucket(secondBucket));
-        assertThat(spyingReplicaManager.getReplicaOrException(firstBucket).isLeader()).isTrue();
-        assertThat(spyingReplicaManager.getReplicaOrException(secondBucket).isLeader()).isTrue();
+        assertReplicaEpochEquals(
+                spyingReplicaManager.getReplicaOrException(firstBucket),
+                true,
+                INITIAL_LEADER_EPOCH,
+                INITIAL_BUCKET_EPOCH + 1);
+        assertReplicaEpochEquals(
+                spyingReplicaManager.getReplicaOrException(secondBucket),
+                true,
+                INITIAL_LEADER_EPOCH,
+                INITIAL_BUCKET_EPOCH);
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -168,6 +168,9 @@ import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.apache.fluss.testutils.common.CommonTestUtils.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 /** Test for {@link ReplicaManager}. */
 class ReplicaManagerTest extends ReplicaTestBase {
@@ -1794,6 +1797,63 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                                 + "TableBucket{tableId=150001, bucket=1}")));
         assertReplicaEpochEquals(
                 replicaManager.getReplicaOrException(tb), true, 1, INITIAL_BUCKET_EPOCH);
+    }
+
+    @Test
+    void testMakeLeadersInParallel() throws Exception {
+        ReplicaManager spyingReplicaManager = spy(replicaManager);
+        replicaManager = spyingReplicaManager;
+
+        CountDownLatch leadersStarted = new CountDownLatch(2);
+        doAnswer(
+                        invocation -> {
+                            leadersStarted.countDown();
+                            if (!leadersStarted.await(10, TimeUnit.SECONDS)) {
+                                throw new AssertionError(
+                                        "Leader transitions did not run in parallel");
+                            }
+                            return invocation.callRealMethod();
+                        })
+                .when(spyingReplicaManager)
+                .makeLeader(any(Replica.class), any(NotifyLeaderAndIsrData.class));
+
+        TableBucket firstBucket = new TableBucket(DATA1_TABLE_ID, 1);
+        TableBucket secondBucket = new TableBucket(DATA1_TABLE_ID, 2);
+        CompletableFuture<List<NotifyLeaderAndIsrResultForBucket>> future =
+                new CompletableFuture<>();
+        spyingReplicaManager.becomeLeaderOrFollower(
+                INITIAL_COORDINATOR_EPOCH,
+                Arrays.asList(
+                        new NotifyLeaderAndIsrData(
+                                PhysicalTablePath.of(DATA1_TABLE_PATH),
+                                firstBucket,
+                                Arrays.asList(1, 2, 3),
+                                new LeaderAndIsr(
+                                        TABLET_SERVER_ID,
+                                        INITIAL_LEADER_EPOCH,
+                                        Arrays.asList(1, 2, 3),
+                                        Collections.emptyList(),
+                                        INITIAL_COORDINATOR_EPOCH,
+                                        INITIAL_BUCKET_EPOCH)),
+                        new NotifyLeaderAndIsrData(
+                                PhysicalTablePath.of(DATA1_TABLE_PATH),
+                                secondBucket,
+                                Arrays.asList(1, 2, 3),
+                                new LeaderAndIsr(
+                                        TABLET_SERVER_ID,
+                                        INITIAL_LEADER_EPOCH,
+                                        Arrays.asList(1, 2, 3),
+                                        Collections.emptyList(),
+                                        INITIAL_COORDINATOR_EPOCH,
+                                        INITIAL_BUCKET_EPOCH))),
+                future::complete);
+
+        assertThat(future.get())
+                .containsExactlyInAnyOrder(
+                        new NotifyLeaderAndIsrResultForBucket(firstBucket),
+                        new NotifyLeaderAndIsrResultForBucket(secondBucket));
+        assertThat(spyingReplicaManager.getReplicaOrException(firstBucket).isLeader()).isTrue();
+        assertThat(spyingReplicaManager.getReplicaOrException(secondBucket).isLeader()).isTrue();
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -1821,7 +1821,6 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                         INITIAL_BUCKET_EPOCH + 1)));
 
         ReplicaManager spyingReplicaManager = spy(replicaManager);
-        replicaManager = spyingReplicaManager;
 
         CountDownLatch leadersStarted = new CountDownLatch(2);
         doAnswer(

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -168,9 +168,6 @@ import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.apache.fluss.testutils.common.CommonTestUtils.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 
 /** Test for {@link ReplicaManager}. */
 class ReplicaManagerTest extends ReplicaTestBase {
@@ -1799,7 +1796,7 @@ class ReplicaManagerTest extends ReplicaTestBase {
     }
 
     @Test
-    void testMakeLeadersInParallelWithPartialFailure() throws Exception {
+    void testMakeLeadersWithPartialFailure() throws Exception {
         TableBucket firstBucket = new TableBucket(DATA1_TABLE_ID, 1);
         TableBucket secondBucket = new TableBucket(DATA1_TABLE_ID, 2);
         List<Integer> replicas = Arrays.asList(1, 2, 3);
@@ -1819,24 +1816,9 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                         INITIAL_COORDINATOR_EPOCH,
                                         INITIAL_BUCKET_EPOCH + 1)));
 
-        ReplicaManager spyingReplicaManager = spy(replicaManager);
-
-        CountDownLatch leadersStarted = new CountDownLatch(2);
-        doAnswer(
-                        invocation -> {
-                            leadersStarted.countDown();
-                            if (!leadersStarted.await(10, TimeUnit.SECONDS)) {
-                                throw new AssertionError(
-                                        "Leader transitions did not run in parallel");
-                            }
-                            return invocation.callRealMethod();
-                        })
-                .when(spyingReplicaManager)
-                .makeLeader(any(Replica.class), any(NotifyLeaderAndIsrData.class));
-
         CompletableFuture<List<NotifyLeaderAndIsrResultForBucket>> future =
                 new CompletableFuture<>();
-        spyingReplicaManager.becomeLeaderOrFollower(
+        replicaManager.becomeLeaderOrFollower(
                 INITIAL_COORDINATOR_EPOCH,
                 Arrays.asList(
                         new NotifyLeaderAndIsrData(
@@ -1877,12 +1859,12 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                                 INITIAL_BUCKET_EPOCH + 1))),
                         new NotifyLeaderAndIsrResultForBucket(secondBucket));
         assertReplicaEpochEquals(
-                spyingReplicaManager.getReplicaOrException(firstBucket),
+                replicaManager.getReplicaOrException(firstBucket),
                 true,
                 INITIAL_LEADER_EPOCH,
                 INITIAL_BUCKET_EPOCH + 1);
         assertReplicaEpochEquals(
-                spyingReplicaManager.getReplicaOrException(secondBucket),
+                replicaManager.getReplicaOrException(secondBucket),
                 true,
                 INITIAL_LEADER_EPOCH,
                 INITIAL_BUCKET_EPOCH);

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -1750,21 +1750,20 @@ class ReplicaManagerTest extends ReplicaTestBase {
         // make tb as leader.
         CompletableFuture<List<NotifyLeaderAndIsrResultForBucket>> future =
                 new CompletableFuture<>();
-        replicaManager.becomeLeaderOrFollower(
-                INITIAL_COORDINATOR_EPOCH,
-                Collections.singletonList(
-                        new NotifyLeaderAndIsrData(
-                                PhysicalTablePath.of(DATA1_TABLE_PATH),
-                                tb,
+        NotifyLeaderAndIsrData data =
+                new NotifyLeaderAndIsrData(
+                        PhysicalTablePath.of(DATA1_TABLE_PATH),
+                        tb,
+                        Arrays.asList(1, 2, 3),
+                        new LeaderAndIsr(
+                                TABLET_SERVER_ID,
+                                1,
                                 Arrays.asList(1, 2, 3),
-                                new LeaderAndIsr(
-                                        TABLET_SERVER_ID,
-                                        1,
-                                        Arrays.asList(1, 2, 3),
-                                        Collections.emptyList(),
-                                        INITIAL_COORDINATOR_EPOCH,
-                                        INITIAL_BUCKET_EPOCH))),
-                future::complete);
+                                Collections.emptyList(),
+                                INITIAL_COORDINATOR_EPOCH,
+                                INITIAL_BUCKET_EPOCH));
+        replicaManager.becomeLeaderOrFollower(
+                INITIAL_COORDINATOR_EPOCH, Arrays.asList(data, data), future::complete);
         assertThat(future.get()).containsOnly(new NotifyLeaderAndIsrResultForBucket(tb));
         assertReplicaEpochEquals(
                 replicaManager.getReplicaOrException(tb), true, 1, INITIAL_BUCKET_EPOCH);

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -119,6 +119,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.fluss.config.ConfigOptions.KV_FORMAT_VERSION_2;
@@ -1799,51 +1800,19 @@ class ReplicaManagerTest extends ReplicaTestBase {
     void testMakeLeadersWithPartialFailure() throws Exception {
         TableBucket firstBucket = new TableBucket(DATA1_TABLE_ID, 1);
         TableBucket secondBucket = new TableBucket(DATA1_TABLE_ID, 2);
-        List<Integer> replicas = Arrays.asList(1, 2, 3);
+        List<NotifyLeaderAndIsrData> leaderData =
+                Arrays.asList(
+                        newLeaderData(firstBucket, INITIAL_BUCKET_EPOCH),
+                        newLeaderData(secondBucket, INITIAL_BUCKET_EPOCH));
         makeLogTableAsLeader(firstBucket.getBucket());
         replicaManager
                 .getReplicaOrException(firstBucket)
-                .makeLeader(
-                        new NotifyLeaderAndIsrData(
-                                PhysicalTablePath.of(DATA1_TABLE_PATH),
-                                firstBucket,
-                                replicas,
-                                new LeaderAndIsr(
-                                        TABLET_SERVER_ID,
-                                        INITIAL_LEADER_EPOCH,
-                                        replicas,
-                                        Collections.emptyList(),
-                                        INITIAL_COORDINATOR_EPOCH,
-                                        INITIAL_BUCKET_EPOCH + 1)));
+                .makeLeader(newLeaderData(firstBucket, INITIAL_BUCKET_EPOCH + 1));
 
         CompletableFuture<List<NotifyLeaderAndIsrResultForBucket>> future =
                 new CompletableFuture<>();
         replicaManager.becomeLeaderOrFollower(
-                INITIAL_COORDINATOR_EPOCH,
-                Arrays.asList(
-                        new NotifyLeaderAndIsrData(
-                                PhysicalTablePath.of(DATA1_TABLE_PATH),
-                                firstBucket,
-                                replicas,
-                                new LeaderAndIsr(
-                                        TABLET_SERVER_ID,
-                                        INITIAL_LEADER_EPOCH,
-                                        replicas,
-                                        Collections.emptyList(),
-                                        INITIAL_COORDINATOR_EPOCH,
-                                        INITIAL_BUCKET_EPOCH)),
-                        new NotifyLeaderAndIsrData(
-                                PhysicalTablePath.of(DATA1_TABLE_PATH),
-                                secondBucket,
-                                replicas,
-                                new LeaderAndIsr(
-                                        TABLET_SERVER_ID,
-                                        INITIAL_LEADER_EPOCH,
-                                        replicas,
-                                        Collections.emptyList(),
-                                        INITIAL_COORDINATOR_EPOCH,
-                                        INITIAL_BUCKET_EPOCH))),
-                future::complete);
+                INITIAL_COORDINATOR_EPOCH, leaderData, future::complete);
 
         assertThat(future.get())
                 .containsExactlyInAnyOrder(
@@ -1868,6 +1837,51 @@ class ReplicaManagerTest extends ReplicaTestBase {
                 true,
                 INITIAL_LEADER_EPOCH,
                 INITIAL_BUCKET_EPOCH);
+    }
+
+    @Test
+    void testInterruptLeaderTransitionWaitWithQueuedTasks() throws Exception {
+        ThreadPoolExecutor transitionExecutor = (ThreadPoolExecutor) replicaTransitionExecutor;
+        transitionExecutor.setCorePoolSize(1);
+        transitionExecutor.setMaximumPoolSize(1);
+        CountDownLatch workerStarted = new CountDownLatch(1);
+        ExecutorService stateChangeExecutor = Executors.newSingleThreadExecutor();
+        List<Runnable> queuedTasks = new ArrayList<>();
+        try {
+            transitionExecutor.submit(
+                    () -> {
+                        workerStarted.countDown();
+                        Thread.sleep(Long.MAX_VALUE);
+                        return null;
+                    });
+            assertThat(workerStarted.await(10, TimeUnit.SECONDS)).isTrue();
+            stateChangeExecutor.submit(
+                    () ->
+                            replicaManager.becomeLeaderOrFollower(
+                                    INITIAL_COORDINATOR_EPOCH,
+                                    Arrays.asList(
+                                            newLeaderData(
+                                                    new TableBucket(DATA1_TABLE_ID, 1),
+                                                    INITIAL_BUCKET_EPOCH),
+                                            newLeaderData(
+                                                    new TableBucket(DATA1_TABLE_ID, 2),
+                                                    INITIAL_BUCKET_EPOCH)),
+                                    ignored -> {}));
+            waitUntil(
+                    () -> transitionExecutor.getQueue().size() == 2,
+                    Duration.ofSeconds(10),
+                    "Leader transitions were not queued");
+
+            queuedTasks.addAll(transitionExecutor.shutdownNow());
+            stateChangeExecutor.shutdownNow();
+            assertThat(stateChangeExecutor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            queuedTasks.addAll(transitionExecutor.shutdownNow());
+            queuedTasks.forEach(Runnable::run);
+            stateChangeExecutor.shutdownNow();
+            stateChangeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+        assertThat(replicaManager.leaderCount()).isZero();
     }
 
     @Test
@@ -2526,6 +2540,21 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                 replicaManager.getReplicaOrException(
                                         new TableBucket(DATA1_TABLE_ID, Integer.MAX_VALUE)))
                 .isInstanceOf(UnknownTableOrBucketException.class);
+    }
+
+    private NotifyLeaderAndIsrData newLeaderData(TableBucket tableBucket, int bucketEpoch) {
+        List<Integer> replicas = Arrays.asList(1, 2, 3);
+        return new NotifyLeaderAndIsrData(
+                PhysicalTablePath.of(DATA1_TABLE_PATH),
+                tableBucket,
+                replicas,
+                new LeaderAndIsr(
+                        TABLET_SERVER_ID,
+                        INITIAL_LEADER_EPOCH,
+                        replicas,
+                        Collections.emptyList(),
+                        INITIAL_COORDINATOR_EPOCH,
+                        bucketEpoch));
     }
 
     private void assertReplicaEpochEquals(

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
@@ -68,6 +68,7 @@ import org.apache.fluss.server.zk.data.TableRegistration;
 import org.apache.fluss.testutils.common.AllCallbackWrapper;
 import org.apache.fluss.testutils.common.ManuallyTriggeredScheduledExecutorService;
 import org.apache.fluss.utils.CloseableRegistry;
+import org.apache.fluss.utils.ExecutorUtils;
 import org.apache.fluss.utils.clock.ManualClock;
 import org.apache.fluss.utils.concurrent.FlussScheduler;
 import org.apache.fluss.utils.function.FunctionWithException;
@@ -159,6 +160,7 @@ public class ReplicaTestBase {
     protected TestCoordinatorGateway testCoordinatorGateway;
     private FlussScheduler scheduler;
     private ExecutorService ioExecutor;
+    private ExecutorService replicaTransitionExecutor;
 
     // remote log related
     protected TestingRemoteLogStorage remoteLogStorage;
@@ -219,6 +221,9 @@ public class ReplicaTestBase {
         scheduler = new FlussScheduler(2);
         scheduler.startup();
         ioExecutor = Executors.newSingleThreadExecutor();
+        replicaTransitionExecutor =
+                Executors.newFixedThreadPool(
+                        conf.get(ConfigOptions.TABLET_SERVER_REPLICA_TRANSITION_THREAD_NUM));
 
         manualClock = new ManualClock(System.currentTimeMillis());
         localDiskManager = LocalDiskManager.create(conf);
@@ -374,6 +379,7 @@ public class ReplicaTestBase {
                 scannerManager,
                 manualClock,
                 ioExecutor,
+                replicaTransitionExecutor,
                 localDiskManager,
                 null);
     }
@@ -381,6 +387,10 @@ public class ReplicaTestBase {
     @AfterEach
     void tearDown() throws Exception {
         closeableRegistry.close();
+
+        if (replicaTransitionExecutor != null) {
+            ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, replicaTransitionExecutor);
+        }
 
         if (logManager != null) {
             logManager.shutdown();

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTestBase.java
@@ -160,7 +160,7 @@ public class ReplicaTestBase {
     protected TestCoordinatorGateway testCoordinatorGateway;
     private FlussScheduler scheduler;
     private ExecutorService ioExecutor;
-    private ExecutorService replicaTransitionExecutor;
+    protected ExecutorService replicaTransitionExecutor;
 
     // remote log related
     protected TestingRemoteLogStorage remoteLogStorage;

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
@@ -106,6 +106,7 @@ public class ReplicaFetcherThreadTest {
     private ReplicaManager followerRM;
     private ReplicaFetcherThread followerFetcher;
     private ExecutorService ioExecutor;
+    private ExecutorService replicaTransitionExecutor;
     private LocalDiskManager leaderLocalDiskManager;
     private LocalDiskManager followerLocalDiskManager;
 
@@ -124,6 +125,7 @@ public class ReplicaFetcherThreadTest {
         Configuration conf = new Configuration();
         tb = new TableBucket(DATA1_TABLE_ID, 0);
         ioExecutor = Executors.newSingleThreadExecutor();
+        replicaTransitionExecutor = Executors.newFixedThreadPool(2);
         leaderLocalDiskManager = createLocalDiskManager(leaderServerId);
         leaderRM = createReplicaManager(leaderServerId, leaderLocalDiskManager);
         followerLocalDiskManager = createLocalDiskManager(followerServerId);
@@ -157,6 +159,9 @@ public class ReplicaFetcherThreadTest {
         }
         if (ioExecutor != null) {
             ioExecutor.shutdownNow();
+        }
+        if (replicaTransitionExecutor != null) {
+            replicaTransitionExecutor.shutdownNow();
         }
     }
 
@@ -552,6 +557,7 @@ public class ReplicaFetcherThreadTest {
                         TestingMetricGroups.TABLET_SERVER_METRICS,
                         manualClock,
                         ioExecutor,
+                        replicaTransitionExecutor,
                         localDiskManager);
         replicaManager.startup();
         return replicaManager;
@@ -574,6 +580,7 @@ public class ReplicaFetcherThreadTest {
                 TabletServerMetricGroup serverMetricGroup,
                 Clock clock,
                 ExecutorService ioExecutor,
+                ExecutorService replicaTransitionExecutor,
                 LocalDiskManager localDiskManager)
                 throws IOException {
             super(
@@ -593,6 +600,7 @@ public class ReplicaFetcherThreadTest {
                     new ScannerManager(conf, scheduler),
                     clock,
                     ioExecutor,
+                    replicaTransitionExecutor,
                     localDiskManager,
                     null);
         }


### PR DESCRIPTION
### Purpose

This PR reduces the latency of replica leader transitions by processing independent buckets concurrently within a `NotifyLeaderAndIsr` request.
Previously, `ReplicaManager.makeLeaders()` transitioned replicas sequentially. This increased request latency when multiple replicas became leaders together, especially for primary-key tables where each transition may initialize RocksDB by restoring a remote snapshot and replaying logs.

Snapshot files within a single bucket are already downloaded concurrently through `ioExecutor`. The main benefit of this change is parallelizing the bucket-level transition: independent buckets can overlap snapshot download, RocksDB initialization and replay, snapshot metadata reads, and remote-log setup.

### Brief change log

Introduce the `tablet-server.replica-transition-thread-num` option to control concurrency, with a default value of 10.

In this first phase, `makeFollowers` remains on the existing state-change executor and is not moved into the background transition pool.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
