### PR TITLE
[flink] Fix LakeSource copy isolation

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/lake/source/LakeSource.java
+++ b/fluss-common/src/main/java/org/apache/fluss/lake/source/LakeSource.java
@@ -85,6 +85,23 @@ public interface LakeSource<Split extends LakeSplit> extends Serializable {
     SimpleVersionedSerializer<Split> getSplitSerializer();
 
     /**
+     * Creates an independent copy of this lake source, including all push-down state that has
+     * already been applied.
+     *
+     * <p>Subsequent calls to {@link #withProject(int[][])}, {@link #withLimit(int)}, or {@link
+     * #withFilters(List)} on either instance must not affect the planning or reading behavior of
+     * the other instance.
+     *
+     * <p>This operation must copy the current state entirely in memory. It must not access a
+     * catalog, load table or schema metadata, or replay ability methods such as push-down
+     * operations. Implementations must also preserve any additional push-down state introduced in
+     * the future.
+     *
+     * @return an independent copy of this lake source
+     */
+    LakeSource<Split> copy();
+
+    /**
      * Context interface for planners, providing the snapshot id of the table in data-lake to plan
      * splits.
      */

--- a/fluss-common/src/main/java/org/apache/fluss/utils/ArrayUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/utils/ArrayUtils.java
@@ -81,6 +81,24 @@ public final class ArrayUtils {
         return resultArray;
     }
 
+    /**
+     * Creates a deep copy of a two-dimensional {@code int} array.
+     *
+     * <p>This method returns {@code null} for a {@code null} input array and preserves {@code null}
+     * nested arrays.
+     */
+    public static int[][] deepCopy(int[][] array) {
+        if (array == null) {
+            return null;
+        }
+
+        int[][] copy = new int[array.length][];
+        for (int i = 0; i < array.length; i++) {
+            copy[i] = array[i] == null ? null : array[i].clone();
+        }
+        return copy;
+    }
+
     /** Check if the second array is a subset of the first array. */
     public static boolean isSubset(int[] a, int[] b) {
         // Iterate over each element in the second array

--- a/fluss-common/src/test/java/org/apache/fluss/lake/source/TestingLakeSource.java
+++ b/fluss-common/src/test/java/org/apache/fluss/lake/source/TestingLakeSource.java
@@ -33,6 +33,8 @@ import java.util.List;
 /** A testing implementation of {@link LakeSource}. */
 public class TestingLakeSource implements LakeSource<LakeSplit> {
 
+    private static final long serialVersionUID = 1L;
+
     // bucket num of source table
     private final int bucketNum;
 
@@ -47,6 +49,17 @@ public class TestingLakeSource implements LakeSource<LakeSplit> {
     public TestingLakeSource(int bucketNum, List<PartitionInfo> partitionInfos) {
         this.bucketNum = bucketNum;
         this.partitionInfos = partitionInfos;
+    }
+
+    private TestingLakeSource(TestingLakeSource source) {
+        this.bucketNum = source.bucketNum;
+        this.partitionInfos =
+                source.partitionInfos == null ? null : new ArrayList<>(source.partitionInfos);
+    }
+
+    @Override
+    public TestingLakeSource copy() {
+        return new TestingLakeSource(this);
     }
 
     @Override

--- a/fluss-common/src/test/java/org/apache/fluss/utils/ArrayUtilsTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/utils/ArrayUtilsTest.java
@@ -70,6 +70,22 @@ public class ArrayUtilsTest {
     }
 
     @Test
+    void testDeepCopyTwoDimensionalIntArray() {
+        int[][] original = new int[][] {new int[] {1, 2}, null, new int[0]};
+
+        int[][] copy = ArrayUtils.deepCopy(original);
+
+        assertThat(copy).isNotSameAs(original);
+        assertThat(copy[0]).isNotSameAs(original[0]).containsExactly(1, 2);
+        assertThat(copy[1]).isNull();
+        assertThat(copy[2]).isNotSameAs(original[2]).isEmpty();
+
+        original[0][0] = 10;
+        assertThat(copy[0]).containsExactly(1, 2);
+        assertThat(ArrayUtils.deepCopy(null)).isNull();
+    }
+
+    @Test
     void testIsSubset() {
         int[] a = new int[] {1, 2, 3, 4, 5};
         int[] b = new int[] {1, 3, 5};

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -264,6 +264,38 @@ public class FlinkTableSource
                 PushdownUtils.computeAvailableStatsColumns(flussRowType, tableConfig);
     }
 
+    private FlinkTableSource(FlinkTableSource source) {
+        this.tablePath = source.tablePath;
+        this.flussConfig = new Configuration(source.flussConfig);
+        this.tableOutputType = source.tableOutputType;
+        this.primaryKeyIndexes = source.primaryKeyIndexes.clone();
+        this.bucketKeyIndexes = source.bucketKeyIndexes.clone();
+        this.partitionKeyIndexes = source.partitionKeyIndexes.clone();
+        this.streaming = source.streaming;
+        this.startupOptions = copyStartupOptions(source.startupOptions);
+        this.lookupAsync = source.lookupAsync;
+        this.insertIfNotExists = source.insertIfNotExists;
+        this.cache = source.cache;
+        this.scanPartitionDiscoveryIntervalMs = source.scanPartitionDiscoveryIntervalMs;
+        this.splitPerAssignmentBatchSize = source.splitPerAssignmentBatchSize;
+        this.isDataLakeEnabled = source.isDataLakeEnabled;
+        this.leaseContext = source.leaseContext;
+        this.mergeEngineType = source.mergeEngineType;
+        this.tableConfig = source.tableConfig;
+        this.availableStatsColumns = new HashSet<>(source.availableStatsColumns);
+        this.producedDataType = source.producedDataType;
+        this.projectedFields =
+                source.projectedFields == null ? null : source.projectedFields.clone();
+        this.singleRowFilter = copyGenericRowData(source.singleRowFilter);
+        this.selectRowCount = source.selectRowCount;
+        this.limit = source.limit;
+        this.partitionFilters = source.partitionFilters;
+        this.tableOptions = new HashMap<>(source.tableOptions);
+        this.lakeSource = source.lakeSource == null ? null : source.lakeSource.copy();
+        this.logRecordBatchFilter = source.logRecordBatchFilter;
+        this.watermarkStrategy = source.watermarkStrategy;
+    }
+
     @Override
     public ChangelogMode getChangelogMode() {
         if (!streaming) {
@@ -501,35 +533,7 @@ public class FlinkTableSource
 
     @Override
     public DynamicTableSource copy() {
-        FlinkTableSource source =
-                new FlinkTableSource(
-                        tablePath,
-                        flussConfig,
-                        tableConfig,
-                        tableOutputType,
-                        primaryKeyIndexes,
-                        bucketKeyIndexes,
-                        partitionKeyIndexes,
-                        streaming,
-                        startupOptions,
-                        lookupAsync,
-                        insertIfNotExists,
-                        cache,
-                        scanPartitionDiscoveryIntervalMs,
-                        splitPerAssignmentBatchSize,
-                        isDataLakeEnabled,
-                        mergeEngineType,
-                        tableOptions,
-                        leaseContext);
-        source.producedDataType = producedDataType;
-        source.projectedFields = projectedFields;
-        source.singleRowFilter = singleRowFilter;
-        source.partitionFilters = partitionFilters;
-        source.lakeSource = lakeSource;
-        source.logRecordBatchFilter = logRecordBatchFilter;
-        source.watermarkStrategy = watermarkStrategy;
-        // Note: availableStatsColumns is already computed in the constructor
-        return source;
+        return new FlinkTableSource(this);
     }
 
     @Override
@@ -709,6 +713,7 @@ public class FlinkTableSource
         }
 
         if (lakePredicates.isEmpty()) {
+            checkNotNull(lakeSource).withFilters(Collections.emptyList());
             return;
         }
 
@@ -792,6 +797,29 @@ public class FlinkTableSource
             pkTypes.put(index, tableOutputType.getTypeAt(index));
         }
         return pkTypes;
+    }
+
+    private static FlinkConnectorOptionsUtils.StartupOptions copyStartupOptions(
+            FlinkConnectorOptionsUtils.StartupOptions startupOptions) {
+        FlinkConnectorOptionsUtils.StartupOptions copy =
+                new FlinkConnectorOptionsUtils.StartupOptions();
+        copy.startupMode = startupOptions.startupMode;
+        copy.startupTimestampMs = startupOptions.startupTimestampMs;
+        return copy;
+    }
+
+    @Nullable
+    private static GenericRowData copyGenericRowData(@Nullable GenericRowData rowData) {
+        if (rowData == null) {
+            return null;
+        }
+
+        GenericRowData copy = new GenericRowData(rowData.getRowKind(), rowData.getArity());
+        for (int i = 0; i < rowData.getArity(); i++) {
+            Object field = rowData.getField(i);
+            copy.setField(i, field instanceof byte[] ? ((byte[]) field).clone() : field);
+        }
+        return copy;
     }
 
     // projection from pk_field_index to index_in_pk

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -282,6 +282,7 @@ public class FlinkTableSource
         this.leaseContext = source.leaseContext;
         this.mergeEngineType = source.mergeEngineType;
         this.tableConfig = source.tableConfig;
+        // Note: availableStatsColumns is already computed in the constructor
         this.availableStatsColumns = new HashSet<>(source.availableStatsColumns);
         this.producedDataType = source.producedDataType;
         this.projectedFields =

--- a/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/source/HudiLakeSource.java
+++ b/fluss-lake/fluss-lake-hudi/src/main/java/org/apache/fluss/lake/hudi/source/HudiLakeSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.fluss.lake.hudi.source;
 
+import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.lake.hudi.utils.FlussToHudiExpressionPredicateConverter;
 import org.apache.fluss.lake.hudi.utils.HudiTableInfo;
@@ -26,6 +27,7 @@ import org.apache.fluss.lake.source.Planner;
 import org.apache.fluss.lake.source.RecordReader;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.predicate.Predicate;
+import org.apache.fluss.utils.ArrayUtils;
 
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.org.apache.avro.Schema;
@@ -55,9 +57,24 @@ public class HudiLakeSource implements LakeSource<HudiSplit> {
         this.tablePath = tablePath;
     }
 
+    private HudiLakeSource(HudiLakeSource source) {
+        this.hudiConfig = new Configuration(source.hudiConfig);
+        this.tablePath = source.tablePath;
+        this.project = ArrayUtils.deepCopy(source.project);
+        this.predicates =
+                source.predicates.isEmpty()
+                        ? Collections.emptyList()
+                        : Collections.unmodifiableList(new ArrayList<>(source.predicates));
+    }
+
+    @Override
+    public HudiLakeSource copy() {
+        return new HudiLakeSource(this);
+    }
+
     @Override
     public void withProject(int[][] project) {
-        this.project = project;
+        this.project = ArrayUtils.deepCopy(project);
     }
 
     @Override
@@ -124,6 +141,11 @@ public class HudiLakeSource implements LakeSource<HudiSplit> {
     @Override
     public SimpleVersionedSerializer<HudiSplit> getSplitSerializer() {
         return new HudiSplitSerializer();
+    }
+
+    @VisibleForTesting
+    List<ExpressionPredicates.Predicate> getPredicates() {
+        return predicates;
     }
 
     private Schema getHudiSchema() {

--- a/fluss-lake/fluss-lake-hudi/src/test/java/org/apache/fluss/lake/hudi/source/HudiLakeSourceTest.java
+++ b/fluss-lake/fluss-lake-hudi/src/test/java/org/apache/fluss/lake/hudi/source/HudiLakeSourceTest.java
@@ -25,8 +25,11 @@ import org.apache.fluss.lake.source.RecordReader;
 import org.apache.fluss.metadata.Schema;
 import org.apache.fluss.metadata.TableDescriptor;
 import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.predicate.PredicateBuilder;
 import org.apache.fluss.types.DataTypes;
+import org.apache.fluss.types.RowType;
 
+import org.apache.hudi.source.ExpressionPredicates;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -35,6 +38,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -114,6 +118,49 @@ class HudiLakeSourceTest {
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("Fail to create Hudi record reader")
                 .hasCauseInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void testCopyHasIndependentProjection() throws Exception {
+        Configuration hudiConfig = hudiConfig();
+        TablePath tablePath = TablePath.of("db1", "copied_projected_pk_table");
+        createPkTable(hudiConfig, tablePath);
+
+        HudiLakeSource source = new HudiLakeSource(hudiConfig, tablePath);
+        int[][] projection = project(1);
+        source.withProject(projection);
+        projection[0][0] = 0;
+        HudiLakeSource copy = source.copy();
+        source.withProject(project(0));
+
+        assertThat(copy).isNotSameAs(source);
+        assertThatThrownBy(() -> copy.createRecordReader(sortedReaderContext(null)))
+                .isInstanceOf(IOException.class)
+                .hasCauseInstanceOf(UnsupportedOperationException.class);
+        assertThat(source.createRecordReader(sortedReaderContext(null)))
+                .isInstanceOf(HudiSortedRecordReader.class);
+    }
+
+    @Test
+    void testCopyHasIndependentFilters() throws Exception {
+        Configuration hudiConfig = hudiConfig();
+        TablePath tablePath = TablePath.of("db1", "copied_filter_table");
+        createPkTable(hudiConfig, tablePath);
+
+        HudiLakeSource source = new HudiLakeSource(hudiConfig, tablePath);
+        PredicateBuilder predicateBuilder =
+                new PredicateBuilder(RowType.of(DataTypes.INT(), DataTypes.STRING()));
+        source.withFilters(Collections.singletonList(predicateBuilder.equal(0, 1)));
+        List<ExpressionPredicates.Predicate> sourcePredicates = source.getPredicates();
+
+        HudiLakeSource copy = source.copy();
+
+        assertThat(copy.getPredicates()).hasSize(1).isNotSameAs(sourcePredicates);
+
+        source.withFilters(Collections.emptyList());
+
+        assertThat(source.getPredicates()).isEmpty();
+        assertThat(copy.getPredicates()).hasSize(1).containsExactlyElementsOf(sourcePredicates);
     }
 
     private Configuration hudiConfig() {

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSource.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSource.java
@@ -27,6 +27,7 @@ import org.apache.fluss.lake.source.Planner;
 import org.apache.fluss.lake.source.RecordReader;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.predicate.Predicate;
+import org.apache.fluss.utils.ArrayUtils;
 
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -38,6 +39,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -56,9 +58,21 @@ public class IcebergLakeSource implements LakeSource<IcebergSplit> {
         this.tablePath = tablePath;
     }
 
+    private IcebergLakeSource(IcebergLakeSource source) {
+        this.icebergConfig = new Configuration(source.icebergConfig);
+        this.tablePath = source.tablePath;
+        this.project = ArrayUtils.deepCopy(source.project);
+        this.filter = source.filter;
+    }
+
+    @Override
+    public IcebergLakeSource copy() {
+        return new IcebergLakeSource(this);
+    }
+
     @Override
     public void withProject(int[][] project) {
-        this.project = project;
+        this.project = ArrayUtils.deepCopy(project);
     }
 
     @Override
@@ -68,6 +82,11 @@ public class IcebergLakeSource implements LakeSource<IcebergSplit> {
 
     @Override
     public FilterPushDownResult withFilters(List<Predicate> predicates) {
+        if (predicates.isEmpty()) {
+            filter = null;
+            return FilterPushDownResult.of(Collections.emptyList(), Collections.emptyList());
+        }
+
         List<Predicate> unConsumedPredicates = new ArrayList<>();
         List<Predicate> consumedPredicates = new ArrayList<>();
         List<Expression> converted = new ArrayList<>();
@@ -82,9 +101,7 @@ public class IcebergLakeSource implements LakeSource<IcebergSplit> {
                 unConsumedPredicates.add(predicate);
             }
         }
-        if (!converted.isEmpty()) {
-            filter = converted.stream().reduce(Expressions::and).orElse(null);
-        }
+        filter = converted.stream().reduce(Expressions::and).orElse(null);
         return FilterPushDownResult.of(consumedPredicates, unConsumedPredicates);
     }
 

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSourceTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSourceTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.fluss.lake.iceberg.source;
 
+import org.apache.fluss.config.Configuration;
 import org.apache.fluss.lake.source.LakeSource;
 import org.apache.fluss.lake.source.RecordReader;
 import org.apache.fluss.metadata.TablePath;
@@ -77,6 +78,18 @@ class IcebergLakeSourceTest extends IcebergSourceTestBase {
     }
 
     @Test
+    void testEmptyFiltersDoNotAccessCatalog() {
+        IcebergLakeSource lakeSource =
+                new IcebergLakeSource(
+                        new Configuration(), TablePath.of("missing_db", "missing_table"));
+
+        LakeSource.FilterPushDownResult result = lakeSource.withFilters(Collections.emptyList());
+
+        assertThat(result.acceptedPredicates()).isEmpty();
+        assertThat(result.remainingPredicates()).isEmpty();
+    }
+
+    @Test
     void testWithFilters() throws Exception {
         TablePath tablePath = TablePath.of("fluss", "test_filters");
         createTable(tablePath, SCHEMA, PARTITION_SPEC);
@@ -122,6 +135,7 @@ class IcebergLakeSourceTest extends IcebergSourceTestBase {
         LakeSource.FilterPushDownResult filterPushDownResult = lakeSource.withFilters(allFilters);
         assertThat(filterPushDownResult.acceptedPredicates()).isEqualTo(allFilters);
         assertThat(filterPushDownResult.remainingPredicates()).isEmpty();
+        LakeSource<IcebergSplit> copiedLakeSource = lakeSource.copy();
 
         // read data to verify the filters work
         List<IcebergSplit> icebergSplits =
@@ -159,6 +173,14 @@ class IcebergLakeSourceTest extends IcebergSourceTestBase {
         assertThat(filterPushDownResult.acceptedPredicates()).isEmpty();
         assertThat(filterPushDownResult.remainingPredicates().toString())
                 .isEqualTo(allFilters.toString());
+
+        assertThat(lakeSource.createPlanner(() -> table.currentSnapshot().snapshotId()).plan())
+                .hasSize(2);
+        assertThat(
+                        copiedLakeSource
+                                .createPlanner(() -> table.currentSnapshot().snapshotId())
+                                .plan())
+                .hasSize(1);
     }
 
     @Test

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergRecordReaderTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergRecordReaderTest.java
@@ -129,11 +129,17 @@ class IcebergRecordReaderTest extends IcebergSourceTestBase {
         InternalRow.FieldGetter[] projectFieldGetters =
                 InternalRow.createFieldGetters(
                         RowType.of(new TinyIntType(), new StringType(), new DoubleType()));
-        lakeSource.withProject(new int[][] {new int[] {5}, new int[] {1}, new int[] {3}});
+        int[][] project = new int[][] {new int[] {5}, new int[] {1}, new int[] {3}};
+        lakeSource.withProject(project);
+        project[0][0] = 0;
+        LakeSource<IcebergSplit> copiedLakeSource = lakeSource.copy();
+        lakeSource.withProject(new int[][] {new int[] {0}});
+        assertThat(copiedLakeSource).isNotSameAs(lakeSource);
 
         List<Row> projectActual = new ArrayList<>();
-        for (IcebergSplit icebergSplit : lakeSource.createPlanner(snapshot::snapshotId).plan()) {
-            RecordReader recordReader = lakeSource.createRecordReader(() -> icebergSplit);
+        for (IcebergSplit icebergSplit :
+                copiedLakeSource.createPlanner(snapshot::snapshotId).plan()) {
+            RecordReader recordReader = copiedLakeSource.createRecordReader(() -> icebergSplit);
             CloseableIterator<LogRecord> iterator = recordReader.read();
             projectActual.addAll(
                     convertToFlinkRow(

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/PaimonLakeSource.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/PaimonLakeSource.java
@@ -26,6 +26,7 @@ import org.apache.fluss.lake.source.Planner;
 import org.apache.fluss.lake.source.RecordReader;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.predicate.Predicate;
+import org.apache.fluss.utils.ArrayUtils;
 
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
@@ -39,6 +40,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -62,9 +64,21 @@ public class PaimonLakeSource implements LakeSource<PaimonSplit> {
         this.tablePath = tablePath;
     }
 
+    private PaimonLakeSource(PaimonLakeSource source) {
+        this.paimonConfig = new Configuration(source.paimonConfig);
+        this.tablePath = source.tablePath;
+        this.project = ArrayUtils.deepCopy(source.project);
+        this.predicate = source.predicate;
+    }
+
+    @Override
+    public PaimonLakeSource copy() {
+        return new PaimonLakeSource(this);
+    }
+
     @Override
     public void withProject(int[][] project) {
-        this.project = project;
+        this.project = ArrayUtils.deepCopy(project);
     }
 
     @Override
@@ -74,6 +88,11 @@ public class PaimonLakeSource implements LakeSource<PaimonSplit> {
 
     @Override
     public FilterPushDownResult withFilters(List<Predicate> predicates) {
+        if (predicates.isEmpty()) {
+            predicate = null;
+            return FilterPushDownResult.of(Collections.emptyList(), Collections.emptyList());
+        }
+
         List<Predicate> unConsumedPredicates = new ArrayList<>();
         List<Predicate> consumedPredicates = new ArrayList<>();
         List<org.apache.paimon.predicate.Predicate> converted = new ArrayList<>();
@@ -88,9 +107,7 @@ public class PaimonLakeSource implements LakeSource<PaimonSplit> {
                 unConsumedPredicates.add(predicate);
             }
         }
-        if (!converted.isEmpty()) {
-            predicate = PredicateBuilder.and(converted);
-        }
+        predicate = converted.isEmpty() ? null : PredicateBuilder.and(converted);
         return FilterPushDownResult.of(consumedPredicates, unConsumedPredicates);
     }
 

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadPrimaryKeyTableITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadPrimaryKeyTableITCase.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.api.config.OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED;
 import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertResultsExactOrder;
 import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertRowResultsIgnoreOrder;
 import static org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.collectBatchRows;
@@ -962,6 +963,93 @@ class FlinkUnionReadPrimaryKeyTableITCase extends FlinkUnionReadTestBase {
         // cancel jobs
         insertResult.getJobClient().get().cancel().get();
         jobClient.cancel().get();
+    }
+
+    @Test
+    void testDifferentPushDownFiltersWithSourceReuse() throws Exception {
+        boolean originalReuseSource =
+                streamTEnv.getConfig().get(TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED);
+        JobClient tieringJob = null;
+        String tableName = "stream_union_different_pushdown_filters";
+        TablePath tablePath = TablePath.of(DEFAULT_DB, tableName);
+        Map<TableBucket, Long> bucketLogEndOffset = new HashMap<>();
+
+        try {
+            streamTEnv.getConfig().set(TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, true);
+            tieringJob = buildTieringJob(execEnv);
+            long tableId =
+                    preparePKTableFullType(
+                            tablePath, DEFAULT_BUCKET_NUM, false, bucketLogEndOffset);
+            waitUntilBucketSynced(tablePath, tableId, DEFAULT_BUCKET_NUM, false);
+            assertReplicaStatus(bucketLogEndOffset);
+            tieringJob.cancel().get();
+            tieringJob = null;
+
+            String query =
+                    "SELECT c8 FROM "
+                            + tableName
+                            + " /*+ OPTIONS('scan.startup.mode' = 'full') */"
+                            + " WHERE c8 = 'string' UNION ALL "
+                            + "SELECT CAST(c5 AS STRING) FROM "
+                            + tableName
+                            + " /*+ OPTIONS('scan.startup.mode' = 'full') */"
+                            + " WHERE c5 = 40";
+            CloseableIterator<Row> iterator = streamTEnv.executeSql(query).collect();
+            List<String> actual = collectRowsWithTimeout(iterator, 2, true);
+            assertThat(actual).containsExactlyInAnyOrder("+I[string]", "+I[40]");
+        } finally {
+            streamTEnv.getConfig().set(TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, originalReuseSource);
+            if (tieringJob != null) {
+                tieringJob.cancel().get();
+            }
+        }
+    }
+
+    @Test
+    void testDifferentProjectionsWithAndWithoutSourceReuse() throws Exception {
+        boolean originalReuseSource =
+                streamTEnv.getConfig().get(TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED);
+        JobClient tieringJob = null;
+        String tableName = "stream_union_different_projections";
+        TablePath tablePath = TablePath.of(DEFAULT_DB, tableName);
+        Map<TableBucket, Long> bucketLogEndOffset = new HashMap<>();
+
+        try {
+            streamTEnv.getConfig().set(TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, false);
+            tieringJob = buildTieringJob(execEnv);
+            long tableId =
+                    preparePKTableFullType(
+                            tablePath, DEFAULT_BUCKET_NUM, false, bucketLogEndOffset);
+            waitUntilBucketSynced(tablePath, tableId, DEFAULT_BUCKET_NUM, false);
+            assertReplicaStatus(bucketLogEndOffset);
+            tieringJob.cancel().get();
+            tieringJob = null;
+
+            String query =
+                    "SELECT c8 FROM "
+                            + tableName
+                            + " /*+ OPTIONS('scan.startup.mode' = 'full') */"
+                            + " UNION ALL SELECT CAST(c5 AS STRING) FROM "
+                            + tableName
+                            + " /*+ OPTIONS('scan.startup.mode' = 'full') */";
+            CloseableIterator<Row> iterator = streamTEnv.executeSql(query).collect();
+            List<String> actual = collectRowsWithTimeout(iterator, 4, true);
+            assertThat(actual)
+                    .containsExactlyInAnyOrder(
+                            "+I[string]", "+I[another_string]", "+I[4]", "+I[40]");
+
+            streamTEnv.getConfig().set(TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, true);
+            iterator = streamTEnv.executeSql(query).collect();
+            actual = collectRowsWithTimeout(iterator, 4, true);
+            assertThat(actual)
+                    .containsExactlyInAnyOrder(
+                            "+I[string]", "+I[another_string]", "+I[4]", "+I[40]");
+        } finally {
+            streamTEnv.getConfig().set(TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, originalReuseSource);
+            if (tieringJob != null) {
+                tieringJob.cancel().get();
+            }
+        }
     }
 
     @Test

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/source/PaimonLakeSourceTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/source/PaimonLakeSourceTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.fluss.lake.paimon.source;
 
+import org.apache.fluss.config.Configuration;
 import org.apache.fluss.lake.source.LakeSource;
 import org.apache.fluss.lake.source.RecordReader;
 import org.apache.fluss.metadata.TablePath;
@@ -76,6 +77,18 @@ class PaimonLakeSourceTest extends PaimonSourceTestBase {
     }
 
     @Test
+    void testEmptyFiltersDoNotAccessCatalog() {
+        PaimonLakeSource lakeSource =
+                new PaimonLakeSource(
+                        new Configuration(), TablePath.of("missing_db", "missing_table"));
+
+        LakeSource.FilterPushDownResult result = lakeSource.withFilters(Collections.emptyList());
+
+        assertThat(result.acceptedPredicates()).isEmpty();
+        assertThat(result.remainingPredicates()).isEmpty();
+    }
+
+    @Test
     void testWithFilters() throws Exception {
         TablePath tablePath = TablePath.of("fluss", "test_filters");
         createTable(tablePath, SCHEMA);
@@ -117,6 +130,7 @@ class PaimonLakeSourceTest extends PaimonSourceTestBase {
         LakeSource.FilterPushDownResult filterPushDownResult = lakeSource.withFilters(allFilters);
         assertThat(filterPushDownResult.acceptedPredicates()).isEqualTo(allFilters);
         assertThat(filterPushDownResult.remainingPredicates()).isEmpty();
+        LakeSource<PaimonSplit> copiedLakeSource = lakeSource.copy();
 
         // read data to verify the filters work
         List<PaimonSplit> paimonSplits = lakeSource.createPlanner(() -> 2).plan();
@@ -162,6 +176,14 @@ class PaimonLakeSourceTest extends PaimonSourceTestBase {
         assertThat(filterPushDownResult.acceptedPredicates()).isEmpty();
         assertThat(filterPushDownResult.remainingPredicates().toString())
                 .isEqualTo(allFilters.toString());
+
+        List<PaimonSplit> unfilteredSplits = lakeSource.createPlanner(() -> 2).plan();
+        assertThat(unfilteredSplits).hasSize(1);
+        assertThat(unfilteredSplits.get(0).dataSplit().dataFiles()).hasSize(2);
+
+        List<PaimonSplit> copiedFilteredSplits = copiedLakeSource.createPlanner(() -> 2).plan();
+        assertThat(copiedFilteredSplits).hasSize(1);
+        assertThat(copiedFilteredSplits.get(0).dataSplit().dataFiles()).hasSize(1);
     }
 
     private static class UnSupportFilterFunction extends LeafFunction {

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/source/PaimonRecordReaderTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/source/PaimonRecordReaderTest.java
@@ -125,10 +125,15 @@ class PaimonRecordReaderTest extends PaimonSourceTestBase {
         prepareLogTable(tablePath, false, DEFAULT_BUCKET_NUM, writtenRows);
 
         LakeSource<PaimonSplit> lakeSource = lakeStorage.createLakeSource(tablePath);
-        lakeSource.withProject(new int[][] {new int[] {5}, new int[] {1}, new int[] {3}});
+        int[][] project = new int[][] {new int[] {5}, new int[] {1}, new int[] {3}};
+        lakeSource.withProject(project);
+        project[0][0] = 0;
+        LakeSource<PaimonSplit> copiedLakeSource = lakeSource.copy();
+        lakeSource.withProject(new int[][] {new int[] {0}});
+        assertThat(copiedLakeSource).isNotSameAs(lakeSource);
         Table table = getTable(tablePath);
         Snapshot snapshot = table.latestSnapshot().get();
-        List<PaimonSplit> paimonSplits = lakeSource.createPlanner(snapshot::id).plan();
+        List<PaimonSplit> paimonSplits = copiedLakeSource.createPlanner(snapshot::id).plan();
 
         List<Row> actual = new ArrayList<>();
 
@@ -136,7 +141,7 @@ class PaimonRecordReaderTest extends PaimonSourceTestBase {
                 InternalRow.createFieldGetters(
                         RowType.of(new FloatType(), new TinyIntType(), new IntType()));
         for (PaimonSplit paimonSplit : paimonSplits) {
-            RecordReader recordReader = lakeSource.createRecordReader(() -> paimonSplit);
+            RecordReader recordReader = copiedLakeSource.createRecordReader(() -> paimonSplit);
             CloseableIterator<LogRecord> iterator = recordReader.read();
             actual.addAll(
                     convertToFlinkRow(


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4056 

<!-- What is the purpose of the change -->

### Brief change log

Add an explicit LakeSource copy contract and state-preserving copies for Paimon, Iceberg, Hudi, and testing sources.

Make FlinkTableSource copies isolate mutable lake pushdown state while preserving projection, filter, aggregate, limit, and watermark settings. Add regression coverage for UNION scans with different projections and filters.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->
UT and IT are added.

### API and Format

<!-- Does this change affect API or storage format -->
No.

### Documentation

<!-- Does this change introduce a new feature -->
No.