### PR TITLE
[server] Fix orphan segments after full truncation

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LocalLog.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LocalLog.java
@@ -328,7 +328,6 @@ public final class LocalLog {
         if (newOffset == segmentToDelete.getBaseOffset()) {
             deleteSegmentFiles(Collections.singletonList(segmentToDelete), reason);
         }
-        reason.logReason(Collections.singletonList(segmentToDelete));
 
         // open a new segment.
         LogSegment newSegment = LogSegment.open(logTabletDir, newOffset, config, logFormat);
@@ -336,6 +335,7 @@ public final class LocalLog {
 
         if (newOffset != segmentToDelete.getBaseOffset()) {
             segments.remove(segmentToDelete.getBaseOffset());
+            deleteSegmentFiles(Collections.singletonList(segmentToDelete), reason);
         }
         return newSegment;
     }

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LocalLog.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LocalLog.java
@@ -324,19 +324,30 @@ public final class LocalLog {
     LogSegment createAndDeleteSegment(
             long newOffset, LogSegment segmentToDelete, SegmentDeletionReason reason)
             throws IOException {
-        // delete the old segment.
-        if (newOffset == segmentToDelete.getBaseOffset()) {
-            deleteSegmentFiles(Collections.singletonList(segmentToDelete), reason);
+        boolean replaceAtSameOffset = newOffset == segmentToDelete.getBaseOffset();
+        if (replaceAtSameOffset) {
+            segmentToDelete.changeFileSuffixes("", FlussPaths.DELETED_FILE_SUFFIX);
         }
 
-        // open a new segment.
-        LogSegment newSegment = LogSegment.open(logTabletDir, newOffset, config, logFormat);
+        LogSegment newSegment;
+        try {
+            newSegment = LogSegment.open(logTabletDir, newOffset, config, logFormat);
+        } catch (IOException e) {
+            if (replaceAtSameOffset) {
+                try {
+                    segmentToDelete.changeFileSuffixes(FlussPaths.DELETED_FILE_SUFFIX, "");
+                } catch (IOException rollbackException) {
+                    e.addSuppressed(rollbackException);
+                }
+            }
+            throw e;
+        }
         segments.add(newSegment);
 
-        if (newOffset != segmentToDelete.getBaseOffset()) {
+        if (!replaceAtSameOffset) {
             segments.remove(segmentToDelete.getBaseOffset());
-            deleteSegmentFiles(Collections.singletonList(segmentToDelete), reason);
         }
+        deleteSegmentFiles(Collections.singletonList(segmentToDelete), reason);
         return newSegment;
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -1565,7 +1565,13 @@ public final class LogTablet {
         Map<Long, WriterAppendInfo> loadedWriters = new HashMap<>();
         for (LogRecordBatch batch : records.batches()) {
             if (batch.hasWriterId()) {
-                updateWriterAppendInfo(writerStateManager, batch, loadedWriters, false);
+                long writerId = batch.writerId();
+                WriterAppendInfo appendInfo =
+                        loadedWriters.computeIfAbsent(
+                                writerId, id -> writerStateManager.prepareUpdate(id));
+                // The records have already been accepted and persisted. Recovery rebuilds writer
+                // state without applying online client sequence validation.
+                appendInfo.appendForRecovery(batch);
             }
         }
         loadedWriters.values().forEach(writerStateManager::update);

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -1301,7 +1301,12 @@ public final class LogTablet {
                 }
 
                 // update write append info.
-                updateWriterAppendInfo(writerStateManager, batch, updatedWriters, isAppendAsLeader);
+                updateWriterAppendInfo(
+                        writerStateManager,
+                        batch,
+                        updatedWriters,
+                        isAppendAsLeader,
+                        WriterAppendInfo.SequenceValidation.ENFORCE);
             }
         }
 
@@ -1439,7 +1444,8 @@ public final class LogTablet {
             WriterStateManager writerStateManager,
             LogRecordBatch batch,
             Map<Long, WriterAppendInfo> writers,
-            boolean isAppendAsLeader) {
+            boolean isAppendAsLeader,
+            WriterAppendInfo.SequenceValidation sequenceValidation) {
         long writerId = batch.writerId();
         // update writers.
         WriterAppendInfo appendInfo =
@@ -1447,7 +1453,8 @@ public final class LogTablet {
         appendInfo.append(
                 batch,
                 writerStateManager.isWriterInBatchExpired(System.currentTimeMillis(), batch),
-                isAppendAsLeader);
+                isAppendAsLeader,
+                sequenceValidation);
     }
 
     static void rebuildWriterState(
@@ -1565,13 +1572,14 @@ public final class LogTablet {
         Map<Long, WriterAppendInfo> loadedWriters = new HashMap<>();
         for (LogRecordBatch batch : records.batches()) {
             if (batch.hasWriterId()) {
-                long writerId = batch.writerId();
-                WriterAppendInfo appendInfo =
-                        loadedWriters.computeIfAbsent(
-                                writerId, id -> writerStateManager.prepareUpdate(id));
                 // The records have already been accepted and persisted. Recovery rebuilds writer
                 // state without applying online client sequence validation.
-                appendInfo.appendForRecovery(batch);
+                updateWriterAppendInfo(
+                        writerStateManager,
+                        batch,
+                        loadedWriters,
+                        false,
+                        WriterAppendInfo.SequenceValidation.WARN_AND_ACCEPT);
             }
         }
         loadedWriters.values().forEach(writerStateManager::update);

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/WriterAppendInfo.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/WriterAppendInfo.java
@@ -21,6 +21,9 @@ import org.apache.fluss.exception.OutOfOrderSequenceException;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.record.LogRecordBatch;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.apache.fluss.record.LogRecordBatchFormat.NO_BATCH_SEQUENCE;
 
 /**
@@ -28,6 +31,8 @@ import static org.apache.fluss.record.LogRecordBatchFormat.NO_BATCH_SEQUENCE;
  * log. It's initialized with writer's state after the last successful append.
  */
 public class WriterAppendInfo {
+    private static final Logger LOG = LoggerFactory.getLogger(WriterAppendInfo.class);
+
     private final long writerId;
     private final TableBucket tableBucket;
     private final WriterStateEntry currentEntry;
@@ -56,6 +61,26 @@ public class WriterAppendInfo {
                 batch.commitTimestamp());
     }
 
+    void appendForRecovery(LogRecordBatch batch) {
+        int currentLastSeq = currentLastBatchSequence();
+        if (!inSequence(currentLastSeq, batch.batchSequence(), false, false)) {
+            LOG.warn(
+                    "Detected discontinuous batch sequence while recovering writer {} at offset {} "
+                            + "in table-bucket {}: incoming sequence {}, current sequence {}. "
+                            + "Accepting the persisted batch.",
+                    writerId,
+                    batch.lastLogOffset(),
+                    tableBucket,
+                    batch.batchSequence(),
+                    currentLastSeq);
+        }
+        appendDataBatch(
+                batch.batchSequence(),
+                new LogOffsetMetadata(batch.baseLogOffset()),
+                batch.lastLogOffset(),
+                batch.commitTimestamp());
+    }
+
     public void appendDataBatch(
             int batchSequence,
             LogOffsetMetadata firstOffsetMetadata,
@@ -64,6 +89,14 @@ public class WriterAppendInfo {
             boolean isAppendAsLeader,
             long batchTimestamp) {
         maybeValidateDataBatch(batchSequence, isWriterInBatchExpired, lastOffset, isAppendAsLeader);
+        appendDataBatch(batchSequence, firstOffsetMetadata, lastOffset, batchTimestamp);
+    }
+
+    private void appendDataBatch(
+            int batchSequence,
+            LogOffsetMetadata firstOffsetMetadata,
+            long lastOffset,
+            long batchTimestamp) {
         updatedEntry.addBath(
                 batchSequence,
                 lastOffset,
@@ -76,10 +109,7 @@ public class WriterAppendInfo {
             boolean isWriterInBatchExpired,
             long lastOffset,
             boolean isAppendAsLeader) {
-        int currentLastSeq =
-                !updatedEntry.isEmpty()
-                        ? updatedEntry.lastBatchSequence()
-                        : currentEntry.lastBatchSequence();
+        int currentLastSeq = currentLastBatchSequence();
         // must be in sequence, even for the first batch should start from 0
         if (!inSequence(currentLastSeq, appendFirstSeq, isWriterInBatchExpired, isAppendAsLeader)) {
             throw new OutOfOrderSequenceException(
@@ -88,6 +118,12 @@ public class WriterAppendInfo {
                                     + "table-bucket %s : %s (incoming batch seq.), %s (current batch seq.)",
                             writerId, lastOffset, tableBucket, appendFirstSeq, currentLastSeq));
         }
+    }
+
+    private int currentLastBatchSequence() {
+        return !updatedEntry.isEmpty()
+                ? updatedEntry.lastBatchSequence()
+                : currentEntry.lastBatchSequence();
     }
 
     public WriterStateEntry toEntry() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/WriterAppendInfo.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/WriterAppendInfo.java
@@ -33,6 +33,11 @@ import static org.apache.fluss.record.LogRecordBatchFormat.NO_BATCH_SEQUENCE;
 public class WriterAppendInfo {
     private static final Logger LOG = LoggerFactory.getLogger(WriterAppendInfo.class);
 
+    enum SequenceValidation {
+        ENFORCE,
+        WARN_AND_ACCEPT
+    }
+
     private final long writerId;
     private final TableBucket tableBucket;
     private final WriterStateEntry currentEntry;
@@ -51,6 +56,14 @@ public class WriterAppendInfo {
 
     public void append(
             LogRecordBatch batch, boolean isWriterInBatchExpired, boolean isAppendAsLeader) {
+        append(batch, isWriterInBatchExpired, isAppendAsLeader, SequenceValidation.ENFORCE);
+    }
+
+    void append(
+            LogRecordBatch batch,
+            boolean isWriterInBatchExpired,
+            boolean isAppendAsLeader,
+            SequenceValidation sequenceValidation) {
         LogOffsetMetadata firstOffsetMetadata = new LogOffsetMetadata(batch.baseLogOffset());
         appendDataBatch(
                 batch.batchSequence(),
@@ -58,27 +71,8 @@ public class WriterAppendInfo {
                 batch.lastLogOffset(),
                 isWriterInBatchExpired,
                 isAppendAsLeader,
-                batch.commitTimestamp());
-    }
-
-    void appendForRecovery(LogRecordBatch batch) {
-        int currentLastSeq = currentLastBatchSequence();
-        if (!inSequence(currentLastSeq, batch.batchSequence(), false, false)) {
-            LOG.warn(
-                    "Detected discontinuous batch sequence while recovering writer {} at offset {} "
-                            + "in table-bucket {}: incoming sequence {}, current sequence {}. "
-                            + "Accepting the persisted batch.",
-                    writerId,
-                    batch.lastLogOffset(),
-                    tableBucket,
-                    batch.batchSequence(),
-                    currentLastSeq);
-        }
-        appendDataBatch(
-                batch.batchSequence(),
-                new LogOffsetMetadata(batch.baseLogOffset()),
-                batch.lastLogOffset(),
-                batch.commitTimestamp());
+                batch.commitTimestamp(),
+                sequenceValidation);
     }
 
     public void appendDataBatch(
@@ -88,7 +82,30 @@ public class WriterAppendInfo {
             boolean isWriterInBatchExpired,
             boolean isAppendAsLeader,
             long batchTimestamp) {
-        maybeValidateDataBatch(batchSequence, isWriterInBatchExpired, lastOffset, isAppendAsLeader);
+        appendDataBatch(
+                batchSequence,
+                firstOffsetMetadata,
+                lastOffset,
+                isWriterInBatchExpired,
+                isAppendAsLeader,
+                batchTimestamp,
+                SequenceValidation.ENFORCE);
+    }
+
+    private void appendDataBatch(
+            int batchSequence,
+            LogOffsetMetadata firstOffsetMetadata,
+            long lastOffset,
+            boolean isWriterInBatchExpired,
+            boolean isAppendAsLeader,
+            long batchTimestamp,
+            SequenceValidation sequenceValidation) {
+        maybeValidateDataBatch(
+                batchSequence,
+                isWriterInBatchExpired,
+                lastOffset,
+                isAppendAsLeader,
+                sequenceValidation);
         appendDataBatch(batchSequence, firstOffsetMetadata, lastOffset, batchTimestamp);
     }
 
@@ -108,15 +125,21 @@ public class WriterAppendInfo {
             int appendFirstSeq,
             boolean isWriterInBatchExpired,
             long lastOffset,
-            boolean isAppendAsLeader) {
+            boolean isAppendAsLeader,
+            SequenceValidation sequenceValidation) {
         int currentLastSeq = currentLastBatchSequence();
         // must be in sequence, even for the first batch should start from 0
         if (!inSequence(currentLastSeq, appendFirstSeq, isWriterInBatchExpired, isAppendAsLeader)) {
-            throw new OutOfOrderSequenceException(
+            String message =
                     String.format(
                             "Out of order batch sequence for writer %s at offset %s in "
                                     + "table-bucket %s : %s (incoming batch seq.), %s (current batch seq.)",
-                            writerId, lastOffset, tableBucket, appendFirstSeq, currentLastSeq));
+                            writerId, lastOffset, tableBucket, appendFirstSeq, currentLastSeq);
+            if (sequenceValidation == SequenceValidation.WARN_AND_ACCEPT) {
+                LOG.warn("{}. Accepting the persisted batch.", message);
+                return;
+            }
+            throw new OutOfOrderSequenceException(message);
         }
     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LocalLogTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LocalLogTest.java
@@ -32,6 +32,7 @@ import org.apache.fluss.record.MemoryLogRecords;
 import org.apache.fluss.server.log.LocalLog.SegmentDeletionReason;
 import org.apache.fluss.server.metrics.group.TestingMetricGroups;
 import org.apache.fluss.utils.CloseableIterator;
+import org.apache.fluss.utils.FlussPaths;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -300,6 +301,39 @@ final class LocalLogTest extends LogTestBase {
                         newOffset,
                         localLog.getSegments().activeSegment().getSizeInBytes());
         assertThat(read.getRecords().sizeInBytes()).isEqualTo(0);
+    }
+
+    @Test
+    void testCreateAndDeleteSegmentWithSameOffset() throws Exception {
+        LogSegment oldActiveSegment = localLog.getSegments().activeSegment();
+        oldActiveSegment.offsetIndex();
+        oldActiveSegment.timeIndex();
+        long baseOffset = oldActiveSegment.getBaseOffset();
+        File oldLogFile = oldActiveSegment.getFileLogRecords().file();
+        File oldOffsetIndexFile = oldActiveSegment.getLazyOffsetIndex().file();
+        File oldTimeIndexFile = oldActiveSegment.timeIndexFile();
+        assertThat(oldLogFile).exists();
+        assertThat(oldOffsetIndexFile).exists();
+        assertThat(oldTimeIndexFile).exists();
+
+        LogSegment newActiveSegment =
+                localLog.createAndDeleteSegment(
+                        baseOffset, oldActiveSegment, SegmentDeletionReason.LOG_ROLL);
+
+        assertThat(localLog.getSegments().activeSegment()).isEqualTo(newActiveSegment);
+        assertThat(newActiveSegment.getFileLogRecords().file()).isEqualTo(oldLogFile);
+        assertThat(newActiveSegment.getLazyOffsetIndex().file()).isEqualTo(oldOffsetIndexFile);
+        assertThat(newActiveSegment.timeIndexFile()).isEqualTo(oldTimeIndexFile);
+        assertThat(oldActiveSegment.getFileLogRecords().file().getName())
+                .endsWith(FlussPaths.DELETED_FILE_SUFFIX);
+        assertThat(oldActiveSegment.getLazyOffsetIndex().file().getName())
+                .endsWith(FlussPaths.DELETED_FILE_SUFFIX);
+        assertThat(oldActiveSegment.timeIndexFile().getName())
+                .endsWith(FlussPaths.DELETED_FILE_SUFFIX);
+        assertThat(oldActiveSegment.deleted()).isTrue();
+        assertThat(newActiveSegment.getFileLogRecords().file()).exists();
+        assertThat(newActiveSegment.offsetIndex().file()).exists();
+        assertThat(newActiveSegment.timeIndex().file()).exists();
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LocalLogTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LocalLogTest.java
@@ -291,6 +291,7 @@ final class LocalLogTest extends LogTestBase {
         assertThat(localLog.getSegments().activeSegment()).isEqualTo(newActiveSegment);
         assertThat(localLog.getSegments().activeSegment()).isNotEqualTo(oldActiveSegment);
         assertThat(localLog.getSegments().activeSegment().getBaseOffset()).isEqualTo(newOffset);
+        assertThat(oldActiveSegment.deleted()).isTrue();
         assertThat(localLog.getRecoveryPoint()).isEqualTo(0L);
         assertThat(localLog.getLocalLogEndOffset()).isEqualTo(newOffset);
         FetchDataInfo read =
@@ -335,6 +336,19 @@ final class LocalLogTest extends LogTestBase {
         FetchDataInfo read =
                 readLog(localLog, 10L, localLog.getSegments().activeSegment().getSizeInBytes());
         assertThat(read.getRecords().sizeInBytes()).isEqualTo(0);
+    }
+
+    @Test
+    void testTruncateFullyAndStartAtDeletesOldActiveSegmentFile() throws Exception {
+        LogSegment oldActiveSegment = localLog.getSegments().activeSegment();
+        File oldLogFile = oldActiveSegment.getFileLogRecords().file();
+        assertThat(oldLogFile).exists();
+
+        localLog.truncateFullyAndStartAt(10L);
+
+        assertThat(localLog.getSegments().baseOffsets()).containsExactly(10L);
+        assertThat(oldActiveSegment.deleted()).isTrue();
+        assertThat(oldLogFile).doesNotExist();
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LogLoaderTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LogLoaderTest.java
@@ -320,6 +320,37 @@ final class LogLoaderTest extends LogTestBase {
     }
 
     @Test
+    void testWriterStateRecoveryAcceptsBatchSequenceGap() throws Exception {
+        LogTablet log = createLogTablet(true);
+        long writerId = 1L;
+
+        log.appendAsFollower(
+                genMemoryLogRecordsWithWriterId(
+                        Collections.singletonList(new Object[] {1, "a"}), writerId, 10, 0L));
+        log.appendAsFollower(
+                genMemoryLogRecordsWithWriterId(
+                        Collections.singletonList(new Object[] {2, "b"}), writerId, 11, 1L));
+        log.roll(Optional.empty());
+
+        MemoryLogRecords recordsWithSequenceGap =
+                genMemoryLogRecordsWithWriterId(
+                        Collections.singletonList(new Object[] {3, "c"}), writerId, 100, 2L);
+        log.activeLogSegment().append(2L, clock.milliseconds(), 2L, recordsWithSequenceGap);
+        log.close();
+
+        log = createLogTablet(false);
+        assertThat(log.localLogEndOffset()).isEqualTo(3L);
+        assertThat(log.writerStateManager().activeWriters().get(writerId).lastBatchSequence())
+                .isEqualTo(100);
+
+        // The recovered state should be persisted in the new snapshot and survive another restart.
+        log.close();
+        log = createLogTablet(false);
+        assertThat(log.writerStateManager().activeWriters().get(writerId).lastBatchSequence())
+                .isEqualTo(100);
+    }
+
+    @Test
     void testWriterSnapshotsRecoveryAfterCleanShutdown() throws Exception {
         LogTablet log = createLogTablet(true);
         assertThat(log.writerStateManager().oldestSnapshotOffset()).isEmpty();

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LogTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LogTabletTest.java
@@ -367,6 +367,46 @@ final class LogTabletTest extends LogTestBase {
     }
 
     @Test
+    void testTruncateToBeforeFirstSegmentDeletesHigherOffsetSegment() throws Exception {
+        logTablet.truncateFullyAndStartAt(10L);
+        logTablet.appendAsLeader(
+                genMemoryLogRecordsByObject(Collections.singletonList(new Object[] {1, "a"})));
+        LogSegment oldActiveSegment = logTablet.activeLogSegment();
+        assertThat(oldActiveSegment.getBaseOffset()).isEqualTo(10L);
+
+        logTablet.truncateTo(5L);
+
+        assertThat(oldActiveSegment.deleted()).isTrue();
+        assertThat(logTablet.logSegments())
+                .extracting(LogSegment::getBaseOffset)
+                .containsExactly(5L);
+        assertThat(logTablet.localLogEndOffset()).isEqualTo(5L);
+
+        logTablet.close();
+        logTablet =
+                LogTablet.create(
+                        tempDir,
+                        PhysicalTablePath.of(DATA1_TABLE_PATH),
+                        logDir,
+                        conf,
+                        new AtomicBoolean(
+                                conf.get(ConfigOptions.LOG_RETENTION_ROLL_ACTIVE_SEGMENT_ENABLED)),
+                        TestingMetricGroups.TABLET_SERVER_METRICS,
+                        0,
+                        scheduler,
+                        LogFormat.ARROW,
+                        1,
+                        false,
+                        SystemClock.getInstance(),
+                        false);
+
+        assertThat(logTablet.logSegments())
+                .extracting(LogSegment::getBaseOffset)
+                .containsExactly(5L);
+        assertThat(logTablet.localLogEndOffset()).isEqualTo(5L);
+    }
+
+    @Test
     void testWriterIdExpirationOnSegmentDeletion() throws Exception {
         long writerId1 = 1L;
         MemoryLogRecords records =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4012 

<!-- What is the purpose of the change -->

`[server] Fix orphan segments after full truncation`:

Delete the previous active segment after creating its replacement. Add regression coverage for upward and downward truncation to ensure stale segment files cannot affect the recovered log end offset.

`[server] Tolerate sequence gaps during writer recovery`:

Rebuild writer state from persisted batches without applying online sequence validation. Warn about discontinuities for observability and verify that the recovered state survives another restart.


### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
