### PR TITLE
[hotfix][docs] Fix typos in JavaDoc and comments

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/metrics/FlinkMetricRegistry.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/metrics/FlinkMetricRegistry.java
@@ -88,7 +88,7 @@ public class FlinkMetricRegistry implements MetricRegistry {
         registerMetric(currentMetricGroup, metric, metricName);
     }
 
-    /** Exposes the metrics of Fluss metics group for flink. */
+    /** Exposes the metrics of Fluss metrics group for flink. */
     public Metric getFlussMetric(String metricName) {
         return metrics.get(metricName);
     }

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotStore.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/CompletedSnapshotStore.java
@@ -75,7 +75,7 @@ public class CompletedSnapshotStore {
 
     /**
      * Local copy of the completed snapshots in snapshot store. This is restored from snapshot
-     * handel store when recovering.
+     * handle store when recovering.
      */
     private final ArrayDeque<CompletedSnapshot> completedSnapshots;
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThread.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/fetcher/ReplicaFetcherThread.java
@@ -83,7 +83,7 @@ final class ReplicaFetcherThread extends ShutdownableThread {
     private final LeaderEndpoint leader;
     private final int fetchBackOffMs;
 
-    // manually add timout logic in here, todo remove this timeout logic if
+    // manually add timeout logic in here, todo remove this timeout logic if
     // we support global request timeout in #279
     private final int timeoutSeconds;
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/ServerTestBase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/ServerTestBase.java
@@ -122,7 +122,7 @@ public abstract class ServerTestBase {
         configuration.setString(ConfigOptions.ADVERTISED_LISTENERS, "CLIENT://198.168.0.1:100");
         configuration.set(ConfigOptions.REMOTE_DATA_DIR, "/tmp/fluss/remote-data");
 
-        // set to small timout to verify the case that zk session is timeout
+        // set to small timeout to verify the case that zk session is timeout
         configuration.set(ConfigOptions.ZOOKEEPER_SESSION_TIMEOUT, Duration.ofMillis(500));
         configuration.set(ConfigOptions.ZOOKEEPER_CONNECTION_TIMEOUT, Duration.ofMillis(500));
         configuration.set(ConfigOptions.ZOOKEEPER_RETRY_WAIT, Duration.ofMillis(500));

--- a/fluss-server/src/test/java/org/apache/fluss/server/authorizer/DefaultAuthorizerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/authorizer/DefaultAuthorizerTest.java
@@ -614,7 +614,7 @@ public class DefaultAuthorizerTest {
         }
 
         runInConcurrent(concurrentTasks);
-        // Make sure all acl notifacations are arrived.
+        // Make sure all acl notifications are arrived.
         retry(
                 Duration.ofMinutes(1),
                 () -> assertThat(listAcls(authorizer, commonResource)).isEqualTo(expectedAcls));


### PR DESCRIPTION
### Purpose

Linked issue: #1874

Fix a first, narrowly scoped slice of the typos listed by codespell: only JavaDoc and comments. No APIs, exception messages, or test assertion strings are changed.

### Brief change log

- `handel` → `handle` in `CompletedSnapshotStore` JavaDoc
- `metics` → `metrics` in `FlinkMetricRegistry` JavaDoc
- `timout` → `timeout` in comments
- `notifacations` → `notifications` in a test comment

Adding `codespell` as a CI gate is left for a follow-up, because it needs a false-positive policy (Flink `plugable` package, method names such as `transfered()`, etc.).

### Tests

Comment/JavaDoc-only change; no behavior change. Existing tests are unaffected.

### API and Format

No API or storage format change.

### Documentation

JavaDoc wording only.