### PR TITLE
[client] Fix flaky testKvSnapshotLeaseAfterCoordinatorServerRestart

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
@@ -1265,7 +1265,6 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isPresent();
 
         restartCoordinatorServer(zkClient);
-        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
 
         lease.dropLease().get();
         assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isNotPresent();
@@ -1278,6 +1277,9 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
                 Duration.ofMinutes(1),
                 "Coordinator server node still exists in ZooKeeper");
         FLUSS_CLUSTER_EXTENSION.startCoordinatorServer();
+        // The client retries once after a metadata refresh, which can be served by a tablet
+        // server that has not learned the new coordinator address yet, so wait for convergence.
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fixes CI flakiness in `FlussAdminITCase.testKvSnapshotLeaseAfterCoordinatorServerRestart`, which intermittently fails with `NetworkException: Connection refused` right after a coordinator restart.
- The lease client recovers from a restart with a single metadata-refresh retry (`RetryableGatewayClientProxy`), and that refresh can be served by a tablet server that has not yet learned the restarted coordinator's new address, so the one retry hits the stale address again. The test only waited for gateway metadata convergence before the third restart's verification; the wait now lives in `restartCoordinatorServer` so all three restarts are covered.

## Test Plan

- `./mvnw test -Dtest='FlussAdminITCase#testKvSnapshotLeaseAfterCoordinatorServerRestart' -pl fluss-client` passes locally. Test-only change; no production code touched.

🤖 AI-assisted changes - reviewed by human developer
