### PR TITLE
[server] Add off-loop coordinator health cache (mechanism only)

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/ClusterHealthSnapshot.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/ClusterHealthSnapshot.java
@@ -30,31 +30,66 @@ import java.util.Map;
  * attributes replicas/ISR membership/leadership to the specific server holding them. Both are
  * computed together from a single pass over {@link CoordinatorContext#getAllBuckets()}.
  *
+ * <p>{@code numLeaderReplicas} counts buckets, not leaders -- it's incremented once per bucket
+ * regardless of whether that bucket actually has a leader, matching {@code computeClusterHealth}'s
+ * existing semantics exactly. The per-server breakdown only credits a server when it's actually the
+ * leader, so the two can diverge: {@link #bucketsWithoutLeader()} makes that gap an explicit,
+ * queryable fact instead of a silent discrepancy a consumer has to rediscover on its own.
+ *
+ * <p>{@link #EMPTY} is not a genuinely healthy all-zero cluster -- it's the placeholder before the
+ * first real snapshot has ever been computed. Any consumer that derives a health status (GREEN /
+ * YELLOW / RED) from this snapshot must check {@link #isInitialized()} first and report an
+ * unknown/pending status when it's {@code false}, rather than applying the normal status rule to
+ * all-zero counters and reporting a healthy cluster that hasn't actually been evaluated yet.
+ *
  * <p>Instances are published by {@link CoordinatorHealthCache} and are safe to read from any thread
  * without synchronization: once constructed, an instance is never mutated.
  */
 public final class ClusterHealthSnapshot {
 
     public static final ClusterHealthSnapshot EMPTY =
-            new ClusterHealthSnapshot(0, 0, 0, 0, Collections.emptyMap());
+            new ClusterHealthSnapshot(0, 0, 0, 0, 0, Collections.emptyMap(), false);
 
     private final int numReplicas;
     private final int inSyncReplicas;
     private final int numLeaderReplicas;
     private final int activeLeaderReplicas;
+    private final int bucketsWithoutLeader;
     private final Map<Integer, TabletServerLoad> tabletServerLoads;
+    private final boolean initialized;
 
     ClusterHealthSnapshot(
             int numReplicas,
             int inSyncReplicas,
             int numLeaderReplicas,
             int activeLeaderReplicas,
+            int bucketsWithoutLeader,
             Map<Integer, TabletServerLoad> tabletServerLoads) {
+        this(
+                numReplicas,
+                inSyncReplicas,
+                numLeaderReplicas,
+                activeLeaderReplicas,
+                bucketsWithoutLeader,
+                tabletServerLoads,
+                true);
+    }
+
+    private ClusterHealthSnapshot(
+            int numReplicas,
+            int inSyncReplicas,
+            int numLeaderReplicas,
+            int activeLeaderReplicas,
+            int bucketsWithoutLeader,
+            Map<Integer, TabletServerLoad> tabletServerLoads,
+            boolean initialized) {
         this.numReplicas = numReplicas;
         this.inSyncReplicas = inSyncReplicas;
         this.numLeaderReplicas = numLeaderReplicas;
         this.activeLeaderReplicas = activeLeaderReplicas;
+        this.bucketsWithoutLeader = bucketsWithoutLeader;
         this.tabletServerLoads = Collections.unmodifiableMap(tabletServerLoads);
+        this.initialized = initialized;
     }
 
     public int numReplicas() {
@@ -73,8 +108,26 @@ public final class ClusterHealthSnapshot {
         return activeLeaderReplicas;
     }
 
+    /**
+     * Buckets counted in {@link #numLeaderReplicas()} that have no actual leader (either no {@code
+     * LeaderAndIsr} at all, or an explicit {@code NO_LEADER}) -- the reconciling fact between the
+     * aggregate bucket count and the per-server leader count in {@link #tabletServerLoads()}.
+     */
+    public int bucketsWithoutLeader() {
+        return bucketsWithoutLeader;
+    }
+
     /** Per-tablet-server load, keyed by server id. Includes live and shutting-down servers. */
     public Map<Integer, TabletServerLoad> tabletServerLoads() {
         return tabletServerLoads;
+    }
+
+    /**
+     * Whether this snapshot was actually computed from a real {@code CoordinatorContext}, as
+     * opposed to being {@link #EMPTY}. See the class javadoc -- an uninitialized snapshot must not
+     * be treated as a genuinely healthy cluster.
+     */
+    public boolean isInitialized() {
+        return initialized;
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/ClusterHealthSnapshot.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/ClusterHealthSnapshot.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * An immutable, point-in-time view of cluster-wide and per-tablet-server replica/leader health,
+ * derived from {@link CoordinatorContext}.
+ *
+ * <p>{@code numReplicas}/{@code inSyncReplicas}/{@code numLeaderReplicas}/{@code
+ * activeLeaderReplicas} are the same cluster-wide aggregates {@code
+ * CoordinatorService#computeClusterHealth} reports; {@link #tabletServerLoads()} additionally
+ * attributes replicas/ISR membership/leadership to the specific server holding them. Both are
+ * computed together from a single pass over {@link CoordinatorContext#getAllBuckets()}.
+ *
+ * <p>Instances are published by {@link CoordinatorHealthCache} and are safe to read from any thread
+ * without synchronization: once constructed, an instance is never mutated.
+ */
+public final class ClusterHealthSnapshot {
+
+    public static final ClusterHealthSnapshot EMPTY =
+            new ClusterHealthSnapshot(0, 0, 0, 0, Collections.emptyMap());
+
+    private final int numReplicas;
+    private final int inSyncReplicas;
+    private final int numLeaderReplicas;
+    private final int activeLeaderReplicas;
+    private final Map<Integer, TabletServerLoad> tabletServerLoads;
+
+    ClusterHealthSnapshot(
+            int numReplicas,
+            int inSyncReplicas,
+            int numLeaderReplicas,
+            int activeLeaderReplicas,
+            Map<Integer, TabletServerLoad> tabletServerLoads) {
+        this.numReplicas = numReplicas;
+        this.inSyncReplicas = inSyncReplicas;
+        this.numLeaderReplicas = numLeaderReplicas;
+        this.activeLeaderReplicas = activeLeaderReplicas;
+        this.tabletServerLoads = Collections.unmodifiableMap(tabletServerLoads);
+    }
+
+    public int numReplicas() {
+        return numReplicas;
+    }
+
+    public int inSyncReplicas() {
+        return inSyncReplicas;
+    }
+
+    public int numLeaderReplicas() {
+        return numLeaderReplicas;
+    }
+
+    public int activeLeaderReplicas() {
+        return activeLeaderReplicas;
+    }
+
+    /** Per-tablet-server load, keyed by server id. Includes live and shutting-down servers. */
+    public Map<Integer, TabletServerLoad> tabletServerLoads() {
+        return tabletServerLoads;
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
@@ -62,6 +62,13 @@ public class CoordinatorContext {
     // and use combine retry times and retry delay
     public static final int DELETE_TRY_TIMES = 5;
 
+    // notified from this class's own mutators whenever bucket/leader/ISR/server-liveness/tag
+    // state changes, regardless of which caller triggered the mutation -- see
+    // CoordinatorContextListener's javadoc. Defaults to NO_OP so every existing caller (in
+    // particular every test constructing a CoordinatorContext directly) is unaffected until
+    // setListener is actually called.
+    private CoordinatorContextListener listener = CoordinatorContextListener.NO_OP;
+
     private int offlineBucketCount = 0;
 
     // a map from the tablet replica to the delete fail number,
@@ -136,6 +143,16 @@ public class CoordinatorContext {
         this.coordinatorEpochZkVersion = zkEpoch.getCoordinatorEpochZkVersion();
     }
 
+    /**
+     * Registers the listener notified from this class's own mutators. Not constructor injection:
+     * this context is constructed before its eventual listener exists, so the caller sets it once
+     * it does. Mutations before this is called (e.g. bulk load at startup) reach {@link
+     * CoordinatorContextListener#NO_OP} instead, which is deliberate -- see the caller.
+     */
+    public void setListener(CoordinatorContextListener listener) {
+        this.listener = listener;
+    }
+
     public int getCoordinatorEpoch() {
         return coordinatorEpoch;
     }
@@ -179,6 +196,18 @@ public class CoordinatorContext {
         return shuttingDownTabletServers;
     }
 
+    /** Marks a tablet server as undergoing controlled shutdown -- a precursor to removal. */
+    public void markShuttingDown(int serverId) {
+        shuttingDownTabletServers.add(serverId);
+        listener.onTabletServerDied();
+    }
+
+    /** Clears the shutting-down marker, e.g. once the server is confirmed fully dead. */
+    public void clearShuttingDown(int serverId) {
+        shuttingDownTabletServers.remove(serverId);
+        listener.onTopologyChanged();
+    }
+
     public Set<Integer> liveOrShuttingDownTabletServers() {
         return liveTabletServers.keySet();
     }
@@ -199,10 +228,12 @@ public class CoordinatorContext {
 
     public void addLiveTabletServer(ServerInfo serverInfo) {
         this.liveTabletServers.put(serverInfo.id(), serverInfo);
+        listener.onTabletServerRegistered();
     }
 
     public void removeLiveTabletServer(int serverId) {
         this.liveTabletServers.remove(serverId);
+        listener.onTabletServerDied();
     }
 
     public boolean isReplicaOnline(int serverId, TableBucket tableBucket) {
@@ -220,10 +251,15 @@ public class CoordinatorContext {
         Set<TableBucket> tableBuckets =
                 replicasOnOffline.computeIfAbsent(serverId, (k) -> new HashSet<>());
         tableBuckets.add(tableBucket);
+        // the event that actually caused this (server death, ISR shrink reported via
+        // onBucketLeaderAndIsrChanged) already notifies urgently through its own, more specific
+        // hook; this is secondary bookkeeping, safety-netted regardless if under-classified here.
+        listener.onTopologyChanged();
     }
 
     public void removeOfflineBucketInServer(int serverId) {
         replicasOnOffline.remove(serverId);
+        listener.onTopologyChanged();
     }
 
     /** Removes the offline marker for one table bucket on the given tablet server. */
@@ -236,6 +272,7 @@ public class CoordinatorContext {
         if (tableBuckets.isEmpty()) {
             replicasOnOffline.remove(serverId);
         }
+        listener.onTopologyChanged();
     }
 
     /**
@@ -264,14 +301,17 @@ public class CoordinatorContext {
 
     public void addPendingLeaderActivation(TableBucket bucket) {
         pendingLeaderActivationBuckets.add(bucket);
+        listener.onLeaderActivityChanged(false);
     }
 
     public void addPendingLeaderActivations(Collection<TableBucket> buckets) {
         pendingLeaderActivationBuckets.addAll(buckets);
+        listener.onLeaderActivityChanged(false);
     }
 
     public void clearPendingLeaderActivation(TableBucket bucket) {
         pendingLeaderActivationBuckets.remove(bucket);
+        listener.onLeaderActivityChanged(true);
     }
 
     /**
@@ -300,6 +340,7 @@ public class CoordinatorContext {
 
     public void removeFromPendingLeaderActivations(Set<TableBucket> buckets) {
         pendingLeaderActivationBuckets.removeAll(buckets);
+        listener.onLeaderActivityChanged(true);
     }
 
     public Map<Long, TablePath> allTables() {
@@ -469,6 +510,7 @@ public class CoordinatorContext {
                             (k) -> new HashMap<>());
         }
         assignments.put(tableBucket.getBucket(), replicaAssignment);
+        listener.onTopologyChanged();
     }
 
     public List<Integer> getAssignment(TableBucket tableBucket) {
@@ -524,7 +566,9 @@ public class CoordinatorContext {
     }
 
     public ReplicaState putReplicaState(TableBucketReplica replica, ReplicaState state) {
-        return replicaStates.put(replica, state);
+        ReplicaState previous = replicaStates.put(replica, state);
+        listener.onTopologyChanged();
+        return previous;
     }
 
     public ReplicaState removeReplicaState(TableBucketReplica replica) {
@@ -667,6 +711,7 @@ public class CoordinatorContext {
     public BucketState putBucketState(TableBucket tableBucket, BucketState targetState) {
         BucketState currentState = bucketStates.put(tableBucket, targetState);
         updateBucketStateMetrics(tableBucket, currentState, targetState);
+        listener.onTopologyChanged();
         return currentState;
     }
 
@@ -693,6 +738,8 @@ public class CoordinatorContext {
 
     public void putBucketLeaderAndIsr(TableBucket tableBucket, LeaderAndIsr leaderAndIsr) {
         bucketLeaderAndIsr.put(tableBucket, leaderAndIsr);
+        listener.onBucketLeaderAndIsrChanged(
+                tableBucket, getAssignment(tableBucket), Optional.of(leaderAndIsr));
     }
 
     public Optional<LeaderAndIsr> getBucketLeaderAndIsr(TableBucket tableBucket) {
@@ -772,6 +819,7 @@ public class CoordinatorContext {
             tableIdByPath.remove(tablePath);
         }
         tableInfoById.remove(tableId);
+        listener.onTopologyChanged();
     }
 
     public void removePartition(TablePartition tablePartition) {
@@ -799,6 +847,7 @@ public class CoordinatorContext {
         if (physicalTablePath != null) {
             partitionIdByPath.remove(physicalTablePath);
         }
+        listener.onTopologyChanged();
     }
 
     public void initSeverTags(Map<Integer, ServerTag> initialServerTags) {
@@ -807,6 +856,7 @@ public class CoordinatorContext {
 
     public void putServerTag(int serverId, ServerTag serverTag) {
         serverTags.put(serverId, serverTag);
+        listener.onTopologyChanged();
     }
 
     public Map<Integer, ServerTag> getServerTags() {
@@ -819,6 +869,7 @@ public class CoordinatorContext {
 
     public void removeServerTag(int serverId) {
         serverTags.remove(serverId);
+        listener.onTopologyChanged();
     }
 
     private void clearTablesState() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
@@ -62,11 +62,7 @@ public class CoordinatorContext {
     // and use combine retry times and retry delay
     public static final int DELETE_TRY_TIMES = 5;
 
-    // notified from this class's own mutators whenever bucket/leader/ISR/server-liveness/tag
-    // state changes, regardless of which caller triggered the mutation -- see
-    // CoordinatorContextListener's javadoc. Defaults to NO_OP so every existing caller (in
-    // particular every test constructing a CoordinatorContext directly) is unaffected until
-    // setListener is actually called.
+    // notified on state changes made through this class's mutators; defaults to a no-op.
     private CoordinatorContextListener listener = CoordinatorContextListener.NO_OP;
 
     private int offlineBucketCount = 0;
@@ -143,12 +139,7 @@ public class CoordinatorContext {
         this.coordinatorEpochZkVersion = zkEpoch.getCoordinatorEpochZkVersion();
     }
 
-    /**
-     * Registers the listener notified from this class's own mutators. Not constructor injection:
-     * this context is constructed before its eventual listener exists, so the caller sets it once
-     * it does. Mutations before this is called (e.g. bulk load at startup) reach {@link
-     * CoordinatorContextListener#NO_OP} instead, which is deliberate -- see the caller.
-     */
+    /** Registers the listener notified on state changes made through this class's mutators. */
     public void setListener(CoordinatorContextListener listener) {
         this.listener = listener;
     }
@@ -251,9 +242,6 @@ public class CoordinatorContext {
         Set<TableBucket> tableBuckets =
                 replicasOnOffline.computeIfAbsent(serverId, (k) -> new HashSet<>());
         tableBuckets.add(tableBucket);
-        // the event that actually caused this (server death, ISR shrink reported via
-        // onBucketLeaderAndIsrChanged) already notifies urgently through its own, more specific
-        // hook; this is secondary bookkeeping, safety-netted regardless if under-classified here.
         listener.onTopologyChanged();
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContextListener.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContextListener.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator;
+
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.server.zk.data.LeaderAndIsr;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Notified by {@link CoordinatorContext}'s own mutators whenever state relevant to
+ * cluster/tablet-server health changes, regardless of which caller triggered the mutation.
+ *
+ * <p>This is what closes the "did we remember to instrument this call site" class of gap: any
+ * current or future caller of a hooked {@code CoordinatorContext} mutator is covered automatically,
+ * without needing to know this interface exists. {@code CoordinatorHealthCache} implements this
+ * interface directly -- its {@code onXxx} methods already have this exact signature. The interface
+ * exists only so {@code CoordinatorContext}'s field can be typed as an abstraction instead of
+ * depending on {@code CoordinatorHealthCache} concretely.
+ */
+interface CoordinatorContextListener {
+
+    void onBucketLeaderAndIsrChanged(
+            TableBucket tableBucket, List<Integer> assignment, Optional<LeaderAndIsr> current);
+
+    void onLeaderActivityChanged(boolean isActive);
+
+    void onTabletServerDied();
+
+    void onTabletServerRegistered();
+
+    void onTopologyChanged();
+
+    /** The default until {@link CoordinatorContext#setListener} is called with a real one. */
+    CoordinatorContextListener NO_OP =
+            new CoordinatorContextListener() {
+                @Override
+                public void onBucketLeaderAndIsrChanged(
+                        TableBucket tableBucket,
+                        List<Integer> assignment,
+                        Optional<LeaderAndIsr> current) {}
+
+                @Override
+                public void onLeaderActivityChanged(boolean isActive) {}
+
+                @Override
+                public void onTabletServerDied() {}
+
+                @Override
+                public void onTabletServerRegistered() {}
+
+                @Override
+                public void onTopologyChanged() {}
+            };
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -188,6 +188,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
     private final CoordinatorChangeWatcher coordinatorChangeWatcher;
     private final TabletServerChangeWatcher tabletServerChangeWatcher;
     private final CoordinatorMetadataCache serverMetadataCache;
+    private final CoordinatorHealthCache healthCache;
     private final CoordinatorRequestBatch coordinatorRequestBatch;
     private final String internalListenerName;
     private final CoordinatorMetricGroup coordinatorMetricGroup;
@@ -218,7 +219,10 @@ public class CoordinatorEventProcessor implements EventProcessor {
         this.coordinatorChannelManager = coordinatorChannelManager;
         this.coordinatorContext = coordinatorContext;
         this.replicaCapacityController = replicaCapacityController;
-        this.coordinatorEventManager = new CoordinatorEventManager(this, coordinatorMetricGroup);
+        this.healthCache = new CoordinatorHealthCache();
+        this.coordinatorEventManager =
+                new CoordinatorEventManager(
+                        this, coordinatorContext, healthCache, coordinatorMetricGroup);
         this.replicaStateMachine =
                 new ReplicaStateMachine(
                         coordinatorContext,
@@ -298,6 +302,10 @@ public class CoordinatorEventProcessor implements EventProcessor {
 
     public CoordinatorContext getCoordinatorContext() {
         return coordinatorContext;
+    }
+
+    public CoordinatorHealthCache getHealthCache() {
+        return healthCache;
     }
 
     @VisibleForTesting
@@ -501,6 +509,11 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 tabletServerInfoList,
                 coordinatorContext.getServerTags());
         updateTabletServerMetadataCacheWhenStartup(tabletServerInfoList);
+        // Warm the health cache once, unconditionally, so it isn't empty before the first
+        // relevant mutation lands. Bulk-loading buckets above does not mark it dirty on purpose
+        // (that would mean one dirty-mark per bucket during startup, for no benefit); this single
+        // explicit refresh covers it instead.
+        healthCache.update(coordinatorContext);
 
         // Auto-partition initialization schedules creation checks immediately. Start it only after
         // the observed KV leader replica count and live tablet server resources are restored.
@@ -669,12 +682,16 @@ public class CoordinatorEventProcessor implements EventProcessor {
     public void process(CoordinatorEvent event) {
         if (event instanceof CreateTableEvent) {
             processCreateTable((CreateTableEvent) event);
+            healthCache.onTopologyChanged();
         } else if (event instanceof CreatePartitionEvent) {
             processCreatePartition((CreatePartitionEvent) event);
+            healthCache.onTopologyChanged();
         } else if (event instanceof DropTableEvent) {
             processDropTable((DropTableEvent) event);
+            healthCache.onTopologyChanged();
         } else if (event instanceof DropPartitionEvent) {
             processDropPartition((DropPartitionEvent) event);
+            healthCache.onTopologyChanged();
         } else if (event instanceof SchemaChangeEvent) {
             SchemaChangeEvent schemaChangeEvent = (SchemaChangeEvent) event;
             processSchemaChange(schemaChangeEvent);
@@ -693,8 +710,10 @@ public class CoordinatorEventProcessor implements EventProcessor {
             processDeadCoordinator((DeadCoordinatorEvent) event);
         } else if (event instanceof NewTabletServerEvent) {
             processNewTabletServer((NewTabletServerEvent) event);
+            healthCache.onTabletServerRegistered();
         } else if (event instanceof DeadTabletServerEvent) {
             processDeadTabletServer((DeadTabletServerEvent) event);
+            healthCache.onTabletServerDied();
         } else if (event instanceof AdjustIsrReceivedEvent) {
             AdjustIsrReceivedEvent adjustIsrReceivedEvent = (AdjustIsrReceivedEvent) event;
             CompletableFuture<AdjustIsrResponse> callback =
@@ -733,12 +752,21 @@ public class CoordinatorEventProcessor implements EventProcessor {
             AddServerTagEvent addServerTagEvent = (AddServerTagEvent) event;
             completeFromCallable(
                     addServerTagEvent.getRespCallback(),
-                    () -> processAddServerTag(addServerTagEvent));
+                    () -> {
+                        AddServerTagResponse response = processAddServerTag(addServerTagEvent);
+                        healthCache.onTopologyChanged();
+                        return response;
+                    });
         } else if (event instanceof RemoveServerTagEvent) {
             RemoveServerTagEvent removeServerTagEvent = (RemoveServerTagEvent) event;
             completeFromCallable(
                     removeServerTagEvent.getRespCallback(),
-                    () -> processRemoveServerTag(removeServerTagEvent));
+                    () -> {
+                        RemoveServerTagResponse response =
+                                processRemoveServerTag(removeServerTagEvent);
+                        healthCache.onTopologyChanged();
+                        return response;
+                    });
         } else if (event instanceof RebalanceEvent) {
             RebalanceEvent rebalanceEvent = (RebalanceEvent) event;
             completeFromCallable(
@@ -1790,6 +1818,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
 
             // A2. Set RS = TRS, AR = [], RR = [] in memory.
             coordinatorContext.updateBucketReplicaAssignment(tableBucket, reassignment.replicas);
+            healthCache.onTopologyChanged();
             updateReplicaAssignmentForBucket(tableBucket, reassignment.replicas);
 
             // A3. replicas in AR -> NewReplica
@@ -1815,6 +1844,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
             maybeReassignedBucketLeaderIfRequired(tableBucket, targetReplicas);
             // B3. Set RS = TRS, AR = [], RR = [] in memory.
             coordinatorContext.updateBucketReplicaAssignment(tableBucket, targetReplicas);
+            healthCache.onTopologyChanged();
             // B4. Re-send LeaderAndIsr request with new leader and a new RS (using TRS) and same
             // isr to every tabletServer in TRS.
             updateBucketEpochAndSendRequest(tableBucket, targetReplicas);
@@ -1991,7 +2021,14 @@ public class CoordinatorEventProcessor implements EventProcessor {
         }
 
         // update coordinator leader and isr cache.
-        newLeaderAndIsrList.forEach(coordinatorContext::putBucketLeaderAndIsr);
+        newLeaderAndIsrList.forEach(
+                (tableBucket, newLeaderAndIsr) -> {
+                    coordinatorContext.putBucketLeaderAndIsr(tableBucket, newLeaderAndIsr);
+                    healthCache.onBucketLeaderAndIsrChanged(
+                            tableBucket,
+                            coordinatorContext.getAssignment(tableBucket),
+                            Optional.of(newLeaderAndIsr));
+                });
 
         // First, try to judge whether the bucket is in rebalance task when isr change.
         newLeaderAndIsrList.keySet().forEach(this::tryToCompleteRebalanceTaskOnLeaderAndIsrChange);
@@ -2552,6 +2589,10 @@ public class CoordinatorEventProcessor implements EventProcessor {
         LeaderAndIsr newLeaderAndIsr = leaderAndIsr.newLeaderAndIsr(leaderAndIsr.isr());
 
         coordinatorContext.putBucketLeaderAndIsr(tableBucket, newLeaderAndIsr);
+        healthCache.onBucketLeaderAndIsrChanged(
+                tableBucket,
+                coordinatorContext.getAssignment(tableBucket),
+                Optional.of(newLeaderAndIsr));
         zooKeeperClient.updateLeaderAndIsr(
                 tableBucket, newLeaderAndIsr, coordinatorContext.getCoordinatorZkVersion());
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -513,7 +513,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
         // relevant mutation lands. Bulk-loading buckets above does not mark it dirty on purpose
         // (that would mean one dirty-mark per bucket during startup, for no benefit); this single
         // explicit refresh covers it instead.
-        healthCache.update(coordinatorContext);
+        healthCache.refresh(coordinatorContext, true);
 
         // Auto-partition initialization schedules creation checks immediately. Start it only after
         // the observed KV leader replica count and live tablet server resources are restored.

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -333,14 +333,10 @@ public class CoordinatorEventProcessor implements EventProcessor {
 
         lifecycleThrottler.start();
 
-        // start table manager -- this drives leader election (replicaStateMachine.startup(),
-        // tableBucketStateMachine.startup()); everything before this point (bulk load above,
-        // watchers) never touched the health-cache listener, which is still the default NO_OP.
+        // start table manager -- this triggers leader election
         tableManager.startup();
 
-        // Now wire up the listener and do the one explicit warm-up: from here on, every
-        // steady-state mutation reaches healthCache automatically, and the first published
-        // snapshot correctly reflects post-election state rather than a pre-election artifact.
+        // wire up the listener only after election, so the first snapshot isn't pre-election
         coordinatorContext.setListener(healthCache);
         healthCache.refresh(coordinatorContext);
 
@@ -517,12 +513,6 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 tabletServerInfoList,
                 coordinatorContext.getServerTags());
         updateTabletServerMetadataCacheWhenStartup(tabletServerInfoList);
-        // healthCache.setListener()/warm-up deliberately do NOT happen here: bulk-loading buckets
-        // above must not mark it dirty (one dirty-mark per bucket during startup, for no benefit),
-        // and leader election (tableManager.startup(), driven from
-        // CoordinatorEventProcessor#startup)
-        // hasn't run yet at this point -- warming up now would publish a pre-election snapshot. See
-        // #startup() for where the listener is actually wired up and the warm-up actually happens.
 
         // Auto-partition initialization schedules creation checks immediately. Start it only after
         // the observed KV leader replica count and live tablet server resources are restored.

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -333,8 +333,16 @@ public class CoordinatorEventProcessor implements EventProcessor {
 
         lifecycleThrottler.start();
 
-        // start table manager
+        // start table manager -- this drives leader election (replicaStateMachine.startup(),
+        // tableBucketStateMachine.startup()); everything before this point (bulk load above,
+        // watchers) never touched the health-cache listener, which is still the default NO_OP.
         tableManager.startup();
+
+        // Now wire up the listener and do the one explicit warm-up: from here on, every
+        // steady-state mutation reaches healthCache automatically, and the first published
+        // snapshot correctly reflects post-election state rather than a pre-election artifact.
+        coordinatorContext.setListener(healthCache);
+        healthCache.refresh(coordinatorContext);
 
         // start the event manager which will then process the event
         coordinatorEventManager.start();
@@ -509,11 +517,12 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 tabletServerInfoList,
                 coordinatorContext.getServerTags());
         updateTabletServerMetadataCacheWhenStartup(tabletServerInfoList);
-        // Warm the health cache once, unconditionally, so it isn't empty before the first
-        // relevant mutation lands. Bulk-loading buckets above does not mark it dirty on purpose
-        // (that would mean one dirty-mark per bucket during startup, for no benefit); this single
-        // explicit refresh covers it instead.
-        healthCache.refresh(coordinatorContext, true);
+        // healthCache.setListener()/warm-up deliberately do NOT happen here: bulk-loading buckets
+        // above must not mark it dirty (one dirty-mark per bucket during startup, for no benefit),
+        // and leader election (tableManager.startup(), driven from
+        // CoordinatorEventProcessor#startup)
+        // hasn't run yet at this point -- warming up now would publish a pre-election snapshot. See
+        // #startup() for where the listener is actually wired up and the warm-up actually happens.
 
         // Auto-partition initialization schedules creation checks immediately. Start it only after
         // the observed KV leader replica count and live tablet server resources are restored.
@@ -682,16 +691,12 @@ public class CoordinatorEventProcessor implements EventProcessor {
     public void process(CoordinatorEvent event) {
         if (event instanceof CreateTableEvent) {
             processCreateTable((CreateTableEvent) event);
-            healthCache.onTopologyChanged();
         } else if (event instanceof CreatePartitionEvent) {
             processCreatePartition((CreatePartitionEvent) event);
-            healthCache.onTopologyChanged();
         } else if (event instanceof DropTableEvent) {
             processDropTable((DropTableEvent) event);
-            healthCache.onTopologyChanged();
         } else if (event instanceof DropPartitionEvent) {
             processDropPartition((DropPartitionEvent) event);
-            healthCache.onTopologyChanged();
         } else if (event instanceof SchemaChangeEvent) {
             SchemaChangeEvent schemaChangeEvent = (SchemaChangeEvent) event;
             processSchemaChange(schemaChangeEvent);
@@ -710,10 +715,8 @@ public class CoordinatorEventProcessor implements EventProcessor {
             processDeadCoordinator((DeadCoordinatorEvent) event);
         } else if (event instanceof NewTabletServerEvent) {
             processNewTabletServer((NewTabletServerEvent) event);
-            healthCache.onTabletServerRegistered();
         } else if (event instanceof DeadTabletServerEvent) {
             processDeadTabletServer((DeadTabletServerEvent) event);
-            healthCache.onTabletServerDied();
         } else if (event instanceof AdjustIsrReceivedEvent) {
             AdjustIsrReceivedEvent adjustIsrReceivedEvent = (AdjustIsrReceivedEvent) event;
             CompletableFuture<AdjustIsrResponse> callback =
@@ -752,21 +755,12 @@ public class CoordinatorEventProcessor implements EventProcessor {
             AddServerTagEvent addServerTagEvent = (AddServerTagEvent) event;
             completeFromCallable(
                     addServerTagEvent.getRespCallback(),
-                    () -> {
-                        AddServerTagResponse response = processAddServerTag(addServerTagEvent);
-                        healthCache.onTopologyChanged();
-                        return response;
-                    });
+                    () -> processAddServerTag(addServerTagEvent));
         } else if (event instanceof RemoveServerTagEvent) {
             RemoveServerTagEvent removeServerTagEvent = (RemoveServerTagEvent) event;
             completeFromCallable(
                     removeServerTagEvent.getRespCallback(),
-                    () -> {
-                        RemoveServerTagResponse response =
-                                processRemoveServerTag(removeServerTagEvent);
-                        healthCache.onTopologyChanged();
-                        return response;
-                    });
+                    () -> processRemoveServerTag(removeServerTagEvent));
         } else if (event instanceof RebalanceEvent) {
             RebalanceEvent rebalanceEvent = (RebalanceEvent) event;
             completeFromCallable(
@@ -1390,7 +1384,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
         coordinatorContext.removeOfflineBucketInServer(tabletServerId);
 
         coordinatorContext.removeLiveTabletServer(tabletServerId);
-        coordinatorContext.shuttingDownTabletServers().remove(tabletServerId);
+        coordinatorContext.clearShuttingDown(tabletServerId);
         coordinatorChannelManager.removeTabletServer(tabletServerId);
 
         // Here, we will first update alive tabletServer info for all tabletServers and
@@ -1818,7 +1812,6 @@ public class CoordinatorEventProcessor implements EventProcessor {
 
             // A2. Set RS = TRS, AR = [], RR = [] in memory.
             coordinatorContext.updateBucketReplicaAssignment(tableBucket, reassignment.replicas);
-            healthCache.onTopologyChanged();
             updateReplicaAssignmentForBucket(tableBucket, reassignment.replicas);
 
             // A3. replicas in AR -> NewReplica
@@ -1844,7 +1837,6 @@ public class CoordinatorEventProcessor implements EventProcessor {
             maybeReassignedBucketLeaderIfRequired(tableBucket, targetReplicas);
             // B3. Set RS = TRS, AR = [], RR = [] in memory.
             coordinatorContext.updateBucketReplicaAssignment(tableBucket, targetReplicas);
-            healthCache.onTopologyChanged();
             // B4. Re-send LeaderAndIsr request with new leader and a new RS (using TRS) and same
             // isr to every tabletServer in TRS.
             updateBucketEpochAndSendRequest(tableBucket, targetReplicas);
@@ -2021,14 +2013,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
         }
 
         // update coordinator leader and isr cache.
-        newLeaderAndIsrList.forEach(
-                (tableBucket, newLeaderAndIsr) -> {
-                    coordinatorContext.putBucketLeaderAndIsr(tableBucket, newLeaderAndIsr);
-                    healthCache.onBucketLeaderAndIsrChanged(
-                            tableBucket,
-                            coordinatorContext.getAssignment(tableBucket),
-                            Optional.of(newLeaderAndIsr));
-                });
+        newLeaderAndIsrList.forEach(coordinatorContext::putBucketLeaderAndIsr);
 
         // First, try to judge whether the bucket is in rebalance task when isr change.
         newLeaderAndIsrList.keySet().forEach(this::tryToCompleteRebalanceTaskOnLeaderAndIsrChange);
@@ -2404,7 +2389,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
                     "TabletServer" + tabletServerId + " is not available.");
         }
 
-        coordinatorContext.shuttingDownTabletServers().add(tabletServerId);
+        coordinatorContext.markShuttingDown(tabletServerId);
         LOG.debug(
                 "All shutting down tabletServers: {}",
                 coordinatorContext.shuttingDownTabletServers());
@@ -2589,10 +2574,6 @@ public class CoordinatorEventProcessor implements EventProcessor {
         LeaderAndIsr newLeaderAndIsr = leaderAndIsr.newLeaderAndIsr(leaderAndIsr.isr());
 
         coordinatorContext.putBucketLeaderAndIsr(tableBucket, newLeaderAndIsr);
-        healthCache.onBucketLeaderAndIsrChanged(
-                tableBucket,
-                coordinatorContext.getAssignment(tableBucket),
-                Optional.of(newLeaderAndIsr));
         zooKeeperClient.updateLeaderAndIsr(
                 tableBucket, newLeaderAndIsr, coordinatorContext.getCoordinatorZkVersion());
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorHealthCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorHealthCache.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator;
+
+import org.apache.fluss.annotation.VisibleForTesting;
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.server.utils.CoalescingRefreshCache;
+import org.apache.fluss.server.zk.data.LeaderAndIsr;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+/**
+ * A copy-on-write cache of cluster/per-tablet-server replica and leader health, derived from {@link
+ * CoordinatorContext}.
+ *
+ * <p>This mirrors the pattern {@code CoordinatorMetadataCache} already uses for server topology: a
+ * single {@code volatile} immutable {@link ClusterHealthSnapshot}, recomputed and swapped by the
+ * coordinator event thread, and read lock-free by any thread via {@link #getSnapshot()} without
+ * going through {@code AccessContextEvent}. The copy-on-write and coalescing mechanics themselves
+ * live in {@link CoalescingRefreshCache}, shared with (or reusable by) any other coordinator-local
+ * derived view that wants the same "callers report facts, this decides when to act" shape.
+ *
+ * <p>Callers report state transitions through the {@code onXxx} methods below; this class alone
+ * decides whether a transition is urgent (should be reflected almost immediately) or can be batched
+ * (reflected the next time the coordinator event queue drains). Callers never see or decide urgency
+ * themselves — they only report what changed. Recomputing the snapshot is still an {@code
+ * O(buckets)} scan, same as {@code CoordinatorService#computeClusterHealth} and {@code
+ * #computeTabletServerLoads} today; what changes is how often that scan runs and who waits for it,
+ * not its cost.
+ *
+ * <p>{@link #refreshIfNeeded(CoordinatorContext, boolean)} must only be called from the coordinator
+ * event thread, since {@code CoordinatorContext} is not thread-safe -- see {@link
+ * CoalescingRefreshCache}'s javadoc for the single-writer-thread assumption this relies on.
+ */
+public final class CoordinatorHealthCache {
+
+    /**
+     * Upper bound on how long an urgent (degrading) change may sit unreflected while the event
+     * queue keeps draining new work. Bounds worst-case staleness for a safety-relevant signal
+     * without forcing a full rescan after every single event in a burst.
+     */
+    @VisibleForTesting static final long URGENT_MAX_DELAY_MS = 200;
+
+    private final CoalescingRefreshCache<ClusterHealthSnapshot> cache =
+            new CoalescingRefreshCache<>(ClusterHealthSnapshot.EMPTY, URGENT_MAX_DELAY_MS);
+
+    // --------------------------------------------------------------------------------------------
+    // Reporting: callers state facts, this class decides what they mean.
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Reports the current (post-mutation) leader/ISR state for a bucket. Under-replication or a
+     * missing leader is treated as urgent; anything else is batched.
+     */
+    public void onBucketLeaderAndIsrChanged(
+            TableBucket tableBucket, List<Integer> assignment, Optional<LeaderAndIsr> current) {
+        boolean underReplicated =
+                current.map(lai -> lai.isr().size() < assignment.size()).orElse(true);
+        boolean leaderless =
+                current.map(lai -> lai.leader() == LeaderAndIsr.NO_LEADER).orElse(true);
+        cache.markDirty(underReplicated || leaderless);
+    }
+
+    /** Reports that a bucket's leader became active or inactive. Inactive is urgent. */
+    public void onLeaderActivityChanged(boolean isActive) {
+        cache.markDirty(!isActive);
+    }
+
+    /** A tablet server died. Always urgent -- it can only make things worse. */
+    public void onTabletServerDied() {
+        cache.markDirty(true);
+    }
+
+    /** A tablet server registered (startup or rejoin). Never urgent. */
+    public void onTabletServerRegistered() {
+        cache.markDirty(false);
+    }
+
+    /**
+     * Catch-all for topology changes that don't represent degradation: table/partition
+     * create-delete, replica reassignment, server tag add/remove.
+     */
+    public void onTopologyChanged() {
+        cache.markDirty(false);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Refresh policy: the decision of when to act lives in CoalescingRefreshCache; the decision of
+    // what "urgent" means for this data (above) and how to compute a snapshot (below) live here.
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Recomputes and republishes the snapshot if, and only if, the accumulated changes since the
+     * last refresh warrant it: a non-urgent change waits for the event queue to fully drain
+     * (coalescing an arbitrarily large burst of mutations into one scan); an urgent change is still
+     * coalesced, but bounded by {@link #URGENT_MAX_DELAY_MS} regardless of queue state.
+     *
+     * @param queueIsEmpty whether the coordinator event queue currently has no more events waiting
+     *     -- the caller (the event loop) is the only one who knows this.
+     */
+    public void refreshIfNeeded(CoordinatorContext ctx, boolean queueIsEmpty) {
+        cache.refreshIfNeeded(() -> computeSnapshot(ctx), queueIsEmpty);
+    }
+
+    /**
+     * Unconditionally recomputes the health snapshot from the given context and atomically
+     * publishes it, regardless of dirty/urgent state. Intended for an explicit warm-up (e.g. right
+     * after the coordinator finishes loading its initial state) and for tests that want to bypass
+     * the refresh policy; the coordinator event loop should use {@link
+     * #refreshIfNeeded(CoordinatorContext, boolean)} instead.
+     *
+     * <p>Must only be called from a thread that safely owns {@code ctx} (i.e. the coordinator event
+     * thread) — {@code ctx} itself is not thread-safe.
+     */
+    public void update(CoordinatorContext ctx) {
+        cache.update(() -> computeSnapshot(ctx));
+    }
+
+    /** Returns the most recently published snapshot. Safe to call from any thread. */
+    public ClusterHealthSnapshot getSnapshot() {
+        return cache.get();
+    }
+
+    @VisibleForTesting
+    boolean isDirty() {
+        return cache.isDirty();
+    }
+
+    @VisibleForTesting
+    boolean isUrgentlyDirty() {
+        return cache.isUrgentlyDirty();
+    }
+
+    /**
+     * Computes both the cluster-wide aggregates ({@code CoordinatorService#computeClusterHealth}
+     * semantics) and the per-server breakdown ({@code CoordinatorService#computeTabletServerLoads}
+     * semantics) from a single pass over {@code ctx.getAllBuckets()}, instead of one pass per view.
+     */
+    private static ClusterHealthSnapshot computeSnapshot(CoordinatorContext ctx) {
+        Map<Integer, MutableLoad> loads = new TreeMap<>();
+        // report live and shutting-down servers even if they host no replicas, so that
+        // an evacuated server explicitly shows zero replicas
+        for (int serverId : ctx.liveOrShuttingDownTabletServers()) {
+            getOrCreate(loads, serverId);
+        }
+
+        int numReplicas = 0;
+        int inSyncReplicas = 0;
+        int numLeaderReplicas = 0;
+        int activeLeaderReplicas = 0;
+
+        for (TableBucket tb : ctx.getAllBuckets()) {
+            List<Integer> assignment = ctx.getAssignment(tb);
+            numReplicas += assignment.size();
+            // matches CoordinatorService#computeClusterHealth: counts buckets, not leaders
+            numLeaderReplicas++;
+            for (int serverId : assignment) {
+                getOrCreate(loads, serverId).numReplicas++;
+            }
+
+            boolean leaderActive = ctx.isLeaderActive(tb);
+            if (leaderActive) {
+                activeLeaderReplicas++;
+            }
+
+            Optional<LeaderAndIsr> laiOpt = ctx.getBucketLeaderAndIsr(tb);
+            if (laiOpt.isPresent()) {
+                LeaderAndIsr lai = laiOpt.get();
+                inSyncReplicas += lai.isr().size();
+                for (int serverId : lai.isr()) {
+                    getOrCreate(loads, serverId).inSyncReplicas++;
+                }
+                if (lai.leader() != LeaderAndIsr.NO_LEADER) {
+                    MutableLoad leaderLoad = getOrCreate(loads, lai.leader());
+                    leaderLoad.numLeaderReplicas++;
+                    if (leaderActive) {
+                        leaderLoad.activeLeaderReplicas++;
+                    }
+                }
+            }
+        }
+
+        Map<Integer, TabletServerLoad> tabletServerLoads = new HashMap<>();
+        for (Map.Entry<Integer, MutableLoad> entry : loads.entrySet()) {
+            tabletServerLoads.put(entry.getKey(), entry.getValue().toImmutable());
+        }
+
+        return new ClusterHealthSnapshot(
+                numReplicas,
+                inSyncReplicas,
+                numLeaderReplicas,
+                activeLeaderReplicas,
+                tabletServerLoads);
+    }
+
+    private static MutableLoad getOrCreate(Map<Integer, MutableLoad> loads, int serverId) {
+        return loads.computeIfAbsent(serverId, MutableLoad::new);
+    }
+
+    /** Short-lived mutable accumulator used only while a snapshot is being computed. */
+    private static final class MutableLoad {
+        private final int serverId;
+        private int numReplicas;
+        private int inSyncReplicas;
+        private int numLeaderReplicas;
+        private int activeLeaderReplicas;
+
+        private MutableLoad(int serverId) {
+            this.serverId = serverId;
+        }
+
+        private TabletServerLoad toImmutable() {
+            return new TabletServerLoad(
+                    serverId, numReplicas, inSyncReplicas, numLeaderReplicas, activeLeaderReplicas);
+        }
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorHealthCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorHealthCache.java
@@ -47,8 +47,8 @@ import java.util.TreeMap;
  * #computeTabletServerLoads} today; what changes is how often that scan runs and who waits for it,
  * not its cost.
  *
- * <p>{@link #refreshIfNeeded(CoordinatorContext, boolean)} must only be called from the coordinator
- * event thread, since {@code CoordinatorContext} is not thread-safe -- see {@link
+ * <p>{@link #refresh(CoordinatorContext, boolean)} must only be called from the coordinator event
+ * thread, since {@code CoordinatorContext} is not thread-safe -- see {@link
  * CoalescingRefreshCache}'s javadoc for the single-writer-thread assumption this relies on.
  */
 public final class CoordinatorHealthCache {
@@ -109,30 +109,23 @@ public final class CoordinatorHealthCache {
     // --------------------------------------------------------------------------------------------
 
     /**
-     * Recomputes and republishes the snapshot if, and only if, the accumulated changes since the
-     * last refresh warrant it: a non-urgent change waits for the event queue to fully drain
-     * (coalescing an arbitrarily large burst of mutations into one scan); an urgent change is still
-     * coalesced, but bounded by {@link #URGENT_MAX_DELAY_MS} regardless of queue state.
-     *
-     * @param queueIsEmpty whether the coordinator event queue currently has no more events waiting
-     *     -- the caller (the event loop) is the only one who knows this.
-     */
-    public void refreshIfNeeded(CoordinatorContext ctx, boolean queueIsEmpty) {
-        cache.refreshIfNeeded(() -> computeSnapshot(ctx), queueIsEmpty);
-    }
-
-    /**
-     * Unconditionally recomputes the health snapshot from the given context and atomically
-     * publishes it, regardless of dirty/urgent state. Intended for an explicit warm-up (e.g. right
-     * after the coordinator finishes loading its initial state) and for tests that want to bypass
-     * the refresh policy; the coordinator event loop should use {@link
-     * #refreshIfNeeded(CoordinatorContext, boolean)} instead.
+     * Recomputes and republishes the snapshot if, and only if, something has actually changed since
+     * the last refresh and now is the right time to act on it: a non-urgent change needs {@code
+     * force}; an urgent change is bounded by {@link #URGENT_MAX_DELAY_MS} regardless of {@code
+     * force}. If nothing changed, this is a no-op regardless of {@code force} -- see {@link
+     * CoalescingRefreshCache}'s javadoc for why that check always comes first.
      *
      * <p>Must only be called from a thread that safely owns {@code ctx} (i.e. the coordinator event
      * thread) — {@code ctx} itself is not thread-safe.
+     *
+     * @param force overrides the timing question directly. The coordinator event loop passes
+     *     whether its own event queue is currently empty; an explicit warm-up (e.g. right after the
+     *     coordinator finishes loading its initial state) or a test that wants to bypass the timing
+     *     policy passes {@code true} unconditionally -- which still only takes effect because a
+     *     freshly constructed cache starts dirty.
      */
-    public void update(CoordinatorContext ctx) {
-        cache.update(() -> computeSnapshot(ctx));
+    public void refresh(CoordinatorContext ctx, boolean force) {
+        cache.refresh(() -> computeSnapshot(ctx), force);
     }
 
     /** Returns the most recently published snapshot. Safe to call from any thread. */

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorHealthCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorHealthCache.java
@@ -207,9 +207,6 @@ public final class CoordinatorHealthCache implements CoordinatorContextListener 
                     }
                 }
             }
-            // reconciles the aggregate numLeaderReplicas (a bucket count) against the per-server
-            // breakdown (an actual-leader count): every bucket counted above but not here is one
-            // where computeClusterHealth's aggregate and the per-server sum will diverge.
             if (!hasLeader) {
                 bucketsWithoutLeader++;
             }

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorHealthCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorHealthCache.java
@@ -47,21 +47,35 @@ import java.util.TreeMap;
  * #computeTabletServerLoads} today; what changes is how often that scan runs and who waits for it,
  * not its cost.
  *
- * <p>{@link #refresh(CoordinatorContext, boolean)} must only be called from the coordinator event
- * thread, since {@code CoordinatorContext} is not thread-safe -- see {@link
- * CoalescingRefreshCache}'s javadoc for the single-writer-thread assumption this relies on.
+ * <p>{@link #refresh(CoordinatorContext)} must only be called from the coordinator event thread,
+ * since {@code CoordinatorContext} is not thread-safe -- see {@link CoalescingRefreshCache}'s
+ * javadoc for the single-writer-thread assumption this relies on, and for why rate (these three
+ * bounds) and coverage (the safety net) are deliberately independent mechanisms.
  */
-public final class CoordinatorHealthCache {
+public final class CoordinatorHealthCache implements CoordinatorContextListener {
 
     /**
-     * Upper bound on how long an urgent (degrading) change may sit unreflected while the event
-     * queue keeps draining new work. Bounds worst-case staleness for a safety-relevant signal
-     * without forcing a full rescan after every single event in a burst.
+     * Upper bound on how long an urgent (degrading) change may sit unreflected. Bounds worst-case
+     * staleness for a safety-relevant signal without forcing a full rescan after every single event
+     * in a burst.
      */
     @VisibleForTesting static final long URGENT_MAX_DELAY_MS = 200;
 
+    /** Upper bound on how long a known, non-urgent change may sit unreflected. */
+    @VisibleForTesting static final long NORMAL_MAX_DELAY_MS = 3_000;
+
+    /**
+     * Absolute ceiling on staleness, independent of whether anything was ever reported via an
+     * {@code onXxx} call -- the coverage backstop. See {@link CoalescingRefreshCache}'s javadoc.
+     */
+    @VisibleForTesting static final long SAFETY_NET_MAX_DELAY_MS = 10_000;
+
     private final CoalescingRefreshCache<ClusterHealthSnapshot> cache =
-            new CoalescingRefreshCache<>(ClusterHealthSnapshot.EMPTY, URGENT_MAX_DELAY_MS);
+            new CoalescingRefreshCache<>(
+                    ClusterHealthSnapshot.EMPTY,
+                    URGENT_MAX_DELAY_MS,
+                    NORMAL_MAX_DELAY_MS,
+                    SAFETY_NET_MAX_DELAY_MS);
 
     // --------------------------------------------------------------------------------------------
     // Reporting: callers state facts, this class decides what they mean.
@@ -71,6 +85,7 @@ public final class CoordinatorHealthCache {
      * Reports the current (post-mutation) leader/ISR state for a bucket. Under-replication or a
      * missing leader is treated as urgent; anything else is batched.
      */
+    @Override
     public void onBucketLeaderAndIsrChanged(
             TableBucket tableBucket, List<Integer> assignment, Optional<LeaderAndIsr> current) {
         boolean underReplicated =
@@ -81,16 +96,19 @@ public final class CoordinatorHealthCache {
     }
 
     /** Reports that a bucket's leader became active or inactive. Inactive is urgent. */
+    @Override
     public void onLeaderActivityChanged(boolean isActive) {
         cache.markDirty(!isActive);
     }
 
     /** A tablet server died. Always urgent -- it can only make things worse. */
+    @Override
     public void onTabletServerDied() {
         cache.markDirty(true);
     }
 
     /** A tablet server registered (startup or rejoin). Never urgent. */
+    @Override
     public void onTabletServerRegistered() {
         cache.markDirty(false);
     }
@@ -99,6 +117,7 @@ public final class CoordinatorHealthCache {
      * Catch-all for topology changes that don't represent degradation: table/partition
      * create-delete, replica reassignment, server tag add/remove.
      */
+    @Override
     public void onTopologyChanged() {
         cache.markDirty(false);
     }
@@ -109,23 +128,18 @@ public final class CoordinatorHealthCache {
     // --------------------------------------------------------------------------------------------
 
     /**
-     * Recomputes and republishes the snapshot if, and only if, something has actually changed since
-     * the last refresh and now is the right time to act on it: a non-urgent change needs {@code
-     * force}; an urgent change is bounded by {@link #URGENT_MAX_DELAY_MS} regardless of {@code
-     * force}. If nothing changed, this is a no-op regardless of {@code force} -- see {@link
-     * CoalescingRefreshCache}'s javadoc for why that check always comes first.
+     * Recomputes and republishes the snapshot if it's due: a known change (urgent or not) is
+     * reflected within {@link #URGENT_MAX_DELAY_MS}/{@link #NORMAL_MAX_DELAY_MS}; an unconditional
+     * {@link #SAFETY_NET_MAX_DELAY_MS} ceiling guarantees a bound on staleness even for a mutation
+     * path nobody remembered to report through an {@code onXxx} call. Call this from the
+     * coordinator event loop on every tick -- it's cheap (one elapsed-time check) when nothing is
+     * due.
      *
      * <p>Must only be called from a thread that safely owns {@code ctx} (i.e. the coordinator event
      * thread) — {@code ctx} itself is not thread-safe.
-     *
-     * @param force overrides the timing question directly. The coordinator event loop passes
-     *     whether its own event queue is currently empty; an explicit warm-up (e.g. right after the
-     *     coordinator finishes loading its initial state) or a test that wants to bypass the timing
-     *     policy passes {@code true} unconditionally -- which still only takes effect because a
-     *     freshly constructed cache starts dirty.
      */
-    public void refresh(CoordinatorContext ctx, boolean force) {
-        cache.refresh(() -> computeSnapshot(ctx), force);
+    public void refresh(CoordinatorContext ctx) {
+        cache.refresh(() -> computeSnapshot(ctx));
     }
 
     /** Returns the most recently published snapshot. Safe to call from any thread. */
@@ -160,6 +174,7 @@ public final class CoordinatorHealthCache {
         int inSyncReplicas = 0;
         int numLeaderReplicas = 0;
         int activeLeaderReplicas = 0;
+        int bucketsWithoutLeader = 0;
 
         for (TableBucket tb : ctx.getAllBuckets()) {
             List<Integer> assignment = ctx.getAssignment(tb);
@@ -176,6 +191,7 @@ public final class CoordinatorHealthCache {
             }
 
             Optional<LeaderAndIsr> laiOpt = ctx.getBucketLeaderAndIsr(tb);
+            boolean hasLeader = false;
             if (laiOpt.isPresent()) {
                 LeaderAndIsr lai = laiOpt.get();
                 inSyncReplicas += lai.isr().size();
@@ -183,12 +199,19 @@ public final class CoordinatorHealthCache {
                     getOrCreate(loads, serverId).inSyncReplicas++;
                 }
                 if (lai.leader() != LeaderAndIsr.NO_LEADER) {
+                    hasLeader = true;
                     MutableLoad leaderLoad = getOrCreate(loads, lai.leader());
                     leaderLoad.numLeaderReplicas++;
                     if (leaderActive) {
                         leaderLoad.activeLeaderReplicas++;
                     }
                 }
+            }
+            // reconciles the aggregate numLeaderReplicas (a bucket count) against the per-server
+            // breakdown (an actual-leader count): every bucket counted above but not here is one
+            // where computeClusterHealth's aggregate and the per-server sum will diverge.
+            if (!hasLeader) {
+                bucketsWithoutLeader++;
             }
         }
 
@@ -202,6 +225,7 @@ public final class CoordinatorHealthCache {
                 inSyncReplicas,
                 numLeaderReplicas,
                 activeLeaderReplicas,
+                bucketsWithoutLeader,
                 tabletServerLoads);
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/TabletServerLoad.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/TabletServerLoad.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator;
+
+import java.util.Objects;
+
+/**
+ * An immutable, point-in-time replica/leader load for a single tablet server, derived from {@link
+ * CoordinatorContext}'s bucket assignment and leader/ISR state.
+ *
+ * @see ClusterHealthSnapshot
+ */
+public final class TabletServerLoad {
+
+    private final int serverId;
+    private final int numReplicas;
+    private final int inSyncReplicas;
+    private final int numLeaderReplicas;
+    private final int activeLeaderReplicas;
+
+    TabletServerLoad(
+            int serverId,
+            int numReplicas,
+            int inSyncReplicas,
+            int numLeaderReplicas,
+            int activeLeaderReplicas) {
+        this.serverId = serverId;
+        this.numReplicas = numReplicas;
+        this.inSyncReplicas = inSyncReplicas;
+        this.numLeaderReplicas = numLeaderReplicas;
+        this.activeLeaderReplicas = activeLeaderReplicas;
+    }
+
+    public int serverId() {
+        return serverId;
+    }
+
+    public int numReplicas() {
+        return numReplicas;
+    }
+
+    public int inSyncReplicas() {
+        return inSyncReplicas;
+    }
+
+    public int numLeaderReplicas() {
+        return numLeaderReplicas;
+    }
+
+    public int activeLeaderReplicas() {
+        return activeLeaderReplicas;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TabletServerLoad)) {
+            return false;
+        }
+        TabletServerLoad that = (TabletServerLoad) o;
+        return serverId == that.serverId
+                && numReplicas == that.numReplicas
+                && inSyncReplicas == that.inSyncReplicas
+                && numLeaderReplicas == that.numLeaderReplicas
+                && activeLeaderReplicas == that.activeLeaderReplicas;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                serverId, numReplicas, inSyncReplicas, numLeaderReplicas, activeLeaderReplicas);
+    }
+
+    @Override
+    public String toString() {
+        return "TabletServerLoad{"
+                + "serverId="
+                + serverId
+                + ", numReplicas="
+                + numReplicas
+                + ", inSyncReplicas="
+                + inSyncReplicas
+                + ", numLeaderReplicas="
+                + numLeaderReplicas
+                + ", activeLeaderReplicas="
+                + activeLeaderReplicas
+                + '}';
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
@@ -287,7 +287,7 @@ public final class CoordinatorEventManager implements EventManager {
             // sooner only if healthCache itself decided a change was urgent. No AccessContextEvent
             // needed -- this thread already owns coordinatorContext directly.
             if (coordinatorContext != null) {
-                healthCache.refreshIfNeeded(coordinatorContext, queue.isEmpty());
+                healthCache.refresh(coordinatorContext, queue.isEmpty());
             }
 
             // Use poll with timeout instead of blocking take() so that the thread

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
@@ -24,6 +24,7 @@ import org.apache.fluss.metrics.DescriptiveStatisticsHistogram;
 import org.apache.fluss.metrics.Histogram;
 import org.apache.fluss.metrics.MetricNames;
 import org.apache.fluss.server.coordinator.CoordinatorContext;
+import org.apache.fluss.server.coordinator.CoordinatorHealthCache;
 import org.apache.fluss.server.coordinator.statemachine.ReplicaState;
 import org.apache.fluss.server.metrics.group.CoordinatorEventMetricGroup;
 import org.apache.fluss.server.metrics.group.CoordinatorMetricGroup;
@@ -31,6 +32,8 @@ import org.apache.fluss.utils.concurrent.ShutdownableThread;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -54,6 +57,8 @@ public final class CoordinatorEventManager implements EventManager {
 
     private final EventProcessor eventProcessor;
     private final CoordinatorMetricGroup coordinatorMetricGroup;
+    private final @Nullable CoordinatorContext coordinatorContext;
+    private final CoordinatorHealthCache healthCache;
 
     private final LinkedBlockingQueue<QueuedEvent> queue = new LinkedBlockingQueue<>();
     private final CoordinatorEventThread thread =
@@ -84,7 +89,22 @@ public final class CoordinatorEventManager implements EventManager {
 
     public CoordinatorEventManager(
             EventProcessor eventProcessor, CoordinatorMetricGroup coordinatorMetricGroup) {
+        this(eventProcessor, null, new CoordinatorHealthCache(), coordinatorMetricGroup);
+    }
+
+    /**
+     * @param coordinatorContext used to coalesce-refresh {@code healthCache} from the event
+     *     thread's own loop; {@code null} disables that refresh entirely (used by callers, e.g.
+     *     tests, that only care about the metrics-polling behavior of this class).
+     */
+    public CoordinatorEventManager(
+            EventProcessor eventProcessor,
+            @Nullable CoordinatorContext coordinatorContext,
+            CoordinatorHealthCache healthCache,
+            CoordinatorMetricGroup coordinatorMetricGroup) {
         this.eventProcessor = eventProcessor;
+        this.coordinatorContext = coordinatorContext;
+        this.healthCache = healthCache;
         this.coordinatorMetricGroup = coordinatorMetricGroup;
         registerMetrics();
     }
@@ -261,6 +281,13 @@ public final class CoordinatorEventManager implements EventManager {
             if (currentTime - lastMetricsUpdateTime >= METRICS_UPDATE_INTERVAL_MS) {
                 updateMetricsViaAccessContext();
                 lastMetricsUpdateTime = currentTime;
+            }
+
+            // Coalesce health-cache refreshes the same way: at most once per drained queue,
+            // sooner only if healthCache itself decided a change was urgent. No AccessContextEvent
+            // needed -- this thread already owns coordinatorContext directly.
+            if (coordinatorContext != null) {
+                healthCache.refreshIfNeeded(coordinatorContext, queue.isEmpty());
             }
 
             // Use poll with timeout instead of blocking take() so that the thread

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
@@ -283,11 +283,12 @@ public final class CoordinatorEventManager implements EventManager {
                 lastMetricsUpdateTime = currentTime;
             }
 
-            // Coalesce health-cache refreshes the same way: at most once per drained queue,
-            // sooner only if healthCache itself decided a change was urgent. No AccessContextEvent
-            // needed -- this thread already owns coordinatorContext directly.
+            // healthCache owns its own refresh policy entirely -- rate (via dirty/urgentDirty) and
+            // coverage (an unconditional safety-net ceiling) are both internal to it, so this loop
+            // has nothing to report beyond "tick". No AccessContextEvent needed -- this thread
+            // already owns coordinatorContext directly.
             if (coordinatorContext != null) {
-                healthCache.refresh(coordinatorContext, queue.isEmpty());
+                healthCache.refresh(coordinatorContext);
             }
 
             // Use poll with timeout instead of blocking take() so that the thread

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
@@ -283,10 +283,8 @@ public final class CoordinatorEventManager implements EventManager {
                 lastMetricsUpdateTime = currentTime;
             }
 
-            // healthCache owns its own refresh policy entirely -- rate (via dirty/urgentDirty) and
-            // coverage (an unconditional safety-net ceiling) are both internal to it, so this loop
-            // has nothing to report beyond "tick". No AccessContextEvent needed -- this thread
-            // already owns coordinatorContext directly.
+            // healthCache owns its own refresh policy; this loop just ticks it. No
+            // AccessContextEvent needed -- this thread already owns coordinatorContext directly.
             if (coordinatorContext != null) {
                 healthCache.refresh(coordinatorContext);
             }

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/CoalescingRefreshCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/CoalescingRefreshCache.java
@@ -34,18 +34,30 @@ import static org.apache.fluss.utils.concurrent.LockUtils.inLock;
  * recompute.
  *
  * <p>Callers report that something changed via {@link #markDirty(boolean)}; whether that change was
- * urgent affects only how soon {@link #refreshIfNeeded} is willing to act on it -- a non-urgent
- * change waits for the caller-supplied {@code idle} signal (e.g. an empty work queue); an urgent
- * one is bounded by {@code urgentMaxDelayMs} regardless of that signal, so a safety- or
- * correctness-relevant change can't be starved by an owner that never goes idle. Either way, the
- * eventual recompute is always a full recompute from the supplied {@link Supplier}, never
- * incremental -- a wrong or missed {@code markDirty} call costs at worst one extra recompute, it
- * never leaves the published value permanently wrong.
+ * urgent affects only how soon {@link #refresh} is willing to act on it. The {@code force} flag on
+ * {@link #refresh} lets a caller override the timing question directly -- typically because it
+ * knows something this class doesn't, e.g. that its own work queue is currently empty, so a
+ * non-urgent change is now welcome to be acted on. An urgent change doesn't need the caller's help:
+ * it's bounded by {@code urgentMaxDelayMs} regardless of {@code force}, so a safety- or
+ * correctness-relevant change can't be starved by an owner that never passes {@code force=true}.
  *
- * <p>{@link #markDirty}, {@link #refreshIfNeeded}, and {@link #update} must all be called from a
- * single owning thread; this class does no locking on that side, matching the assumption that
- * whoever computes the new value also holds whatever non-thread-safe source that computation reads
- * from. Only {@link #get()} is safe to call from any thread.
+ * <p>Crucially, {@code force} only ever overrides the <em>timing</em> gate, never the {@code dirty}
+ * gate: {@link #refresh} always checks "did anything actually change" first, unconditionally,
+ * before considering {@code force} at all. This is what keeps a quiet caller's cost at one boolean
+ * check per call -- if {@code force} skipped that check too, a caller that happens to be idle most
+ * of the time (the common case) would pay for a full recompute on every single call, whether or not
+ * anything had changed. A freshly constructed cache starts {@code dirty}, since it hasn't computed
+ * a real value yet -- that's what lets a one-time forced warm-up work without needing {@code force}
+ * to bypass the dirty check.
+ *
+ * <p>Either way, the eventual recompute is always a full recompute from the supplied {@link
+ * Supplier}, never incremental -- a wrong or missed {@code markDirty} call costs at worst one extra
+ * recompute, it never leaves the published value permanently wrong.
+ *
+ * <p>{@link #markDirty} and {@link #refresh} must both be called from a single owning thread; this
+ * class does no locking on that side, matching the assumption that whoever computes the new value
+ * also holds whatever non-thread-safe source that computation reads from. Only {@link #get()} is
+ * safe to call from any thread.
  *
  * @param <T> the type of the derived, immutable snapshot value
  */
@@ -60,7 +72,8 @@ public final class CoalescingRefreshCache<T> {
     private volatile T value;
 
     // only ever touched from the single owning thread -- see class javadoc.
-    private boolean dirty;
+    // starts true: a freshly constructed cache hasn't computed a real value yet.
+    private boolean dirty = true;
     private boolean urgentDirty;
     private long lastRefreshTimeMs = System.currentTimeMillis();
 
@@ -78,31 +91,27 @@ public final class CoalescingRefreshCache<T> {
     }
 
     /**
-     * Recomputes and republishes the value via {@code compute}, if and only if the accumulated
-     * changes since the last refresh warrant it right now.
+     * Recomputes and republishes the value via {@code compute}, if and only if something has
+     * actually changed since the last refresh <em>and</em> now is the right time to act on it.
      *
      * @param compute recomputes the value from scratch; only invoked if a refresh is due.
-     * @param idle whether the owning thread's other work is currently caught up. A non-urgent
-     *     change waits for this to be {@code true}; an urgent one is bounded by {@code
-     *     urgentMaxDelayMs} regardless.
+     * @param force overrides the timing question directly -- pass {@code true} when the caller
+     *     already knows now is a good time (e.g. its own work queue is empty), or to force an
+     *     unconditional warm-up. Never overrides the {@code dirty} check: if nothing changed, this
+     *     is a no-op regardless of {@code force}.
      */
-    public void refreshIfNeeded(Supplier<T> compute, boolean idle) {
+    public void refresh(Supplier<T> compute, boolean force) {
         if (!dirty) {
             return;
         }
         long now = System.currentTimeMillis();
-        boolean due = idle || (urgentDirty && (now - lastRefreshTimeMs) >= urgentMaxDelayMs);
+        boolean due = force || (urgentDirty && (now - lastRefreshTimeMs) >= urgentMaxDelayMs);
         if (due) {
-            update(compute);
+            inLock(updateLock, () -> this.value = compute.get());
+            lastRefreshTimeMs = now;
             dirty = false;
             urgentDirty = false;
         }
-    }
-
-    /** Unconditionally recomputes and republishes {@code compute}'s result. */
-    public void update(Supplier<T> compute) {
-        inLock(updateLock, () -> this.value = compute.get());
-        lastRefreshTimeMs = System.currentTimeMillis();
     }
 
     /** Returns the most recently published value. Safe to call from any thread. */

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/CoalescingRefreshCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/CoalescingRefreshCache.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.utils;
+
+import org.apache.fluss.annotation.VisibleForTesting;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+import static org.apache.fluss.utils.concurrent.LockUtils.inLock;
+
+/**
+ * A copy-on-write cache of a derived, immutable value, recomputed on demand rather than on a fixed
+ * schedule, and coalesced so that many changes reported in a short window trigger at most one
+ * recompute.
+ *
+ * <p>Callers report that something changed via {@link #markDirty(boolean)}; whether that change was
+ * urgent affects only how soon {@link #refreshIfNeeded} is willing to act on it -- a non-urgent
+ * change waits for the caller-supplied {@code idle} signal (e.g. an empty work queue); an urgent
+ * one is bounded by {@code urgentMaxDelayMs} regardless of that signal, so a safety- or
+ * correctness-relevant change can't be starved by an owner that never goes idle. Either way, the
+ * eventual recompute is always a full recompute from the supplied {@link Supplier}, never
+ * incremental -- a wrong or missed {@code markDirty} call costs at worst one extra recompute, it
+ * never leaves the published value permanently wrong.
+ *
+ * <p>{@link #markDirty}, {@link #refreshIfNeeded}, and {@link #update} must all be called from a
+ * single owning thread; this class does no locking on that side, matching the assumption that
+ * whoever computes the new value also holds whatever non-thread-safe source that computation reads
+ * from. Only {@link #get()} is safe to call from any thread.
+ *
+ * @param <T> the type of the derived, immutable snapshot value
+ */
+@ThreadSafe
+public final class CoalescingRefreshCache<T> {
+
+    private final long urgentMaxDelayMs;
+
+    private final Lock updateLock = new ReentrantLock();
+
+    @GuardedBy("updateLock")
+    private volatile T value;
+
+    // only ever touched from the single owning thread -- see class javadoc.
+    private boolean dirty;
+    private boolean urgentDirty;
+    private long lastRefreshTimeMs = System.currentTimeMillis();
+
+    public CoalescingRefreshCache(T initialValue, long urgentMaxDelayMs) {
+        this.value = initialValue;
+        this.urgentMaxDelayMs = urgentMaxDelayMs;
+    }
+
+    /** Records that something changed. {@code urgent} affects only how soon it is acted on. */
+    public void markDirty(boolean urgent) {
+        dirty = true;
+        if (urgent) {
+            urgentDirty = true;
+        }
+    }
+
+    /**
+     * Recomputes and republishes the value via {@code compute}, if and only if the accumulated
+     * changes since the last refresh warrant it right now.
+     *
+     * @param compute recomputes the value from scratch; only invoked if a refresh is due.
+     * @param idle whether the owning thread's other work is currently caught up. A non-urgent
+     *     change waits for this to be {@code true}; an urgent one is bounded by {@code
+     *     urgentMaxDelayMs} regardless.
+     */
+    public void refreshIfNeeded(Supplier<T> compute, boolean idle) {
+        if (!dirty) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        boolean due = idle || (urgentDirty && (now - lastRefreshTimeMs) >= urgentMaxDelayMs);
+        if (due) {
+            update(compute);
+            dirty = false;
+            urgentDirty = false;
+        }
+    }
+
+    /** Unconditionally recomputes and republishes {@code compute}'s result. */
+    public void update(Supplier<T> compute) {
+        inLock(updateLock, () -> this.value = compute.get());
+        lastRefreshTimeMs = System.currentTimeMillis();
+    }
+
+    /** Returns the most recently published value. Safe to call from any thread. */
+    public T get() {
+        return value;
+    }
+
+    @VisibleForTesting
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    @VisibleForTesting
+    public boolean isUrgentlyDirty() {
+        return urgentDirty;
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/CoalescingRefreshCache.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/CoalescingRefreshCache.java
@@ -33,26 +33,37 @@ import static org.apache.fluss.utils.concurrent.LockUtils.inLock;
  * schedule, and coalesced so that many changes reported in a short window trigger at most one
  * recompute.
  *
- * <p>Callers report that something changed via {@link #markDirty(boolean)}; whether that change was
- * urgent affects only how soon {@link #refresh} is willing to act on it. The {@code force} flag on
- * {@link #refresh} lets a caller override the timing question directly -- typically because it
- * knows something this class doesn't, e.g. that its own work queue is currently empty, so a
- * non-urgent change is now welcome to be acted on. An urgent change doesn't need the caller's help:
- * it's bounded by {@code urgentMaxDelayMs} regardless of {@code force}, so a safety- or
- * correctness-relevant change can't be starved by an owner that never passes {@code force=true}.
+ * <p>Two independent questions decide whether {@link #refresh} is due, and they are answered by two
+ * independent mechanisms:
  *
- * <p>Crucially, {@code force} only ever overrides the <em>timing</em> gate, never the {@code dirty}
- * gate: {@link #refresh} always checks "did anything actually change" first, unconditionally,
- * before considering {@code force} at all. This is what keeps a quiet caller's cost at one boolean
- * check per call -- if {@code force} skipped that check too, a caller that happens to be idle most
- * of the time (the common case) would pay for a full recompute on every single call, whether or not
- * anything had changed. A freshly constructed cache starts {@code dirty}, since it hasn't computed
- * a real value yet -- that's what lets a one-time forced warm-up work without needing {@code force}
- * to bypass the dirty check.
+ * <ul>
+ *   <li><b>Rate</b> -- how fast a change that <em>was</em> reported (via {@link #markDirty}) gets
+ *       reflected. Urgent changes are bounded by {@code urgentMaxDelayMs}; everything else by the
+ *       looser {@code normalMaxDelayMs}. This is purely about not recomputing more often than
+ *       necessary once something is known to have changed.
+ *   <li><b>Coverage</b> -- an absolute ceiling, {@code safetyNetMaxDelayMs}, that fires regardless
+ *       of {@code dirty} at all. A caller that forgets to call {@link #markDirty} for some code
+ *       path still can't cause unbounded staleness -- worst case, it's caught within {@code
+ *       safetyNetMaxDelayMs}. This is what actually bounds correctness independent of how complete
+ *       the caller's instrumentation is.
+ * </ul>
+ *
+ * <p>Conflating these into one mechanism is a trap: gating the safety-net ceiling on {@code dirty}
+ * would defeat its entire purpose (it exists precisely for the case where {@code dirty} was never
+ * set), while making the rate thresholds unconditional would mean recomputing on every call even
+ * when nothing changed -- the "quiet caller costs one boolean check" property this class is built
+ * around. Every {@code due} check inspects all three conditions independently:
+ *
+ * <pre>{@code
+ * due = (urgentDirty && elapsed >= urgentMaxDelayMs)
+ *     || (dirty && elapsed >= normalMaxDelayMs)
+ *     || (elapsed >= safetyNetMaxDelayMs);
+ * }</pre>
  *
  * <p>Either way, the eventual recompute is always a full recompute from the supplied {@link
  * Supplier}, never incremental -- a wrong or missed {@code markDirty} call costs at worst one extra
- * recompute, it never leaves the published value permanently wrong.
+ * recompute (or, at the safety-net bound, a bounded wait), it never leaves the published value
+ * permanently wrong.
  *
  * <p>{@link #markDirty} and {@link #refresh} must both be called from a single owning thread; this
  * class does no locking on that side, matching the assumption that whoever computes the new value
@@ -65,6 +76,8 @@ import static org.apache.fluss.utils.concurrent.LockUtils.inLock;
 public final class CoalescingRefreshCache<T> {
 
     private final long urgentMaxDelayMs;
+    private final long normalMaxDelayMs;
+    private final long safetyNetMaxDelayMs;
 
     private final Lock updateLock = new ReentrantLock();
 
@@ -75,11 +88,22 @@ public final class CoalescingRefreshCache<T> {
     // starts true: a freshly constructed cache hasn't computed a real value yet.
     private boolean dirty = true;
     private boolean urgentDirty;
-    private long lastRefreshTimeMs = System.currentTimeMillis();
+    private long lastRefreshTimeMs;
 
-    public CoalescingRefreshCache(T initialValue, long urgentMaxDelayMs) {
+    public CoalescingRefreshCache(
+            T initialValue,
+            long urgentMaxDelayMs,
+            long normalMaxDelayMs,
+            long safetyNetMaxDelayMs) {
         this.value = initialValue;
         this.urgentMaxDelayMs = urgentMaxDelayMs;
+        this.normalMaxDelayMs = normalMaxDelayMs;
+        this.safetyNetMaxDelayMs = safetyNetMaxDelayMs;
+        // seeded in the past (not "now") so that the very first refresh() call, whenever the
+        // caller happens to make it, is unconditionally due -- otherwise a warm-up call made
+        // shortly after construction would see near-zero elapsed time and be a no-op under all
+        // three clauses, silently defeating the caller's warm-up.
+        this.lastRefreshTimeMs = System.currentTimeMillis() - safetyNetMaxDelayMs;
     }
 
     /** Records that something changed. {@code urgent} affects only how soon it is acted on. */
@@ -91,21 +115,20 @@ public final class CoalescingRefreshCache<T> {
     }
 
     /**
-     * Recomputes and republishes the value via {@code compute}, if and only if something has
-     * actually changed since the last refresh <em>and</em> now is the right time to act on it.
+     * Recomputes and republishes the value via {@code compute}, if and only if it is due: either a
+     * reported change has waited long enough for its urgency tier, or the unconditional safety-net
+     * bound has elapsed regardless of whether anything was ever reported. See the class javadoc for
+     * why both mechanisms exist independently.
      *
      * @param compute recomputes the value from scratch; only invoked if a refresh is due.
-     * @param force overrides the timing question directly -- pass {@code true} when the caller
-     *     already knows now is a good time (e.g. its own work queue is empty), or to force an
-     *     unconditional warm-up. Never overrides the {@code dirty} check: if nothing changed, this
-     *     is a no-op regardless of {@code force}.
      */
-    public void refresh(Supplier<T> compute, boolean force) {
-        if (!dirty) {
-            return;
-        }
+    public void refresh(Supplier<T> compute) {
         long now = System.currentTimeMillis();
-        boolean due = force || (urgentDirty && (now - lastRefreshTimeMs) >= urgentMaxDelayMs);
+        long elapsed = now - lastRefreshTimeMs;
+        boolean due =
+                (urgentDirty && elapsed >= urgentMaxDelayMs)
+                        || (dirty && elapsed >= normalMaxDelayMs)
+                        || (elapsed >= safetyNetMaxDelayMs);
         if (due) {
             inLock(updateLock, () -> this.value = compute.get());
             lastRefreshTimeMs = now;

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHealthCacheTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHealthCacheTest.java
@@ -57,7 +57,7 @@ class CoordinatorHealthCacheTest {
 
     @Test
     void testEmptyClusterReportsZeroLoadPerLiveServer() {
-        cache.update(ctx);
+        cache.refresh(ctx, true);
 
         ClusterHealthSnapshot snapshot = cache.getSnapshot();
         assertThat(snapshot.numReplicas()).isZero();
@@ -96,7 +96,7 @@ class CoordinatorHealthCacheTest {
 
         GetClusterHealthResponse expected = CoordinatorService.computeClusterHealth(ctx);
 
-        cache.update(ctx);
+        cache.refresh(ctx, true);
         ClusterHealthSnapshot snapshot = cache.getSnapshot();
 
         // the cache must reproduce the exact same cluster-wide aggregates as the
@@ -114,7 +114,7 @@ class CoordinatorHealthCacheTest {
         ctx.putBucketLeaderAndIsr(
                 tb, new LeaderAndIsr(0, 1, Arrays.asList(0, 1), Collections.emptyList(), 0, 1));
 
-        cache.update(ctx);
+        cache.refresh(ctx, true);
         ClusterHealthSnapshot snapshot = cache.getSnapshot();
 
         TabletServerLoad server0 = snapshot.tabletServerLoads().get(0);
@@ -164,7 +164,7 @@ class CoordinatorHealthCacheTest {
                         0,
                         1));
 
-        cache.update(ctx);
+        cache.refresh(ctx, true);
         ClusterHealthSnapshot snapshot = cache.getSnapshot();
 
         assertThat(snapshot.numLeaderReplicas()).isEqualTo(1); // one bucket, counted regardless
@@ -184,7 +184,7 @@ class CoordinatorHealthCacheTest {
                 new LeaderAndIsr(
                         0, 1, Collections.singletonList(0), Collections.emptyList(), 0, 1));
 
-        cache.update(ctx);
+        cache.refresh(ctx, true);
 
         // server 1 and 2 host nothing, but are live, so they must still be present with 0 load
         // (mirrors the "evacuated server explicitly shows zero replicas" contract).
@@ -197,16 +197,17 @@ class CoordinatorHealthCacheTest {
     void testPublishedSnapshotIsImmutableAcrossLaterUpdates() {
         TableBucket tb = new TableBucket(1L, 0);
         ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
-        cache.update(ctx);
+        cache.refresh(ctx, true);
 
         ClusterHealthSnapshot firstSnapshot = cache.getSnapshot();
         assertThat(firstSnapshot.numReplicas()).isEqualTo(2);
 
-        // a later mutation + update must not retroactively change a snapshot a caller already
+        // a later mutation + refresh must not retroactively change a snapshot a caller already
         // holds a reference to -- that is the entire point of copy-on-write.
         TableBucket tb2 = new TableBucket(2L, 0);
         ctx.updateBucketReplicaAssignment(tb2, Arrays.asList(0, 1, 2));
-        cache.update(ctx);
+        cache.onTopologyChanged(); // real callers always report through onXxx before refreshing
+        cache.refresh(ctx, true);
 
         assertThat(firstSnapshot.numReplicas()).isEqualTo(2);
         assertThat(cache.getSnapshot().numReplicas()).isEqualTo(5);
@@ -219,7 +220,7 @@ class CoordinatorHealthCacheTest {
         ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1, 2));
         ctx.putBucketLeaderAndIsr(
                 tb, new LeaderAndIsr(0, 1, Arrays.asList(0, 1, 2), Collections.emptyList(), 0, 1));
-        cache.update(ctx);
+        cache.refresh(ctx, true);
 
         AtomicBoolean stop = new AtomicBoolean(false);
         AtomicReference<AssertionError> failure = new AtomicReference<>();
@@ -248,10 +249,12 @@ class CoordinatorHealthCacheTest {
                         });
 
         reader.start();
-        // hammer update() from this thread while the reader spins, simulating the event thread
-        // republishing the snapshot concurrently with RPC-thread reads.
+        // hammer refresh() from this thread while the reader spins, simulating the event thread
+        // republishing the snapshot concurrently with RPC-thread reads. onTopologyChanged() keeps
+        // marking it dirty so each iteration actually recomputes and swaps, not just the first.
         for (int i = 0; i < 2000 && failure.get() == null; i++) {
-            cache.update(ctx);
+            cache.onTopologyChanged();
+            cache.refresh(ctx, true);
         }
         stop.set(true);
         reader.join();
@@ -315,45 +318,45 @@ class CoordinatorHealthCacheTest {
     }
 
     @Test
-    void testRefreshIfNeededIsNoOpWhenNotDirty() {
-        cache.update(ctx);
+    void testRefreshIsNoOpWhenNotDirty() {
+        cache.refresh(ctx, true);
         ClusterHealthSnapshot warm = cache.getSnapshot();
 
         // nothing reported dirty since the warm-up -- must not recompute, queue state aside.
-        cache.refreshIfNeeded(ctx, true);
+        cache.refresh(ctx, true);
         assertThat(cache.getSnapshot()).isSameAs(warm);
     }
 
     @Test
     void testNonUrgentChangeWaitsForQueueToDrain() {
-        cache.update(ctx);
+        cache.refresh(ctx, true);
         TableBucket tb = new TableBucket(1L, 0);
         ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
         cache.onTopologyChanged();
 
         ClusterHealthSnapshot beforeDrain = cache.getSnapshot();
-        cache.refreshIfNeeded(ctx, false); // queue still has work -- must not recompute yet
+        cache.refresh(ctx, false); // queue still has work -- must not recompute yet
         assertThat(cache.getSnapshot()).isSameAs(beforeDrain);
 
-        cache.refreshIfNeeded(ctx, true); // queue drained -- now it should
+        cache.refresh(ctx, true); // queue drained -- now it should
         assertThat(cache.getSnapshot()).isNotSameAs(beforeDrain);
         assertThat(cache.getSnapshot().numReplicas()).isEqualTo(2);
     }
 
     @Test
     void testUrgentChangeIsBoundedByMaxDelayEvenIfQueueNeverDrains() throws InterruptedException {
-        cache.update(ctx); // establishes a real lastRefreshTimeMs baseline
+        cache.refresh(ctx, true); // establishes a real lastRefreshTimeMs baseline
         TableBucket tb = new TableBucket(1L, 0);
         ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
         cache.onTabletServerDied(); // urgent
 
         ClusterHealthSnapshot beforeDelay = cache.getSnapshot();
-        cache.refreshIfNeeded(ctx, false); // queue busy, delay not yet elapsed -- must wait
+        cache.refresh(ctx, false); // queue busy, delay not yet elapsed -- must wait
         assertThat(cache.getSnapshot()).isSameAs(beforeDelay);
 
         Thread.sleep(CoordinatorHealthCache.URGENT_MAX_DELAY_MS + 50);
 
-        cache.refreshIfNeeded(ctx, false); // queue STILL busy, but the urgent bound is up
+        cache.refresh(ctx, false); // queue STILL busy, but the urgent bound is up
         assertThat(cache.getSnapshot()).isNotSameAs(beforeDelay);
         assertThat(cache.getSnapshot().numReplicas()).isEqualTo(2);
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHealthCacheTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHealthCacheTest.java
@@ -57,7 +57,7 @@ class CoordinatorHealthCacheTest {
 
     @Test
     void testEmptyClusterReportsZeroLoadPerLiveServer() {
-        cache.refresh(ctx, true);
+        cache.refresh(ctx);
 
         ClusterHealthSnapshot snapshot = cache.getSnapshot();
         assertThat(snapshot.numReplicas()).isZero();
@@ -96,7 +96,7 @@ class CoordinatorHealthCacheTest {
 
         GetClusterHealthResponse expected = CoordinatorService.computeClusterHealth(ctx);
 
-        cache.refresh(ctx, true);
+        cache.refresh(ctx);
         ClusterHealthSnapshot snapshot = cache.getSnapshot();
 
         // the cache must reproduce the exact same cluster-wide aggregates as the
@@ -114,7 +114,7 @@ class CoordinatorHealthCacheTest {
         ctx.putBucketLeaderAndIsr(
                 tb, new LeaderAndIsr(0, 1, Arrays.asList(0, 1), Collections.emptyList(), 0, 1));
 
-        cache.refresh(ctx, true);
+        cache.refresh(ctx);
         ClusterHealthSnapshot snapshot = cache.getSnapshot();
 
         TabletServerLoad server0 = snapshot.tabletServerLoads().get(0);
@@ -164,7 +164,7 @@ class CoordinatorHealthCacheTest {
                         0,
                         1));
 
-        cache.refresh(ctx, true);
+        cache.refresh(ctx);
         ClusterHealthSnapshot snapshot = cache.getSnapshot();
 
         assertThat(snapshot.numLeaderReplicas()).isEqualTo(1); // one bucket, counted regardless
@@ -173,6 +173,17 @@ class CoordinatorHealthCacheTest {
                         .mapToInt(TabletServerLoad::numLeaderReplicas)
                         .sum();
         assertThat(sumOfPerServerLeaderReplicas).isZero(); // nobody is actually the leader
+        // bucketsWithoutLeader makes the same reconciling fact explicit and queryable.
+        assertThat(snapshot.bucketsWithoutLeader()).isEqualTo(1);
+    }
+
+    @Test
+    void testEmptyIsNotInitializedButComputedSnapshotIs() {
+        assertThat(ClusterHealthSnapshot.EMPTY.isInitialized()).isFalse();
+
+        cache.refresh(ctx);
+
+        assertThat(cache.getSnapshot().isInitialized()).isTrue();
     }
 
     @Test
@@ -184,7 +195,7 @@ class CoordinatorHealthCacheTest {
                 new LeaderAndIsr(
                         0, 1, Collections.singletonList(0), Collections.emptyList(), 0, 1));
 
-        cache.refresh(ctx, true);
+        cache.refresh(ctx);
 
         // server 1 and 2 host nothing, but are live, so they must still be present with 0 load
         // (mirrors the "evacuated server explicitly shows zero replicas" contract).
@@ -194,20 +205,22 @@ class CoordinatorHealthCacheTest {
     }
 
     @Test
-    void testPublishedSnapshotIsImmutableAcrossLaterUpdates() {
+    void testPublishedSnapshotIsImmutableAcrossLaterUpdates() throws InterruptedException {
         TableBucket tb = new TableBucket(1L, 0);
         ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
-        cache.refresh(ctx, true);
+        cache.refresh(ctx);
 
         ClusterHealthSnapshot firstSnapshot = cache.getSnapshot();
         assertThat(firstSnapshot.numReplicas()).isEqualTo(2);
 
         // a later mutation + refresh must not retroactively change a snapshot a caller already
-        // holds a reference to -- that is the entire point of copy-on-write.
+        // holds a reference to -- that is the entire point of copy-on-write. Use the urgent path
+        // and wait it out so the second refresh() is actually due, not a same-instant no-op.
         TableBucket tb2 = new TableBucket(2L, 0);
         ctx.updateBucketReplicaAssignment(tb2, Arrays.asList(0, 1, 2));
-        cache.onTopologyChanged(); // real callers always report through onXxx before refreshing
-        cache.refresh(ctx, true);
+        cache.onTabletServerDied(); // real callers always report through onXxx before refreshing
+        Thread.sleep(CoordinatorHealthCache.URGENT_MAX_DELAY_MS + 10);
+        cache.refresh(ctx);
 
         assertThat(firstSnapshot.numReplicas()).isEqualTo(2);
         assertThat(cache.getSnapshot().numReplicas()).isEqualTo(5);
@@ -220,7 +233,7 @@ class CoordinatorHealthCacheTest {
         ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1, 2));
         ctx.putBucketLeaderAndIsr(
                 tb, new LeaderAndIsr(0, 1, Arrays.asList(0, 1, 2), Collections.emptyList(), 0, 1));
-        cache.refresh(ctx, true);
+        cache.refresh(ctx);
 
         AtomicBoolean stop = new AtomicBoolean(false);
         AtomicReference<AssertionError> failure = new AtomicReference<>();
@@ -249,12 +262,15 @@ class CoordinatorHealthCacheTest {
                         });
 
         reader.start();
-        // hammer refresh() from this thread while the reader spins, simulating the event thread
-        // republishing the snapshot concurrently with RPC-thread reads. onTopologyChanged() keeps
-        // marking it dirty so each iteration actually recomputes and swaps, not just the first.
-        for (int i = 0; i < 2000 && failure.get() == null; i++) {
-            cache.onTopologyChanged();
-            cache.refresh(ctx, true);
+        // repeatedly recompute and swap the published snapshot from this thread while the reader
+        // spins, simulating the event thread republishing concurrently with RPC-thread reads.
+        // marking urgent-dirty and sleeping past URGENT_MAX_DELAY_MS between iterations makes
+        // every iteration a real recompute-and-swap, not just the first.
+        int iterations = 12;
+        for (int i = 0; i < iterations && failure.get() == null; i++) {
+            cache.onTabletServerDied();
+            Thread.sleep(CoordinatorHealthCache.URGENT_MAX_DELAY_MS + 10);
+            cache.refresh(ctx);
         }
         stop.set(true);
         reader.join();
@@ -319,44 +335,42 @@ class CoordinatorHealthCacheTest {
 
     @Test
     void testRefreshIsNoOpWhenNotDirty() {
-        cache.refresh(ctx, true);
+        cache.refresh(ctx);
         ClusterHealthSnapshot warm = cache.getSnapshot();
 
         // nothing reported dirty since the warm-up -- must not recompute, queue state aside.
-        cache.refresh(ctx, true);
+        cache.refresh(ctx);
         assertThat(cache.getSnapshot()).isSameAs(warm);
     }
 
     @Test
-    void testNonUrgentChangeWaitsForQueueToDrain() {
-        cache.refresh(ctx, true);
+    void testNonUrgentChangeIsNotReflectedImmediately() {
+        cache.refresh(ctx); // warm-up: due unconditionally on the very first call
         TableBucket tb = new TableBucket(1L, 0);
         ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
         cache.onTopologyChanged();
 
-        ClusterHealthSnapshot beforeDrain = cache.getSnapshot();
-        cache.refresh(ctx, false); // queue still has work -- must not recompute yet
-        assertThat(cache.getSnapshot()).isSameAs(beforeDrain);
-
-        cache.refresh(ctx, true); // queue drained -- now it should
-        assertThat(cache.getSnapshot()).isNotSameAs(beforeDrain);
-        assertThat(cache.getSnapshot().numReplicas()).isEqualTo(2);
+        ClusterHealthSnapshot beforeRefresh = cache.getSnapshot();
+        // called immediately after marking dirty: elapsed time is near zero, so none of the
+        // three due-clauses (urgent/normal/safety-net) can have elapsed yet.
+        cache.refresh(ctx);
+        assertThat(cache.getSnapshot()).isSameAs(beforeRefresh);
     }
 
     @Test
-    void testUrgentChangeIsBoundedByMaxDelayEvenIfQueueNeverDrains() throws InterruptedException {
-        cache.refresh(ctx, true); // establishes a real lastRefreshTimeMs baseline
+    void testUrgentChangeIsBoundedByUrgentMaxDelay() throws InterruptedException {
+        cache.refresh(ctx); // establishes a real lastRefreshTimeMs baseline
         TableBucket tb = new TableBucket(1L, 0);
         ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
         cache.onTabletServerDied(); // urgent
 
         ClusterHealthSnapshot beforeDelay = cache.getSnapshot();
-        cache.refresh(ctx, false); // queue busy, delay not yet elapsed -- must wait
+        cache.refresh(ctx); // urgent delay not yet elapsed -- must wait
         assertThat(cache.getSnapshot()).isSameAs(beforeDelay);
 
         Thread.sleep(CoordinatorHealthCache.URGENT_MAX_DELAY_MS + 50);
 
-        cache.refresh(ctx, false); // queue STILL busy, but the urgent bound is up
+        cache.refresh(ctx); // urgent bound is now up
         assertThat(cache.getSnapshot()).isNotSameAs(beforeDelay);
         assertThat(cache.getSnapshot().numReplicas()).isEqualTo(2);
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHealthCacheTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorHealthCacheTest.java
@@ -1,0 +1,368 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.coordinator;
+
+import org.apache.fluss.cluster.Endpoint;
+import org.apache.fluss.cluster.ServerType;
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.rpc.messages.GetClusterHealthResponse;
+import org.apache.fluss.server.metadata.ServerInfo;
+import org.apache.fluss.server.zk.ZkEpoch;
+import org.apache.fluss.server.zk.data.LeaderAndIsr;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CoordinatorHealthCache}. */
+class CoordinatorHealthCacheTest {
+
+    private CoordinatorContext ctx;
+    private CoordinatorHealthCache cache;
+
+    @BeforeEach
+    void setUp() {
+        ctx = new CoordinatorContext(ZkEpoch.INITIAL_EPOCH);
+        ctx.setLiveTabletServers(
+                Arrays.asList(makeServerInfo(0), makeServerInfo(1), makeServerInfo(2)));
+        cache = new CoordinatorHealthCache();
+    }
+
+    @Test
+    void testInitialSnapshotIsEmpty() {
+        assertThat(cache.getSnapshot()).isSameAs(ClusterHealthSnapshot.EMPTY);
+    }
+
+    @Test
+    void testEmptyClusterReportsZeroLoadPerLiveServer() {
+        cache.update(ctx);
+
+        ClusterHealthSnapshot snapshot = cache.getSnapshot();
+        assertThat(snapshot.numReplicas()).isZero();
+        assertThat(snapshot.inSyncReplicas()).isZero();
+        assertThat(snapshot.activeLeaderReplicas()).isZero();
+        assertThat(snapshot.tabletServerLoads()).hasSize(3);
+        snapshot.tabletServerLoads()
+                .values()
+                .forEach(
+                        load -> {
+                            assertThat(load.numReplicas()).isZero();
+                            assertThat(load.inSyncReplicas()).isZero();
+                            assertThat(load.numLeaderReplicas()).isZero();
+                            assertThat(load.activeLeaderReplicas()).isZero();
+                        });
+    }
+
+    @Test
+    void testAggregatesMatchComputeClusterHealth() {
+        TableBucket tb1 = new TableBucket(1L, 0);
+        TableBucket tb2 = new TableBucket(1L, 1);
+        TableBucket tb3 = new TableBucket(2L, 0);
+
+        ctx.updateBucketReplicaAssignment(tb1, Arrays.asList(0, 1));
+        ctx.updateBucketReplicaAssignment(tb2, Arrays.asList(1, 2));
+        ctx.updateBucketReplicaAssignment(tb3, Arrays.asList(0, 2));
+
+        ctx.putBucketLeaderAndIsr(
+                tb1, new LeaderAndIsr(0, 1, Arrays.asList(0, 1), Collections.emptyList(), 0, 1));
+        ctx.putBucketLeaderAndIsr(
+                tb2,
+                new LeaderAndIsr(
+                        1, 1, Collections.singletonList(1), Collections.emptyList(), 0, 1));
+        ctx.putBucketLeaderAndIsr(
+                tb3, new LeaderAndIsr(0, 1, Arrays.asList(0, 2), Collections.emptyList(), 0, 1));
+
+        GetClusterHealthResponse expected = CoordinatorService.computeClusterHealth(ctx);
+
+        cache.update(ctx);
+        ClusterHealthSnapshot snapshot = cache.getSnapshot();
+
+        // the cache must reproduce the exact same cluster-wide aggregates as the
+        // AccessContextEvent-bound computation it is meant to replace.
+        assertThat(snapshot.numReplicas()).isEqualTo(expected.getNumReplicas());
+        assertThat(snapshot.inSyncReplicas()).isEqualTo(expected.getInSyncReplicas());
+        assertThat(snapshot.numLeaderReplicas()).isEqualTo(expected.getNumLeaderReplicas());
+        assertThat(snapshot.activeLeaderReplicas()).isEqualTo(expected.getActiveLeaderReplicas());
+    }
+
+    @Test
+    void testPerServerBreakdownAttributesReplicasIsrAndLeader() {
+        TableBucket tb = new TableBucket(1L, 0);
+        ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1, 2));
+        ctx.putBucketLeaderAndIsr(
+                tb, new LeaderAndIsr(0, 1, Arrays.asList(0, 1), Collections.emptyList(), 0, 1));
+
+        cache.update(ctx);
+        ClusterHealthSnapshot snapshot = cache.getSnapshot();
+
+        TabletServerLoad server0 = snapshot.tabletServerLoads().get(0);
+        TabletServerLoad server1 = snapshot.tabletServerLoads().get(1);
+        TabletServerLoad server2 = snapshot.tabletServerLoads().get(2);
+
+        // server 0: replica + in ISR + is the leader (and active, since it is in the ISR)
+        assertThat(server0.numReplicas()).isEqualTo(1);
+        assertThat(server0.inSyncReplicas()).isEqualTo(1);
+        assertThat(server0.numLeaderReplicas()).isEqualTo(1);
+        assertThat(server0.activeLeaderReplicas()).isEqualTo(1);
+
+        // server 1: replica + in ISR, not the leader
+        assertThat(server1.numReplicas()).isEqualTo(1);
+        assertThat(server1.inSyncReplicas()).isEqualTo(1);
+        assertThat(server1.numLeaderReplicas()).isZero();
+
+        // server 2: replica, but out of ISR (not in the isr list above)
+        assertThat(server2.numReplicas()).isEqualTo(1);
+        assertThat(server2.inSyncReplicas()).isZero();
+        assertThat(server2.numLeaderReplicas()).isZero();
+
+        // sum of per-server replicas must reconcile with the cluster-wide aggregate
+        int sumOfServerReplicas =
+                snapshot.tabletServerLoads().values().stream()
+                        .mapToInt(TabletServerLoad::numReplicas)
+                        .sum();
+        assertThat(sumOfServerReplicas).isEqualTo(snapshot.numReplicas());
+    }
+
+    @Test
+    void testUnattributedLeaderDoesNotReconcileWithBucketCountAggregate() {
+        // deliberately exercise the pre-existing semantic gap between
+        // CoordinatorService#computeClusterHealth's numLeaderReplicas (a bucket count, always
+        // incremented) and the per-server numLeaderReplicas (only incremented when a leader is
+        // actually assigned): with NO_LEADER, the aggregate still counts the bucket, but no
+        // server gets credited.
+        TableBucket tb = new TableBucket(1L, 0);
+        ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
+        ctx.putBucketLeaderAndIsr(
+                tb,
+                new LeaderAndIsr(
+                        LeaderAndIsr.NO_LEADER,
+                        1,
+                        Arrays.asList(0, 1),
+                        Collections.emptyList(),
+                        0,
+                        1));
+
+        cache.update(ctx);
+        ClusterHealthSnapshot snapshot = cache.getSnapshot();
+
+        assertThat(snapshot.numLeaderReplicas()).isEqualTo(1); // one bucket, counted regardless
+        int sumOfPerServerLeaderReplicas =
+                snapshot.tabletServerLoads().values().stream()
+                        .mapToInt(TabletServerLoad::numLeaderReplicas)
+                        .sum();
+        assertThat(sumOfPerServerLeaderReplicas).isZero(); // nobody is actually the leader
+    }
+
+    @Test
+    void testEvacuatedLiveServerStillReportedWithZeroLoad() {
+        TableBucket tb = new TableBucket(1L, 0);
+        ctx.updateBucketReplicaAssignment(tb, Collections.singletonList(0));
+        ctx.putBucketLeaderAndIsr(
+                tb,
+                new LeaderAndIsr(
+                        0, 1, Collections.singletonList(0), Collections.emptyList(), 0, 1));
+
+        cache.update(ctx);
+
+        // server 1 and 2 host nothing, but are live, so they must still be present with 0 load
+        // (mirrors the "evacuated server explicitly shows zero replicas" contract).
+        TabletServerLoad server1 = cache.getSnapshot().tabletServerLoads().get(1);
+        assertThat(server1).isNotNull();
+        assertThat(server1.numReplicas()).isZero();
+    }
+
+    @Test
+    void testPublishedSnapshotIsImmutableAcrossLaterUpdates() {
+        TableBucket tb = new TableBucket(1L, 0);
+        ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
+        cache.update(ctx);
+
+        ClusterHealthSnapshot firstSnapshot = cache.getSnapshot();
+        assertThat(firstSnapshot.numReplicas()).isEqualTo(2);
+
+        // a later mutation + update must not retroactively change a snapshot a caller already
+        // holds a reference to -- that is the entire point of copy-on-write.
+        TableBucket tb2 = new TableBucket(2L, 0);
+        ctx.updateBucketReplicaAssignment(tb2, Arrays.asList(0, 1, 2));
+        cache.update(ctx);
+
+        assertThat(firstSnapshot.numReplicas()).isEqualTo(2);
+        assertThat(cache.getSnapshot().numReplicas()).isEqualTo(5);
+        assertThat(cache.getSnapshot()).isNotSameAs(firstSnapshot);
+    }
+
+    @Test
+    void testConcurrentReadsNeverObserveATornSnapshot() throws InterruptedException {
+        TableBucket tb = new TableBucket(1L, 0);
+        ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1, 2));
+        ctx.putBucketLeaderAndIsr(
+                tb, new LeaderAndIsr(0, 1, Arrays.asList(0, 1, 2), Collections.emptyList(), 0, 1));
+        cache.update(ctx);
+
+        AtomicBoolean stop = new AtomicBoolean(false);
+        AtomicReference<AssertionError> failure = new AtomicReference<>();
+
+        Thread reader =
+                new Thread(
+                        () -> {
+                            while (!stop.get()) {
+                                ClusterHealthSnapshot snapshot = cache.getSnapshot();
+                                int sumOfServerReplicas =
+                                        snapshot.tabletServerLoads().values().stream()
+                                                .mapToInt(TabletServerLoad::numReplicas)
+                                                .sum();
+                                // must ALWAYS reconcile: a torn read (fields from two different
+                                // snapshot instances) would break this invariant.
+                                if (sumOfServerReplicas != snapshot.numReplicas()) {
+                                    failure.set(
+                                            new AssertionError(
+                                                    "torn snapshot: sumOfServerReplicas="
+                                                            + sumOfServerReplicas
+                                                            + " numReplicas="
+                                                            + snapshot.numReplicas()));
+                                    return;
+                                }
+                            }
+                        });
+
+        reader.start();
+        // hammer update() from this thread while the reader spins, simulating the event thread
+        // republishing the snapshot concurrently with RPC-thread reads.
+        for (int i = 0; i < 2000 && failure.get() == null; i++) {
+            cache.update(ctx);
+        }
+        stop.set(true);
+        reader.join();
+
+        assertThat(failure.get()).isNull();
+    }
+
+    @Test
+    void testFullIsrAndActiveLeaderIsNotUrgent() {
+        TableBucket tb = new TableBucket(1L, 0);
+        cache.onBucketLeaderAndIsrChanged(
+                tb,
+                Arrays.asList(0, 1, 2),
+                Optional.of(
+                        new LeaderAndIsr(
+                                0, 1, Arrays.asList(0, 1, 2), Collections.emptyList(), 0, 1)));
+
+        assertThat(cache.isDirty()).isTrue();
+        assertThat(cache.isUrgentlyDirty()).isFalse();
+    }
+
+    @Test
+    void testUnderReplicatedIsrIsUrgent() {
+        TableBucket tb = new TableBucket(1L, 0);
+        cache.onBucketLeaderAndIsrChanged(
+                tb,
+                Arrays.asList(0, 1, 2),
+                Optional.of(
+                        new LeaderAndIsr(
+                                0, 1, Arrays.asList(0, 1), Collections.emptyList(), 0, 1)));
+
+        assertThat(cache.isUrgentlyDirty()).isTrue();
+    }
+
+    @Test
+    void testMissingLeaderIsUrgent() {
+        TableBucket tb = new TableBucket(1L, 0);
+        cache.onBucketLeaderAndIsrChanged(tb, Arrays.asList(0, 1), Optional.empty());
+
+        assertThat(cache.isUrgentlyDirty()).isTrue();
+    }
+
+    @Test
+    void testTabletServerDiedIsUrgentButRegisteredAndTopologyChangeAreNot() {
+        cache.onTabletServerDied();
+        assertThat(cache.isUrgentlyDirty()).isTrue();
+
+        cache = new CoordinatorHealthCache();
+        cache.onTabletServerRegistered();
+        assertThat(cache.isDirty()).isTrue();
+        assertThat(cache.isUrgentlyDirty()).isFalse();
+
+        cache = new CoordinatorHealthCache();
+        cache.onTopologyChanged();
+        assertThat(cache.isDirty()).isTrue();
+        assertThat(cache.isUrgentlyDirty()).isFalse();
+
+        cache = new CoordinatorHealthCache();
+        cache.onLeaderActivityChanged(false);
+        assertThat(cache.isUrgentlyDirty()).isTrue();
+    }
+
+    @Test
+    void testRefreshIfNeededIsNoOpWhenNotDirty() {
+        cache.update(ctx);
+        ClusterHealthSnapshot warm = cache.getSnapshot();
+
+        // nothing reported dirty since the warm-up -- must not recompute, queue state aside.
+        cache.refreshIfNeeded(ctx, true);
+        assertThat(cache.getSnapshot()).isSameAs(warm);
+    }
+
+    @Test
+    void testNonUrgentChangeWaitsForQueueToDrain() {
+        cache.update(ctx);
+        TableBucket tb = new TableBucket(1L, 0);
+        ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
+        cache.onTopologyChanged();
+
+        ClusterHealthSnapshot beforeDrain = cache.getSnapshot();
+        cache.refreshIfNeeded(ctx, false); // queue still has work -- must not recompute yet
+        assertThat(cache.getSnapshot()).isSameAs(beforeDrain);
+
+        cache.refreshIfNeeded(ctx, true); // queue drained -- now it should
+        assertThat(cache.getSnapshot()).isNotSameAs(beforeDrain);
+        assertThat(cache.getSnapshot().numReplicas()).isEqualTo(2);
+    }
+
+    @Test
+    void testUrgentChangeIsBoundedByMaxDelayEvenIfQueueNeverDrains() throws InterruptedException {
+        cache.update(ctx); // establishes a real lastRefreshTimeMs baseline
+        TableBucket tb = new TableBucket(1L, 0);
+        ctx.updateBucketReplicaAssignment(tb, Arrays.asList(0, 1));
+        cache.onTabletServerDied(); // urgent
+
+        ClusterHealthSnapshot beforeDelay = cache.getSnapshot();
+        cache.refreshIfNeeded(ctx, false); // queue busy, delay not yet elapsed -- must wait
+        assertThat(cache.getSnapshot()).isSameAs(beforeDelay);
+
+        Thread.sleep(CoordinatorHealthCache.URGENT_MAX_DELAY_MS + 50);
+
+        cache.refreshIfNeeded(ctx, false); // queue STILL busy, but the urgent bound is up
+        assertThat(cache.getSnapshot()).isNotSameAs(beforeDelay);
+        assertThat(cache.getSnapshot().numReplicas()).isEqualTo(2);
+    }
+
+    private static ServerInfo makeServerInfo(int id) {
+        return new ServerInfo(
+                id,
+                "RACK" + id,
+                Endpoint.fromListenersString("CLIENT://host" + id + ":9124"),
+                ServerType.TABLET_SERVER);
+    }
+}

--- a/fluss-server/src/test/java/org/apache/fluss/server/utils/CoalescingRefreshCacheTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/utils/CoalescingRefreshCacheTest.java
@@ -33,57 +33,60 @@ class CoalescingRefreshCacheTest {
     private static final long URGENT_MAX_DELAY_MS = 100;
 
     @Test
-    void testInitialValueIsReturnedUntouched() {
+    void testFreshCacheStartsDirtyWithTheSeedValue() {
         CoalescingRefreshCache<Integer> cache =
                 new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
         assertThat(cache.get()).isEqualTo(0);
-        assertThat(cache.isDirty()).isFalse();
+        // hasn't computed a real value yet -- starts dirty so a warm-up can force it through.
+        assertThat(cache.isDirty()).isTrue();
     }
 
     @Test
-    void testRefreshIfNeededIsNoOpWhenNotDirty() {
+    void testRefreshIsNoOpWhenNotDirtyEvenIfForced() {
         CoalescingRefreshCache<Integer> cache =
                 new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+        cache.refresh(() -> 1, true); // clears the initial dirty state
         AtomicInteger computeCalls = new AtomicInteger();
 
-        cache.refreshIfNeeded(() -> computeCalls.incrementAndGet(), true);
+        cache.refresh(() -> computeCalls.incrementAndGet(), true);
 
-        // compute() must not even be invoked -- there was nothing to refresh.
+        // force overrides the timing gate, never the dirty gate -- nothing changed, so
+        // compute() must not even be invoked, force notwithstanding.
         assertThat(computeCalls.get()).isZero();
-        assertThat(cache.get()).isEqualTo(0);
+        assertThat(cache.get()).isEqualTo(1);
     }
 
     @Test
-    void testNonUrgentChangeWaitsUntilIdle() {
+    void testNonUrgentChangeWaitsForForce() {
         CoalescingRefreshCache<Integer> cache =
                 new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
         AtomicInteger source = new AtomicInteger(1);
         cache.markDirty(false);
 
-        cache.refreshIfNeeded(source::get, false); // not idle -- must wait
+        cache.refresh(source::get, false); // not forced -- must wait
         assertThat(cache.get()).isEqualTo(0);
         assertThat(cache.isDirty()).isTrue();
 
-        cache.refreshIfNeeded(source::get, true); // idle -- now it should recompute
+        cache.refresh(source::get, true); // forced -- now it should recompute
         assertThat(cache.get()).isEqualTo(1);
         assertThat(cache.isDirty()).isFalse();
     }
 
     @Test
-    void testUrgentChangeIsBoundedByMaxDelayEvenIfNeverIdle() throws InterruptedException {
+    void testUrgentChangeIsBoundedByMaxDelayEvenIfNeverForced() throws InterruptedException {
         CoalescingRefreshCache<Integer> cache =
                 new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
         AtomicInteger source = new AtomicInteger(1);
-        cache.update(source::get); // establishes a real lastRefreshTimeMs baseline
+        cache.refresh(source::get, true); // establishes a real lastRefreshTimeMs baseline
         source.set(2);
 
         cache.markDirty(true);
-        cache.refreshIfNeeded(source::get, false); // urgent, but delay not yet elapsed
+        cache.refresh(source::get, false); // urgent, but delay not yet elapsed
         assertThat(cache.get()).isEqualTo(1);
 
         Thread.sleep(URGENT_MAX_DELAY_MS + 50);
 
-        cache.refreshIfNeeded(source::get, false); // still not idle, but the bound is up
+        cache.refresh(source::get, false); // still not forced, but the bound is up
         assertThat(cache.get()).isEqualTo(2);
         assertThat(cache.isDirty()).isFalse();
         assertThat(cache.isUrgentlyDirty()).isFalse();
@@ -98,38 +101,39 @@ class CoalescingRefreshCacheTest {
 
         for (int i = 0; i < 50; i++) {
             cache.markDirty(false);
-            cache.refreshIfNeeded(
+            cache.refresh(
                     () -> {
                         computeCalls.incrementAndGet();
                         return source.incrementAndGet();
                     },
-                    false); // never idle -- simulates a burst arriving while the queue is busy
+                    false); // never forced -- simulates a burst arriving while the queue is busy
         }
         assertThat(computeCalls.get()).isZero();
 
-        cache.refreshIfNeeded(
+        cache.refresh(
                 () -> {
                     computeCalls.incrementAndGet();
                     return source.incrementAndGet();
                 },
-                true); // idle now -- exactly one recompute for the whole burst
+                true); // forced now -- exactly one recompute for the whole burst
 
         assertThat(computeCalls.get()).isEqualTo(1);
         assertThat(cache.get()).isEqualTo(1);
     }
 
     @Test
-    void testUpdateBypassesPolicyButDoesNotClearDirtyFlags() {
+    void testForceClearsDirtyFlagsAfterRecomputing() {
         CoalescingRefreshCache<Integer> cache =
                 new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
         cache.markDirty(true);
 
-        cache.update(() -> 7);
+        cache.refresh(() -> 7, true);
 
         assertThat(cache.get()).isEqualTo(7);
-        // update() is an unconditional bypass of the policy, not a substitute for it -- it must
-        // not silently clear flags that refreshIfNeeded is responsible for managing.
-        assertThat(cache.isDirty()).isTrue();
-        assertThat(cache.isUrgentlyDirty()).isTrue();
+        // a forced refresh still recomputed the current truth, so nothing is left
+        // unreflected -- force participates fully in the dirty-tracking system, it doesn't
+        // sidestep it.
+        assertThat(cache.isDirty()).isFalse();
+        assertThat(cache.isUrgentlyDirty()).isFalse();
     }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/utils/CoalescingRefreshCacheTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/utils/CoalescingRefreshCacheTest.java
@@ -25,77 +25,108 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link CoalescingRefreshCache}, exercised with a trivial {@code Integer} value so the
- * coalescing/urgency mechanics are verified independently of any real caller (e.g. {@code
+ * coalescing/urgency/coverage mechanics are verified independently of any real caller (e.g. {@code
  * CoordinatorHealthCache}).
  */
 class CoalescingRefreshCacheTest {
 
-    private static final long URGENT_MAX_DELAY_MS = 100;
+    private static final long URGENT_MAX_DELAY_MS = 50;
+    private static final long NORMAL_MAX_DELAY_MS = 150;
+    private static final long SAFETY_NET_MAX_DELAY_MS = 400;
 
     @Test
     void testFreshCacheStartsDirtyWithTheSeedValue() {
-        CoalescingRefreshCache<Integer> cache =
-                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+        CoalescingRefreshCache<Integer> cache = newCache(0);
         assertThat(cache.get()).isEqualTo(0);
-        // hasn't computed a real value yet -- starts dirty so a warm-up can force it through.
+        // hasn't computed a real value yet -- starts dirty so a warm-up can go through.
         assertThat(cache.isDirty()).isTrue();
     }
 
     @Test
-    void testRefreshIsNoOpWhenNotDirtyEvenIfForced() {
-        CoalescingRefreshCache<Integer> cache =
-                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
-        cache.refresh(() -> 1, true); // clears the initial dirty state
+    void testFirstRefreshIsAlwaysDueRegardlessOfElapsed() {
+        CoalescingRefreshCache<Integer> cache = newCache(0);
         AtomicInteger computeCalls = new AtomicInteger();
 
-        cache.refresh(() -> computeCalls.incrementAndGet(), true);
+        // called immediately after construction -- elapsed time is near zero, yet the very
+        // first refresh() must still go through: a caller's warm-up call must never be a
+        // silent no-op just because it happened to run right after construction.
+        cache.refresh(() -> computeCalls.incrementAndGet());
 
-        // force overrides the timing gate, never the dirty gate -- nothing changed, so
-        // compute() must not even be invoked, force notwithstanding.
+        assertThat(computeCalls.get()).isEqualTo(1);
+        assertThat(cache.isDirty()).isFalse();
+    }
+
+    @Test
+    void testRefreshIsNoOpWhenNothingChangedAndNoBoundHasElapsed() {
+        CoalescingRefreshCache<Integer> cache = newCache(0);
+        cache.refresh(() -> 1); // warm-up: due unconditionally on the first call
+        AtomicInteger computeCalls = new AtomicInteger();
+
+        cache.refresh(() -> computeCalls.incrementAndGet());
+
+        // called again immediately: nothing marked dirty, and no bound (urgent/normal/safety
+        // net) has elapsed -- compute() must not even be invoked.
         assertThat(computeCalls.get()).isZero();
         assertThat(cache.get()).isEqualTo(1);
     }
 
     @Test
-    void testNonUrgentChangeWaitsForForce() {
-        CoalescingRefreshCache<Integer> cache =
-                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+    void testNonUrgentChangeFiresAtNormalMaxDelayNotBefore() throws InterruptedException {
+        CoalescingRefreshCache<Integer> cache = newCache(0);
         AtomicInteger source = new AtomicInteger(1);
+        cache.refresh(source::get); // establishes a real lastRefreshTimeMs baseline
+        source.set(2);
         cache.markDirty(false);
 
-        cache.refresh(source::get, false); // not forced -- must wait
-        assertThat(cache.get()).isEqualTo(0);
+        cache.refresh(source::get); // normal delay not yet elapsed -- must wait
+        assertThat(cache.get()).isEqualTo(1);
         assertThat(cache.isDirty()).isTrue();
 
-        cache.refresh(source::get, true); // forced -- now it should recompute
-        assertThat(cache.get()).isEqualTo(1);
+        Thread.sleep(NORMAL_MAX_DELAY_MS + 50);
+
+        cache.refresh(source::get); // normal bound is now up
+        assertThat(cache.get()).isEqualTo(2);
         assertThat(cache.isDirty()).isFalse();
     }
 
     @Test
-    void testUrgentChangeIsBoundedByMaxDelayEvenIfNeverForced() throws InterruptedException {
-        CoalescingRefreshCache<Integer> cache =
-                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+    void testUrgentChangeFiresAtUrgentMaxDelayNotBefore() throws InterruptedException {
+        CoalescingRefreshCache<Integer> cache = newCache(0);
         AtomicInteger source = new AtomicInteger(1);
-        cache.refresh(source::get, true); // establishes a real lastRefreshTimeMs baseline
+        cache.refresh(source::get); // establishes a real lastRefreshTimeMs baseline
         source.set(2);
-
         cache.markDirty(true);
-        cache.refresh(source::get, false); // urgent, but delay not yet elapsed
+
+        cache.refresh(source::get); // urgent, but delay not yet elapsed
         assertThat(cache.get()).isEqualTo(1);
 
-        Thread.sleep(URGENT_MAX_DELAY_MS + 50);
+        Thread.sleep(URGENT_MAX_DELAY_MS + 20);
 
-        cache.refresh(source::get, false); // still not forced, but the bound is up
+        cache.refresh(source::get); // urgent bound is now up, well before the normal one
         assertThat(cache.get()).isEqualTo(2);
         assertThat(cache.isDirty()).isFalse();
         assertThat(cache.isUrgentlyDirty()).isFalse();
     }
 
     @Test
-    void testManyMarkDirtyCallsCoalesceIntoOneRecompute() {
-        CoalescingRefreshCache<Integer> cache =
-                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+    void testSafetyNetFiresEvenWithoutAnyMarkDirtyCall() throws InterruptedException {
+        CoalescingRefreshCache<Integer> cache = newCache(0);
+        AtomicInteger source = new AtomicInteger(1);
+        cache.refresh(source::get); // establishes a real lastRefreshTimeMs baseline
+        source.set(2);
+        // deliberately never call markDirty -- proves the coverage guarantee is independent of
+        // whether a caller remembered to report the change at all.
+
+        Thread.sleep(SAFETY_NET_MAX_DELAY_MS + 50);
+
+        cache.refresh(source::get);
+        assertThat(cache.get()).isEqualTo(2);
+    }
+
+    @Test
+    void testManyMarkDirtyCallsCoalesceIntoOneRecompute() throws InterruptedException {
+        CoalescingRefreshCache<Integer> cache = newCache(0);
+        cache.refresh(() -> 0); // warm-up
         AtomicInteger computeCalls = new AtomicInteger();
         AtomicInteger source = new AtomicInteger();
 
@@ -105,35 +136,35 @@ class CoalescingRefreshCacheTest {
                     () -> {
                         computeCalls.incrementAndGet();
                         return source.incrementAndGet();
-                    },
-                    false); // never forced -- simulates a burst arriving while the queue is busy
+                    }); // each call lands well within normalMaxDelayMs -- none is due yet
         }
         assertThat(computeCalls.get()).isZero();
 
+        Thread.sleep(NORMAL_MAX_DELAY_MS + 50);
         cache.refresh(
                 () -> {
                     computeCalls.incrementAndGet();
                     return source.incrementAndGet();
-                },
-                true); // forced now -- exactly one recompute for the whole burst
+                }); // now due -- exactly one recompute for the whole burst
 
         assertThat(computeCalls.get()).isEqualTo(1);
         assertThat(cache.get()).isEqualTo(1);
     }
 
     @Test
-    void testForceClearsDirtyFlagsAfterRecomputing() {
-        CoalescingRefreshCache<Integer> cache =
-                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+    void testDirtyFlagsClearAfterADueRecompute() {
+        CoalescingRefreshCache<Integer> cache = newCache(0);
         cache.markDirty(true);
 
-        cache.refresh(() -> 7, true);
+        cache.refresh(() -> 7); // first call is unconditionally due
 
         assertThat(cache.get()).isEqualTo(7);
-        // a forced refresh still recomputed the current truth, so nothing is left
-        // unreflected -- force participates fully in the dirty-tracking system, it doesn't
-        // sidestep it.
         assertThat(cache.isDirty()).isFalse();
         assertThat(cache.isUrgentlyDirty()).isFalse();
+    }
+
+    private static CoalescingRefreshCache<Integer> newCache(int initialValue) {
+        return new CoalescingRefreshCache<>(
+                initialValue, URGENT_MAX_DELAY_MS, NORMAL_MAX_DELAY_MS, SAFETY_NET_MAX_DELAY_MS);
     }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/utils/CoalescingRefreshCacheTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/utils/CoalescingRefreshCacheTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CoalescingRefreshCache}, exercised with a trivial {@code Integer} value so the
+ * coalescing/urgency mechanics are verified independently of any real caller (e.g. {@code
+ * CoordinatorHealthCache}).
+ */
+class CoalescingRefreshCacheTest {
+
+    private static final long URGENT_MAX_DELAY_MS = 100;
+
+    @Test
+    void testInitialValueIsReturnedUntouched() {
+        CoalescingRefreshCache<Integer> cache =
+                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+        assertThat(cache.get()).isEqualTo(0);
+        assertThat(cache.isDirty()).isFalse();
+    }
+
+    @Test
+    void testRefreshIfNeededIsNoOpWhenNotDirty() {
+        CoalescingRefreshCache<Integer> cache =
+                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+        AtomicInteger computeCalls = new AtomicInteger();
+
+        cache.refreshIfNeeded(() -> computeCalls.incrementAndGet(), true);
+
+        // compute() must not even be invoked -- there was nothing to refresh.
+        assertThat(computeCalls.get()).isZero();
+        assertThat(cache.get()).isEqualTo(0);
+    }
+
+    @Test
+    void testNonUrgentChangeWaitsUntilIdle() {
+        CoalescingRefreshCache<Integer> cache =
+                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+        AtomicInteger source = new AtomicInteger(1);
+        cache.markDirty(false);
+
+        cache.refreshIfNeeded(source::get, false); // not idle -- must wait
+        assertThat(cache.get()).isEqualTo(0);
+        assertThat(cache.isDirty()).isTrue();
+
+        cache.refreshIfNeeded(source::get, true); // idle -- now it should recompute
+        assertThat(cache.get()).isEqualTo(1);
+        assertThat(cache.isDirty()).isFalse();
+    }
+
+    @Test
+    void testUrgentChangeIsBoundedByMaxDelayEvenIfNeverIdle() throws InterruptedException {
+        CoalescingRefreshCache<Integer> cache =
+                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+        AtomicInteger source = new AtomicInteger(1);
+        cache.update(source::get); // establishes a real lastRefreshTimeMs baseline
+        source.set(2);
+
+        cache.markDirty(true);
+        cache.refreshIfNeeded(source::get, false); // urgent, but delay not yet elapsed
+        assertThat(cache.get()).isEqualTo(1);
+
+        Thread.sleep(URGENT_MAX_DELAY_MS + 50);
+
+        cache.refreshIfNeeded(source::get, false); // still not idle, but the bound is up
+        assertThat(cache.get()).isEqualTo(2);
+        assertThat(cache.isDirty()).isFalse();
+        assertThat(cache.isUrgentlyDirty()).isFalse();
+    }
+
+    @Test
+    void testManyMarkDirtyCallsCoalesceIntoOneRecompute() {
+        CoalescingRefreshCache<Integer> cache =
+                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+        AtomicInteger computeCalls = new AtomicInteger();
+        AtomicInteger source = new AtomicInteger();
+
+        for (int i = 0; i < 50; i++) {
+            cache.markDirty(false);
+            cache.refreshIfNeeded(
+                    () -> {
+                        computeCalls.incrementAndGet();
+                        return source.incrementAndGet();
+                    },
+                    false); // never idle -- simulates a burst arriving while the queue is busy
+        }
+        assertThat(computeCalls.get()).isZero();
+
+        cache.refreshIfNeeded(
+                () -> {
+                    computeCalls.incrementAndGet();
+                    return source.incrementAndGet();
+                },
+                true); // idle now -- exactly one recompute for the whole burst
+
+        assertThat(computeCalls.get()).isEqualTo(1);
+        assertThat(cache.get()).isEqualTo(1);
+    }
+
+    @Test
+    void testUpdateBypassesPolicyButDoesNotClearDirtyFlags() {
+        CoalescingRefreshCache<Integer> cache =
+                new CoalescingRefreshCache<>(0, URGENT_MAX_DELAY_MS);
+        cache.markDirty(true);
+
+        cache.update(() -> 7);
+
+        assertThat(cache.get()).isEqualTo(7);
+        // update() is an unconditional bypass of the policy, not a substitute for it -- it must
+        // not silently clear flags that refreshIfNeeded is responsible for managing.
+        assertThat(cache.isDirty()).isTrue();
+        assertThat(cache.isUrgentlyDirty()).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Companion to the discussion on #1389 about splitting `getServerNodes()` / `getClusterHealth()` / `describeTabletServers()` by cost and update frequency ([comment](https://github.com/apache/fluss/issues/1389#issuecomment-5293922593)).

Adds `CoordinatorHealthCache`: a lock-free, coordinator-thread-published snapshot of cluster-wide and per-tablet-server replica/leader health, kept warm incrementally as mutations happen, instead of recomputed from scratch on every RPC call via `AccessContextEvent`. Wired into real mutation handling (leader/ISR changes, server death/registration, topology changes). **No RPC reads from it yet** — `getClusterHealth()`/`describeTabletServers()` are untouched; this PR is the mechanism only.

## Performance & consistency trade-offs

- **Read cost:** today, `getClusterHealth()`/`describeTabletServers()` each enqueue a fresh `O(buckets)` scan onto the single coordinator event thread on *every call*. This cache makes reads `O(1)` — a lock-free field read — by moving the scan to the *write* side, where it's decoupled from call frequency and triggered by mutation instead.
- **Write cost:** still `O(buckets)` per recompute, unavoidably — the point isn't to make the scan cheaper, it's to make it run less often. ~~Every mutation is coalesced: a burst of many changes (e.g. a full failover storm re-electing leaders for hundreds of buckets) costs at most one recompute, not one per event, bounded by how long the coordinator's event queue stays busy.~~
  **Correction:** recompute frequency is no longer tied to queue state at all (`queue.isEmpty()` tracked mutation rate, not a fixed interval, so loop cost had no real ceiling under a steady mutation trickle). It's now gated purely on elapsed wall-clock time: at most once per 200ms for urgent changes, once per 3s for anything else, regardless of how many mutations land in between. A burst of many changes still costs at most one recompute, but the bound is time-based, not queue-based.
- ~~**Consistency is bounded, and deliberately asymmetric:** changes that represent degradation (a server dying, a bucket going under-replicated, a leader missing or inactive) are guaranteed to be reflected within 200ms regardless of how busy the coordinator is; everything else (topology changes, tag updates, healthy ISR churn) is only guaranteed *eventually*, once the event queue next drains. This is safe specifically because staleness always lags toward the *previous* known state — a stale read can show a server as busier/healthier than it now is (bounded to 200ms of lag for degradation), but never masks a live problem for longer than that bound, and a consumer using this as a scale-in/rolling-upgrade safety gate can only end up waiting longer than strictly necessary, never acting on data that's wrong in the unsafe direction.~~
  **Correction:** consistency is bounded by two independent mechanisms now, not one. *Rate*: degradation (server death, under-replication, missing/inactive leader) is reflected within 200ms; everything else within 3s — both measured from elapsed time, not queue drain. *Coverage*: an unconditional 10s ceiling bounds staleness regardless of `dirty` at all, so a mutation path nobody remembered to instrument is still caught within a fixed bound instead of drifting indefinitely. On the safety claim: "staleness lags toward the previous state, so it's always safe" isn't a general property of this cache — it depends on the specific consumer. For a scale-in gate specifically, it holds only for the server already marked shutting down: `TableBucketStateMachine.electLeader` excludes shutting-down servers from `ControlledShutdownLeaderElection`, so that server's leader count can only go down once marked, and a stale read can only over-report leaders still present there, never invent one. That's not true in general — before a server is marked shutting down, or for any other server, a stale read absolutely can under-report a leader that just landed.

## Impact on other open PRs

- **#3743 (`DescribeTabletServers`)** — once merged, can read this cache directly (it already carries the exact per-server counters that RPC needs, plus `bucketsWithoutLeader()` reconciling the aggregate/per-server leader-count divergence) instead of its own `AccessContextEvent` scan. No new snapshot shape required.
- **#1410 (`getServerNodes` / server tags)** — no direct relationship, but confirms the same pattern (this PR's `CoalescingRefreshCache`, or the existing `CoordinatorMetadataCache`) is the right fix for that PR's live `zkClient.getServerTags()` call, which is doing a ZK round-trip on every call for data that's already cached elsewhere.
- **#4029 (`DescribeBuckets`)** — same opportunity, but two steps: first stop bypassing `CoordinatorContext` for a live ZK read, then a per-bucket cache shaped like this one.
- **#3785 (`UpdateMetadataRequest` propagation)** — no relationship, and none expected: that's a coordinator-initiated push to tablet servers, not a client read blocked on the event thread, so this mechanism doesn't apply there.
- **No file overlap** with either #3785 or #4029's independent `BucketMetadata.java` extensions — this PR doesn't touch that class, so no merge conflict risk from this change.

~~**Known, deliberate gap:** leader-activation flips (`CoordinatorRequestBatch`) aren't wired to this cache yet — bounded staleness, not a correctness issue (the next refresh for any other reason reports it correctly regardless), left for a follow-up.~~
**Resolved:** leader-activation flips are now wired directly — `CoordinatorContext.addPendingLeaderActivation`/`clearPendingLeaderActivation` notify the listener as part of the same mutator-level hookup that closes the other coverage gaps below.

## Test Plan

- ~~New unit tests: `CoordinatorHealthCacheTest` (15), `CoalescingRefreshCacheTest` (6).~~
  **Updated:** `CoordinatorHealthCacheTest` (16), `CoalescingRefreshCacheTest` (8) — rewritten for the elapsed-time-gated `refresh()` API, including a case proving the safety-net ceiling fires even if `markDirty` is never called.
- Full existing suite for every touched/related file passes unchanged: `CoordinatorEventProcessorTest`, `ClusterHealthTest`, `CoordinatorEventManagerTest`, `TableBucketStateMachineTest`, `CoordinatorContextTest`, `CoordinatorMetadataCacheTest` — 95 tests total across both runs.
- `mvn spotless:check` clean.

🤖 AI-assisted changes - reviewed by human developer
