### PR TITLE
[test] Wait for local leader readiness

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
@@ -943,8 +943,21 @@ public final class FlussClusterExtension
                 "Fail to wait partitions dropped");
     }
 
+    /** Wait until the assigned replica is ready as the local leader and return its server id. */
     public int waitAndGetLeader(TableBucket tb) {
-        return waitLeaderAndIsrReady(tb).leader();
+        ZooKeeperClient zkClient = getZooKeeperClient();
+        return waitValue(
+                () -> {
+                    Optional<LeaderAndIsr> leaderAndIsrOpt = zkClient.getLeaderAndIsr(tb);
+                    if (!leaderAndIsrOpt.isPresent()) {
+                        return Optional.empty();
+                    }
+
+                    int leader = leaderAndIsrOpt.get().leader();
+                    return getReplica(tb, leader, true).map(ignored -> leader);
+                },
+                Duration.ofMinutes(1),
+                "Fail to wait leader replica ready for " + tb);
     }
 
     public int waitAndGetStandby(TableBucket tb) {


### PR DESCRIPTION
<!--
Generated-by: Codex (gpt-5.6-sol) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: close #4052

`LogFetcherITCase#testFetchWithSchemaChange` failed in [this CI job](https://github.com/apache/fluss/actions/runs/32277065376/job/96146976916?pr=3233) because `waitAndGetLeader` returned the ZooKeeper-assigned leader before that TabletServer had completed its local leader transition. The test could then send a leader-only request too early and receive an error response without `base_offset`.

### Brief change log

- Make `FlussClusterExtension#waitAndGetLeader` wait for both the ZooKeeper leader assignment and the corresponding locally ready leader replica.
- Document the stronger readiness guarantee.

### Tests

- `./mvnw -pl fluss-client -am -Dtest=LogFetcherITCase#testFetchWithSchemaChange -Dsurefire.failIfNoSpecifiedTests=false test`

### API and Format

No API or format changes.

### Documentation

No documentation changes.

### Generative AI disclosure

- [x] Yes — Codex (gpt-5.6-sol). All changes were reviewed before submission.