### PR TITLE
[test] Wait for KV flush before limit scan

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaManagerTest.java
@@ -1420,9 +1420,10 @@ class ReplicaManagerTest extends ReplicaTestBase {
 
         // first, send one batch kv.
         CompletableFuture<List<PutKvResultForBucket>> future1 = new CompletableFuture<>();
+        // Limit scan reads from RocksDB, so wait for the asynchronous KV flush to complete.
         replicaManager.putRecordsToKv(
                 20000,
-                1,
+                -1,
                 Collections.singletonMap(tb, genKvRecordBatch(DATA_1_WITH_KEY_AND_VALUE)),
                 null,
                 MergeMode.DEFAULT,


### PR DESCRIPTION
<!--
Generated-by: Codex (gpt-5.6-sol) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: close #3877

`ReplicaManagerTest#testLimitScanPrimaryKeyTable` writes a KV batch with `acks=1` and immediately scans RocksDB. Since `acks=1` only waits for the leader local log append, the scan can race with the asynchronous KV flush and observe the previous state.

### Brief change log

- Use `acks=-1` in the limit scan test so the write completes only after the KV high watermark, which is bounded by the flushed RocksDB offset, has advanced.
- Document why the stronger acknowledgment is required by this test.

### Tests

- `./mvnw -pl fluss-server -am -DskipITs -Dtest=ReplicaManagerTest#testLimitScanPrimaryKeyTable -Dsurefire.failIfNoSpecifiedTests=false test`

### API and Format

No API or format changes.

### Documentation

No documentation changes.

### Generative AI disclosure

- [x] Yes — Codex (gpt-5.6-sol). All changes were reviewed before submission.