### PR TITLE
[common] Fix CHAR min/max statistics collection

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsCollector.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsCollector.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.function.Function;
 
+import static org.apache.fluss.types.DataTypeChecks.getLength;
+
 /**
  * Collector for {@link LogRecordBatchStatistics} that accumulates statistics during record batch
  * construction. Manages statistics data in memory arrays and supports schema-aware statistics
@@ -159,6 +161,11 @@ public class LogRecordBatchStatisticsCollector {
             case DOUBLE:
                 double doubleValue = row.getDouble(schemaIndex);
                 updateMinMaxInternal(statsIndex, doubleValue, Double::compare);
+                break;
+            case CHAR:
+                BinaryString charValue = row.getChar(schemaIndex, getLength(fieldType));
+                updateMinMaxInternal(
+                        statsIndex, charValue, BinaryString::compareTo, BinaryString::copy);
                 break;
             case STRING:
                 BinaryString stringValue = row.getString(schemaIndex);

--- a/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsWriter.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsWriter.java
@@ -31,6 +31,7 @@ import org.apache.fluss.types.TimestampType;
 import java.io.IOException;
 
 import static org.apache.fluss.record.LogRecordBatchFormat.STATISTICS_VERSION;
+import static org.apache.fluss.types.DataTypeChecks.getLength;
 
 /**
  * A high-performance writer for LogRecordBatch statistics that efficiently serializes statistical
@@ -204,6 +205,10 @@ public class LogRecordBatchStatisticsWriter {
                         break;
                     case DOUBLE:
                         reusableRowWriter.writeDouble(i, row.getDouble(i));
+                        break;
+                    case CHAR:
+                        int charLength = getLength(fieldType);
+                        reusableRowWriter.writeChar(i, row.getChar(i, charLength), charLength);
                         break;
                     case STRING:
                         reusableRowWriter.writeString(i, row.getString(i));

--- a/fluss-common/src/test/java/org/apache/fluss/record/LogRecordBatchStatisticsCollectorTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/record/LogRecordBatchStatisticsCollectorTest.java
@@ -170,6 +170,34 @@ public class LogRecordBatchStatisticsCollectorTest {
     }
 
     @Test
+    void testCharStatisticsSerializationRoundTrip() throws IOException {
+        RowType charRowType = DataTypes.ROW(new DataField("char_val", DataTypes.CHAR(3)));
+        LogRecordBatchStatisticsCollector charCollector =
+                new LogRecordBatchStatisticsCollector(charRowType, new int[] {0});
+
+        List<Object[]> charData =
+                Arrays.asList(
+                        new Object[] {"cat"},
+                        new Object[] {"a"},
+                        new Object[] {null},
+                        new Object[] {"dog"});
+        for (Object[] data : charData) {
+            charCollector.processRow(DataTestUtils.row(data));
+        }
+
+        MemorySegment segment = MemorySegment.allocateHeapMemory(1024);
+        charCollector.writeStatistics(new MemorySegmentOutputView(segment));
+
+        DefaultLogRecordBatchStatistics statistics =
+                LogRecordBatchStatisticsParser.parseStatistics(segment, 0, charRowType, 1);
+
+        assertThat(statistics.getMinValues().getChar(0, 3)).isEqualTo(BinaryString.fromString("a"));
+        assertThat(statistics.getMaxValues().getChar(0, 3))
+                .isEqualTo(BinaryString.fromString("dog"));
+        assertThat(statistics.getNullCounts()[0]).isEqualTo(1);
+    }
+
+    @Test
     void testPartialStatsIndexMapping() throws IOException {
         RowType fullRowType =
                 DataTypes.ROW(

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/RecordBatchFilterTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/RecordBatchFilterTest.java
@@ -125,6 +125,27 @@ class RecordBatchFilterTest {
         assertThat(result).isTrue();
     }
 
+    @Test
+    void testCharStatisticsCanPruneRecordBatch() throws IOException {
+        RowType rowType = RowType.of(DataTypes.CHAR(3));
+        LogRecordBatchStatisticsCollector collector =
+                new LogRecordBatchStatisticsCollector(rowType, new int[] {0});
+        collector.processRow(GenericRow.of(BinaryString.fromString("cat")));
+        collector.processRow(GenericRow.of(BinaryString.fromString("ant")));
+        collector.processRow(GenericRow.of(BinaryString.fromString("dog")));
+
+        MemorySegmentOutputView outputView = new MemorySegmentOutputView(1024);
+        collector.writeStatistics(outputView);
+        DefaultLogRecordBatchStatistics statistics =
+                LogRecordBatchStatisticsParser.parseStatistics(
+                        outputView.getMemorySegment(), 0, rowType, TEST_SCHEMA_ID);
+
+        Predicate predicate =
+                new PredicateBuilder(rowType).greaterThan(0, BinaryString.fromString("zoo"));
+
+        assertThat(mayMatch(predicate, TEST_SCHEMA_ID, null, 3L, statistics)).isFalse();
+    }
+
     // =====================================================
     // Schema Evolution Tests
     // =====================================================


### PR DESCRIPTION
### Purpose

Linked issue: close #4066

`DataTypeChecks.isSupportedStatisticsType()` lists `CHAR` as a supported
statistics type, but `LogRecordBatchStatisticsCollector` does not handle
`CHAR` when collecting min/max values. As a result, the bounds remain null
and predicates on `CHAR` columns cannot prune record batches.

`LogRecordBatchStatisticsWriter` also does not handle non-null `CHAR`
min/max values, so adding collector support alone would cause statistics
serialization to fail.

### Brief change log

- Add `CHAR` min/max collection using `InternalRow#getChar`,
  `BinaryString::compareTo`, and `BinaryString::copy`.
- Add `CHAR` statistics serialization using
  `AlignedRowWriter#writeChar`.
- Add a serialization round-trip test covering min/max values, null count,
  and a value shorter than the declared `CHAR` length.
- Add a predicate pruning test for a `CHAR` column.

### Tests

- `LogRecordBatchStatisticsCollectorTest#testCharStatisticsSerializationRoundTrip`:
  verifies that `CHAR(3)` values, including the shorter value `"a"`, are
  collected and serialized with the expected min/max values and null count.
- `RecordBatchFilterTest#testCharStatisticsCanPruneRecordBatch`:
  verifies that `CHAR` statistics can exclude a record batch that cannot
  satisfy the predicate.
- Targeted tests: 24 tests, 0 failures.
- `mvn spotless:check -pl fluss-common,fluss-server` passes.
- Checkstyle and Apache RAT validation pass.

### API and Format

No public API or statistics format change.

The implementation uses the existing `CHAR` internal representation and
statistics serialization format.

### Documentation

No documentation change; behavior-only bug fix.

- [ ] No generative AI tools used
- [x] Yes (please specify the tool below)

Assisted by: OpenAI Codex following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md).