### PR TITLE
[docs] Use a non-expiring Slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 <p align="center">
   <a href="https://github.com/apache/fluss/actions/workflows/ci.yaml"><img src="https://github.com/apache/fluss/actions/workflows/ci.yaml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/apache/fluss/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-4EB1BA.svg" alt="License"></a>
-  <a href="https://join.slack.com/t/apache-fluss/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw"><img src="https://img.shields.io/badge/slack-join_chat-brightgreen.svg?logo=slack" alt="Slack"></a>
+  <a href="https://join.slack.com/t/apache-fluss/shared_invite/zt-473vgmvjr-cmIma~_iAA4cN02o5u2pDQ"><img src="https://img.shields.io/badge/slack-join_chat-brightgreen.svg?logo=slack" alt="Slack"></a>
   <a href="https://deepwiki.com/apache/fluss"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 

--- a/website/community/how-to-contribute/bug-reports-feature-requests.md
+++ b/website/community/how-to-contribute/bug-reports-feature-requests.md
@@ -42,7 +42,7 @@ When filing an issue, make sure to answer these five questions:
 5. What did you see instead?
 
 Troubleshooting questions should be posted on:
-* [Slack (#troubleshooting)](https://join.slack.com/t/apache-fluss/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw)
+* [Slack (#troubleshooting)](https://join.slack.com/t/apache-fluss/shared_invite/zt-473vgmvjr-cmIma~_iAA4cN02o5u2pDQ)
 * [GitHub Discussions](https://github.com/apache/fluss/discussions)
 
 ## How to suggest a feature or enhancement

--- a/website/community/how-to-contribute/overview.md
+++ b/website/community/how-to-contribute/overview.md
@@ -65,7 +65,7 @@ Good for: experienced contributors and committers who want to help others land t
 Contributions are easier when you are connected with other contributors. Join the conversation on:
 
 - [GitHub Discussions](https://github.com/apache/fluss/discussions) — design questions, usage help, and general discussion.
-- [Slack](https://join.slack.com/t/apache-fluss/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw) — real-time chat with contributors and users.
+- [Slack](https://join.slack.com/t/apache-fluss/shared_invite/zt-473vgmvjr-cmIma~_iAA4cN02o5u2pDQ) — real-time chat with contributors and users.
 - [Mailing Lists](../welcome.mdx) — `dev@fluss.apache.org` for development, `user@fluss.apache.org` for user questions.
 
 Thank you for helping make Apache Fluss better.

--- a/website/community/welcome.mdx
+++ b/website/community/welcome.mdx
@@ -28,9 +28,9 @@ Fluss has two mailing lists:
   - [Archive](https://lists.apache.org/list.html?user@fluss.apache.org)
 
 ## Slack
-We use the [Fluss workspace](https://apache-fluss.slack.com/) on Slack for real-time communication and collaboration. You can join the community using [this invite link](https://join.slack.com/t/apache-fluss/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw).
+We use the [Fluss workspace](https://apache-fluss.slack.com/) on Slack for real-time communication and collaboration. You can join the community using [this invite link](https://join.slack.com/t/apache-fluss/shared_invite/zt-473vgmvjr-cmIma~_iAA4cN02o5u2pDQ).
 
-Please note that this link may occasionally break when Slack does an upgrade. If you encounter problems using it, please let us know by creating an issue on GitHub.
+This invite link does not expire, but it can be used by up to 400 people. If you encounter problems using it, please let us know by creating an issue on GitHub.
 
 ## Community Events
 Join our monthly community gatherings to get involved:

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -349,7 +349,7 @@ const config: Config = {
           title: 'Community',
           items: [
             {label: 'GitHub', href: 'https://github.com/apache/fluss'},
-            {label: 'Slack', href: 'https://join.slack.com/t/apache-fluss/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw'},
+            {label: 'Slack', href: 'https://join.slack.com/t/apache-fluss/shared_invite/zt-473vgmvjr-cmIma~_iAA4cN02o5u2pDQ'},
             {label: 'Welcome', to: '/community/welcome'},
             {label: 'Contribute', to: '/community/welcome'},
           ],

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -109,7 +109,7 @@ function useHeroVisibilityClass(ref: React.RefObject<HTMLElement>) {
 }
 
 const SLACK_INVITE =
-    'https://join.slack.com/t/apache-fluss/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw';
+    'https://join.slack.com/t/apache-fluss/shared_invite/zt-473vgmvjr-cmIma~_iAA4cN02o5u2pDQ';
 
 function HeroDiagram() {
     // Inline SVG: a four-column architectural map of the Fluss data plane.


### PR DESCRIPTION
## Summary
- replace the expired Apache Fluss Slack invite link with a non-expiring invite URL
- update all tracked Slack entry points in the README and community website
- document that the invite link is limited to 400 people

## Test Plan
- `git diff --check`
- verified the new invite URL redirects to the Apache Fluss Slack workspace
- confirmed the previous invite URLs no longer appear in tracked files
- `npm run typecheck` *(blocked by existing `Cannot find namespace 'JSX'` errors outside this change)*
- `npm run build` *(blocked by existing Docusaurus package version mismatch: core 3.9.2 vs theme-mermaid 3.10.2)*

🤖 AI-assisted changes - reviewed by human developer