### PR TITLE
[build] Exclude module-info.class from shaded fat-JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -886,6 +886,11 @@
                                 <exclude>log4j2.properties</exclude>
                                 <exclude>log4j-test.properties</exclude>
                                 <exclude>log4j2-test.properties</exclude>
+                                <!-- Do not copy module-info.class from shaded dependencies.
+                                     Otherwise, the shaded uber-JAR will inherit a third-party module descriptor (e.g. from commons-lang3)
+                                     which breaks JPMS modular consumption. -->
+                                <exclude>module-info.class</exclude>
+                                <exclude>META-INF/versions/**/module-info.class</exclude>
                                 <!-- Do not copy the signatures in the META-INF folder.
                                 Otherwise, this might cause SecurityExceptions when using the JAR. -->
                                 <exclude>META-INF/*.SF</exclude>


### PR DESCRIPTION
### Generative AI disclosure
- [x] Yes (Antigravity)
- [ ] No generative AI tools used

### Purpose
Linked issue: close #4045

All shaded uber-JARs (such as `fluss-client`, `fluss-flink-1.20`, `fluss-server`) currently leak `META-INF/versions/9/module-info.class` from shaded dependencies (like `commons-lang3`). This causes the Java Platform Module System (JPMS) on Java 9+ to treat these JARs as module `org.apache.commons.lang3` rather than deriving an automatic module, breaking downstream modular consumption.

### Brief change log
- In the root `pom.xml`, configure the global `maven-shade-plugin` filter (`<artifact>*</artifact>`) to exclude `module-info.class` and `META-INF/versions/**/module-info.class`.

### Tests
- Verified module descriptors with `jar --describe-module --file=[jar-path] --release 21` on `fluss-client`, `fluss-flink-1.20`, `fluss-flink-1.19`, and `fluss-server` (all now correctly derive automatic modules).
- Ran `./mvnw spotless:check` and `./mvnw checkstyle:check` (all passed cleanly).

### API and Format
Does not affect API or storage format.

### Documentation
Does not introduce new features or require documentation changes.