### PR TITLE
[docs] Align Flink add_acl procedure docs with the implementation

### DIFF
--- a/website/docs/engine-flink/procedures.md
+++ b/website/docs/engine-flink/procedures.md
@@ -38,10 +38,10 @@ CALL [catalog_name.]sys.add_acl(
 
 **Parameters:**
 
-- `resource` (required): The resource to grant permissions on. Can be `'CLUSTER'` for cluster-level permissions or a specific resource name (e.g., database or table name).
-- `permission` (required): The permission type to grant. Valid values are `'ALLOW'` or `'DENY'`.
+- `resource` (required): The resource to grant permissions on. Must be `'cluster'` for cluster-level permissions, `'cluster.<database>'` for a database, or `'cluster.<database>.<table>'` for a table.
+- `permission` (required): The permission type to grant. Currently only `'ALLOW'` is supported.
 - `principal` (required): The principal to grant permissions to, in the format `'Type:Name'` (e.g., `'User:Alice'`).
-- `operation` (required): The operation type to grant. Valid values include `'READ'`, `'WRITE'`, `'CREATE'`, `'DELETE'`, `'ALTER'`, `'DESCRIBE'`, `'CLUSTER_ACTION'`, `'IDEMPOTENT_WRITE'`.
+- `operation` (required): The operation type to grant. Valid values are `'READ'`, `'WRITE'`, `'CREATE'`, `'DROP'`, `'ALTER'`, `'DESCRIBE'`, and `'ALL'`. `'ANY'` is only for filters and should not be used when adding ACLs.
 - `host` (optional): The host from which the principal can access the resource. Defaults to `'*'` (all hosts).
 
 **Example:**
@@ -52,7 +52,7 @@ USE fluss_catalog;
 
 -- Grant read permission to user Alice from any host
 CALL sys.add_acl(
-  resource => 'CLUSTER',
+  resource => 'cluster',
   permission => 'ALLOW',
   principal => 'User:Alice',
   operation => 'READ',
@@ -61,7 +61,7 @@ CALL sys.add_acl(
 
 -- Grant write permission to user Bob from a specific host
 CALL sys.add_acl(
-  resource => 'my_database.my_table',
+  resource => 'cluster.my_database.my_table',
   permission => 'ALLOW',
   principal => 'User:Bob',
   operation => 'WRITE',
@@ -97,7 +97,7 @@ USE fluss_catalog;
 
 -- Remove a specific ACL entry
 CALL sys.drop_acl(
-  resource => 'CLUSTER',
+  resource => 'cluster',
   permission => 'ALLOW',
   principal => 'User:Alice',
   operation => 'READ',


### PR DESCRIPTION
### Purpose

Linked issue: close #4099

The Flink Procedures page documented `sys.add_acl` with resource, permission, and operation values the procedure rejects. This updates that page to match the parser and the Security authorization docs.

### Brief change log

- Document the required resource form: `cluster`, `cluster.<database>`, `cluster.<database>.<table>`
- Drop unsupported `DENY`, `DELETE`, `CLUSTER_ACTION`, and `IDEMPOTENT_WRITE`
- List the operations the procedure actually accepts, including `DROP` and `ALL`
- Fix the table-level and drop examples so they use a valid resource string

### Tests

Docs-only change. The rejected values were reproduced on `0.9.1-incubating` against a SASL + authorizer cluster.

### API and Format

No API or storage format change.

### Documentation

Updates `website/docs/engine-flink/procedures.md` only.