### PR TITLE
[client] Include original partition name in historical lookup errors

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/lookup/LookupSender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/lookup/LookupSender.java
@@ -566,21 +566,27 @@ class LookupSender implements Runnable {
         }
 
         for (AbstractLookupQuery<?> lookup : lookups) {
+            String originalPartitionNameMsg =
+                    lookup.originalPartitionName() == null
+                            ? ""
+                            : " for historical partition " + lookup.originalPartitionName();
             if (canRetry(lookup, exception)) {
                 long retryDelayMs = prepareRetry(lookup, exception);
                 LOG.warn(
-                        "Get error {} response on table bucket {}, retrying after {} ms ({} attempts left). Error: {}",
+                        "Get error {} response on table bucket {}{}, retrying after {} ms ({} attempts left). Error: {}",
                         lookupType,
                         tableBucket,
+                        originalPartitionNameMsg,
                         retryDelayMs,
                         maxRetries - lookup.retries(),
                         error.formatErrMsg());
                 reEnqueueLookup(lookup);
             } else {
                 LOG.warn(
-                        "Get error {} response on table bucket {}, fail. Error: {}",
+                        "Get error {} response on table bucket {}{}, fail. Error: {}",
                         lookupType,
                         tableBucket,
+                        originalPartitionNameMsg,
                         error.formatErrMsg());
                 lookup.future().completeExceptionally(exception);
             }


### PR DESCRIPTION
### Purpose

small fix to include original partition name in historical lookup errors

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
