### PR TITLE
[server] Restore KV minRetainOffset on follower restart

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/DefaultCompletedFetchBufferLifecycleTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/DefaultCompletedFetchBufferLifecycleTest.java
@@ -157,7 +157,8 @@ class DefaultCompletedFetchBufferLifecycleTest {
         return new DefaultCompletedFetch(
                 tableBucket,
                 DATA1_TABLE_PATH,
-                new FetchLogResultForBucket(tableBucket, genMemoryLogRecordsByObject(DATA1), 10L),
+                FetchLogResultForBucket.records(
+                        tableBucket, genMemoryLogRecordsByObject(DATA1), 10L, -1L, -1L),
                 readContext,
                 logScannerStatus,
                 true,

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/DefaultCompletedFetchTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/DefaultCompletedFetchTest.java
@@ -105,8 +105,12 @@ public class DefaultCompletedFetchTest {
         int bucketId = 0; // records for 0-10.
         TableBucket tb = new TableBucket(DATA2_TABLE_ID, bucketId);
         FetchLogResultForBucket resultForBucket0 =
-                new FetchLogResultForBucket(
-                        tb, createMemoryLogRecords(DATA2, LogFormat.ARROW, recordBatchMagic), 10L);
+                FetchLogResultForBucket.records(
+                        tb,
+                        createMemoryLogRecords(DATA2, LogFormat.ARROW, recordBatchMagic),
+                        10L,
+                        -1L,
+                        -1L);
         DefaultCompletedFetch defaultCompletedFetch =
                 makeCompletedFetch(tb, resultForBucket0, fetchOffset);
         List<ScanRecord> scanRecords = defaultCompletedFetch.fetchRecords(8);
@@ -128,8 +132,12 @@ public class DefaultCompletedFetchTest {
         int bucketId = 0; // records for 0-10.
         TableBucket tb = new TableBucket(DATA2_TABLE_ID, bucketId);
         FetchLogResultForBucket resultForBucket0 =
-                new FetchLogResultForBucket(
-                        tb, createMemoryLogRecords(DATA2, LogFormat.ARROW, recordBatchMagic), 10L);
+                FetchLogResultForBucket.records(
+                        tb,
+                        createMemoryLogRecords(DATA2, LogFormat.ARROW, recordBatchMagic),
+                        10L,
+                        -1L,
+                        -1L);
         DefaultCompletedFetch defaultCompletedFetch =
                 makeCompletedFetch(tb, resultForBucket0, fetchOffset);
         List<ScanRecord> scanRecords = defaultCompletedFetch.fetchRecords(-10);
@@ -142,7 +150,7 @@ public class DefaultCompletedFetchTest {
         int bucketId = 0; // records for 0-10.
         TableBucket tb = new TableBucket(DATA2_TABLE_ID, bucketId);
         FetchLogResultForBucket resultForBucket0 =
-                new FetchLogResultForBucket(tb, MemoryLogRecords.EMPTY, 0L);
+                FetchLogResultForBucket.records(tb, MemoryLogRecords.EMPTY, 0L, -1L, -1L);
         DefaultCompletedFetch defaultCompletedFetch =
                 makeCompletedFetch(tb, resultForBucket0, fetchOffset);
         List<ScanRecord> scanRecords = defaultCompletedFetch.fetchRecords(10);
@@ -185,7 +193,7 @@ public class DefaultCompletedFetchTest {
             memoryLogRecords = createMemoryLogRecords(DATA2, LogFormat.INDEXED, magic);
         }
         FetchLogResultForBucket resultForBucket0 =
-                new FetchLogResultForBucket(tb, memoryLogRecords, 10L);
+                FetchLogResultForBucket.records(tb, memoryLogRecords, 10L, -1L, -1L);
         DefaultCompletedFetch defaultCompletedFetch =
                 makeCompletedFetch(tb, resultForBucket0, fetchOffset, projection);
         List<ScanRecord> scanRecords = defaultCompletedFetch.fetchRecords(8);
@@ -323,7 +331,7 @@ public class DefaultCompletedFetchTest {
         int bucketId = 0;
         TableBucket tb = new TableBucket(DATA2_TABLE_ID, bucketId);
         FetchLogResultForBucket resultForBucket =
-                new FetchLogResultForBucket(
+                FetchLogResultForBucket.records(
                         tb,
                         createRecordsWithoutBaseLogOffset(
                                 schema.getRowType(),
@@ -333,7 +341,9 @@ public class DefaultCompletedFetchTest {
                                 LOG_MAGIC_VALUE_V0,
                                 complexData,
                                 LogFormat.ARROW),
-                        3L);
+                        3L,
+                        -1L,
+                        -1L);
         DefaultCompletedFetch defaultCompletedFetch =
                 new DefaultCompletedFetch(
                         tb,

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetchBufferTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetchBufferTest.java
@@ -297,7 +297,8 @@ public class LogFetchBufferTest {
         return new DefaultCompletedFetch(
                 tableBucket,
                 DATA1_TABLE_PATH,
-                new FetchLogResultForBucket(tableBucket, genMemoryLogRecordsByObject(DATA1), 10L),
+                FetchLogResultForBucket.records(
+                        tableBucket, genMemoryLogRecordsByObject(DATA1), 10L, -1L, -1L),
                 readContext,
                 logScannerStatus,
                 true,

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetchCollectorTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetchCollectorTest.java
@@ -92,7 +92,8 @@ public class LogFetchCollectorTest {
         int bucketId = 0; // records for 0-10.
         TableBucket tb = new TableBucket(DATA1_TABLE_ID, bucketId);
         FetchLogResultForBucket resultForBucket0 =
-                new FetchLogResultForBucket(tb, genMemoryLogRecordsByObject(DATA1), 10L);
+                FetchLogResultForBucket.records(
+                        tb, genMemoryLogRecordsByObject(DATA1), 10L, -1L, -1L);
         CompletedFetch completedFetch = makeCompletedFetch(tb, resultForBucket0, fetchOffset);
 
         // Validate that the buffer is empty until after we add the fetch data.
@@ -141,9 +142,11 @@ public class LogFetchCollectorTest {
         logScannerStatus.assignScanBuckets(scanBuckets);
 
         FetchLogResultForBucket resultForBucket1 =
-                new FetchLogResultForBucket(tb1, genMemoryLogRecordsByObject(DATA1), 10L);
+                FetchLogResultForBucket.records(
+                        tb1, genMemoryLogRecordsByObject(DATA1), 10L, -1L, -1L);
         FetchLogResultForBucket resultForBucket2 =
-                new FetchLogResultForBucket(tb2, genMemoryLogRecordsByObject(DATA1), 10L);
+                FetchLogResultForBucket.records(
+                        tb2, genMemoryLogRecordsByObject(DATA1), 10L, -1L, -1L);
         CompletedFetch completedFetch1 = makeCompletedFetch(tb1, resultForBucket1, 0L);
         CompletedFetch completedFetch2 = makeCompletedFetch(tb2, resultForBucket2, 0L);
 
@@ -174,12 +177,14 @@ public class LogFetchCollectorTest {
         CompletedFetch completedFetch1 =
                 makeCompletedFetch(
                         tb1,
-                        new FetchLogResultForBucket(tb1, genMemoryLogRecordsByObject(DATA1), 10L),
+                        FetchLogResultForBucket.records(
+                                tb1, genMemoryLogRecordsByObject(DATA1), 10L, -1L, -1L),
                         0L);
         CompletedFetch completedFetch2 =
                 makeCompletedFetch(
                         tb2,
-                        new FetchLogResultForBucket(tb2, genMemoryLogRecordsByObject(DATA1), 10L),
+                        FetchLogResultForBucket.records(
+                                tb2, genMemoryLogRecordsByObject(DATA1), 10L, -1L, -1L),
                         0L);
 
         logFetchBuffer.add(completedFetch1);
@@ -223,7 +228,8 @@ public class LogFetchCollectorTest {
 
         TableBucket tb = new TableBucket(DATA1_TABLE_ID, 0);
         FetchLogResultForBucket result =
-                new FetchLogResultForBucket(tb, genMemoryLogRecordsByObject(DATA1), 10L);
+                FetchLogResultForBucket.records(
+                        tb, genMemoryLogRecordsByObject(DATA1), 10L, -1L, -1L);
         CompletedFetch completedFetch = makeCompletedFetch(tb, result, 0L);
         logFetchBuffer.add(completedFetch);
 
@@ -249,7 +255,7 @@ public class LogFetchCollectorTest {
                 new LogFetchCollector(logScannerStatus, conf, metadataUpdater);
 
         TableBucket tb = new TableBucket(DATA1_TABLE_ID, 1);
-        FetchLogResultForBucket filteredEmpty = new FetchLogResultForBucket(tb, 10L, 20L);
+        FetchLogResultForBucket filteredEmpty = FetchLogResultForBucket.empty(tb, 10L, 20L);
         CompletedFetch completedFetch = makeCompletedFetch(tb, filteredEmpty, 0L);
         logFetchBuffer.add(completedFetch);
 
@@ -281,7 +287,8 @@ public class LogFetchCollectorTest {
         CompletedFetch completedFetch =
                 makeCompletedFetch(
                         tb,
-                        new FetchLogResultForBucket(tb, genMemoryLogRecordsByObject(DATA1), 10L),
+                        FetchLogResultForBucket.records(
+                                tb, genMemoryLogRecordsByObject(DATA1), 10L, -1L, -1L),
                         0L);
         logFetchBuffer.add(completedFetch);
         logScannerStatus.unassignScanBuckets(Collections.singletonList(tb));
@@ -326,7 +333,7 @@ public class LogFetchCollectorTest {
                 new LogFetchCollector(logScannerStatus, conf, metadataUpdater);
 
         TableBucket tb = new TableBucket(DATA1_TABLE_ID, 0);
-        FetchLogResultForBucket result = new FetchLogResultForBucket(tb, records, 4L);
+        FetchLogResultForBucket result = FetchLogResultForBucket.records(tb, records, 4L, -1L, -1L);
         CompletedFetch completedFetch = makeCompletedFetch(tb, result, 0L);
         logFetchBuffer.add(completedFetch);
 

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetcherTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/LogFetcherTest.java
@@ -245,7 +245,7 @@ public class LogFetcherTest {
             fetchLogData.forEach(
                     (tableBucket, fetchData) -> {
                         FetchLogResultForBucket fetchLogResultForBucket =
-                                new FetchLogResultForBucket(
+                                FetchLogResultForBucket.error(
                                         tableBucket,
                                         ApiError.fromThrowable(
                                                 new NotLeaderOrFollowerException(

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/entity/FetchLogResultForBucket.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/entity/FetchLogResultForBucket.java
@@ -27,6 +27,7 @@ import org.apache.fluss.rpc.protocol.ApiError;
 
 import javax.annotation.Nullable;
 
+import static org.apache.fluss.utils.Preconditions.checkArgument;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
 /** Result of {@link FetchLogRequest} for each table bucket. */
@@ -36,6 +37,7 @@ public class FetchLogResultForBucket extends ResultForBucket {
     private final @Nullable LogRecords records;
     private final long highWatermark;
     private final long filteredEndOffset;
+    private final long minRetainOffset;
 
     public FetchLogResultForBucket(
             TableBucket tableBucket, LogRecords records, long highWatermark) {
@@ -44,6 +46,7 @@ public class FetchLogResultForBucket extends ResultForBucket {
                 null,
                 checkNotNull(records, "records can not be null"),
                 highWatermark,
+                -1L,
                 -1L,
                 ApiError.NONE);
     }
@@ -59,11 +62,29 @@ public class FetchLogResultForBucket extends ResultForBucket {
                 checkNotNull(records, "records can not be null"),
                 highWatermark,
                 filteredEndOffset,
+                -1L,
+                ApiError.NONE);
+    }
+
+    /** Creates a successful local fetch result carrying the KV snapshot retention boundary. */
+    public FetchLogResultForBucket(
+            TableBucket tableBucket,
+            LogRecords records,
+            long highWatermark,
+            long filteredEndOffset,
+            long minRetainOffset) {
+        this(
+                tableBucket,
+                null,
+                checkNotNull(records, "records can not be null"),
+                highWatermark,
+                filteredEndOffset,
+                checkMinRetainOffset(minRetainOffset),
                 ApiError.NONE);
     }
 
     public FetchLogResultForBucket(TableBucket tableBucket, ApiError error) {
-        this(tableBucket, null, null, -1L, -1L, error);
+        this(tableBucket, null, null, -1L, -1L, -1L, error);
     }
 
     public FetchLogResultForBucket(
@@ -73,6 +94,7 @@ public class FetchLogResultForBucket extends ResultForBucket {
                 checkNotNull(remoteLogFetchInfo, "remote log fetch info can not be null"),
                 null,
                 highWatermark,
+                -1L,
                 -1L,
                 ApiError.NONE);
     }
@@ -84,7 +106,7 @@ public class FetchLogResultForBucket extends ResultForBucket {
      */
     public FetchLogResultForBucket(
             TableBucket tableBucket, long highWatermark, long filteredEndOffset) {
-        this(tableBucket, null, null, highWatermark, filteredEndOffset, ApiError.NONE);
+        this(tableBucket, null, null, highWatermark, filteredEndOffset, -1L, ApiError.NONE);
     }
 
     private FetchLogResultForBucket(
@@ -93,12 +115,31 @@ public class FetchLogResultForBucket extends ResultForBucket {
             @Nullable LogRecords records,
             long highWatermark,
             long filteredEndOffset,
+            long minRetainOffset,
             ApiError error) {
         super(tableBucket, error);
         this.remoteLogFetchInfo = remoteLogFetchInfo;
         this.records = records;
         this.highWatermark = highWatermark;
         this.filteredEndOffset = filteredEndOffset;
+        this.minRetainOffset = minRetainOffset;
+    }
+
+    /** Returns a successful fetch result carrying the KV snapshot retention boundary. */
+    public FetchLogResultForBucket withMinRetainOffset(long minRetainOffset) {
+        checkArgument(minRetainOffset >= 0, "Min retain offset must be non-negative.");
+        if (failed()) {
+            throw new IllegalStateException(
+                    "Min retain offset cannot be attached to a failed fetch result.");
+        }
+        return new FetchLogResultForBucket(
+                getTableBucket(),
+                remoteLogFetchInfo,
+                records,
+                highWatermark,
+                filteredEndOffset,
+                minRetainOffset,
+                ApiError.NONE);
     }
 
     /**
@@ -146,5 +187,20 @@ public class FetchLogResultForBucket extends ResultForBucket {
      */
     public long getFilteredEndOffset() {
         return filteredEndOffset;
+    }
+
+    /** Returns whether a KV snapshot retention boundary is included in this fetch result. */
+    public boolean hasMinRetainOffset() {
+        return minRetainOffset >= 0;
+    }
+
+    /** Returns the KV snapshot retention boundary included in this fetch result. */
+    public long getMinRetainOffset() {
+        return minRetainOffset;
+    }
+
+    private static long checkMinRetainOffset(long minRetainOffset) {
+        checkArgument(minRetainOffset >= 0, "Min retain offset must be non-negative.");
+        return minRetainOffset;
     }
 }

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/entity/FetchLogResultForBucket.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/entity/FetchLogResultForBucket.java
@@ -39,76 +39,6 @@ public class FetchLogResultForBucket extends ResultForBucket {
     private final long filteredEndOffset;
     private final long minRetainOffset;
 
-    public FetchLogResultForBucket(
-            TableBucket tableBucket, LogRecords records, long highWatermark) {
-        this(
-                tableBucket,
-                null,
-                checkNotNull(records, "records can not be null"),
-                highWatermark,
-                -1L,
-                -1L,
-                ApiError.NONE);
-    }
-
-    public FetchLogResultForBucket(
-            TableBucket tableBucket,
-            LogRecords records,
-            long highWatermark,
-            long filteredEndOffset) {
-        this(
-                tableBucket,
-                null,
-                checkNotNull(records, "records can not be null"),
-                highWatermark,
-                filteredEndOffset,
-                -1L,
-                ApiError.NONE);
-    }
-
-    /** Creates a successful local fetch result carrying the KV snapshot retention boundary. */
-    public FetchLogResultForBucket(
-            TableBucket tableBucket,
-            LogRecords records,
-            long highWatermark,
-            long filteredEndOffset,
-            long minRetainOffset) {
-        this(
-                tableBucket,
-                null,
-                checkNotNull(records, "records can not be null"),
-                highWatermark,
-                filteredEndOffset,
-                checkMinRetainOffset(minRetainOffset),
-                ApiError.NONE);
-    }
-
-    public FetchLogResultForBucket(TableBucket tableBucket, ApiError error) {
-        this(tableBucket, null, null, -1L, -1L, -1L, error);
-    }
-
-    public FetchLogResultForBucket(
-            TableBucket tableBucket, RemoteLogFetchInfo remoteLogFetchInfo, long highWatermark) {
-        this(
-                tableBucket,
-                checkNotNull(remoteLogFetchInfo, "remote log fetch info can not be null"),
-                null,
-                highWatermark,
-                -1L,
-                -1L,
-                ApiError.NONE);
-    }
-
-    /**
-     * Create a filtered empty response with the correct next fetch offset. This is used when all
-     * batches are filtered out but we need to inform the client about the correct offset to
-     * continue fetching from.
-     */
-    public FetchLogResultForBucket(
-            TableBucket tableBucket, long highWatermark, long filteredEndOffset) {
-        this(tableBucket, null, null, highWatermark, filteredEndOffset, -1L, ApiError.NONE);
-    }
-
     private FetchLogResultForBucket(
             TableBucket tableBucket,
             @Nullable RemoteLogFetchInfo remoteLogFetchInfo,
@@ -125,21 +55,47 @@ public class FetchLogResultForBucket extends ResultForBucket {
         this.minRetainOffset = minRetainOffset;
     }
 
-    /** Returns a successful fetch result carrying the KV snapshot retention boundary. */
-    public FetchLogResultForBucket withMinRetainOffset(long minRetainOffset) {
-        checkArgument(minRetainOffset >= 0, "Min retain offset must be non-negative.");
-        if (failed()) {
-            throw new IllegalStateException(
-                    "Min retain offset cannot be attached to a failed fetch result.");
-        }
+    /** Creates a successful local fetch result. */
+    public static FetchLogResultForBucket records(
+            TableBucket tableBucket,
+            LogRecords records,
+            long highWatermark,
+            long filteredEndOffset,
+            long minRetainOffset) {
+        checkArgument(minRetainOffset >= -1L, "Min retain offset must be at least -1.");
         return new FetchLogResultForBucket(
-                getTableBucket(),
-                remoteLogFetchInfo,
-                records,
+                tableBucket,
+                null,
+                checkNotNull(records, "records can not be null"),
                 highWatermark,
                 filteredEndOffset,
                 minRetainOffset,
                 ApiError.NONE);
+    }
+
+    /** Creates a successful remote fetch result. */
+    public static FetchLogResultForBucket remote(
+            TableBucket tableBucket, RemoteLogFetchInfo remoteLogFetchInfo, long highWatermark) {
+        return new FetchLogResultForBucket(
+                tableBucket,
+                checkNotNull(remoteLogFetchInfo, "remote log fetch info can not be null"),
+                null,
+                highWatermark,
+                -1L,
+                -1L,
+                ApiError.NONE);
+    }
+
+    /** Creates a successful empty fetch result. */
+    public static FetchLogResultForBucket empty(
+            TableBucket tableBucket, long highWatermark, long filteredEndOffset) {
+        return new FetchLogResultForBucket(
+                tableBucket, null, null, highWatermark, filteredEndOffset, -1L, ApiError.NONE);
+    }
+
+    /** Creates a failed fetch result. */
+    public static FetchLogResultForBucket error(TableBucket tableBucket, ApiError error) {
+        return new FetchLogResultForBucket(tableBucket, null, null, -1L, -1L, -1L, error);
     }
 
     /**
@@ -196,11 +152,6 @@ public class FetchLogResultForBucket extends ResultForBucket {
 
     /** Returns the KV snapshot retention boundary included in this fetch result. */
     public long getMinRetainOffset() {
-        return minRetainOffset;
-    }
-
-    private static long checkMinRetainOffset(long minRetainOffset) {
-        checkArgument(minRetainOffset >= 0, "Min retain offset must be non-negative.");
         return minRetainOffset;
     }
 }

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/util/CommonRpcMessageUtils.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/util/CommonRpcMessageUtils.java
@@ -242,6 +242,11 @@ public class CommonRpcMessageUtils {
             }
         }
 
+        if (!fetchLogResultForBucket.failed() && respForBucket.hasMinRetainOffset()) {
+            fetchLogResultForBucket =
+                    fetchLogResultForBucket.withMinRetainOffset(respForBucket.getMinRetainOffset());
+        }
+
         return fetchLogResultForBucket;
     }
 

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/util/CommonRpcMessageUtils.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/util/CommonRpcMessageUtils.java
@@ -183,7 +183,7 @@ public class CommonRpcMessageUtils {
         FetchLogResultForBucket fetchLogResultForBucket;
         if (respForBucket.hasErrorCode()) {
             fetchLogResultForBucket =
-                    new FetchLogResultForBucket(tb, ApiError.fromErrorMessage(respForBucket));
+                    FetchLogResultForBucket.error(tb, ApiError.fromErrorMessage(respForBucket));
         } else {
             if (respForBucket.hasRemoteLogFetchInfo()) {
                 PbRemoteLogFetchInfo pbRlfInfo = respForBucket.getRemoteLogFetchInfo();
@@ -218,7 +218,7 @@ public class CommonRpcMessageUtils {
                                 remoteLogSegmentList,
                                 pbRlfInfo.getFirstStartPos());
                 fetchLogResultForBucket =
-                        new FetchLogResultForBucket(
+                        FetchLogResultForBucket.remote(
                                 tb, rlFetchInfo, respForBucket.getHighWatermark());
             } else {
                 ByteBuffer recordsBuffer = toByteBuffer(respForBucket.getRecordsSlice());
@@ -226,25 +226,19 @@ public class CommonRpcMessageUtils {
                         respForBucket.hasRecords()
                                 ? MemoryLogRecords.pointToByteBuffer(recordsBuffer)
                                 : MemoryLogRecords.EMPTY;
-                if (respForBucket.hasFilteredEndOffset()
-                        && respForBucket.getFilteredEndOffset() >= 0) {
-                    fetchLogResultForBucket =
-                            new FetchLogResultForBucket(
-                                    tb,
-                                    records,
-                                    respForBucket.getHighWatermark(),
-                                    respForBucket.getFilteredEndOffset());
-                } else {
-                    fetchLogResultForBucket =
-                            new FetchLogResultForBucket(
-                                    tb, records, respForBucket.getHighWatermark());
-                }
+                boolean hasFilteredEndOffset =
+                        respForBucket.hasFilteredEndOffset()
+                                && respForBucket.getFilteredEndOffset() >= 0;
+                fetchLogResultForBucket =
+                        FetchLogResultForBucket.records(
+                                tb,
+                                records,
+                                respForBucket.getHighWatermark(),
+                                hasFilteredEndOffset ? respForBucket.getFilteredEndOffset() : -1L,
+                                respForBucket.hasMinRetainOffset()
+                                        ? respForBucket.getMinRetainOffset()
+                                        : -1L);
             }
-        }
-
-        if (!fetchLogResultForBucket.failed() && respForBucket.hasMinRetainOffset()) {
-            fetchLogResultForBucket =
-                    fetchLogResultForBucket.withMinRetainOffset(respForBucket.getMinRetainOffset());
         }
 
         return fetchLogResultForBucket;

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -936,6 +936,9 @@ message PbFetchLogRespForBucket {
   // non-empty records field when only trailing batches were filtered. The client should start
   // its next fetch from the later of this offset and the end of the records it received.
   optional int64 filtered_end_offset = 9;
+  // The safe local log retention boundary confirmed by a committed KV snapshot. This is only
+  // returned for KV follower fetches and is distinct from the physical log_start_offset.
+  optional int64 min_retain_offset = 10;
 }
 
 message PbPutKvReqForBucket {

--- a/fluss-rust/crates/fluss/proto/FlussApi.proto
+++ b/fluss-rust/crates/fluss/proto/FlussApi.proto
@@ -936,6 +936,9 @@ message PbFetchLogRespForBucket {
   // non-empty records field when only trailing batches were filtered. The client should start
   // its next fetch from the later of this offset and the end of the records it received.
   optional int64 filtered_end_offset = 9;
+  // The safe local log retention boundary confirmed by a committed KV snapshot. This is only
+  // returned for KV follower fetches and is distinct from the physical log_start_offset.
+  optional int64 min_retain_offset = 10;
 }
 
 message PbPutKvReqForBucket {

--- a/fluss-rust/crates/fluss/src/client/table/scanner.rs
+++ b/fluss-rust/crates/fluss/src/client/table/scanner.rs
@@ -2998,6 +2998,7 @@ mod tests {
                     remote_log_fetch_info: None,
                     records: None,
                     filtered_end_offset,
+                    min_retain_offset: None,
                 }],
             }],
         }
@@ -3052,6 +3053,7 @@ mod tests {
                     remote_log_fetch_info: None,
                     records: None,
                     filtered_end_offset: None,
+                    min_retain_offset: None,
                 }],
             }],
         };
@@ -3111,6 +3113,7 @@ mod tests {
                     remote_log_fetch_info: None,
                     records: None,
                     filtered_end_offset: None,
+                    min_retain_offset: None,
                 }],
             }],
         };
@@ -3460,6 +3463,7 @@ mod tests {
                             remote_log_fetch_info: None,
                             records: None,
                             filtered_end_offset: None,
+                            min_retain_offset: None,
                         }],
                     }],
                 };

--- a/fluss-rust/crates/fluss/src/proto/fluss.rs
+++ b/fluss-rust/crates/fluss/src/proto/fluss.rs
@@ -1245,6 +1245,10 @@ pub struct PbFetchLogRespForBucket {
     /// its next fetch from the later of this offset and the end of the records it received.
     #[prost(int64, optional, tag = "9")]
     pub filtered_end_offset: ::core::option::Option<i64>,
+    /// The safe local log retention boundary confirmed by a committed KV snapshot. This is only
+    /// returned for KV follower fetches and is distinct from the physical log_start_offset.
+    #[prost(int64, optional, tag = "10")]
+    pub min_retain_offset: ::core::option::Option<i64>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PbPutKvReqForBucket {

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogReadInfo.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogReadInfo.java
@@ -26,11 +26,17 @@ public class LogReadInfo {
     private final FetchDataInfo fetchedData;
     private final long highWatermark;
     private final long logEndOffset;
+    private final long minRetainOffset;
 
-    public LogReadInfo(FetchDataInfo fetchedData, long highWatermark, long logEndOffset) {
+    public LogReadInfo(
+            FetchDataInfo fetchedData,
+            long highWatermark,
+            long logEndOffset,
+            long minRetainOffset) {
         this.fetchedData = fetchedData;
         this.highWatermark = highWatermark;
         this.logEndOffset = logEndOffset;
+        this.minRetainOffset = minRetainOffset;
     }
 
     public FetchDataInfo getFetchedData() {
@@ -45,6 +51,14 @@ public class LogReadInfo {
         return logEndOffset;
     }
 
+    public boolean hasMinRetainOffset() {
+        return minRetainOffset >= 0;
+    }
+
+    public long getMinRetainOffset() {
+        return minRetainOffset;
+    }
+
     @Override
     public String toString() {
         return "LogReadInfo("
@@ -54,6 +68,8 @@ public class LogReadInfo {
                 + highWatermark
                 + ", logEndOffset="
                 + logEndOffset
+                + ", minRetainOffset="
+                + minRetainOffset
                 + ')';
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -672,6 +672,16 @@ public final class LogTablet {
         }
     }
 
+    /**
+     * Advances the minimum retain offset monotonically.
+     *
+     * <p>Updates may arrive concurrently from replica recovery, coordinator snapshot notifications,
+     * and follower fetch processing, while log cleanup reads the value from a different thread.
+     * {@link AtomicLong} provides cross-thread visibility and makes the check-and-update atomic.
+     * The CAS loop implements a monotonic maximum: if another updater changes the value after it
+     * was read, the loop reloads the latest value and retries only when this update is still
+     * larger. This prevents a delayed, smaller offset from overwriting a newer retention boundary.
+     */
     public void updateMinRetainOffset(long minRetainOffset) {
         long currentMinRetainOffset = this.minRetainOffset.get();
         while (minRetainOffset > currentMinRetainOffset) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogTablet.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.fluss.utils.Preconditions.checkArgument;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
@@ -123,7 +124,7 @@ public final class LogTablet {
 
     // The minimum offset that should be retained in the local log. This is used to ensure that,
     // the offset of kv snapshot should be retained, otherwise, kv recovery will fail.
-    private volatile long minRetainOffset;
+    private final AtomicLong minRetainOffset;
     // tracking the log start offset in remote storage
     private volatile long remoteLogStartOffset = Long.MAX_VALUE;
     // tracking the log end offset in remote storage
@@ -185,7 +186,7 @@ public final class LogTablet {
         // Default value to 0L for changelog to avoid cleaning up any segments in case of not
         // updating this value in time. Default value to Long.MAX_VALUE for normal log table,
         // as we don't need to retain logs for kv recovery.
-        this.minRetainOffset = isChangelog ? 0L : Long.MAX_VALUE;
+        this.minRetainOffset = new AtomicLong(isChangelog ? 0L : Long.MAX_VALUE);
     }
 
     public PhysicalTablePath getPhysicalTablePath() {
@@ -672,11 +673,14 @@ public final class LogTablet {
     }
 
     public void updateMinRetainOffset(long minRetainOffset) {
-        if (minRetainOffset > this.minRetainOffset) {
-            this.minRetainOffset = minRetainOffset;
-
-            // try to delete the old segments that are not needed.
-            deleteSegmentsAlreadyExistsInRemote();
+        long currentMinRetainOffset = this.minRetainOffset.get();
+        while (minRetainOffset > currentMinRetainOffset) {
+            if (this.minRetainOffset.compareAndSet(currentMinRetainOffset, minRetainOffset)) {
+                // try to delete the old segments that are not needed.
+                deleteSegmentsAlreadyExistsInRemote();
+                return;
+            }
+            currentMinRetainOffset = this.minRetainOffset.get();
         }
     }
 
@@ -830,7 +834,8 @@ public final class LogTablet {
 
         try {
             // shouldn't clean up segments that will be used by kv recovery.
-            long effectiveCleanupToOffset = Math.min(minRetainOffset, requestedCleanupToOffset);
+            long effectiveCleanupToOffset =
+                    Math.min(minRetainOffset.get(), requestedCleanupToOffset);
             cleanupAction.cleanup(effectiveCleanupToOffset);
         } catch (IOException e) {
             LOG.error(
@@ -1611,6 +1616,6 @@ public final class LogTablet {
 
     @VisibleForTesting
     public long getMinRetainOffset() {
-        return minRetainOffset;
+        return minRetainOffset.get();
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -1921,6 +1921,8 @@ public final class Replica {
         // the fetch do not prevent a follower from coming into sync.
         long initialHighWatermark = logTablet.getHighWatermark();
         long initialLogEndOffset = logTablet.localLogEndOffset();
+        long initialMinRetainOffset =
+                fetchParams.isFromFollower() && isKvTable() ? logTablet.getMinRetainOffset() : -1L;
         long readOffset =
                 fetchParams.fetchOffset() == FetchParams.FETCH_FROM_EARLIEST_OFFSET
                         ? logTablet.logStartOffset()
@@ -1947,7 +1949,8 @@ public final class Replica {
                 IOUtils.closeQuietly(filterContext.getReadContext());
             }
         }
-        return new LogReadInfo(fetchDataInfo, initialHighWatermark, initialLogEndOffset);
+        return new LogReadInfo(
+                fetchDataInfo, initialHighWatermark, initialLogEndOffset, initialMinRetainOffset);
     }
 
     /**

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1786,29 +1786,17 @@ public class ReplicaManager implements ServerReconfigurable {
                     fetchParams.markReadOneMessage();
                 }
                 limitBytes = Math.max(0, limitBytes - recordBatchSize);
-                FetchLogResultForBucket fetchLogResult;
-                if (readInfo.hasMinRetainOffset()) {
-                    fetchLogResult =
-                            new FetchLogResultForBucket(
-                                    tb,
-                                    fetchedData.getRecords(),
-                                    readInfo.getHighWatermark(),
-                                    fetchedData.hasFilteredEndOffset()
-                                            ? fetchedData.getFilteredEndOffset()
-                                            : -1L,
-                                    readInfo.getMinRetainOffset());
-                } else if (fetchedData.hasFilteredEndOffset()) {
-                    fetchLogResult =
-                            new FetchLogResultForBucket(
-                                    tb,
-                                    fetchedData.getRecords(),
-                                    readInfo.getHighWatermark(),
-                                    fetchedData.getFilteredEndOffset());
-                } else {
-                    fetchLogResult =
-                            new FetchLogResultForBucket(
-                                    tb, fetchedData.getRecords(), readInfo.getHighWatermark());
-                }
+                FetchLogResultForBucket fetchLogResult =
+                        FetchLogResultForBucket.records(
+                                tb,
+                                fetchedData.getRecords(),
+                                readInfo.getHighWatermark(),
+                                fetchedData.hasFilteredEndOffset()
+                                        ? fetchedData.getFilteredEndOffset()
+                                        : -1L,
+                                readInfo.hasMinRetainOffset()
+                                        ? readInfo.getMinRetainOffset()
+                                        : -1L);
                 logReadResult.put(
                         tb,
                         new LogReadResult(fetchLogResult, fetchedData.getFetchOffsetMetadata()));
@@ -1835,7 +1823,7 @@ public class ReplicaManager implements ServerReconfigurable {
                 if (replica != null && e instanceof LogOffsetOutOfRangeException) {
                     result = handleFetchOutOfRangeException(replica, fetchOffset, e);
                 } else {
-                    result = new FetchLogResultForBucket(tb, ApiError.fromThrowable(e));
+                    result = FetchLogResultForBucket.error(tb, ApiError.fromThrowable(e));
                 }
                 logReadResult.put(
                         tb, new LogReadResult(result, LogOffsetMetadata.UNKNOWN_OFFSET_METADATA));
@@ -1866,7 +1854,7 @@ public class ReplicaManager implements ServerReconfigurable {
             RemoteLogFetchInfo remoteLogFetchInfo =
                     fetchLogFromRemote(replica, normalizedFetchOffset);
             if (remoteLogFetchInfo != null) {
-                return new FetchLogResultForBucket(
+                return FetchLogResultForBucket.remote(
                         tb, remoteLogFetchInfo, replica.getLogHighWatermark());
             }
             // Remote log is expected to cover the offset, but segments/manifest may not be ready
@@ -1895,8 +1883,8 @@ public class ReplicaManager implements ServerReconfigurable {
             // todo: currently, we just return empty records directly
             // need to return the info of datalake to make client can fetch
             // from datalake directly
-            return new FetchLogResultForBucket(
-                    tb, MemoryLogRecords.EMPTY, replica.getLogHighWatermark());
+            return FetchLogResultForBucket.records(
+                    tb, MemoryLogRecords.EMPTY, replica.getLogHighWatermark(), -1L, -1L);
         }
         // Once we get a fetch out of range exception from local storage, we need to check whether
         // the log segment already upload to the remote storage. If uploaded, we will return a list
@@ -1906,13 +1894,13 @@ public class ReplicaManager implements ServerReconfigurable {
             try {
                 RemoteLogFetchInfo remoteLogFetchInfo = fetchLogFromRemote(replica, fetchOffset);
                 if (remoteLogFetchInfo != null) {
-                    return new FetchLogResultForBucket(
+                    return FetchLogResultForBucket.remote(
                             tb, remoteLogFetchInfo, replica.getLogHighWatermark());
                 }
             } catch (Exception ex) {
-                return new FetchLogResultForBucket(tb, ApiError.fromThrowable(ex));
+                return FetchLogResultForBucket.error(tb, ApiError.fromThrowable(ex));
             }
-            return new FetchLogResultForBucket(
+            return FetchLogResultForBucket.error(
                     tb,
                     ApiError.fromThrowable(
                             new LogOffsetOutOfRangeException(
@@ -1920,7 +1908,7 @@ public class ReplicaManager implements ServerReconfigurable {
                                             "The fetch offset %s is out of range for table bucket %s",
                                             fetchOffset, tb))));
         } else {
-            return new FetchLogResultForBucket(tb, ApiError.fromThrowable(e));
+            return FetchLogResultForBucket.error(tb, ApiError.fromThrowable(e));
         }
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -1787,7 +1787,17 @@ public class ReplicaManager implements ServerReconfigurable {
                 }
                 limitBytes = Math.max(0, limitBytes - recordBatchSize);
                 FetchLogResultForBucket fetchLogResult;
-                if (fetchedData.hasFilteredEndOffset()) {
+                if (readInfo.hasMinRetainOffset()) {
+                    fetchLogResult =
+                            new FetchLogResultForBucket(
+                                    tb,
+                                    fetchedData.getRecords(),
+                                    readInfo.getHighWatermark(),
+                                    fetchedData.hasFilteredEndOffset()
+                                            ? fetchedData.getFilteredEndOffset()
+                                            : -1L,
+                                    readInfo.getMinRetainOffset());
+                } else if (fetchedData.hasFilteredEndOffset()) {
                     fetchLogResult =
                             new FetchLogResultForBucket(
                                     tb,

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThread.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThread.java
@@ -344,6 +344,9 @@ final class ReplicaFetcherThread extends ShutdownableThread {
                 }
             }
 
+            // Propagate the leader's KV snapshot retention boundary to the follower even when the
+            // successful response contains no records, so obsolete local log segments can be
+            // cleaned up.
             Replica replica = replicaManager.getReplicaOrException(tableBucket);
             if (replica.isKvTable() && replicaData.hasMinRetainOffset()) {
                 replica.getLogTablet().updateMinRetainOffset(replicaData.getMinRetainOffset());

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThread.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThread.java
@@ -344,6 +344,11 @@ final class ReplicaFetcherThread extends ShutdownableThread {
                 }
             }
 
+            Replica replica = replicaManager.getReplicaOrException(tableBucket);
+            if (replica.isKvTable() && replicaData.hasMinRetainOffset()) {
+                replica.getLogTablet().updateMinRetainOffset(replicaData.getMinRetainOffset());
+            }
+
             if (nextFetchOffset != -1L && fairBucketStatusMap.contains(tableBucket)) {
                 BucketFetchStatus newFetchStatus =
                         new BucketFetchStatus(

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletService.java
@@ -235,7 +235,10 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
                 //  to skip the authorization.
                 authorizer != null && request.getFollowerServerId() < 0
                         ? authorizeRequestData(
-                                READ, fetchLogData, errorResponseMap, FetchLogResultForBucket::new)
+                                READ,
+                                fetchLogData,
+                                errorResponseMap,
+                                FetchLogResultForBucket::error)
                         : fetchLogData;
         if (interesting.isEmpty()) {
             return CompletableFuture.completedFuture(makeFetchLogResponse(errorResponseMap));

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/ServerRpcMessageUtils.java
@@ -1024,6 +1024,9 @@ public class ServerRpcMessageUtils {
             if (bucketResult.hasFilteredEndOffset()) {
                 fetchLogRespForBucket.setFilteredEndOffset(bucketResult.getFilteredEndOffset());
             }
+            if (bucketResult.hasMinRetainOffset()) {
+                fetchLogRespForBucket.setMinRetainOffset(bucketResult.getMinRetainOffset());
+            }
             if (tb.getPartitionId() != null) {
                 fetchLogRespForBucket.setPartitionId(tb.getPartitionId());
             }

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LogTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LogTabletTest.java
@@ -51,7 +51,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.fluss.record.TestData.DATA1;
@@ -122,6 +126,63 @@ final class LogTabletTest extends LogTestBase {
         // A new non-empty range can become readable after the empty state.
         logTablet.updateRemoteLogEndOffset(5L);
         assertThat(logTablet.canFetchFromRemoteLog(0L)).isTrue();
+    }
+
+    @Test
+    void testMinRetainOffsetIsMonotonicWithConcurrentUpdates() throws Exception {
+        File kvLogDir =
+                LogTestUtils.makeRandomLogTabletDir(
+                        tempDir,
+                        DATA1_TABLE_PATH.getDatabaseName(),
+                        DATA1_TABLE_ID,
+                        DATA1_TABLE_PATH.getTableName());
+        LogTablet kvLogTablet =
+                LogTablet.create(
+                        tempDir,
+                        PhysicalTablePath.of(DATA1_TABLE_PATH),
+                        kvLogDir,
+                        conf,
+                        new AtomicBoolean(false),
+                        TestingMetricGroups.TABLET_SERVER_METRICS,
+                        0,
+                        scheduler,
+                        LogFormat.ARROW,
+                        1,
+                        true,
+                        SystemClock.getInstance(),
+                        true);
+        int updateThreadCount = 32;
+        ExecutorService executor = Executors.newFixedThreadPool(updateThreadCount);
+        CountDownLatch ready = new CountDownLatch(updateThreadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            for (int i = 1; i <= updateThreadCount; i++) {
+                final long minRetainOffset = i;
+                executor.execute(
+                        () -> {
+                            ready.countDown();
+                            try {
+                                start.await();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                return;
+                            }
+                            kvLogTablet.updateMinRetainOffset(minRetainOffset);
+                        });
+            }
+
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            executor.shutdown();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+
+            assertThat(kvLogTablet.getMinRetainOffset()).isEqualTo(updateThreadCount);
+            kvLogTablet.updateMinRetainOffset(1L);
+            assertThat(kvLogTablet.getMinRetainOffset()).isEqualTo(updateThreadCount);
+        } finally {
+            executor.shutdownNow();
+            kvLogTablet.close();
+        }
     }
 
     @Test

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/KvFollowerRetentionRestoreITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/KvFollowerRetentionRestoreITCase.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.replica;
+
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.MemorySize;
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.record.KvRecord;
+import org.apache.fluss.rpc.gateway.TabletServerGateway;
+import org.apache.fluss.rpc.messages.PutKvResponse;
+import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
+import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.server.zk.data.LeaderAndIsr;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.fluss.record.TestData.DATA1_SCHEMA_PK;
+import static org.apache.fluss.server.testutils.RpcMessageTestUtils.createTable;
+import static org.apache.fluss.server.testutils.RpcMessageTestUtils.newPutKvRequest;
+import static org.apache.fluss.testutils.DataTestUtils.genKvRecords;
+import static org.apache.fluss.testutils.DataTestUtils.toKvRecordBatch;
+import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT case for restoring a follower's KV log retention boundary after restart. */
+class KvFollowerRetentionRestoreITCase {
+
+    @RegisterExtension
+    public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
+            FlussClusterExtension.builder()
+                    .setNumOfTabletServers(2)
+                    .setClusterConf(initConfig())
+                    .build();
+
+    @Test
+    void testCleanupLocalLogsAfterFollowerRestartWithoutNewWrites() throws Exception {
+        TablePath tablePath = TablePath.of("test_db", "test_follower_retention_restore");
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder()
+                        .schema(DATA1_SCHEMA_PK)
+                        .distributedBy(1, "a")
+                        .property(ConfigOptions.TABLE_LOG_TTL, Duration.ofMillis(1))
+                        .build();
+        long tableId = createTable(FLUSS_CLUSTER_EXTENSION, tablePath, tableDescriptor);
+        TableBucket tableBucket = new TableBucket(tableId, 0);
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(tableBucket);
+
+        LeaderAndIsr leaderAndIsr = FLUSS_CLUSTER_EXTENSION.waitLeaderAndIsrReady(tableBucket);
+        int leader = leaderAndIsr.leader();
+        int follower =
+                leaderAndIsr.isr().stream().filter(replica -> replica != leader).findFirst().get();
+        TabletServerGateway leaderGateway =
+                FLUSS_CLUSTER_EXTENSION.newTabletServerClientForNode(leader);
+
+        for (int batchId = 0; batchId < 4; batchId++) {
+            List<KvRecord> records = new ArrayList<>();
+            for (int recordId = 0; recordId < 10; recordId++) {
+                int key = batchId * 10 + recordId;
+                records.addAll(genKvRecords(new Object[] {key, "value_" + key}));
+            }
+            PutKvResponse response =
+                    leaderGateway
+                            .putKv(
+                                    newPutKvRequest(
+                                            tableId,
+                                            tableBucket.getBucket(),
+                                            -1,
+                                            toKvRecordBatch(records)))
+                            .get();
+            assertThat(response.getBucketsRespAt(0).hasErrorCode()).isFalse();
+        }
+
+        Replica leaderReplica = FLUSS_CLUSTER_EXTENSION.waitAndGetLeaderReplica(tableBucket);
+        Replica followerReplica =
+                FLUSS_CLUSTER_EXTENSION.waitAndGetFollowerReplica(tableBucket, follower);
+        long logEndOffset = leaderReplica.getLocalLogEndOffset();
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(followerReplica.getLocalLogEndOffset()).isEqualTo(logEndOffset);
+                    assertThat(followerReplica.getLogTablet().getHighWatermark())
+                            .isEqualTo(logEndOffset);
+                    assertThat(followerReplica.getLogTablet().getSegments().size())
+                            .isGreaterThan(1);
+                });
+        int segmentsBeforeRestart = followerReplica.getLogTablet().getSegments().size();
+
+        // The stopped follower misses the snapshot notification that advances minRetainOffset.
+        FLUSS_CLUSTER_EXTENSION.stopTabletServer(follower);
+        FLUSS_CLUSTER_EXTENSION.waitUntilReplicaShrinkFromIsr(tableBucket, follower);
+        CompletedSnapshot snapshot = FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(tableBucket);
+        assertThat(snapshot.getLogOffset()).isEqualTo(logEndOffset);
+        retry(
+                Duration.ofMinutes(1),
+                () ->
+                        assertThat(leaderReplica.getLogTablet().getMinRetainOffset())
+                                .isEqualTo(logEndOffset));
+
+        // Do not write after the snapshot. The restarted follower must recover the retention
+        // boundary from a successful empty fetch response.
+        FLUSS_CLUSTER_EXTENSION.startTabletServer(follower);
+        FLUSS_CLUSTER_EXTENSION.waitUntilReplicaExpandToIsr(tableBucket, follower);
+        Replica restartedFollower =
+                FLUSS_CLUSTER_EXTENSION.waitAndGetFollowerReplica(tableBucket, follower);
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(restartedFollower.getLocalLogEndOffset()).isEqualTo(logEndOffset);
+                    assertThat(restartedFollower.getLogTablet().getMinRetainOffset())
+                            .isEqualTo(logEndOffset);
+                    assertThat(restartedFollower.getLogTablet().getSegments().size())
+                            .isLessThan(segmentsBeforeRestart);
+                    assertThat(restartedFollower.getLocalLogStartOffset()).isPositive();
+                });
+        assertThat(leaderReplica.getLocalLogEndOffset()).isEqualTo(logEndOffset);
+    }
+
+    private static Configuration initConfig() {
+        Configuration conf = new Configuration();
+        conf.setInt(ConfigOptions.DEFAULT_REPLICATION_FACTOR, 2);
+        conf.set(ConfigOptions.LOG_SEGMENT_FILE_SIZE, MemorySize.parse("100b"));
+        conf.set(ConfigOptions.LOG_RETENTION_CHECK_INTERVAL, Duration.ofMillis(100));
+        conf.set(ConfigOptions.REMOTE_LOG_TASK_INTERVAL_DURATION, Duration.ZERO);
+        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofHours(1));
+        conf.set(ConfigOptions.LOG_REPLICA_MAX_LAG_TIME, Duration.ofSeconds(5));
+        return conf;
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/KvFollowerRetentionRestoreITCase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/KvFollowerRetentionRestoreITCase.java
@@ -29,6 +29,7 @@ import org.apache.fluss.rpc.messages.PutKvResponse;
 import org.apache.fluss.server.kv.snapshot.CompletedSnapshot;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
 import org.apache.fluss.server.zk.data.LeaderAndIsr;
+import org.apache.fluss.utils.clock.ManualClock;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -48,11 +49,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** IT case for restoring a follower's KV log retention boundary after restart. */
 class KvFollowerRetentionRestoreITCase {
 
+    private static final Duration LOG_TTL = Duration.ofHours(1);
+    private static final ManualClock MANUAL_CLOCK = new ManualClock(System.currentTimeMillis());
+
     @RegisterExtension
     public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
             FlussClusterExtension.builder()
                     .setNumOfTabletServers(2)
                     .setClusterConf(initConfig())
+                    .setClock(MANUAL_CLOCK)
                     .build();
 
     @Test
@@ -62,7 +67,7 @@ class KvFollowerRetentionRestoreITCase {
                 TableDescriptor.builder()
                         .schema(DATA1_SCHEMA_PK)
                         .distributedBy(1, "a")
-                        .property(ConfigOptions.TABLE_LOG_TTL, Duration.ofMillis(1))
+                        .property(ConfigOptions.TABLE_LOG_TTL, LOG_TTL)
                         .build();
         long tableId = createTable(FLUSS_CLUSTER_EXTENSION, tablePath, tableDescriptor);
         TableBucket tableBucket = new TableBucket(tableId, 0);
@@ -103,10 +108,9 @@ class KvFollowerRetentionRestoreITCase {
                     assertThat(followerReplica.getLocalLogEndOffset()).isEqualTo(logEndOffset);
                     assertThat(followerReplica.getLogTablet().getHighWatermark())
                             .isEqualTo(logEndOffset);
-                    assertThat(followerReplica.getLogTablet().getSegments().size())
-                            .isGreaterThan(1);
+                    assertThat(followerReplica.getLogTablet().getMinRetainOffset()).isZero();
+                    assertThat(followerReplica.getLogTablet().getSegments().size()).isEqualTo(4);
                 });
-        int segmentsBeforeRestart = followerReplica.getLogTablet().getSegments().size();
 
         // The stopped follower misses the snapshot notification that advances minRetainOffset.
         FLUSS_CLUSTER_EXTENSION.stopTabletServer(follower);
@@ -118,6 +122,7 @@ class KvFollowerRetentionRestoreITCase {
                 () ->
                         assertThat(leaderReplica.getLogTablet().getMinRetainOffset())
                                 .isEqualTo(logEndOffset));
+        MANUAL_CLOCK.advanceTime(LOG_TTL.plusMillis(1));
 
         // Do not write after the snapshot. The restarted follower must recover the retention
         // boundary from a successful empty fetch response.
@@ -131,8 +136,9 @@ class KvFollowerRetentionRestoreITCase {
                     assertThat(restartedFollower.getLocalLogEndOffset()).isEqualTo(logEndOffset);
                     assertThat(restartedFollower.getLogTablet().getMinRetainOffset())
                             .isEqualTo(logEndOffset);
-                    assertThat(restartedFollower.getLogTablet().getSegments().size())
-                            .isLessThan(segmentsBeforeRestart);
+                    // since minRetainOffset is equal to logEndOffset, the follower should have
+                    // cleaned up all segments except the last one.
+                    assertThat(restartedFollower.getLogTablet().getSegments().size()).isEqualTo(1);
                     assertThat(restartedFollower.getLocalLogStartOffset()).isPositive();
                 });
         assertThat(leaderReplica.getLocalLogEndOffset()).isEqualTo(logEndOffset);

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/delay/DelayedFetchLogTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/delay/DelayedFetchLogTest.java
@@ -54,7 +54,7 @@ public class DelayedFetchLogTest extends ReplicaTestBase {
         makeLogTableAsLeader(tb.getBucket());
 
         FetchLogResultForBucket preFetchResultForBucket =
-                new FetchLogResultForBucket(tb, MemoryLogRecords.EMPTY, 0L);
+                FetchLogResultForBucket.records(tb, MemoryLogRecords.EMPTY, 0L, -1L, -1L);
         CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> delayedResponse =
                 new CompletableFuture<>();
         DelayedFetchLog delayedFetchLog =
@@ -113,7 +113,7 @@ public class DelayedFetchLogTest extends ReplicaTestBase {
         makeLogTableAsLeader(tb.getBucket());
 
         FetchLogResultForBucket preFetchResultForBucket =
-                new FetchLogResultForBucket(tb, MemoryLogRecords.EMPTY, 0L);
+                FetchLogResultForBucket.records(tb, MemoryLogRecords.EMPTY, 0L, -1L, -1L);
         CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> delayedResponse =
                 new CompletableFuture<>();
         DelayedFetchLog delayedFetchLog =

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
@@ -24,6 +24,7 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.record.MemoryLogRecords;
 import org.apache.fluss.rpc.RpcClient;
 import org.apache.fluss.rpc.entity.ProduceLogResultForBucket;
 import org.apache.fluss.rpc.metrics.TestingClientMetricGroup;
@@ -76,9 +77,13 @@ import java.util.function.Consumer;
 
 import static org.apache.fluss.record.TestData.DATA1;
 import static org.apache.fluss.record.TestData.DATA1_SCHEMA;
+import static org.apache.fluss.record.TestData.DATA1_SCHEMA_PK;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR;
+import static org.apache.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR_PK;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_ID;
+import static org.apache.fluss.record.TestData.DATA1_TABLE_ID_PK;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_PATH;
+import static org.apache.fluss.record.TestData.DATA1_TABLE_PATH_PK;
 import static org.apache.fluss.record.TestData.DEFAULT_REMOTE_DATA_DIR;
 import static org.apache.fluss.server.coordinator.CoordinatorContext.INITIAL_COORDINATOR_EPOCH;
 import static org.apache.fluss.server.metrics.group.TestingMetricGroups.USER_METRICS;
@@ -105,9 +110,12 @@ public class ReplicaFetcherThreadTest {
     private ServerNode leader;
     private ReplicaManager followerRM;
     private ReplicaFetcherThread followerFetcher;
+    private TestingLeaderEndpoint leaderEndpoint;
     private ExecutorService ioExecutor;
     private LocalDiskManager leaderLocalDiskManager;
     private LocalDiskManager followerLocalDiskManager;
+    private KvManager leaderKvManager;
+    private KvManager followerKvManager;
 
     @BeforeAll
     static void baseBeforeAll() {
@@ -122,6 +130,7 @@ public class ReplicaFetcherThreadTest {
         ZOO_KEEPER_EXTENSION_WRAPPER.getCustomExtension().cleanupRoot();
         manualClock = new ManualClock(System.currentTimeMillis());
         Configuration conf = new Configuration();
+        conf.set(ConfigOptions.LOG_REPLICA_FETCH_WAIT_MAX_TIME, Duration.ofSeconds(5));
         tb = new TableBucket(DATA1_TABLE_ID, 0);
         ioExecutor = Executors.newSingleThreadExecutor();
         leaderLocalDiskManager = createLocalDiskManager(leaderServerId);
@@ -135,12 +144,9 @@ public class ReplicaFetcherThreadTest {
         ServerNode follower =
                 new ServerNode(
                         followerServerId, "localhost", 10001, ServerType.TABLET_SERVER, "rack2");
+        leaderEndpoint = new TestingLeaderEndpoint(conf, leaderRM, follower);
         followerFetcher =
-                new ReplicaFetcherThread(
-                        "test-fetcher-thread",
-                        followerRM,
-                        new TestingLeaderEndpoint(conf, leaderRM, follower),
-                        1000);
+                new ReplicaFetcherThread("test-fetcher-thread", followerRM, leaderEndpoint, 1000);
 
         registerTableInZkClient();
         // make the tb(table, 0) to be leader in leaderRM and to be follower in followerRM.
@@ -149,6 +155,21 @@ public class ReplicaFetcherThreadTest {
 
     @AfterEach
     public void tearDown() throws Exception {
+        if (followerFetcher != null && followerFetcher.isAlive()) {
+            followerFetcher.shutdown();
+        }
+        if (leaderRM != null) {
+            leaderRM.getDelayedFetchLogManager().shutdown();
+        }
+        if (followerRM != null) {
+            followerRM.getDelayedFetchLogManager().shutdown();
+        }
+        if (leaderKvManager != null) {
+            leaderKvManager.shutdown();
+        }
+        if (followerKvManager != null) {
+            followerKvManager.shutdown();
+        }
         if (leaderLocalDiskManager != null) {
             leaderLocalDiskManager.close();
         }
@@ -200,6 +221,59 @@ public class ReplicaFetcherThreadTest {
                 () ->
                         assertThat(followerRM.getReplicaOrException(tb).getLocalLogEndOffset())
                                 .isEqualTo(20L));
+    }
+
+    @Test
+    void testRestoreKvMinRetainOffsetFromDelayedEmptyFetchResponse() throws Exception {
+        leaderEndpoint.enableLongPolling();
+        TableBucket pkTableBucket = new TableBucket(DATA1_TABLE_ID_PK, 0);
+        zkClient.registerTable(
+                DATA1_TABLE_PATH_PK,
+                TableRegistration.newTable(
+                        DATA1_TABLE_ID_PK, DEFAULT_REMOTE_DATA_DIR, DATA1_TABLE_DESCRIPTOR_PK));
+        zkClient.registerFirstSchema(DATA1_TABLE_PATH_PK, DATA1_SCHEMA_PK);
+        makeLeaderAndFollower(PhysicalTablePath.of(DATA1_TABLE_PATH_PK), pkTableBucket);
+
+        Replica leaderReplica = leaderRM.getReplicaOrException(pkTableBucket);
+        Replica followerReplica = followerRM.getReplicaOrException(pkTableBucket);
+        for (int i = 0; i < 3; i++) {
+            MemoryLogRecords records = genMemoryLogRecordsWithWriterId(DATA1, 100L + i, 0, i * 10L);
+            leaderReplica.appendRecordsToFollower(records);
+            followerReplica.appendRecordsToFollower(records);
+            if (i < 2) {
+                leaderReplica.getLogTablet().roll(Optional.empty());
+                followerReplica.getLogTablet().roll(Optional.empty());
+            }
+        }
+        leaderReplica.getLogTablet().updateHighWatermark(30L);
+        followerReplica.getLogTablet().updateHighWatermark(30L);
+        leaderReplica.getLogTablet().updateMinRetainOffset(30L);
+        followerReplica.getLogTablet().updateHighestCopiedEndOffset(30L);
+
+        assertThat(leaderReplica.getLocalLogEndOffset()).isEqualTo(30L);
+        assertThat(followerReplica.getLocalLogEndOffset()).isEqualTo(30L);
+        assertThat(followerReplica.getLogTablet().getMinRetainOffset()).isZero();
+        assertThat(followerReplica.getLogTablet().getSegments()).hasSize(3);
+
+        followerFetcher.addBuckets(
+                Collections.singletonMap(
+                        pkTableBucket,
+                        new InitialFetchStatus(
+                                DATA1_TABLE_ID_PK, DATA1_TABLE_PATH_PK, leader.id(), 30L)));
+        followerFetcher.start();
+
+        retry(
+                Duration.ofSeconds(20),
+                () -> assertThat(leaderRM.getDelayedFetchLogManager().numDelayed()).isPositive());
+        assertThat(followerReplica.getLogTablet().getMinRetainOffset()).isZero();
+        assertThat(followerReplica.getLogTablet().getSegments()).hasSize(3);
+
+        retry(
+                Duration.ofSeconds(20),
+                () -> {
+                    assertThat(followerReplica.getLogTablet().getMinRetainOffset()).isEqualTo(30L);
+                    assertThat(followerReplica.getLogTablet().getSegments()).hasSize(2);
+                });
     }
 
     @Test
@@ -478,12 +552,17 @@ public class ReplicaFetcherThreadTest {
     }
 
     private void makeLeaderAndFollower() {
+        makeLeaderAndFollower(PhysicalTablePath.of(DATA1_TABLE_PATH), tb);
+    }
+
+    private void makeLeaderAndFollower(
+            PhysicalTablePath physicalTablePath, TableBucket tableBucket) {
         leaderRM.becomeLeaderOrFollower(
                 INITIAL_COORDINATOR_EPOCH,
                 Collections.singletonList(
                         new NotifyLeaderAndIsrData(
-                                PhysicalTablePath.of(DATA1_TABLE_PATH),
-                                tb,
+                                physicalTablePath,
+                                tableBucket,
                                 Arrays.asList(leaderServerId, followerServerId),
                                 new LeaderAndIsr(
                                         leaderServerId,
@@ -497,8 +576,8 @@ public class ReplicaFetcherThreadTest {
                 INITIAL_COORDINATOR_EPOCH,
                 Collections.singletonList(
                         new NotifyLeaderAndIsrData(
-                                PhysicalTablePath.of(DATA1_TABLE_PATH),
-                                tb,
+                                physicalTablePath,
+                                tableBucket,
                                 Arrays.asList(leaderServerId, followerServerId),
                                 new LeaderAndIsr(
                                         leaderServerId,
@@ -535,12 +614,27 @@ public class ReplicaFetcherThreadTest {
                         TestingMetricGroups.TABLET_SERVER_METRICS,
                         localDiskManager);
         logManager.startup();
+        KvManager kvManager =
+                KvManager.create(
+                        conf,
+                        zkClient,
+                        logManager,
+                        TestingMetricGroups.TABLET_SERVER_METRICS,
+                        localDiskManager,
+                        null,
+                        manualClock);
+        kvManager.startup();
+        if (serverId == leaderServerId) {
+            leaderKvManager = kvManager;
+        } else {
+            followerKvManager = kvManager;
+        }
         ReplicaManager replicaManager =
                 new TestingReplicaManager(
                         conf,
                         scheduler,
                         logManager,
-                        null,
+                        kvManager,
                         zkClient,
                         serverId,
                         new TabletServerMetadataCache(

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/TestingLeaderEndpoint.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/TestingLeaderEndpoint.java
@@ -207,18 +207,17 @@ public class TestingLeaderEndpoint implements LeaderEndpoint {
                         ByteBuffer buffer = ByteBuffer.allocate(fileRecords.sizeInBytes());
                         unchecked(() -> fileRecords.readInto(buffer, 0)).run();
                         MemoryLogRecords memRecords = MemoryLogRecords.pointToByteBuffer(buffer);
+                        long filteredEndOffset =
+                                value.hasFilteredEndOffset() ? value.getFilteredEndOffset() : -1L;
+                        long minRetainOffset =
+                                value.hasMinRetainOffset() ? value.getMinRetainOffset() : -1L;
                         FetchLogResultForBucket memoryResult =
-                                value.hasMinRetainOffset()
-                                        ? new FetchLogResultForBucket(
-                                                tb,
-                                                memRecords,
-                                                value.getHighWatermark(),
-                                                value.hasFilteredEndOffset()
-                                                        ? value.getFilteredEndOffset()
-                                                        : -1L,
-                                                value.getMinRetainOffset())
-                                        : new FetchLogResultForBucket(
-                                                tb, memRecords, value.getHighWatermark());
+                                FetchLogResultForBucket.records(
+                                        tb,
+                                        memRecords,
+                                        value.getHighWatermark(),
+                                        filteredEndOffset,
+                                        minRetainOffset);
                         result.put(tb, memoryResult);
                     } else {
                         result.put(tb, value);

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/TestingLeaderEndpoint.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/fetcher/TestingLeaderEndpoint.java
@@ -55,6 +55,10 @@ public class TestingLeaderEndpoint implements LeaderEndpoint {
     /** The max fetch size for a bucket in bytes. */
     private final int maxFetchSizeForBucket;
 
+    private final int minFetchBytes;
+    private final int maxFetchWaitMs;
+    private volatile boolean longPollingEnabled;
+
     /**
      * If set, fetchLog will return a future that completes after the specified delay, simulating a
      * slow leader. The response will carry a pooled ByteBuf to track buffer release.
@@ -74,6 +78,9 @@ public class TestingLeaderEndpoint implements LeaderEndpoint {
         this.maxFetchSize = (int) conf.get(ConfigOptions.LOG_REPLICA_FETCH_MAX_BYTES).getBytes();
         this.maxFetchSizeForBucket =
                 (int) conf.get(ConfigOptions.LOG_REPLICA_FETCH_MAX_BYTES_FOR_BUCKET).getBytes();
+        this.minFetchBytes = (int) conf.get(ConfigOptions.LOG_REPLICA_FETCH_MIN_BYTES).getBytes();
+        this.maxFetchWaitMs =
+                (int) conf.get(ConfigOptions.LOG_REPLICA_FETCH_WAIT_MAX_TIME).toMillis();
     }
 
     @Override
@@ -106,7 +113,10 @@ public class TestingLeaderEndpoint implements LeaderEndpoint {
         Map<TableBucket, FetchReqInfo> fetchLogData = getFetchLogData(fetchLogRequest);
         replicaManager.fetchLogRecords(
                 new FetchParams(
-                        fetchLogRequest.getFollowerServerId(), fetchLogRequest.getMaxBytes()),
+                        fetchLogRequest.getFollowerServerId(),
+                        fetchLogRequest.getMaxBytes(),
+                        fetchLogRequest.getMinBytes(),
+                        fetchLogRequest.getMaxWaitMs()),
                 fetchLogData,
                 null,
                 result -> {
@@ -139,6 +149,11 @@ public class TestingLeaderEndpoint implements LeaderEndpoint {
         this.delayMs = 0;
     }
 
+    /** Enables the configured follower fetch long-poll settings for tests. */
+    public void enableLongPolling() {
+        longPollingEnabled = true;
+    }
+
     /** Returns all pooled ByteBufs allocated for delayed fetch responses. */
     public java.util.List<ByteBuf> getAllAllocatedByteBufs() {
         return allocatedByteBufs;
@@ -166,7 +181,12 @@ public class TestingLeaderEndpoint implements LeaderEndpoint {
     public Optional<FetchLogContext> buildFetchLogContext(
             Map<TableBucket, BucketFetchStatus> replicas) {
         return RemoteLeaderEndpoint.buildFetchLogContext(
-                replicas, localNode.id(), maxFetchSize, maxFetchSizeForBucket, -1, -1);
+                replicas,
+                localNode.id(),
+                maxFetchSize,
+                maxFetchSizeForBucket,
+                longPollingEnabled ? minFetchBytes : FetchParams.DEFAULT_MIN_FETCH_BYTES,
+                longPollingEnabled ? maxFetchWaitMs : (int) FetchParams.DEFAULT_MAX_WAIT_MS);
     }
 
     @Override
@@ -187,10 +207,19 @@ public class TestingLeaderEndpoint implements LeaderEndpoint {
                         ByteBuffer buffer = ByteBuffer.allocate(fileRecords.sizeInBytes());
                         unchecked(() -> fileRecords.readInto(buffer, 0)).run();
                         MemoryLogRecords memRecords = MemoryLogRecords.pointToByteBuffer(buffer);
-                        result.put(
-                                tb,
-                                new FetchLogResultForBucket(
-                                        tb, memRecords, value.getHighWatermark()));
+                        FetchLogResultForBucket memoryResult =
+                                value.hasMinRetainOffset()
+                                        ? new FetchLogResultForBucket(
+                                                tb,
+                                                memRecords,
+                                                value.getHighWatermark(),
+                                                value.hasFilteredEndOffset()
+                                                        ? value.getFilteredEndOffset()
+                                                        : -1L,
+                                                value.getMinRetainOffset())
+                                        : new FetchLogResultForBucket(
+                                                tb, memRecords, value.getHighWatermark());
+                        result.put(tb, memoryResult);
                     } else {
                         result.put(tb, value);
                     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/tablet/TestTabletServerGateway.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/tablet/TestTabletServerGateway.java
@@ -182,7 +182,8 @@ public class TestTabletServerGateway implements TabletServerGateway {
         fetchLogData.forEach(
                 (tableBucket, fetchData) -> {
                     FetchLogResultForBucket fetchLogResultForBucket =
-                            new FetchLogResultForBucket(tableBucket, MemoryLogRecords.EMPTY, 0L);
+                            FetchLogResultForBucket.records(
+                                    tableBucket, MemoryLogRecords.EMPTY, 0L, -1L, -1L);
                     resultForBucketMap.put(tableBucket, fetchLogResultForBucket);
                 });
         return CompletableFuture.completedFuture(makeFetchLogResponse(resultForBucketMap));

--- a/fluss-server/src/test/java/org/apache/fluss/server/utils/ServerRpcMessageUtilsTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/utils/ServerRpcMessageUtilsTest.java
@@ -18,11 +18,16 @@
 package org.apache.fluss.server.utils;
 
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.record.KvRecordBatch;
+import org.apache.fluss.record.MemoryLogRecords;
 import org.apache.fluss.row.encode.KvValueLayout;
+import org.apache.fluss.rpc.entity.FetchLogResultForBucket;
 import org.apache.fluss.rpc.entity.LookupResultForBucket;
 import org.apache.fluss.rpc.entity.PutKvResultForBucket;
+import org.apache.fluss.rpc.messages.FetchLogResponse;
 import org.apache.fluss.rpc.messages.LookupResponse;
+import org.apache.fluss.rpc.messages.PbFetchLogRespForBucket;
 import org.apache.fluss.rpc.messages.PbBucketMetadata;
 import org.apache.fluss.rpc.messages.PbPartitionMetadata;
 import org.apache.fluss.rpc.messages.PbPutKvReqForBucket;
@@ -30,6 +35,7 @@ import org.apache.fluss.rpc.messages.PbPutKvRespForBucket;
 import org.apache.fluss.rpc.messages.PbTableMetadata;
 import org.apache.fluss.rpc.messages.PutKvRequest;
 import org.apache.fluss.rpc.messages.PutKvResponse;
+import org.apache.fluss.rpc.util.CommonRpcMessageUtils;
 import org.apache.fluss.rpc.messages.UpdateMetadataRequest;
 import org.apache.fluss.server.entity.PutKvDataForBucket;
 import org.apache.fluss.server.metadata.BucketMetadata;
@@ -55,6 +61,49 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link ServerRpcMessageUtils}. */
 class ServerRpcMessageUtilsTest {
+
+    @Test
+    void testFetchLogResponseContainsMinRetainOffset() {
+        TableBucket tableBucket = new TableBucket(1L, 0);
+        FetchLogResultForBucket result =
+                new FetchLogResultForBucket(tableBucket, MemoryLogRecords.EMPTY, 10L, -1L, 8L);
+
+        FetchLogResponse response =
+                ServerRpcMessageUtils.makeFetchLogResponse(
+                        Collections.singletonMap(tableBucket, result));
+
+        PbFetchLogRespForBucket bucketResponse =
+                response.getTablesRespsList().get(0).getBucketsRespsList().get(0);
+        assertThat(bucketResponse.hasMinRetainOffset()).isTrue();
+        assertThat(bucketResponse.getMinRetainOffset()).isEqualTo(8L);
+
+        FetchLogResultForBucket decodedResult =
+                CommonRpcMessageUtils.getFetchLogResultForBucket(
+                        tableBucket, TablePath.of("db", "table"), bucketResponse);
+        assertThat(decodedResult.hasMinRetainOffset()).isTrue();
+        assertThat(decodedResult.getMinRetainOffset()).isEqualTo(8L);
+
+        FetchLogResponse responseWithoutMinRetainOffset =
+                ServerRpcMessageUtils.makeFetchLogResponse(
+                        Collections.singletonMap(
+                                tableBucket,
+                                new FetchLogResultForBucket(
+                                        tableBucket, MemoryLogRecords.EMPTY, 10L)));
+        PbFetchLogRespForBucket bucketResponseWithoutMinRetainOffset =
+                responseWithoutMinRetainOffset
+                        .getTablesRespsList()
+                        .get(0)
+                        .getBucketsRespsList()
+                        .get(0);
+        assertThat(bucketResponseWithoutMinRetainOffset.hasMinRetainOffset()).isFalse();
+        assertThat(
+                        CommonRpcMessageUtils.getFetchLogResultForBucket(
+                                        tableBucket,
+                                        TablePath.of("db", "table"),
+                                        bucketResponseWithoutMinRetainOffset)
+                                .hasMinRetainOffset())
+                .isFalse();
+    }
 
     @Test
     void testLookupResponseSupportsMixedValueLayouts() {

--- a/fluss-server/src/test/java/org/apache/fluss/server/utils/ServerRpcMessageUtilsTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/utils/ServerRpcMessageUtilsTest.java
@@ -27,16 +27,16 @@ import org.apache.fluss.rpc.entity.LookupResultForBucket;
 import org.apache.fluss.rpc.entity.PutKvResultForBucket;
 import org.apache.fluss.rpc.messages.FetchLogResponse;
 import org.apache.fluss.rpc.messages.LookupResponse;
-import org.apache.fluss.rpc.messages.PbFetchLogRespForBucket;
 import org.apache.fluss.rpc.messages.PbBucketMetadata;
+import org.apache.fluss.rpc.messages.PbFetchLogRespForBucket;
 import org.apache.fluss.rpc.messages.PbPartitionMetadata;
 import org.apache.fluss.rpc.messages.PbPutKvReqForBucket;
 import org.apache.fluss.rpc.messages.PbPutKvRespForBucket;
 import org.apache.fluss.rpc.messages.PbTableMetadata;
 import org.apache.fluss.rpc.messages.PutKvRequest;
 import org.apache.fluss.rpc.messages.PutKvResponse;
-import org.apache.fluss.rpc.util.CommonRpcMessageUtils;
 import org.apache.fluss.rpc.messages.UpdateMetadataRequest;
+import org.apache.fluss.rpc.util.CommonRpcMessageUtils;
 import org.apache.fluss.server.entity.PutKvDataForBucket;
 import org.apache.fluss.server.metadata.BucketMetadata;
 import org.apache.fluss.server.metadata.ClusterMetadata;
@@ -66,7 +66,7 @@ class ServerRpcMessageUtilsTest {
     void testFetchLogResponseContainsMinRetainOffset() {
         TableBucket tableBucket = new TableBucket(1L, 0);
         FetchLogResultForBucket result =
-                new FetchLogResultForBucket(tableBucket, MemoryLogRecords.EMPTY, 10L, -1L, 8L);
+                FetchLogResultForBucket.records(tableBucket, MemoryLogRecords.EMPTY, 10L, -1L, 8L);
 
         FetchLogResponse response =
                 ServerRpcMessageUtils.makeFetchLogResponse(
@@ -87,8 +87,8 @@ class ServerRpcMessageUtilsTest {
                 ServerRpcMessageUtils.makeFetchLogResponse(
                         Collections.singletonMap(
                                 tableBucket,
-                                new FetchLogResultForBucket(
-                                        tableBucket, MemoryLogRecords.EMPTY, 10L)));
+                                FetchLogResultForBucket.records(
+                                        tableBucket, MemoryLogRecords.EMPTY, 10L, -1L, -1L)));
         PbFetchLogRespForBucket bucketResponseWithoutMinRetainOffset =
                 responseWithoutMinRetainOffset
                         .getTablesRespsList()


### PR DESCRIPTION
## Summary
- Restore follower `minRetainOffset` from the latest committed KV snapshot when KV followers are handled in `makeFollowers`.
- Coalesce pending restores into one asynchronous task per TabletServer, keeping ZooKeeper access outside the replica state-change lock.
- Bound ZooKeeper pressure with 32-bucket client batches, the configured max-inflight limit, startup jitter, and exponential retry backoff.
- Distinguish confirmed-empty snapshots from unresolved reads, and ignore stale results after notifications, role changes, replica replacement, or shutdown.
- Fixes #4054

## Test Plan
- `ZooKeeperClientTest`: 23 tests passed.
- `ReplicaManagerTest`: 41 tests passed.
- `mvn -o -pl fluss-server -DskipTests -Dfast verify` passed (Checkstyle 0 violations and Spotless passed).

🤖 AI-assisted changes - reviewed by human developer
