### PR TITLE
[server] Fix race condition in table/partition deletion ordering

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/TableManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/TableManager.java
@@ -272,8 +272,8 @@ public class TableManager {
     private void completeDeleteTable(long tableId) {
         Set<TableBucketReplica> replicas = coordinatorContext.getAllReplicasForTable(tableId);
         replicaStateMachine.handleStateChanges(replicas, ReplicaState.NonExistentReplica);
-        asyncDeleteRemoteDirectory(tableId);
         asyncDeleteTableMetadata(tableId);
+        asyncDeleteRemoteDirectory(tableId);
         coordinatorContext.removeTable(tableId);
         // Release the manager's in-flight tracking so the next batch can be submitted.
         lifecycleThrottler.onTableDropCompleted(tableId);
@@ -284,8 +284,8 @@ public class TableManager {
                 coordinatorContext.getAllReplicasForPartition(
                         tablePartition.getTableId(), tablePartition.getPartitionId());
         replicaStateMachine.handleStateChanges(replicas, ReplicaState.NonExistentReplica);
-        asyncDeleteRemoteDirectory(tablePartition);
         asyncDeletePartitionMetadata(tablePartition.getPartitionId());
+        asyncDeleteRemoteDirectory(tablePartition);
         coordinatorContext.removePartition(tablePartition);
         lifecycleThrottler.onPartitionDropCompleted(tablePartition);
     }


### PR DESCRIPTION
## Summary
- Swap the submission order so that metadata deletion (ZK) is submitted to the ioExecutor before remote directory cleanup
- Since the ioExecutor is a single-threaded pool, slow remote filesystem operations can block the faster metadata deletion, causing flaky test timeouts in `CoordinatorEventProcessorTest.testCreateAndDropTable`

Fixes #1026

## Brief change log
- Swapped the call order in `completeDeleteTable()` so `asyncDeleteTableMetadata()` is submitted before `asyncDeleteRemoteDirectory()`
- Applied the same reordering in `completeDeletePartition()` for consistency

## Test Plan
- Existing `CoordinatorEventProcessorTest.testCreateAndDropTable`
- The fix addresses the race condition at the root cause level