### PR TITLE
[client] Clean up batches when synchronous sends fail

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/write/IncompleteBatches.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/IncompleteBatches.java
@@ -45,13 +45,9 @@ final class IncompleteBatches {
         }
     }
 
-    public void remove(WriteBatch batch) {
+    public boolean removeIfPresent(WriteBatch batch) {
         synchronized (incomplete) {
-            boolean removed = this.incomplete.remove(batch);
-            if (!removed) {
-                throw new IllegalStateException(
-                        "Remove from the incomplete set failed. This should be impossible.");
-            }
+            return this.incomplete.remove(batch);
         }
     }
 

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -62,7 +63,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.fluss.record.LogRecordBatchFormat.NO_BATCH_SEQUENCE;
@@ -108,8 +108,11 @@ public final class RecordAccumulator {
     /** The chunked allocation manager factory, stored for explicit native memory release. */
     private final ChunkedAllocationManager.ChunkedFactory chunkedFactory;
 
-    /** Guard to make {@link #destroyResources()} idempotent. */
-    private final AtomicBoolean resourcesDestroyed = new AtomicBoolean(false);
+    /** Coordinates batch memory deallocation with resource destruction. */
+    private final Object resourcesLock = new Object();
+
+    @GuardedBy("resourcesLock")
+    private boolean resourcesDestroyed;
 
     /** The pool of lazily created arrow {@link ArrowWriter}s for arrow log write batch. */
     private final ArrowWriterPool arrowWriterPool;
@@ -323,20 +326,26 @@ public final class RecordAccumulator {
         return batches;
     }
 
-    public void reEnqueue(ReadyWriteBatch readyWriteBatch) {
+    /** Re-enqueue a batch unless it was completed concurrently. */
+    public boolean reEnqueue(ReadyWriteBatch readyWriteBatch) {
         WriteBatch batch = readyWriteBatch.writeBatch();
         if (batch.isDone()) {
-            return;
+            return false;
         }
         batch.reEnqueued();
         Deque<WriteBatch> deque =
                 getOrCreateDeque(readyWriteBatch.tableBucket(), batch.physicalTablePath());
         synchronized (deque) {
+            if (batch.isDone()) {
+                return false;
+            }
+            batch.reEnqueued();
             if (idempotenceManager.idempotenceEnabled()) {
                 insertInSequenceOrder(deque, batch, readyWriteBatch.tableBucket());
             } else {
                 deque.addFirst(batch);
             }
+            return true;
         }
     }
 
@@ -498,12 +507,24 @@ public final class RecordAccumulator {
 
     private void abortBatch(final Exception reason, WriteBatch batch) {
         Deque<WriteBatch> dq = getDeque(batch.physicalTablePath(), batch.bucketId());
+        boolean aborted;
         synchronized (dq) {
-            batch.abortRecordAppends();
+            aborted = batch.trySetAborted();
+            if (aborted) {
+                batch.abortRecordAppends();
+            }
             dq.remove(batch);
         }
-        batch.abort(reason);
-        deallocate(batch);
+
+        // A response may have completed the batch after abortAllBatches() took its snapshot. In
+        // that case, skip the abort callback but still claim deallocation if it is still pending.
+        try {
+            if (aborted) {
+                batch.completeAbort(reason);
+            }
+        } finally {
+            deallocate(batch);
+        }
     }
 
     /** Get the deque for the given table-bucket, creating it if necessary. */
@@ -563,10 +584,19 @@ public final class RecordAccumulator {
         }
     }
 
-    /** Deallocate the record batch. */
+    /**
+     * Deallocate the record batch if this call wins ownership of it.
+     *
+     * <p>Response handling and fatal cleanup may race, so removing the batch from the incomplete
+     * set determines which caller returns its memory. The same lock prevents resource destruction
+     * from overtaking that return.
+     */
     public void deallocate(WriteBatch batch) {
-        incomplete.remove(batch);
-        writerBufferPool.returnAll(batch.pooledMemorySegments());
+        synchronized (resourcesLock) {
+            if (incomplete.removeIfPresent(batch) && !resourcesDestroyed) {
+                writerBufferPool.returnAll(batch.pooledMemorySegments());
+            }
+        }
     }
 
     /**
@@ -1359,13 +1389,16 @@ public final class RecordAccumulator {
      */
     @VisibleForTesting
     public void destroyResources() {
-        if (!resourcesDestroyed.compareAndSet(false, true)) {
-            return;
+        synchronized (resourcesLock) {
+            if (resourcesDestroyed) {
+                return;
+            }
+            resourcesDestroyed = true;
+            writerBufferPool.close();
+            arrowWriterPool.close();
+            bufferAllocator.close();
+            chunkedFactory.close();
         }
-        writerBufferPool.close();
-        arrowWriterPool.close();
-        bufferAllocator.close();
-        chunkedFactory.close();
     }
 
     /** Per table bucket and write batches. */

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
@@ -329,10 +329,6 @@ public final class RecordAccumulator {
     /** Re-enqueue a batch unless it was completed concurrently. */
     public boolean reEnqueue(ReadyWriteBatch readyWriteBatch) {
         WriteBatch batch = readyWriteBatch.writeBatch();
-        if (batch.isDone()) {
-            return false;
-        }
-        batch.reEnqueued();
         Deque<WriteBatch> deque =
                 getOrCreateDeque(readyWriteBatch.tableBucket(), batch.physicalTablePath());
         synchronized (deque) {

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
@@ -439,14 +439,8 @@ public class Sender implements Runnable {
                     batches);
         } else {
             writeBatchByTable.forEach(
-                (tableId, writeBatches) -> {
-                    try {
-                        sendWriteRequestsForTable(gateway, tableId, acks, writeBatches);
-                    } catch (Exception e) {
-                        handleWriteRequestException(e, writeBatches);
-                    }
-                }
-            );
+                    (tableId, writeBatches) ->
+                            sendWriteRequestsForTable(gateway, tableId, acks, writeBatches));
         }
     }
 
@@ -487,18 +481,23 @@ public class Sender implements Runnable {
         if (writeBatches.isEmpty()) {
             return;
         }
-        if (logBatches) {
-            sendProduceLogRequestAndHandleResponse(
-                    gateway,
-                    makeProduceLogRequest(tableId, acks, maxRequestTimeoutMs, writeBatches),
-                    tableId,
-                    writeBatches);
-        } else {
-            sendPutKvRequestAndHandleResponse(
-                    gateway,
-                    makePutKvRequest(tableId, acks, maxRequestTimeoutMs, writeBatches),
-                    tableId,
-                    writeBatches);
+        try {
+            if (logBatches) {
+                sendProduceLogRequestAndHandleResponse(
+                        gateway,
+                        makeProduceLogRequest(tableId, acks, maxRequestTimeoutMs, writeBatches),
+                        tableId,
+                        writeBatches);
+            } else {
+                sendPutKvRequestAndHandleResponse(
+                        gateway,
+                        makePutKvRequest(tableId, acks, maxRequestTimeoutMs, writeBatches),
+                        tableId,
+                        writeBatches);
+            }
+        } catch (Exception e) {
+            // A synchronous failure belongs only to the batches in this individual RPC.
+            handleWriteRequestException(e, writeBatches);
         }
     }
 

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
@@ -49,6 +49,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -176,9 +177,7 @@ public class Sender implements Runnable {
             }
         } catch (Throwable t) {
             LOG.error("Fatal error in Fluss write sender thread: ", t);
-            running = false;
-            forceClose = true;
-            maybeAbortBatches(t);
+            handleFatalError(t, Collections.emptyList());
             ExceptionUtils.rethrow(t);
         } finally {
             destroyResources();
@@ -435,7 +434,7 @@ public class Sender implements Runnable {
                         // encoding runs out of direct memory. No callback is registered in that
                         // case. Fail the affected batches with the client-side cause before
                         // propagating the fatal error to stop the sender.
-                        handleFatalWriteRequestError(error, writeBatches);
+                        handleFatalError(error, writeBatches);
                         throw error;
                     } catch (Exception e) {
                         handleWriteRequestException(e, writeBatches);
@@ -646,7 +645,7 @@ public class Sender implements Runnable {
     private void handleWriteRequestException(Throwable t, List<ReadyWriteBatch> writeBatches) {
         Throwable cause = Errors.maybeUnwrapException(t);
         if (cause instanceof Error) {
-            handleFatalWriteRequestError(cause, writeBatches);
+            handleFatalError(cause, writeBatches);
             return;
         }
 
@@ -663,10 +662,13 @@ public class Sender implements Runnable {
         metadataUpdater.invalidPhysicalTableBucketMeta(invalidMetadataTablesSet);
     }
 
-    private void handleFatalWriteRequestError(Throwable t, List<ReadyWriteBatch> writeBatches) {
+    private void handleFatalError(Throwable t, List<ReadyWriteBatch> writeBatches) {
+        accumulator.close();
         running = false;
         forceClose = true;
-        failWriteBatches(t, writeBatches);
+        if (!writeBatches.isEmpty()) {
+            failWriteBatches(t, writeBatches);
+        }
         maybeAbortBatches(t);
         wakeup();
     }

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
@@ -410,8 +410,18 @@ public class Sender implements Runnable {
                     batches);
         } else {
             writeBatchByTable.forEach(
-                    (tableId, writeBatches) ->
-                            sendWriteRequestsForTable(gateway, tableId, acks, writeBatches));
+                (tableId, writeBatches) -> {
+                    try {
+                        sendWriteRequestsForTable(gateway, tableId, acks, writeBatches);
+                    } catch (Throwable t) {
+                        // A gateway may throw before returning a future, for example when RPC
+                        // encoding runs out of direct memory. No callback is registered in that
+                        // case, so complete the drained batches to release their buffer pages
+                        // and in-flight state.
+                        handleWriteRequestException(t, writeBatches);
+                    }
+                }
+            );
         }
     }
 

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
@@ -49,13 +49,13 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.fluss.client.utils.ClientRpcMessageUtils.makeProduceLogRequest;
 import static org.apache.fluss.client.utils.ClientRpcMessageUtils.makePutKvRequest;
@@ -95,6 +95,9 @@ public class Sender implements Runnable {
 
     /** true when the caller wants to ignore all unsent/inflight messages and force close. */
     private volatile boolean forceClose;
+
+    /** The first fatal error that requires the sender thread to abort all incomplete batches. */
+    private final AtomicReference<Throwable> fatalError = new AtomicReference<>();
 
     private final Object wakeupLock = new Object();
     private boolean wakeup;
@@ -176,11 +179,17 @@ public class Sender implements Runnable {
                 }
             }
         } catch (Throwable t) {
-            LOG.error("Fatal error in Fluss write sender thread: ", t);
-            handleFatalError(t, Collections.emptyList());
+            recordFatalError(t);
             ExceptionUtils.rethrow(t);
         } finally {
-            destroyResources();
+            try {
+                Throwable t = fatalError.get();
+                if (t != null) {
+                    maybeAbortBatches(t);
+                }
+            } finally {
+                destroyResources();
+            }
         }
 
         // TODO if force close failed, add logic to abort incomplete batches.
@@ -328,11 +337,15 @@ public class Sender implements Runnable {
     }
 
     private void reEnqueueBatch(ReadyWriteBatch readyWriteBatch) {
-        accumulator.reEnqueue(readyWriteBatch);
+        boolean reEnqueued = accumulator.reEnqueue(readyWriteBatch);
         maybeRemoveFromInflightBatches(readyWriteBatch);
 
-        // metrics for retry record count.
-        writerMetricGroup.recordsRetryTotal().inc(readyWriteBatch.writeBatch().getRecordCount());
+        if (reEnqueued) {
+            // metrics for retry record count.
+            writerMetricGroup
+                    .recordsRetryTotal()
+                    .inc(readyWriteBatch.writeBatch().getRecordCount());
+        }
     }
 
     /**
@@ -429,13 +442,6 @@ public class Sender implements Runnable {
                 (tableId, writeBatches) -> {
                     try {
                         sendWriteRequestsForTable(gateway, tableId, acks, writeBatches);
-                    } catch (Error error) {
-                        // A gateway may throw before returning a future, for example when RPC
-                        // encoding runs out of direct memory. No callback is registered in that
-                        // case. Fail the affected batches with the client-side cause before
-                        // propagating the fatal error to stop the sender.
-                        handleFatalError(error, writeBatches);
-                        throw error;
                     } catch (Exception e) {
                         handleWriteRequestException(e, writeBatches);
                     }
@@ -645,7 +651,7 @@ public class Sender implements Runnable {
     private void handleWriteRequestException(Throwable t, List<ReadyWriteBatch> writeBatches) {
         Throwable cause = Errors.maybeUnwrapException(t);
         if (cause instanceof Error) {
-            handleFatalError(cause, writeBatches);
+            recordFatalError(cause);
             return;
         }
 
@@ -662,22 +668,16 @@ public class Sender implements Runnable {
         metadataUpdater.invalidPhysicalTableBucketMeta(invalidMetadataTablesSet);
     }
 
-    private void handleFatalError(Throwable t, List<ReadyWriteBatch> writeBatches) {
+    private void recordFatalError(Throwable t) {
+        // Request callbacks may run on a network thread. Only publish the fatal state here; the
+        // sender thread aborts incomplete batches in run() before destroying accumulator resources.
         accumulator.close();
+        if (fatalError.compareAndSet(null, t)) {
+            LOG.error("Fatal error in Fluss write sender:", t);
+        }
         running = false;
         forceClose = true;
-        if (!writeBatches.isEmpty()) {
-            failWriteBatches(t, writeBatches);
-        }
-        maybeAbortBatches(t);
         wakeup();
-    }
-
-    private void failWriteBatches(Throwable t, List<ReadyWriteBatch> writeBatches) {
-        Exception exception = ExceptionUtils.toException(t);
-        for (ReadyWriteBatch batch : writeBatches) {
-            failBatch(batch, exception, false);
-        }
     }
 
     /** Handle the exception and return a set of tables for which the metadata is invalid. */

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
@@ -151,30 +151,38 @@ public class Sender implements Runnable {
     public void run() {
         LOG.debug("Starting Fluss write sender thread.");
 
-        // main loop, runs until close is called.
-        while (running) {
-            try {
-                runOnce();
-            } catch (Throwable t) {
-                LOG.error("Uncaught error in Fluss write sender thread: ", t);
+        try {
+            // main loop, runs until close is called.
+            while (running) {
+                try {
+                    runOnce();
+                } catch (Exception e) {
+                    LOG.error("Uncaught error in Fluss write sender thread: ", e);
+                }
             }
-        }
 
-        LOG.debug(
-                "Beginning shutdown of Fluss log record write I/O thread, sending remaining records.");
+            LOG.debug(
+                    "Beginning shutdown of Fluss log record write I/O thread, sending remaining records.");
 
-        // okay we stopped accepting requests but there may still be requests in the accumulator or
-        // waiting for acknowledgment, wait until these are completed.
-        // TODO Check the in flight request count in the accumulator.
-        while (!forceClose && ((accumulator.hasUnDrained()))) {
-            try {
-                runOnce();
-            } catch (Exception e) {
-                LOG.error("Uncaught error in Fluss write sender I/O thread: ", e);
+            // okay we stopped accepting requests but there may still be requests in the accumulator
+            // or waiting for acknowledgment, wait until these are completed.
+            // TODO Check the in flight request count in the accumulator.
+            while (!forceClose && ((accumulator.hasUnDrained()))) {
+                try {
+                    runOnce();
+                } catch (Exception e) {
+                    LOG.error("Uncaught error in Fluss write sender I/O thread: ", e);
+                }
             }
+        } catch (Throwable t) {
+            LOG.error("Fatal error in Fluss write sender thread: ", t);
+            running = false;
+            forceClose = true;
+            maybeAbortBatches(t);
+            ExceptionUtils.rethrow(t);
+        } finally {
+            destroyResources();
         }
-
-        destroyResources();
 
         // TODO if force close failed, add logic to abort incomplete batches.
         LOG.debug("Shutdown of Fluss write sender I/O thread has completed.");
@@ -189,10 +197,13 @@ public class Sender implements Runnable {
             try {
                 idempotenceManager.maybeWaitForWriterId(targetTables);
             } catch (Throwable t) {
+                if (t instanceof Error) {
+                    throw (Error) t;
+                }
                 // TODO: If 'only request to init writer_id when we have valid target tables' have
                 // been down, this if check can be removed.
                 if (!targetTables.isEmpty()) {
-                    maybeAbortBatches((Exception) t);
+                    maybeAbortBatches(t);
                 } else {
                     LOG.trace("No target tables, ignore init writer id error", t);
                 }
@@ -304,10 +315,16 @@ public class Sender implements Runnable {
         }
     }
 
-    private void maybeAbortBatches(Exception exception) {
-        if (accumulator.hasIncomplete()) {
-            LOG.error("Aborting write batches due to fatal error", exception);
-            accumulator.abortAllBatches(exception);
+    private void maybeAbortBatches(Throwable t) {
+        try {
+            if (accumulator.hasIncomplete()) {
+                LOG.error("Aborting write batches due to fatal error", t);
+                accumulator.abortAllBatches(ExceptionUtils.toException(t));
+            }
+        } finally {
+            synchronized (inFlightBatchesLock) {
+                inFlightBatches.clear();
+            }
         }
     }
 
@@ -413,12 +430,15 @@ public class Sender implements Runnable {
                 (tableId, writeBatches) -> {
                     try {
                         sendWriteRequestsForTable(gateway, tableId, acks, writeBatches);
-                    } catch (Throwable t) {
+                    } catch (Error error) {
                         // A gateway may throw before returning a future, for example when RPC
                         // encoding runs out of direct memory. No callback is registered in that
-                        // case, so complete the drained batches to release their buffer pages
-                        // and in-flight state.
-                        handleWriteRequestException(t, writeBatches);
+                        // case. Fail the affected batches with the client-side cause before
+                        // propagating the fatal error to stop the sender.
+                        handleFatalWriteRequestError(error, writeBatches);
+                        throw error;
+                    } catch (Exception e) {
+                        handleWriteRequestException(e, writeBatches);
                     }
                 }
             );
@@ -624,6 +644,12 @@ public class Sender implements Runnable {
     }
 
     private void handleWriteRequestException(Throwable t, List<ReadyWriteBatch> writeBatches) {
+        Throwable cause = Errors.maybeUnwrapException(t);
+        if (cause instanceof Error) {
+            handleFatalWriteRequestError(cause, writeBatches);
+            return;
+        }
+
         ApiError error = ApiError.fromThrowable(t);
 
         // if batch failed because of retrievable exception, we need to retry send all those
@@ -635,6 +661,21 @@ public class Sender implements Runnable {
         }
 
         metadataUpdater.invalidPhysicalTableBucketMeta(invalidMetadataTablesSet);
+    }
+
+    private void handleFatalWriteRequestError(Throwable t, List<ReadyWriteBatch> writeBatches) {
+        running = false;
+        forceClose = true;
+        failWriteBatches(t, writeBatches);
+        maybeAbortBatches(t);
+        wakeup();
+    }
+
+    private void failWriteBatches(Throwable t, List<ReadyWriteBatch> writeBatches) {
+        Exception exception = ExceptionUtils.toException(t);
+        for (ReadyWriteBatch batch : writeBatches) {
+            failBatch(batch, exception, false);
+        }
     }
 
     /** Handle the exception and return a set of tables for which the metadata is invalid. */

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/WriteBatch.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/WriteBatch.java
@@ -167,11 +167,20 @@ public abstract class WriteBatch {
 
     /** Abort the batch and complete the future and callbacks. */
     public void abort(Exception exception) {
-        if (!finalState.compareAndSet(null, FinalState.ABORTED)) {
+        if (!trySetAborted()) {
             throw new IllegalStateException(
                     "Batch has already been completed in final stata " + finalState.get());
         }
 
+        completeAbort(exception);
+    }
+
+    boolean trySetAborted() {
+        return finalState.compareAndSet(null, FinalState.ABORTED);
+    }
+
+    /** Complete the abort after the caller has atomically changed the final state. */
+    void completeAbort(Exception exception) {
         LOG.trace(
                 "Abort batch for table path {} with bucket_id {}",
                 physicalTablePath,

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/RecordAccumulatorTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/RecordAccumulatorTest.java
@@ -65,6 +65,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -488,6 +489,59 @@ class RecordAccumulatorTest {
         accum.awaitFlushCompletion();
         assertThat(accum.hasUnDrained()).isFalse();
         assertThat(accum.hasIncomplete()).isFalse();
+    }
+
+    @Test
+    void testAbortAllBatchesHandlesConcurrentCompletion() throws Exception {
+        IndexedRow row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
+        RecordAccumulator accum = createTestRecordAccumulator(1024, 10L * 1024);
+        CompletableFuture<Exception> completedFuture = new CompletableFuture<>();
+        CompletableFuture<Exception> abortedFuture = new CompletableFuture<>();
+
+        try {
+            cluster = updateCluster(Arrays.asList(bucket1, bucket2));
+            accum.append(
+                    createRecord(row),
+                    (bucket, offset, exception) -> completedFuture.complete(exception),
+                    cluster,
+                    tb1.getBucket(),
+                    false);
+            accum.append(
+                    createRecord(row),
+                    (bucket, offset, exception) -> abortedFuture.complete(exception),
+                    cluster,
+                    tb2.getBucket(),
+                    false);
+
+            List<ReadyWriteBatch> batches =
+                    accum.drain(cluster, Collections.singleton(node1.id()), Integer.MAX_VALUE)
+                            .get(node1.id());
+            ReadyWriteBatch completedBatch =
+                    batches.stream()
+                            .filter(batch -> batch.tableBucket().equals(tb1))
+                            .findFirst()
+                            .get();
+            ReadyWriteBatch abortedBatch =
+                    batches.stream()
+                            .filter(batch -> batch.tableBucket().equals(tb2))
+                            .findFirst()
+                            .get();
+
+            assertThat(completedBatch.writeBatch().complete()).isTrue();
+            RuntimeException abortReason = new RuntimeException("fatal write failure");
+            accum.abortAllBatches(abortReason);
+
+            // A late response may still try to deallocate the batch after fatal cleanup.
+            accum.deallocate(completedBatch.writeBatch());
+            assertThat(accum.reEnqueue(abortedBatch)).isFalse();
+
+            assertThat(completedFuture.get()).isNull();
+            assertThat(abortedFuture.get()).isSameAs(abortReason);
+            assertThat(accum.hasUnDrained()).isFalse();
+            assertThat(accum.hasIncomplete()).isFalse();
+        } finally {
+            accum.destroyResources();
+        }
     }
 
     @Test

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
@@ -27,6 +27,7 @@ import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.MemorySize;
 import org.apache.fluss.exception.AuthorizationException;
+import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.exception.NetworkException;
 import org.apache.fluss.exception.OutOfOrderSequenceException;
 import org.apache.fluss.exception.PartitionNotExistException;
@@ -387,6 +388,14 @@ final class SenderTest {
         assertThat(sender.isRunning()).isFalse();
         assertThat(sender.numOfInFlightBatches(kvBucket)).isZero();
         assertThat(accumulator.hasIncomplete()).isFalse();
+        assertThatThrownBy(
+                        () ->
+                                appendKvToAccumulator(
+                                        kvBucket,
+                                        compactedRow(DATA1_ROW_TYPE, new Object[] {2, "b"}),
+                                        (tb, leo, e) -> {}))
+                .isInstanceOf(FlussRuntimeException.class)
+                .hasMessage("Writer closed while send in progress");
     }
 
     @Test

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
@@ -351,6 +351,42 @@ final class SenderTest {
     }
 
     @Test
+    void testSynchronousGatewayErrorReleasesDrainedKvBatch() throws Exception {
+        sender.destroyResources();
+
+        Map<TablePath, TableInfo> tableInfos = new HashMap<>();
+        tableInfos.put(DATA1_TABLE_PATH, DATA1_TABLE_INFO);
+        tableInfos.put(DATA1_TABLE_PATH_PK, DATA1_TABLE_INFO_PK);
+        TestTabletServerGateway failingGateway =
+                new TestTabletServerGateway(false, Collections.emptySet()) {
+                    @Override
+                    public CompletableFuture<PutKvResponse> putKv(PutKvRequest request) {
+                        throw new OutOfMemoryError("Direct buffer memory");
+                    }
+                };
+        metadataUpdater =
+                TestingMetadataUpdater.builder(tableInfos)
+                        .withTabletServerGateway(TestingMetadataUpdater.NODE1.id(), failingGateway)
+                        .build();
+        writerMetricGroup = TestingWriterMetricGroup.newInstance();
+        sender = setupWithIdempotenceState();
+
+        TableBucket kvBucket = new TableBucket(DATA1_TABLE_ID_PK, 0);
+        CompletableFuture<Exception> future = new CompletableFuture<>();
+        appendKvToAccumulator(
+                kvBucket,
+                compactedRow(DATA1_ROW_TYPE, new Object[] {1, "a"}),
+                (tb, leo, e) -> future.complete(e));
+
+        sender.runOnce();
+
+        assertThat(future).isCompleted();
+        assertThat(future.get()).hasMessageContaining("Direct buffer memory");
+        assertThat(sender.numOfInFlightBatches(kvBucket)).isZero();
+        assertThat(accumulator.hasIncomplete()).isFalse();
+    }
+
+    @Test
     void testRetries() throws Exception {
         // create a sender with retries = 1.
         int maxRetries = 1;

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
@@ -75,6 +75,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.fluss.record.LogRecordBatchFormat.NO_WRITER_ID;
 import static org.apache.fluss.record.TestData.DATA1_ROW_TYPE;
@@ -396,6 +401,48 @@ final class SenderTest {
                                         (tb, leo, e) -> {}))
                 .isInstanceOf(FlussRuntimeException.class)
                 .hasMessage("Writer closed while send in progress");
+    }
+
+    @Test
+    void testAsynchronousGatewayErrorIsCleanedUpBySenderThread() throws Exception {
+        TableBucket kvBucket = new TableBucket(DATA1_TABLE_ID_PK, 0);
+        CompletableFuture<Exception> resultFuture = new CompletableFuture<>();
+        AtomicReference<Thread> callbackThread = new AtomicReference<>();
+        AtomicReference<Thread> senderThread = new AtomicReference<>();
+        appendKvToAccumulator(
+                kvBucket,
+                compactedRow(DATA1_ROW_TYPE, new Object[] {1, "a"}),
+                (tb, leo, e) -> {
+                    callbackThread.set(Thread.currentThread());
+                    resultFuture.complete(e);
+                });
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> senderTask =
+                executor.submit(
+                        () -> {
+                            senderThread.set(Thread.currentThread());
+                            sender.run();
+                        });
+        try {
+            retry(
+                    Duration.ofSeconds(20),
+                    () -> assertThat(pendingRequestSize(kvBucket)).isEqualTo(1));
+
+            OutOfMemoryError error = new OutOfMemoryError("Direct buffer memory");
+            failRequest(kvBucket, 0, error);
+            senderTask.get(20, TimeUnit.SECONDS);
+
+            assertThat(resultFuture.get()).hasCause(error);
+            assertThat(callbackThread.get()).isSameAs(senderThread.get());
+            assertThat(sender.isRunning()).isFalse();
+            assertThat(sender.numOfInFlightBatches(kvBucket)).isZero();
+            assertThat(accumulator.hasIncomplete()).isFalse();
+        } finally {
+            sender.forceClose();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(20, TimeUnit.SECONDS)).isTrue();
+        }
     }
 
     @Test

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
@@ -61,6 +61,8 @@ import org.apache.fluss.utils.clock.SystemClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -79,6 +81,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.fluss.record.LogRecordBatchFormat.NO_WRITER_ID;
@@ -343,6 +346,97 @@ final class SenderTest {
         assertThat(secondHistoricalFuture.get()).isNull();
     }
 
+    @ParameterizedTest
+    @CsvSource({"false, true", "true, true", "false, false", "true, false"})
+    void testSynchronousFailureOnlyAffectsOwnedPartitionRequest(
+            boolean failHistorical, boolean retriable) throws Exception {
+        sender.destroyResources();
+        TableInfo tableInfo = createHistoricalTableInfo();
+        PhysicalTablePath activePath = PhysicalTablePath.of(tableInfo.getTablePath(), "20990101");
+        PhysicalTablePath originalPath = PhysicalTablePath.of(tableInfo.getTablePath(), "20000101");
+        PhysicalTablePath historicalPath =
+                PhysicalTablePath.of(tableInfo.getTablePath(), HISTORICAL_PARTITION_VALUE);
+        TableBucket activeBucket = new TableBucket(tableInfo.getTableId(), 21L, 0);
+        TableBucket historicalBucket = new TableBucket(tableInfo.getTableId(), 22L, 0);
+        RuntimeException sendFailure =
+                retriable
+                        ? new NetworkException("synchronous send failure")
+                        : new AuthorizationException("synchronous send failure");
+        AtomicBoolean failOnce = new AtomicBoolean(true);
+        TestTabletServerGateway gateway =
+                new TestTabletServerGateway(false, Collections.emptySet()) {
+                    @Override
+                    public CompletableFuture<PutKvResponse> putKv(PutKvRequest request) {
+                        if (request.getBucketsReqAt(0).hasOriginalPartitionName() == failHistorical
+                                && failOnce.getAndSet(false)) {
+                            throw sendFailure;
+                        }
+                        return super.putKv(request);
+                    }
+                };
+        metadataUpdater =
+                TestingMetadataUpdater.builder(
+                                Collections.singletonMap(tableInfo.getTablePath(), tableInfo))
+                        .withTabletServerGateway(TestingMetadataUpdater.NODE1.id(), gateway)
+                        .build();
+        Map<PhysicalTablePath, TableBucket> tableBucketsByPath = new HashMap<>();
+        tableBucketsByPath.put(activePath, activeBucket);
+        tableBucketsByPath.put(historicalPath, historicalBucket);
+        Cluster cluster = partitionedCluster(tableInfo, tableBucketsByPath);
+        metadataUpdater.updateCluster(cluster);
+        sender = setupWithIdempotenceState();
+
+        CompletableFuture<Exception> activeFuture =
+                appendKvRecord(tableInfo, activePath, 1, cluster);
+        accumulator.routeWritesTo(originalPath, historicalPath, historicalBucket.getPartitionId());
+        CompletableFuture<Exception> historicalFuture =
+                appendKvRecord(tableInfo, originalPath, 2, cluster);
+        PutKvResponse activeResponse = createPutKvResponse(activeBucket, 1L);
+        PutKvResponse historicalResponse =
+                makePutKvResponse(
+                        Collections.singletonList(
+                                PutKvResultForBucket.historicalSuccess(
+                                        historicalBucket, 1L, originalPath.getPartitionName())));
+        TableBucket failedBucket = failHistorical ? historicalBucket : activeBucket;
+        TableBucket unaffectedBucket = failHistorical ? activeBucket : historicalBucket;
+        CompletableFuture<Exception> failedFuture =
+                failHistorical ? historicalFuture : activeFuture;
+        CompletableFuture<Exception> unaffectedFuture =
+                failHistorical ? activeFuture : historicalFuture;
+
+        sender.runOnce();
+
+        // Even when the first RPC fails, the other request is sent and retains its in-flight state.
+        assertThat(gateway.pendingRequestSize()).isOne();
+        assertThat(sender.numOfInFlightBatches(unaffectedBucket)).isOne();
+        assertThat(sender.numOfInFlightBatches(failedBucket)).isZero();
+        assertThat(unaffectedFuture).isNotDone();
+        assertThat(writerMetricGroup.recordsRetryTotal().getCount()).isEqualTo(retriable ? 1L : 0L);
+        if (retriable) {
+            assertThat(failedFuture).isNotDone();
+        } else {
+            assertThat(failedFuture).isCompleted();
+            assertThat(failedFuture.get()).isInstanceOf(AuthorizationException.class);
+        }
+        gateway.response(0, failHistorical ? activeResponse : historicalResponse);
+        assertThat(unaffectedFuture.get()).isNull();
+
+        if (retriable) {
+            metadataUpdater.updateCluster(cluster);
+            sender.runOnce();
+            assertThat(gateway.pendingRequestSize()).isOne();
+            PutKvRequest retryRequest = (PutKvRequest) gateway.getRequest(0);
+            assertThat(retryRequest.getBucketsReqAt(0).hasOriginalPartitionName())
+                    .isEqualTo(failHistorical);
+            assertThat(sender.numOfInFlightBatches(unaffectedBucket)).isZero();
+            assertThat(sender.numOfInFlightBatches(failedBucket)).isOne();
+            gateway.response(0, failHistorical ? historicalResponse : activeResponse);
+            assertThat(failedFuture.get()).isNull();
+        }
+        assertThat(accumulator.hasUnDrained()).isFalse();
+        assertThat(accumulator.hasIncomplete()).isFalse();
+    }
+
     @Test
     void testSimple() throws Exception {
         long offset = 0;
@@ -447,8 +541,8 @@ final class SenderTest {
 
     @Test
     void testRetries() throws Exception {
-        // create a sender with retries = 1.
-        int maxRetries = 1;
+        // Allow multiple retries so a duplicated attempt increment exhausts the budget too early.
+        int maxRetries = 2;
         Sender sender1 =
                 setupWithIdempotenceState(
                         new IdempotenceManager(
@@ -476,10 +570,13 @@ final class SenderTest {
         sender1.runOnce();
         assertThat(sender1.numOfInFlightBatches(tb1)).isEqualTo(1);
 
-        // timeout error can retry send.
-        finishRequest(tb1, 0, createProduceLogResponse(tb1, Errors.REQUEST_TIME_OUT));
-        sender1.runOnce();
-        assertThat(sender1.numOfInFlightBatches(tb1)).isEqualTo(1);
+        // Every allowed retry must leave the write pending until the next response.
+        for (int retry = 0; retry < maxRetries; retry++) {
+            finishRequest(tb1, 0, createProduceLogResponse(tb1, Errors.REQUEST_TIME_OUT));
+            assertThat(future2).isNotDone();
+            sender1.runOnce();
+            assertThat(sender1.numOfInFlightBatches(tb1)).isEqualTo(1);
+        }
 
         // Even if timeout error can retry send, but the retry number > maxRetries, which will
         // return error.

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
@@ -98,6 +98,7 @@ import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.apache.fluss.utils.PartitionUtils.HISTORICAL_PARTITION_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** ITCase for {@link Sender}. */
 final class SenderTest {
@@ -351,17 +352,18 @@ final class SenderTest {
     }
 
     @Test
-    void testSynchronousGatewayErrorReleasesDrainedKvBatch() throws Exception {
+    void testSynchronousGatewayErrorStopsSenderAndReleasesDrainedKvBatch() throws Exception {
         sender.destroyResources();
 
         Map<TablePath, TableInfo> tableInfos = new HashMap<>();
         tableInfos.put(DATA1_TABLE_PATH, DATA1_TABLE_INFO);
         tableInfos.put(DATA1_TABLE_PATH_PK, DATA1_TABLE_INFO_PK);
+        OutOfMemoryError error = new OutOfMemoryError("Direct buffer memory");
         TestTabletServerGateway failingGateway =
                 new TestTabletServerGateway(false, Collections.emptySet()) {
                     @Override
                     public CompletableFuture<PutKvResponse> putKv(PutKvRequest request) {
-                        throw new OutOfMemoryError("Direct buffer memory");
+                        throw error;
                     }
                 };
         metadataUpdater =
@@ -378,10 +380,11 @@ final class SenderTest {
                 compactedRow(DATA1_ROW_TYPE, new Object[] {1, "a"}),
                 (tb, leo, e) -> future.complete(e));
 
-        sender.runOnce();
+        assertThatThrownBy(sender::run).isSameAs(error);
 
         assertThat(future).isCompleted();
-        assertThat(future.get()).hasMessageContaining("Direct buffer memory");
+        assertThat(future.get()).hasCause(error);
+        assertThat(sender.isRunning()).isFalse();
         assertThat(sender.numOfInFlightBatches(kvBucket)).isZero();
         assertThat(accumulator.hasIncomplete()).isFalse();
     }

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/ServerConnection.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/ServerConnection.java
@@ -329,15 +329,25 @@ final class ServerConnection {
             inflightRequests.put(inflight.requestId, inflight);
 
             // TODO: maybe we need to add timeout for the inflight requests
-            ByteBuf byteBuf;
+            ByteBuf byteBuf = null;
             try {
                 byteBuf = inflight.toByteBuf(channel.alloc());
+                connectionMetrics.updateMetricsBeforeSendRequest(apiKey, rawRequest.totalSize());
             } catch (Throwable t) {
                 LOG.error("Failed to encode request for '{}'.", ApiKeys.forId(inflight.apiKey), t);
+                if (byteBuf != null) {
+                    try {
+                        byteBuf.release();
+                    } catch (Throwable releaseFailure) {
+                        if (releaseFailure != t) {
+                            t.addSuppressed(releaseFailure);
+                        }
+                    }
+                }
                 inflightRequests.remove(inflight.requestId);
                 if (t instanceof Error) {
                     responseFuture.completeExceptionally(t);
-                    throw (Error) t;
+                    return responseFuture;
                 }
                 responseFuture.completeExceptionally(
                         new FlussRuntimeException(
@@ -347,8 +357,6 @@ final class ServerConnection {
                                 t));
                 return responseFuture;
             }
-
-            connectionMetrics.updateMetricsBeforeSendRequest(apiKey, rawRequest.totalSize());
 
             channel.writeAndFlush(byteBuf)
                     .addListener(

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/ServerConnection.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/ServerConnection.java
@@ -332,15 +332,19 @@ final class ServerConnection {
             ByteBuf byteBuf;
             try {
                 byteBuf = inflight.toByteBuf(channel.alloc());
-            } catch (Exception e) {
-                LOG.error("Failed to encode request for '{}'.", ApiKeys.forId(inflight.apiKey), e);
+            } catch (Throwable t) {
+                LOG.error("Failed to encode request for '{}'.", ApiKeys.forId(inflight.apiKey), t);
                 inflightRequests.remove(inflight.requestId);
+                if (t instanceof Error) {
+                    responseFuture.completeExceptionally(t);
+                    throw (Error) t;
+                }
                 responseFuture.completeExceptionally(
                         new FlussRuntimeException(
                                 String.format(
                                         "Failed to encode request for '%s'",
                                         ApiKeys.forId(inflight.apiKey)),
-                                e));
+                                t));
                 return responseFuture;
             }
 
@@ -624,5 +628,10 @@ final class ServerConnection {
     @VisibleForTesting
     ConnectionState getConnectionState() {
         return state;
+    }
+
+    @VisibleForTesting
+    int numInflightRequests() {
+        return inflightRequests.size();
     }
 }

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/protocol/MessageCodec.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/protocol/MessageCodec.java
@@ -117,13 +117,24 @@ public final class MessageCodec {
         int frameLength = REQUEST_HEADER_LENGTH + requestSize;
         int bufferSize = frameLength + 4;
         ByteBuf buffer = allocator.ioBuffer(bufferSize, bufferSize);
-        // header
-        buffer.writeInt(frameLength);
-        buffer.writeShort(apiKey);
-        buffer.writeShort(apiVersion);
-        buffer.writeInt(requestId);
-        // payload
-        request.writeTo(buffer);
-        return buffer;
+        try {
+            // header
+            buffer.writeInt(frameLength);
+            buffer.writeShort(apiKey);
+            buffer.writeShort(apiVersion);
+            buffer.writeInt(requestId);
+            // payload
+            request.writeTo(buffer);
+            return buffer;
+        } catch (Throwable t) {
+            try {
+                buffer.release();
+            } catch (Throwable releaseFailure) {
+                if (releaseFailure != t) {
+                    t.addSuppressed(releaseFailure);
+                }
+            }
+            throw t;
+        }
     }
 }

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/ServerConnectionTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/ServerConnectionTest.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -84,9 +85,12 @@ import static org.apache.fluss.metrics.MetricNames.CLIENT_RESPONSES_RATE_AVG;
 import static org.apache.fluss.metrics.MetricNames.CLIENT_RESPONSES_RATE_TOTAL;
 import static org.apache.fluss.rpc.netty.NettyUtils.getClientSocketChannelClass;
 import static org.apache.fluss.rpc.netty.NettyUtils.newEventLoopGroup;
+import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.apache.fluss.utils.NetUtils.getAvailablePort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /** Test for {@link ServerConnection}. */
 public class ServerConnectionTest {
@@ -197,6 +201,29 @@ public class ServerConnectionTest {
         assertThat(metric.getMetricType()).isEqualTo(MetricType.GAUGE);
         assertThat(((Gauge<?>) metric).getValue()).isEqualTo(2L);
         connection.close().get();
+    }
+
+    @Test
+    void testEncodingErrorRemovesInflightRequest() throws Exception {
+        ServerConnection connection =
+                new ServerConnection(
+                        bootstrap,
+                        serverNode,
+                        TestingClientMetricGroup.newInstance(),
+                        clientAuthenticator,
+                        (con, ignore) -> {});
+        try {
+            retry(Duration.ofSeconds(20), () -> assertThat(connection.isReady()).isTrue());
+
+            OutOfMemoryError error = new OutOfMemoryError("Direct buffer memory");
+            ApiMessage request = mock(ApiMessage.class);
+            when(request.totalSize()).thenThrow(error);
+
+            assertThatThrownBy(() -> connection.send(ApiKeys.LOOKUP, request)).isSameAs(error);
+            assertThat(connection.numInflightRequests()).isZero();
+        } finally {
+            connection.close().get();
+        }
     }
 
     @Test

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/ServerConnectionTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/ServerConnectionTest.java
@@ -55,6 +55,7 @@ import org.apache.fluss.rpc.protocol.ApiKeys;
 import org.apache.fluss.security.auth.AuthenticationFactory;
 import org.apache.fluss.security.auth.ClientAuthenticator;
 import org.apache.fluss.shaded.netty4.io.netty.bootstrap.Bootstrap;
+import org.apache.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.fluss.shaded.netty4.io.netty.channel.ChannelFuture;
 import org.apache.fluss.shaded.netty4.io.netty.channel.EventLoopGroup;
 import org.apache.fluss.utils.NetUtils;
@@ -63,7 +64,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -85,10 +85,10 @@ import static org.apache.fluss.metrics.MetricNames.CLIENT_RESPONSES_RATE_AVG;
 import static org.apache.fluss.metrics.MetricNames.CLIENT_RESPONSES_RATE_TOTAL;
 import static org.apache.fluss.rpc.netty.NettyUtils.getClientSocketChannelClass;
 import static org.apache.fluss.rpc.netty.NettyUtils.newEventLoopGroup;
-import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
 import static org.apache.fluss.utils.NetUtils.getAvailablePort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -204,24 +204,45 @@ public class ServerConnectionTest {
     }
 
     @Test
-    void testEncodingErrorRemovesInflightRequest() throws Exception {
+    void testEncodingErrorDoesNotInterruptPendingRequests() throws Exception {
+        CountDownLatch connectionLatch = new CountDownLatch(1);
+        Bootstrap delayedBootstrap =
+                new Bootstrap() {
+                    @Override
+                    public ChannelFuture connect(String host, int port) {
+                        return bootstrap
+                                .connect(host, port)
+                                .addListener(f -> connectionLatch.await(1, TimeUnit.MINUTES));
+                    }
+                };
         ServerConnection connection =
                 new ServerConnection(
-                        bootstrap,
+                        delayedBootstrap,
                         serverNode,
                         TestingClientMetricGroup.newInstance(),
                         clientAuthenticator,
                         (con, ignore) -> {});
         try {
-            retry(Duration.ofSeconds(20), () -> assertThat(connection.isReady()).isTrue());
-
             OutOfMemoryError error = new OutOfMemoryError("Direct buffer memory");
             ApiMessage request = mock(ApiMessage.class);
-            when(request.totalSize()).thenThrow(error);
+            when(request.totalSize()).thenReturn(0).thenThrow(error);
+            when(request.writeTo(any(ByteBuf.class))).thenReturn(0);
 
-            assertThatThrownBy(() -> connection.send(ApiKeys.LOOKUP, request)).isSameAs(error);
+            CompletableFuture<ApiMessage> failedFuture = connection.send(ApiKeys.LOOKUP, request);
+            LookupRequest validRequest = new LookupRequest().setTableId(1);
+            validRequest.addBucketsReq().setBucketId(1);
+            CompletableFuture<ApiMessage> successfulFuture =
+                    connection.send(ApiKeys.LOOKUP, validRequest);
+            assertThat(failedFuture).isNotDone();
+            assertThat(successfulFuture).isNotDone();
+
+            connectionLatch.countDown();
+
+            assertThatThrownBy(() -> failedFuture.get(20, TimeUnit.SECONDS)).hasCause(error);
+            assertThat(successfulFuture.get(20, TimeUnit.SECONDS)).isNotNull();
             assertThat(connection.numInflightRequests()).isZero();
         } finally {
+            connectionLatch.countDown();
             connection.close().get();
         }
     }

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/protocol/MessageCodecTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/protocol/MessageCodecTest.java
@@ -34,6 +34,7 @@ import org.apache.fluss.rpc.netty.server.RequestsMetrics;
 import org.apache.fluss.security.auth.PlainTextAuthenticationPlugin;
 import org.apache.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.fluss.shaded.netty4.io.netty.buffer.ByteBufAllocator;
+import org.apache.fluss.shaded.netty4.io.netty.buffer.Unpooled;
 import org.apache.fluss.shaded.netty4.io.netty.channel.Channel;
 import org.apache.fluss.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.fluss.shaded.netty4.io.netty.channel.ChannelId;
@@ -47,6 +48,8 @@ import java.util.Collections;
 
 import static org.apache.fluss.testutils.ByteBufChannel.toByteBuf;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -102,6 +105,29 @@ class MessageCodecTest {
         assertThat(actual.getClientSoftwareName()).isEqualTo("test");
         assertThat(actual.getClientSoftwareVersion()).isEqualTo("1.0.0");
         assertThat(byteBuf.readerIndex()).isEqualTo(byteBuf.writerIndex());
+    }
+
+    @Test
+    void testEncodeRequestReleasesBufferOnFailure() {
+        ByteBufAllocator allocator = mock(ByteBufAllocator.class);
+        ByteBuf buffer = Unpooled.buffer();
+        when(allocator.ioBuffer(anyInt(), anyInt())).thenReturn(buffer);
+
+        OutOfMemoryError error = new OutOfMemoryError("Direct buffer memory");
+        ApiMessage request = mock(ApiMessage.class);
+        when(request.totalSize()).thenReturn(1);
+        when(request.writeTo(buffer)).thenThrow(error);
+
+        assertThatThrownBy(
+                        () ->
+                                MessageCodec.encodeRequest(
+                                        allocator,
+                                        ApiKeys.API_VERSIONS.id,
+                                        ApiKeys.API_VERSIONS.highestSupportedVersion,
+                                        1001,
+                                        request))
+                .isSameAs(error);
+        assertThat(buffer.refCnt()).isZero();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Clean up drained write batches when request construction or gateway submission throws before returning a future.
- Scope failure handling to batches from the affected table request.
- Add regression coverage for direct-memory OOM during synchronous KV sends.

## Root cause

Sender registers drained batches as in-flight before invoking the tablet-server gateway. If RPC request construction or encoding throws synchronously, no response future or completion callback is installed. The affected batches therefore remain incomplete, retain writer-buffer pages indefinitely, and can eventually block the writer after the buffer is exhausted.

## Test Plan

- Ran `SenderTest`: 22 tests passed.
- Checkstyle, Spotless, and RAT checks passed for the affected reactor build.
- Verified the staged diff with `git diff --cached --check`.

Fixes #4018

🤖 AI-assisted changes - reviewed by human developer
