### PR TITLE
[server] Add support of sharable file cache capacity for historical partition lookup

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigOptions.java
@@ -428,7 +428,7 @@ public class ConfigOptions {
                             .defaultValue(0.10)
                             .withDescription(
                                     "The maximum fraction of the total capacity of the volume containing the first available data directory allocated to historical partition lookup caches on a TabletServer. "
-                                            + "Up to ten table lookupers are cached, and each receives one tenth of this capacity. Historical lookup cache files are stored under that data directory; additional data volumes are not used. "
+                                            + "Up to ten table lookupers share this capacity. Historical lookup cache files are stored under that data directory; additional data volumes are not used. "
                                             + "The valid range is (0.0, 1.0].");
 
     public static final ConfigOption<Duration>

--- a/fluss-common/src/main/java/org/apache/fluss/lake/lakestorage/LakeStorage.java
+++ b/fluss-common/src/main/java/org/apache/fluss/lake/lakestorage/LakeStorage.java
@@ -18,13 +18,9 @@
 package org.apache.fluss.lake.lakestorage;
 
 import org.apache.fluss.annotation.PublicEvolving;
-import org.apache.fluss.config.TableConfig;
 import org.apache.fluss.lake.source.LakeSource;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
 import org.apache.fluss.metadata.TablePath;
-
-import static org.apache.fluss.utils.Preconditions.checkArgument;
-import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
 /**
  * The LakeStorage interface defines how to implement lakehouse storage system such as Paimon and
@@ -56,64 +52,15 @@ public interface LakeStorage {
     LakeSource<?> createLakeSource(TablePath tablePath);
 
     /**
-     * Creates a table-level point lookuper for the specified lake table.
+     * Creates a TabletServer-scoped runtime for lake table point lookup.
      *
-     * @param tablePath the logical path identifying the table in the lakehouse storage
-     * @param context runtime context for creating the lookuper
-     * @return a table-level point lookuper
+     * @param ioTmpDir local directory shared by lookupers for temporary files
+     * @param lookupCacheMaxDiskBytes maximum local lookup cache size in bytes
+     * @return the lookup runtime
      */
-    default LakeTableLookuper createLakeTableLookuper(
-            TablePath tablePath, LookuperContext context) {
+    default LakeTableLookupRuntime createLakeTableLookupRuntime(
+            String ioTmpDir, long lookupCacheMaxDiskBytes) {
         throw new UnsupportedOperationException(
                 "Point lookup is not supported for this lake storage.");
-    }
-
-    /** Runtime context for creating a lake table lookuper. */
-    final class LookuperContext {
-        private final String ioTmpDir;
-        private final TableConfig tableConfig;
-        private final long lookupCacheMaxDiskBytes;
-        private final Runnable diskWriteGuard;
-
-        /**
-         * Creates a lookuper context.
-         *
-         * @param ioTmpDir local directory for temporary files used by the lookuper
-         * @param tableConfig configuration of the Fluss table
-         * @param lookupCacheMaxDiskBytes maximum local lookup cache size in bytes
-         * @param diskWriteGuard guard invoked before creating a local lookup cache file
-         */
-        public LookuperContext(
-                String ioTmpDir,
-                TableConfig tableConfig,
-                long lookupCacheMaxDiskBytes,
-                Runnable diskWriteGuard) {
-            this.ioTmpDir = checkNotNull(ioTmpDir, "ioTmpDir must not be null.");
-            this.tableConfig = checkNotNull(tableConfig, "tableConfig must not be null.");
-            checkArgument(
-                    lookupCacheMaxDiskBytes > 0, "lookupCacheMaxDiskBytes must be greater than 0.");
-            this.lookupCacheMaxDiskBytes = lookupCacheMaxDiskBytes;
-            this.diskWriteGuard = checkNotNull(diskWriteGuard, "diskWriteGuard must not be null.");
-        }
-
-        /** Returns the local directory for temporary files used by the lookuper. */
-        public String ioTmpDir() {
-            return ioTmpDir;
-        }
-
-        /** Returns the configuration of the Fluss table. */
-        public TableConfig tableConfig() {
-            return tableConfig;
-        }
-
-        /** Returns the maximum local lookup cache size in bytes. */
-        public long lookupCacheMaxDiskBytes() {
-            return lookupCacheMaxDiskBytes;
-        }
-
-        /** Returns the guard invoked before creating a local lookup cache file. */
-        public Runnable diskWriteGuard() {
-            return diskWriteGuard;
-        }
     }
 }

--- a/fluss-common/src/main/java/org/apache/fluss/lake/lakestorage/LakeTableLookupRuntime.java
+++ b/fluss-common/src/main/java/org/apache/fluss/lake/lakestorage/LakeTableLookupRuntime.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.lakestorage;
+
+import org.apache.fluss.annotation.PublicEvolving;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.TableConfig;
+import org.apache.fluss.metadata.TablePath;
+
+import static org.apache.fluss.utils.Preconditions.checkNotNull;
+
+/** TabletServer-scoped runtime for creating lake table lookupers. */
+@PublicEvolving
+public interface LakeTableLookupRuntime extends AutoCloseable {
+
+    /**
+     * Creates a table-level point lookuper for the specified lake table.
+     *
+     * @param tablePath the logical path identifying the table in the lakehouse storage
+     * @param context runtime context for creating the lookuper
+     * @return a table-level point lookuper
+     */
+    LakeTableLookuper createLakeTableLookuper(TablePath tablePath, Context context);
+
+    /** Updates the maximum local lookup cache size in bytes. */
+    void updateLookupCacheMaxDiskBytes(long lookupCacheMaxDiskBytes);
+
+    /** Runtime context for creating a lake table lookuper. */
+    final class Context {
+        private final Configuration lakeConfiguration;
+        private final String cacheNamespace;
+        private final TableConfig tableConfig;
+        private final Runnable diskWriteGuard;
+
+        /**
+         * Creates a lookuper context.
+         *
+         * @param lakeConfiguration configuration of the lake storage for this lookuper
+         * @param cacheNamespace namespace identifying cache entries owned by this lookuper
+         * @param tableConfig configuration of the Fluss table
+         * @param diskWriteGuard guard invoked before creating a local lookup cache file
+         */
+        public Context(
+                Configuration lakeConfiguration,
+                String cacheNamespace,
+                TableConfig tableConfig,
+                Runnable diskWriteGuard) {
+            this.lakeConfiguration =
+                    checkNotNull(lakeConfiguration, "lakeConfiguration must not be null.");
+            this.cacheNamespace = checkNotNull(cacheNamespace, "cacheNamespace must not be null.");
+            this.tableConfig = checkNotNull(tableConfig, "tableConfig must not be null.");
+            this.diskWriteGuard = checkNotNull(diskWriteGuard, "diskWriteGuard must not be null.");
+        }
+
+        /** Returns the lake storage configuration for this lookuper. */
+        public Configuration lakeConfiguration() {
+            return lakeConfiguration;
+        }
+
+        /** Returns the namespace identifying cache entries owned by this lookuper. */
+        public String cacheNamespace() {
+            return cacheNamespace;
+        }
+
+        /** Returns the configuration of the Fluss table. */
+        public TableConfig tableConfig() {
+            return tableConfig;
+        }
+
+        /** Returns the guard invoked before creating a local lookup cache file. */
+        public Runnable diskWriteGuard() {
+            return diskWriteGuard;
+        }
+    }
+}

--- a/fluss-common/src/main/java/org/apache/fluss/lake/lakestorage/PluginLakeStorageWrapper.java
+++ b/fluss-common/src/main/java/org/apache/fluss/lake/lakestorage/PluginLakeStorageWrapper.java
@@ -139,12 +139,53 @@ public class PluginLakeStorageWrapper implements LakeStoragePlugin {
         }
 
         @Override
-        public LakeTableLookuper createLakeTableLookuper(
-                TablePath tablePath, LookuperContext context) {
+        public LakeTableLookupRuntime createLakeTableLookupRuntime(
+                String ioTmpDir, long lookupCacheMaxDiskBytes) {
+            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+                return new ClassLoaderFixingLakeTableLookupRuntime(
+                        inner.createLakeTableLookupRuntime(ioTmpDir, lookupCacheMaxDiskBytes),
+                        loader);
+            }
+        }
+    }
+
+    static class ClassLoaderFixingLakeTableLookupRuntime
+            implements LakeTableLookupRuntime, WrappingProxy<LakeTableLookupRuntime> {
+
+        private final LakeTableLookupRuntime inner;
+        private final ClassLoader loader;
+
+        private ClassLoaderFixingLakeTableLookupRuntime(
+                LakeTableLookupRuntime inner, ClassLoader loader) {
+            this.inner = inner;
+            this.loader = loader;
+        }
+
+        @Override
+        public LakeTableLookuper createLakeTableLookuper(TablePath tablePath, Context context) {
             try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
                 return new ClassLoaderFixingLakeTableLookuper(
                         inner.createLakeTableLookuper(tablePath, context), loader);
             }
+        }
+
+        @Override
+        public void updateLookupCacheMaxDiskBytes(long lookupCacheMaxDiskBytes) {
+            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+                inner.updateLookupCacheMaxDiskBytes(lookupCacheMaxDiskBytes);
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+                inner.close();
+            }
+        }
+
+        @Override
+        public LakeTableLookupRuntime getWrappedDelegate() {
+            return inner;
         }
     }
 

--- a/fluss-common/src/test/java/org/apache/fluss/lake/lakestorage/LakeStorageTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/lake/lakestorage/LakeStorageTest.java
@@ -91,6 +91,19 @@ class LakeStorageTest {
                         ((PluginLakeStorageWrapper.ClassLoaderFixingLakeCatalog) lakeCatalog)
                                 .getWrappedDelegate())
                 .isInstanceOf(TestPaimonLakeCatalog.class);
+
+        LakeTableLookupRuntime lookupRuntime =
+                lakeStorage.createLakeTableLookupRuntime("lookup-dir", 1024L);
+        assertThat(lookupRuntime)
+                .isInstanceOf(
+                        PluginLakeStorageWrapper.ClassLoaderFixingLakeTableLookupRuntime.class);
+        TestLakeTableLookupRuntime innerLookupRuntime =
+                (TestLakeTableLookupRuntime)
+                        ((PluginLakeStorageWrapper.ClassLoaderFixingLakeTableLookupRuntime)
+                                        lookupRuntime)
+                                .getWrappedDelegate();
+        lookupRuntime.close();
+        assertThat(innerLookupRuntime.closed).isTrue();
     }
 
     private static class TestingPluginManager implements PluginManager {
@@ -124,7 +137,6 @@ class LakeStorageTest {
     }
 
     private static class TestPaimonLakeStorage implements LakeStorage {
-
         public TestPaimonLakeStorage() {}
 
         @Override
@@ -140,6 +152,30 @@ class LakeStorageTest {
         @Override
         public LakeSource<?> createLakeSource(TablePath tablePath) {
             throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public LakeTableLookupRuntime createLakeTableLookupRuntime(
+                String ioTmpDir, long lookupCacheMaxDiskBytes) {
+            return new TestLakeTableLookupRuntime();
+        }
+    }
+
+    private static class TestLakeTableLookupRuntime implements LakeTableLookupRuntime {
+
+        private boolean closed;
+
+        @Override
+        public LakeTableLookuper createLakeTableLookuper(TablePath tablePath, Context context) {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public void updateLookupCacheMaxDiskBytes(long lookupCacheMaxDiskBytes) {}
+
+        @Override
+        public void close() {
+            closed = true;
         }
     }
 

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/PaimonLakeStorage.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/PaimonLakeStorage.java
@@ -19,8 +19,10 @@ package org.apache.fluss.lake.paimon;
 
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.lake.lakestorage.LakeStorage;
+import org.apache.fluss.lake.lakestorage.LakeTableLookupRuntime;
 import org.apache.fluss.lake.lakestorage.LakeTableLookuper;
 import org.apache.fluss.lake.paimon.lookup.PaimonLakeTableLookuper;
+import org.apache.fluss.lake.paimon.lookup.SharedLookupFileCache;
 import org.apache.fluss.lake.paimon.source.PaimonLakeSource;
 import org.apache.fluss.lake.paimon.source.PaimonSplit;
 import org.apache.fluss.lake.paimon.tiering.PaimonCommittable;
@@ -29,6 +31,14 @@ import org.apache.fluss.lake.paimon.tiering.PaimonWriteResult;
 import org.apache.fluss.lake.source.LakeSource;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
 import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.utils.IOUtils;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.options.MemorySize;
+
+import static org.apache.fluss.utils.Preconditions.checkArgument;
+import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
 /** Paimon implementation of {@link LakeStorage}. */
 public class PaimonLakeStorage implements LakeStorage {
@@ -55,13 +65,50 @@ public class PaimonLakeStorage implements LakeStorage {
     }
 
     @Override
-    public LakeTableLookuper createLakeTableLookuper(TablePath tablePath, LookuperContext context) {
-        return new PaimonLakeTableLookuper(
-                paimonConfig,
-                tablePath,
-                context.ioTmpDir(),
-                context.tableConfig(),
-                context.lookupCacheMaxDiskBytes(),
-                context.diskWriteGuard());
+    public LakeTableLookupRuntime createLakeTableLookupRuntime(
+            String ioTmpDir, long lookupCacheMaxDiskBytes) {
+        return new PaimonLakeTableLookupRuntime(ioTmpDir, lookupCacheMaxDiskBytes);
+    }
+
+    /** Paimon lookup runtime sharing one I/O manager across table lookupers. */
+    private static final class PaimonLakeTableLookupRuntime implements LakeTableLookupRuntime {
+        private final IOManager ioManager;
+        private final SharedLookupFileCache lookupFileCache;
+
+        private PaimonLakeTableLookupRuntime(String ioTmpDir, long lookupCacheMaxDiskBytes) {
+            checkArgument(
+                    lookupCacheMaxDiskBytes > 0, "lookupCacheMaxDiskBytes must be greater than 0.");
+            this.ioManager = IOManager.create(checkNotNull(ioTmpDir, "ioTmpDir must not be null."));
+            // ponytail: one runtime-wide retention; add a server option if this needs tuning.
+            this.lookupFileCache =
+                    new SharedLookupFileCache(
+                            CoreOptions.LOOKUP_CACHE_FILE_RETENTION.defaultValue(),
+                            new MemorySize(lookupCacheMaxDiskBytes));
+        }
+
+        @Override
+        public LakeTableLookuper createLakeTableLookuper(TablePath tablePath, Context context) {
+            return new PaimonLakeTableLookuper(
+                    new Configuration(context.lakeConfiguration()),
+                    tablePath,
+                    ioManager,
+                    lookupFileCache,
+                    context.cacheNamespace(),
+                    context.tableConfig(),
+                    context.diskWriteGuard());
+        }
+
+        @Override
+        public void updateLookupCacheMaxDiskBytes(long lookupCacheMaxDiskBytes) {
+            checkArgument(
+                    lookupCacheMaxDiskBytes > 0, "lookupCacheMaxDiskBytes must be greater than 0.");
+            lookupFileCache.updateMaxDiskSize(new MemorySize(lookupCacheMaxDiskBytes));
+        }
+
+        @Override
+        public void close() {
+            IOUtils.closeQuietly(lookupFileCache, "shared Paimon lookup-file cache");
+            IOUtils.closeQuietly(ioManager, "shared Paimon lookup IO manager");
+        }
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/NamespacedLookupFileCache.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/NamespacedLookupFileCache.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.paimon.lookup;
+
+import org.apache.paimon.mergetree.LookupFile;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Policy;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.stats.CacheStats;
+
+import javax.annotation.Nullable;
+
+import java.util.AbstractMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+import static org.apache.fluss.utils.Preconditions.checkNotNull;
+
+/** Namespace-scoped cache view delegating all storage to a shared lookup-file cache. */
+final class NamespacedLookupFileCache implements Cache<String, LookupFile> {
+
+    private final Cache<SharedLookupFileCache.Key, LookupFile> sharedCache;
+    private final String namespace;
+
+    NamespacedLookupFileCache(
+            Cache<SharedLookupFileCache.Key, LookupFile> sharedCache, String namespace) {
+        this.sharedCache = checkNotNull(sharedCache, "sharedCache must not be null.");
+        this.namespace = checkNotNull(namespace, "namespace must not be null.");
+    }
+
+    @Override
+    public @Nullable LookupFile getIfPresent(Object fileName) {
+        return fileName instanceof String ? sharedCache.getIfPresent(key((String) fileName)) : null;
+    }
+
+    @Override
+    public LookupFile get(
+            String fileName, Function<? super String, ? extends LookupFile> mappingFunction) {
+        return sharedCache.get(key(fileName), ignored -> mappingFunction.apply(fileName));
+    }
+
+    @Override
+    public Map<String, LookupFile> getAllPresent(Iterable<?> fileNames) {
+        Map<String, LookupFile> result = new LinkedHashMap<>();
+        for (Object fileName : fileNames) {
+            LookupFile lookupFile = getIfPresent(fileName);
+            if (lookupFile != null) {
+                result.put((String) fileName, lookupFile);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void put(String fileName, LookupFile lookupFile) {
+        sharedCache.put(key(fileName), lookupFile);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends LookupFile> entries) {
+        entries.forEach(this::put);
+    }
+
+    @Override
+    public void invalidate(Object fileName) {
+        if (fileName instanceof String) {
+            sharedCache.invalidate(key((String) fileName));
+        }
+    }
+
+    @Override
+    public void invalidateAll(Iterable<?> fileNames) {
+        for (Object fileName : fileNames) {
+            invalidate(fileName);
+        }
+    }
+
+    @Override
+    public void invalidateAll() {
+        // ponytail: O(n) namespace scan; add a namespace index if cache cardinality makes close
+        // slow.
+        Set<SharedLookupFileCache.Key> keys = new HashSet<>();
+        for (SharedLookupFileCache.Key key : sharedCache.asMap().keySet()) {
+            if (key.namespace.equals(namespace)) {
+                keys.add(key);
+            }
+        }
+        sharedCache.invalidateAll(keys);
+    }
+
+    @Override
+    public long estimatedSize() {
+        return sharedCache.asMap().keySet().stream()
+                .filter(key -> key.namespace.equals(namespace))
+                .count();
+    }
+
+    @Override
+    public CacheStats stats() {
+        return sharedCache.stats();
+    }
+
+    @Override
+    public ConcurrentMap<String, LookupFile> asMap() {
+        return new NamespacedMap();
+    }
+
+    @Override
+    public void cleanUp() {
+        sharedCache.cleanUp();
+    }
+
+    @Override
+    public Policy<String, LookupFile> policy() {
+        throw new UnsupportedOperationException(
+                "Policy access is not supported by the namespaced cache view.");
+    }
+
+    /** Concurrent-map view required by Paimon's closed-entry removal path. */
+    private final class NamespacedMap extends AbstractMap<String, LookupFile>
+            implements ConcurrentMap<String, LookupFile> {
+
+        @Override
+        public Set<Entry<String, LookupFile>> entrySet() {
+            Set<Entry<String, LookupFile>> entries = new HashSet<>();
+            sharedCache
+                    .asMap()
+                    .forEach(
+                            (key, lookupFile) -> {
+                                if (key.namespace.equals(namespace)) {
+                                    entries.add(
+                                            new SimpleImmutableEntry<>(key.fileName, lookupFile));
+                                }
+                            });
+            return entries;
+        }
+
+        @Override
+        public @Nullable LookupFile get(Object fileName) {
+            return fileName instanceof String
+                    ? sharedCache.asMap().get(key((String) fileName))
+                    : null;
+        }
+
+        @Override
+        public @Nullable LookupFile put(String fileName, LookupFile lookupFile) {
+            return sharedCache.asMap().put(key(fileName), lookupFile);
+        }
+
+        @Override
+        public @Nullable LookupFile remove(Object fileName) {
+            return fileName instanceof String
+                    ? sharedCache.asMap().remove(key((String) fileName))
+                    : null;
+        }
+
+        @Override
+        public boolean remove(Object fileName, Object lookupFile) {
+            return fileName instanceof String
+                    && sharedCache.asMap().remove(key((String) fileName), lookupFile);
+        }
+
+        @Override
+        public @Nullable LookupFile putIfAbsent(String fileName, LookupFile lookupFile) {
+            return sharedCache.asMap().putIfAbsent(key(fileName), lookupFile);
+        }
+
+        @Override
+        public boolean replace(String fileName, LookupFile oldValue, LookupFile newValue) {
+            return sharedCache.asMap().replace(key(fileName), oldValue, newValue);
+        }
+
+        @Override
+        public @Nullable LookupFile replace(String fileName, LookupFile lookupFile) {
+            return sharedCache.asMap().replace(key(fileName), lookupFile);
+        }
+
+        @Override
+        public void clear() {
+            invalidateAll();
+        }
+    }
+
+    private SharedLookupFileCache.Key key(String fileName) {
+        return new SharedLookupFileCache.Key(namespace, fileName);
+    }
+}

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuper.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuper.java
@@ -18,7 +18,6 @@
 package org.apache.fluss.lake.paimon.lookup;
 
 import org.apache.fluss.config.Configuration;
-import org.apache.fluss.config.MemorySize;
 import org.apache.fluss.config.TableConfig;
 import org.apache.fluss.exception.DiskWriteLockedException;
 import org.apache.fluss.exception.KvStorageException;
@@ -36,7 +35,6 @@ import org.apache.fluss.types.RowType;
 import org.apache.fluss.utils.ExceptionUtils;
 import org.apache.fluss.utils.IOUtils;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
@@ -48,7 +46,6 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.query.LocalTableQuery;
 import org.apache.paimon.table.sink.RowPartitionKeyExtractor;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableScan;
@@ -70,15 +67,15 @@ import static org.apache.fluss.config.ConfigOptions.KV_FORMAT_VERSION_2;
 import static org.apache.fluss.lake.paimon.PaimonLakeCatalog.LEGACY_SYSTEM_COLUMNS;
 import static org.apache.fluss.lake.paimon.utils.PaimonConversions.toPaimon;
 import static org.apache.fluss.lake.paimon.utils.PaimonConversions.toPaimonPartition;
-import static org.apache.fluss.utils.Preconditions.checkArgument;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
 /**
  * Paimon implementation of {@link LakeTableLookuper} for primary-key tables.
  *
- * <p>The catalog, table, local query, and I/O manager are initialized lazily on the first lookup.
- * For each partition and bucket, the lookuper scans the latest Paimon snapshot once and registers
- * its data files with {@link LocalTableQuery}. Paimon then creates local lookup files lazily as
+ * <p>The catalog, table, and local query are initialized lazily on the first lookup. The I/O
+ * manager is supplied by the lake storage and may be shared with other table lookupers. For each
+ * partition and bucket, the lookuper scans the latest Paimon snapshot once and registers its data
+ * files with {@link PaimonLocalTableQuery}. Paimon then creates local lookup files lazily as
  * individual remote data files are queried.
  *
  * <p>A cached partition-bucket file set can become stale when Paimon compaction replaces its data
@@ -87,7 +84,7 @@ import static org.apache.fluss.utils.Preconditions.checkNotNull;
  * lookup I/O failure refreshes that partition-bucket with the files from the latest snapshot and
  * retries once.
  *
- * <p>Lookup concurrency is delegated to {@link LocalTableQuery}. Older Paimon versions may
+ * <p>Lookup concurrency is delegated to {@link PaimonLocalTableQuery}. Older Paimon versions may
  * serialize lookups internally, while Paimon 2.0 supports concurrent lookups without an additional
  * Fluss-level lock.
  *
@@ -98,9 +95,10 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
 
     private final Configuration paimonConfig;
     private final TablePath tablePath;
-    private final String ioTmpDir;
+    private final IOManager ioManager;
+    private final SharedLookupFileCache lookupFileCache;
+    private final String cacheNamespace;
     private final TableConfig tableConfig;
-    private final long lookupCacheMaxDiskBytes;
     private final Runnable diskWriteGuard;
 
     private final ThreadLocal<Boolean> lookupFileDownloaded;
@@ -109,34 +107,34 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
 
     private @Nullable Catalog catalog;
     private @Nullable FileStoreTable fileStoreTable;
-    private @Nullable IOManager ioManager;
     private @Nullable List<String> trimmedPrimaryKeys;
 
     // CompactedKeyDecoder contains immutable type metadata and creates all decode state per
     // invocation, so it can be shared by concurrent lookups.
     private @Nullable CompactedKeyDecoder compactedKeyDecoder;
 
-    private volatile @Nullable LocalTableQuery localTableQuery;
+    private volatile @Nullable PaimonLocalTableQuery localTableQuery;
     // Guarded by initializationLock.
     private volatile boolean closed;
 
-    /** Creates a lookuper with the specified local lookup cache limit. */
+    /** Creates a lookuper using an I/O manager shared with other table lookupers. */
     public PaimonLakeTableLookuper(
             Configuration paimonConfig,
             TablePath tablePath,
-            String ioTmpDir,
+            IOManager ioManager,
+            SharedLookupFileCache lookupFileCache,
+            String cacheNamespace,
             TableConfig tableConfig,
-            long lookupCacheMaxDiskBytes,
             Runnable diskWriteGuard) {
         this.paimonConfig = checkNotNull(paimonConfig, "paimonConfig must not be null.");
         this.tablePath = checkNotNull(tablePath, "tablePath must not be null.");
-        this.ioTmpDir = checkNotNull(ioTmpDir, "ioTmpDir must not be null.");
+        this.lookupFileCache = checkNotNull(lookupFileCache, "lookupFileCache must not be null.");
+        this.cacheNamespace = checkNotNull(cacheNamespace, "cacheNamespace must not be null.");
         this.tableConfig = checkNotNull(tableConfig, "tableConfig must not be null.");
-        checkArgument(
-                lookupCacheMaxDiskBytes > 0, "lookupCacheMaxDiskBytes must be greater than 0.");
-        this.lookupCacheMaxDiskBytes = lookupCacheMaxDiskBytes;
         this.diskWriteGuard = checkNotNull(diskWriteGuard, "diskWriteGuard must not be null.");
         this.lookupFileDownloaded = new ThreadLocal<>();
+        this.ioManager =
+                new TrackingIOManager(checkNotNull(ioManager, "ioManager must not be null."));
         this.initializationLock = new Object();
         this.registeredFiles = new ConcurrentHashMap<>();
     }
@@ -168,13 +166,11 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
             }
             closed = true;
             IOUtils.closeQuietly(localTableQuery, "Paimon lookup engine");
-            IOUtils.closeQuietly(ioManager, "Paimon lookup IO manager");
             IOUtils.closeQuietly(catalog, "Paimon catalog");
             registeredFiles.clear();
             localTableQuery = null;
             compactedKeyDecoder = null;
             trimmedPrimaryKeys = null;
-            ioManager = null;
             fileStoreTable = null;
             catalog = null;
         }
@@ -198,16 +194,14 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
 
     private void initialize(RowType valueRowType) throws Exception {
         Catalog newCatalog = null;
-        IOManager newIOManager = null;
-        LocalTableQuery newLocalTableQuery = null;
+        PaimonLocalTableQuery newLocalTableQuery = null;
         boolean initialized = false;
         try {
             newCatalog =
                     CatalogFactory.createCatalog(
                             CatalogContext.create(Options.fromMap(paimonConfig.toMap())));
             FileStoreTable newFileStoreTable =
-                    withLookupCacheOptions(
-                            (FileStoreTable) newCatalog.getTable(toPaimon(tablePath)));
+                    (FileStoreTable) newCatalog.getTable(toPaimon(tablePath));
             if (newFileStoreTable.primaryKeys().isEmpty()) {
                 throw new UnsupportedOperationException(
                         "Point lookup is only supported for primary-key Paimon tables.");
@@ -230,16 +224,13 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
                         CompactedKeyDecoder.createKeyDecoder(valueRowType, newTrimmedPrimaryKeys);
             }
 
-            newIOManager = createIOManager(ioTmpDir);
             newLocalTableQuery =
-                    newFileStoreTable
-                            .newLocalTableQuery()
+                    new PaimonLocalTableQuery(newFileStoreTable, lookupFileCache, cacheNamespace)
                             .withValueProjection(businessFieldProjection(newFileStoreTable))
-                            .withIOManager(newIOManager);
+                            .withIOManager(ioManager);
 
             catalog = newCatalog;
             fileStoreTable = newFileStoreTable;
-            ioManager = newIOManager;
             trimmedPrimaryKeys = newTrimmedPrimaryKeys;
             compactedKeyDecoder = newCompactedKeyDecoder;
             // Keep this volatile write last to publish all initialized fields together.
@@ -248,20 +239,9 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
         } finally {
             if (!initialized) {
                 IOUtils.closeQuietly(newLocalTableQuery, "Paimon local table query");
-                IOUtils.closeQuietly(newIOManager, "Paimon lookup IO manager");
                 IOUtils.closeQuietly(newCatalog, "Paimon catalog");
             }
         }
-    }
-
-    private FileStoreTable withLookupCacheOptions(FileStoreTable table) {
-        String key = CoreOptions.LOOKUP_CACHE_MAX_DISK_SIZE.key();
-        String maxDiskSize = new MemorySize(lookupCacheMaxDiskBytes).toString();
-        return table.copy(Collections.singletonMap(key, maxDiskSize));
-    }
-
-    private IOManager createIOManager(String ioTmpDir) {
-        return new TrackingIOManager(IOManager.create(ioTmpDir));
     }
 
     private static int[] businessFieldProjection(FileStoreTable fileStoreTable) {
@@ -479,8 +459,8 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
         }
 
         @Override
-        public void close() throws Exception {
-            delegate.close();
+        public void close() {
+            // The shared delegate is owned by PaimonLakeStorage.
         }
     }
 

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLocalTableQuery.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLocalTableQuery.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.paimon.lookup;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.FileStore;
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.KeyValueFileStore;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.data.serializer.RowCompactedSerializer;
+import org.apache.paimon.deletionvectors.DeletionVector;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.KeyValueFileReaderFactory;
+import org.apache.paimon.io.cache.CacheManager;
+import org.apache.paimon.lookup.LookupStoreFactory;
+import org.apache.paimon.mergetree.Levels;
+import org.apache.paimon.mergetree.LookupFile;
+import org.apache.paimon.mergetree.LookupLevels;
+import org.apache.paimon.mergetree.lookup.LookupSerializerFactory;
+import org.apache.paimon.mergetree.lookup.PersistValueProcessor;
+import org.apache.paimon.mergetree.lookup.RemoteLookupFileManager;
+import org.apache.paimon.operation.metrics.PartialLookupMetrics;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.query.TableQuery;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Filter;
+import org.apache.paimon.utils.KeyComparatorSupplier;
+import org.apache.paimon.utils.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
+
+import static org.apache.paimon.lookup.LookupStoreFactory.bloomFilterBuilderFactory;
+import static org.apache.paimon.mergetree.LookupFile.localFilePrefix;
+
+/**
+ * Fluss-owned fork of Paimon 2.0.0's {@code LocalTableQuery}, using a shared namespaced lookup
+ * cache.
+ */
+final class PaimonLocalTableQuery implements TableQuery {
+
+    private final Map<BinaryRow, Map<Integer, BucketLookupState>> tableView;
+
+    private final CoreOptions options;
+
+    private final Supplier<Comparator<InternalRow>> keyComparatorSupplier;
+
+    private final KeyValueFileReaderFactory.Builder readerFactoryBuilder;
+
+    private final LookupStoreFactory lookupStoreFactory;
+
+    private final int startLevel;
+
+    private IOManager ioManager;
+
+    private final Cache<String, LookupFile> lookupFileCache;
+
+    private final RowType rowType;
+    private final RowType partitionType;
+    private final FileIO fileIO;
+
+    @Nullable private Filter<InternalRow> cacheRowFilter;
+
+    @Nullable private PartialLookupMetrics partialLookupMetrics;
+
+    PaimonLocalTableQuery(
+            FileStoreTable table,
+            SharedLookupFileCache sharedLookupFileCache,
+            String cacheNamespace) {
+        this.options = table.coreOptions();
+        this.lookupFileCache = sharedLookupFileCache.namespaced(cacheNamespace);
+        this.tableView = new ConcurrentHashMap<>();
+        FileStore<?> tableStore = table.store();
+        if (!(tableStore instanceof KeyValueFileStore)) {
+            throw new UnsupportedOperationException(
+                    "Table Query only supports table with primary key.");
+        }
+        KeyValueFileStore store = (KeyValueFileStore) tableStore;
+
+        this.readerFactoryBuilder = store.newReaderFactoryBuilder();
+        this.rowType = table.schema().logicalRowType();
+        this.partitionType = table.schema().logicalPartitionType();
+        this.fileIO = table.fileIO();
+        RowType keyType = readerFactoryBuilder.keyType();
+        this.keyComparatorSupplier = new KeyComparatorSupplier(readerFactoryBuilder.keyType());
+        this.lookupStoreFactory =
+                LookupStoreFactory.create(
+                        options,
+                        new CacheManager(
+                                options.lookupCacheMaxMemory(),
+                                options.lookupCacheHighPrioPoolRatio()),
+                        new RowCompactedSerializer(keyType).createSliceComparator());
+        startLevel = options.needLookup() ? 1 : 0;
+    }
+
+    public void refreshFiles(
+            BinaryRow partition,
+            int bucket,
+            List<DataFileMeta> beforeFiles,
+            List<DataFileMeta> dataFiles) {
+        // Both tableView and its nested bucket maps are ConcurrentHashMaps; this nested
+        // computeIfAbsent pattern relies on each map providing atomic insertion.
+        BucketLookupState state =
+                tableView
+                        .computeIfAbsent(partition, k -> new ConcurrentHashMap<>())
+                        .computeIfAbsent(bucket, k -> new BucketLookupState());
+        state.lock.writeLock().lock();
+        try {
+            if (state.lookupLevels == null) {
+                // Initial phase: ignore beforeFiles as they represent deletions from previous state
+                state.lookupLevels = createLookupLevels(partition, bucket, dataFiles);
+            } else {
+                state.lookupLevels.getLevels().update(beforeFiles, dataFiles);
+            }
+        } finally {
+            state.lock.writeLock().unlock();
+        }
+    }
+
+    private LookupLevels<KeyValue> createLookupLevels(
+            BinaryRow partition, int bucket, List<DataFileMeta> dataFiles) {
+        Levels levels = new Levels(keyComparatorSupplier.get(), dataFiles, options.numLevels());
+        // TODO pass DeletionVector factory
+        KeyValueFileReaderFactory factory =
+                readerFactoryBuilder.build(partition, bucket, DeletionVector.emptyFactory());
+        Options options = this.options.toConfiguration();
+
+        RowType readValueType = readerFactoryBuilder.readValueType();
+        LookupLevels<KeyValue> lookupLevels =
+                new LookupLevels<>(
+                        schemaId -> readValueType,
+                        0L,
+                        levels,
+                        keyComparatorSupplier.get(),
+                        readerFactoryBuilder.keyType(),
+                        PersistValueProcessor.factory(readValueType),
+                        LookupSerializerFactory.INSTANCE.get(),
+                        file -> {
+                            RecordReader<KeyValue> reader = factory.createRecordReader(file);
+                            if (cacheRowFilter != null) {
+                                reader =
+                                        reader.filter(
+                                                keyValue -> cacheRowFilter.test(keyValue.value()));
+                            }
+                            return reader;
+                        },
+                        file ->
+                                Preconditions.checkNotNull(ioManager, "IOManager is required.")
+                                        .createChannel(
+                                                localFilePrefix(
+                                                        partitionType, partition, bucket, file))
+                                        .getPathFile(),
+                        lookupStoreFactory,
+                        bloomFilterBuilderFactory(options),
+                        lookupFileCache);
+
+        // Optimization - download lookup files if already persisted to object store
+        // We download these files if three conditions are met
+        // 1) lookup.remote-file.enabled is true - files are persisted in the first place
+        // 2) deletion-vectors.enabled is false - SSTables only contain row positions, not values,
+        // when DVs are enabled
+        // 3) The client is accessing the full data row, as opposed to a projection
+        //    - The persisted remote SSTable files are created during compaction and hold the entire
+        // data row value
+        //    - We could deserialize and project in memory, but we'll have to read much more data,
+        // not as clear of a win
+        boolean fullValueRead = readerFactoryBuilder.readValueType().equals(rowType);
+        if (this.options.lookupRemoteFileEnabled()
+                && !this.options.deletionVectorsEnabled()
+                && fullValueRead) {
+            // Calling the constructor tells `lookupLevels` to load remote files
+            new RemoteLookupFileManager<>(
+                    fileIO,
+                    factory.pathFactory(),
+                    lookupLevels,
+                    this.options.lookupRemoteLevelThreshold());
+        }
+
+        return lookupLevels;
+    }
+
+    @Nullable
+    @Override
+    public InternalRow lookup(BinaryRow partition, int bucket, InternalRow key) throws IOException {
+        PartialLookupMetrics currentMetrics = partialLookupMetrics;
+        LookupLevels.LookupContext context =
+                currentMetrics == null ? null : new LookupLevels.LookupContext();
+        try {
+            return lookup(partition, bucket, key, context);
+        } finally {
+            if (currentMetrics != null) {
+                currentMetrics.reportLookup(context != null && context.remoteAccessed());
+            }
+        }
+    }
+
+    @Nullable
+    private InternalRow lookup(
+            BinaryRow partition,
+            int bucket,
+            InternalRow key,
+            @Nullable LookupLevels.LookupContext context)
+            throws IOException {
+        Map<Integer, BucketLookupState> buckets = tableView.get(partition);
+        if (buckets == null || buckets.isEmpty()) {
+            return null;
+        }
+        BucketLookupState state = buckets.get(bucket);
+        if (state == null) {
+            return null;
+        }
+
+        state.lock.readLock().lock();
+        try {
+            LookupLevels<KeyValue> lookupLevels = state.lookupLevels;
+            if (lookupLevels == null) {
+                return null;
+            }
+
+            KeyValue kv = lookupLevels.lookup(key, startLevel, context);
+            if (kv == null || kv.valueKind().isRetract()) {
+                return null;
+            } else {
+                return kv.value();
+            }
+        } finally {
+            state.lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public PaimonLocalTableQuery withValueProjection(int[] projection) {
+        this.readerFactoryBuilder.withReadValueType(rowType.project(projection));
+        return this;
+    }
+
+    public PaimonLocalTableQuery withIOManager(IOManager ioManager) {
+        this.ioManager = ioManager;
+        return this;
+    }
+
+    public PaimonLocalTableQuery withCacheRowFilter(Filter<InternalRow> cacheRowFilter) {
+        this.cacheRowFilter = cacheRowFilter;
+        return this;
+    }
+
+    public PaimonLocalTableQuery withMetrics(@Nullable PartialLookupMetrics metrics) {
+        this.partialLookupMetrics = metrics;
+        return this;
+    }
+
+    @Override
+    public InternalRowSerializer createValueSerializer() {
+        return InternalSerializers.create(readerFactoryBuilder.readValueType());
+    }
+
+    @Override
+    public void close() throws IOException {
+        // ConcurrentHashMap iteration is weakly consistent. close is expected not to race with
+        // refreshFiles for the same query instance; callers may rebuild this query after close.
+        for (Map.Entry<BinaryRow, Map<Integer, BucketLookupState>> buckets : tableView.entrySet()) {
+            for (Map.Entry<Integer, BucketLookupState> bucket : buckets.getValue().entrySet()) {
+                BucketLookupState state = bucket.getValue();
+                state.lock.writeLock().lock();
+                try {
+                    if (state.lookupLevels != null) {
+                        state.lookupLevels.close();
+                    }
+                } finally {
+                    state.lock.writeLock().unlock();
+                }
+            }
+        }
+        lookupFileCache.invalidateAll();
+        tableView.clear();
+    }
+
+    private static class BucketLookupState {
+
+        private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+        @Nullable private LookupLevels<KeyValue> lookupLevels;
+    }
+}

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/SharedLookupFileCache.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/SharedLookupFileCache.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.paimon.lookup;
+
+import org.apache.fluss.annotation.Internal;
+
+import org.apache.paimon.mergetree.LookupFile;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.RemovalCause;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.Objects;
+
+import static org.apache.fluss.utils.Preconditions.checkNotNull;
+import static org.apache.paimon.mergetree.LookupUtils.fileKibiBytes;
+
+/** A weighted lookup-file cache shared by multiple Paimon table lookupers. */
+@Internal
+public final class SharedLookupFileCache implements AutoCloseable {
+
+    private final Cache<Key, LookupFile> cache;
+
+    /** Creates a shared lookup-file cache. */
+    public SharedLookupFileCache(Duration fileRetention, MemorySize maxDiskSize) {
+        checkNotNull(fileRetention, "fileRetention must not be null.");
+        checkNotNull(maxDiskSize, "maxDiskSize must not be null.");
+        this.cache =
+                Caffeine.newBuilder()
+                        .expireAfterAccess(fileRetention)
+                        .maximumWeight(Math.max(1L, maxDiskSize.getKibiBytes()))
+                        .weigher(
+                                (Key key, LookupFile lookupFile) ->
+                                        Math.max(1, fileKibiBytes(lookupFile.localFile())))
+                        .removalListener(SharedLookupFileCache::removeLookupFile)
+                        .executor(Runnable::run)
+                        .build();
+    }
+
+    Cache<String, LookupFile> namespaced(String namespace) {
+        return new NamespacedLookupFileCache(cache, namespace);
+    }
+
+    /** Updates the maximum cache weight. */
+    public void updateMaxDiskSize(MemorySize maxDiskSize) {
+        cache.policy().eviction().get().setMaximum(Math.max(1L, maxDiskSize.getKibiBytes()));
+    }
+
+    @Override
+    public void close() {
+        cache.invalidateAll();
+        cache.cleanUp();
+    }
+
+    private static void removeLookupFile(
+            @Nullable Key key, @Nullable LookupFile lookupFile, RemovalCause cause) {
+        if (lookupFile != null) {
+            try {
+                lookupFile.close(cause);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    static final class Key {
+        final String namespace;
+        final String fileName;
+
+        Key(String namespace, String fileName) {
+            this.namespace = checkNotNull(namespace, "namespace must not be null.");
+            this.fileName = checkNotNull(fileName, "fileName must not be null.");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Key)) {
+                return false;
+            }
+            Key key = (Key) o;
+            return namespace.equals(key.namespace) && fileName.equals(key.fileName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(namespace, fileName);
+        }
+    }
+}

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuperTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuperTest.java
@@ -22,9 +22,11 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.MemorySize;
 import org.apache.fluss.config.TableConfig;
 import org.apache.fluss.exception.DiskWriteLockedException;
+import org.apache.fluss.lake.lakestorage.LakeTableLookupRuntime;
 import org.apache.fluss.lake.lakestorage.LakeTableLookuper;
 import org.apache.fluss.lake.lakestorage.TestingLakeCatalogContext;
 import org.apache.fluss.lake.paimon.PaimonLakeCatalog;
+import org.apache.fluss.lake.paimon.PaimonLakeStorage;
 import org.apache.fluss.metadata.KvFormat;
 import org.apache.fluss.metadata.ResolvedPartitionSpec;
 import org.apache.fluss.metadata.Schema;
@@ -61,16 +63,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.fluss.config.ConfigOptions.KV_FORMAT_VERSION_2;
 import static org.apache.fluss.lake.paimon.utils.PaimonConversions.toPaimon;
@@ -96,6 +104,7 @@ class PaimonLakeTableLookuperTest {
     private Configuration paimonConfig;
     private PaimonLakeCatalog lakeCatalog;
     private Catalog paimonCatalog;
+    private LakeTableLookupRuntime lookupRuntime;
 
     @BeforeEach
     void setUp() {
@@ -105,10 +114,17 @@ class PaimonLakeTableLookuperTest {
         paimonCatalog =
                 CatalogFactory.createCatalog(
                         CatalogContext.create(Options.fromMap(paimonConfig.toMap())));
+        lookupRuntime =
+                new PaimonLakeStorage(paimonConfig)
+                        .createLakeTableLookupRuntime(
+                                tempWarehouseDir.getAbsolutePath(), LOOKUP_CACHE_MAX_DISK_BYTES);
     }
 
     @AfterEach
     void tearDown() throws Exception {
+        if (lookupRuntime != null) {
+            lookupRuntime.close();
+        }
         if (paimonCatalog != null) {
             paimonCatalog.close();
         }
@@ -129,13 +145,8 @@ class PaimonLakeTableLookuperTest {
                         0, Collections.singletonList(paimonRow(1, "20240101", "Alice"))));
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
-                        tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
-                        tableConfig(KvFormat.COMPACTED),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
-                        NO_OP_DISK_WRITE_GUARD)) {
+                createLookuper(
+                        tablePath, tableConfig(KvFormat.COMPACTED), NO_OP_DISK_WRITE_GUARD)) {
             List<Boolean> lookupFileDownloads = new ArrayList<>();
             LakeTableLookuper.LookupContext context =
                     lookupContext(
@@ -185,13 +196,7 @@ class PaimonLakeTableLookuperTest {
                 };
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
-                        tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
-                        tableConfig(KvFormat.COMPACTED),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
-                        diskWriteGuard)) {
+                createLookuper(tablePath, tableConfig(KvFormat.COMPACTED), diskWriteGuard)) {
             LakeTableLookuper.LookupContext cachedPartition =
                     lookupContext(schema, "20240101", 0, SCHEMA_ID);
             LakeTableLookuper.LookupContext uncachedPartition =
@@ -214,6 +219,83 @@ class PaimonLakeTableLookuperTest {
             assertThat(lookuper.lookup(paimonKey(schema, 2, "20240102"), uncachedPartition))
                     .isNotNull();
         }
+    }
+
+    @Test
+    void testSharesIOManagerAndDeletesOnlyClosedLookuperFiles() throws Exception {
+        Schema schema = pkSchema();
+        TablePath firstTablePath = TablePath.of(DB, "shared_io_first");
+        TablePath secondTablePath = TablePath.of(DB, "shared_io_second");
+        FileStoreTable firstTable =
+                createPaimonTable(firstTablePath, partitionedPkDescriptor(schema));
+        FileStoreTable secondTable =
+                createPaimonTable(secondTablePath, partitionedPkDescriptor(schema));
+        writeAndCommitData(
+                firstTable,
+                Collections.singletonMap(
+                        0, Collections.singletonList(paimonRow(1, "20240101", "Alice"))));
+        writeAndCommitData(
+                secondTable,
+                Collections.singletonMap(
+                        0, Collections.singletonList(paimonRow(2, "20240101", "Bob"))));
+
+        File lookupDir = new File(tempWarehouseDir, "shared-lookup-cache");
+        LakeTableLookupRuntime.Context firstLookuperContext =
+                new LakeTableLookupRuntime.Context(
+                        paimonConfig,
+                        "first-table",
+                        tableConfig(KvFormat.COMPACTED),
+                        NO_OP_DISK_WRITE_GUARD);
+        LakeTableLookupRuntime.Context secondLookuperContext =
+                new LakeTableLookupRuntime.Context(
+                        paimonConfig,
+                        "second-table",
+                        tableConfig(KvFormat.COMPACTED),
+                        NO_OP_DISK_WRITE_GUARD);
+        LakeTableLookupRuntime sharedLookupRuntime =
+                new PaimonLakeStorage(paimonConfig)
+                        .createLakeTableLookupRuntime(
+                                lookupDir.getAbsolutePath(), LOOKUP_CACHE_MAX_DISK_BYTES);
+        try {
+            try (LakeTableLookuper firstLookuper =
+                            sharedLookupRuntime.createLakeTableLookuper(
+                                    firstTablePath, firstLookuperContext);
+                    LakeTableLookuper secondLookuper =
+                            sharedLookupRuntime.createLakeTableLookuper(
+                                    secondTablePath, secondLookuperContext)) {
+                assertThat(
+                                firstLookuper.lookup(
+                                        paimonKey(schema, 1, "20240101"),
+                                        lookupContext(schema, "20240101", 0, SCHEMA_ID)))
+                        .isNotNull();
+                Set<java.nio.file.Path> firstLookupFiles = regularFiles(lookupDir);
+                assertThat(firstLookupFiles).isNotEmpty();
+
+                assertThat(
+                                secondLookuper.lookup(
+                                        paimonKey(schema, 2, "20240101"),
+                                        lookupContext(schema, "20240101", 0, SCHEMA_ID)))
+                        .isNotNull();
+                Set<java.nio.file.Path> secondLookupFiles = regularFiles(lookupDir);
+                secondLookupFiles.removeAll(firstLookupFiles);
+                assertThat(secondLookupFiles).isNotEmpty();
+                assertThat(lookupDir.listFiles(File::isDirectory)).hasSize(1);
+
+                firstLookuper.close();
+                assertThat(firstLookupFiles).allMatch(path -> !Files.exists(path));
+                assertThat(secondLookupFiles).allMatch(Files::exists);
+                assertThat(
+                                secondLookuper.lookup(
+                                        paimonKey(schema, 2, "20240101"),
+                                        lookupContext(schema, "20240101", 0, SCHEMA_ID)))
+                        .isNotNull();
+            }
+            assertThat(regularFiles(lookupDir)).isEmpty();
+            assertThat(lookupDir.listFiles(File::isDirectory)).hasSize(1);
+        } finally {
+            sharedLookupRuntime.close();
+        }
+        assertThat(lookupDir.listFiles(File::isDirectory)).isEmpty();
     }
 
     @Test
@@ -242,13 +324,8 @@ class PaimonLakeTableLookuperTest {
                         0, Collections.singletonList(paimonRow(2, secondPartition, "Bob"))));
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
-                        tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
-                        tableConfig(KvFormat.COMPACTED),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
-                        NO_OP_DISK_WRITE_GUARD)) {
+                createLookuper(
+                        tablePath, tableConfig(KvFormat.COMPACTED), NO_OP_DISK_WRITE_GUARD)) {
             BinaryValue firstValue =
                     decodeValue(
                             lookuper.lookup(
@@ -284,13 +361,7 @@ class PaimonLakeTableLookuperTest {
                         0, Collections.singletonList(paimonRow(1, "20240101", "Alice"))));
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
-                        tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
-                        tableConfig(KvFormat.INDEXED),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
-                        NO_OP_DISK_WRITE_GUARD)) {
+                createLookuper(tablePath, tableConfig(KvFormat.INDEXED), NO_OP_DISK_WRITE_GUARD)) {
             LakeTableLookuper.LookupContext context =
                     lookupContext(schema, "20240101", 0, SCHEMA_ID);
 
@@ -330,12 +401,9 @@ class PaimonLakeTableLookuperTest {
                         0, Collections.singletonList(paimonRow(1, "sub-1", "20240101", "Alice"))));
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
+                createLookuper(
                         tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
                         tableConfig(KvFormat.COMPACTED, KV_FORMAT_VERSION_2),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
                         NO_OP_DISK_WRITE_GUARD)) {
             LakeTableLookuper.LookupContext context =
                     lookupContext(schema, "20240101", 0, SCHEMA_ID);
@@ -387,12 +455,9 @@ class PaimonLakeTableLookuperTest {
                         .build();
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
+                createLookuper(
                         tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
                         tableConfig(KvFormat.COMPACTED, KV_FORMAT_VERSION_2),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
                         NO_OP_DISK_WRITE_GUARD)) {
             // Inject a late initialization failure: the Paimon table requires sub_id in its
             // lookup key, but the first lookup's value row type deliberately omits that field.
@@ -451,13 +516,7 @@ class PaimonLakeTableLookuperTest {
                 };
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
-                        tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
-                        tableConfig(KvFormat.COMPACTED),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
-                        diskWriteGuard)) {
+                createLookuper(tablePath, tableConfig(KvFormat.COMPACTED), diskWriteGuard)) {
             assertThat(
                             lookuper.lookup(
                                     paimonKey(schema, 5, "20240101"),
@@ -569,13 +628,8 @@ class PaimonLakeTableLookuperTest {
                 Collections.singletonMap(0, Collections.singletonList(paimonRow(1, 7, "Alice"))));
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
-                        tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
-                        tableConfig(KvFormat.COMPACTED),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
-                        NO_OP_DISK_WRITE_GUARD)) {
+                createLookuper(
+                        tablePath, tableConfig(KvFormat.COMPACTED), NO_OP_DISK_WRITE_GUARD)) {
             LakeTableLookuper.LookupContext context =
                     new LakeTableLookuper.LookupContext(
                             ResolvedPartitionSpec.fromPartitionName(
@@ -607,13 +661,8 @@ class PaimonLakeTableLookuperTest {
         createPaimonTable(tablePath, tableDescriptor);
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
-                        tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
-                        tableConfig(KvFormat.COMPACTED),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
-                        NO_OP_DISK_WRITE_GUARD)) {
+                createLookuper(
+                        tablePath, tableConfig(KvFormat.COMPACTED), NO_OP_DISK_WRITE_GUARD)) {
             LakeTableLookuper.LookupContext context =
                     new LakeTableLookuper.LookupContext(
                             new ResolvedPartitionSpec(
@@ -666,13 +715,8 @@ class PaimonLakeTableLookuperTest {
                         Collections.singletonList(paimonRow(2, "20240101", "Bob", "new-value"))));
 
         try (LakeTableLookuper lookuper =
-                new PaimonLakeTableLookuper(
-                        paimonConfig,
-                        tablePath,
-                        tempWarehouseDir.getAbsolutePath(),
-                        tableConfig(KvFormat.COMPACTED),
-                        LOOKUP_CACHE_MAX_DISK_BYTES,
-                        NO_OP_DISK_WRITE_GUARD)) {
+                createLookuper(
+                        tablePath, tableConfig(KvFormat.COMPACTED), NO_OP_DISK_WRITE_GUARD)) {
             BinaryValue oldSchemaValue =
                     decodeValue(
                             lookuper.lookup(
@@ -738,6 +782,23 @@ class PaimonLakeTableLookuperTest {
         config.set(ConfigOptions.TABLE_KV_FORMAT, kvFormat);
         config.set(ConfigOptions.TABLE_KV_FORMAT_VERSION, kvFormatVersion);
         return new TableConfig(config);
+    }
+
+    private LakeTableLookuper createLookuper(
+            TablePath tablePath, TableConfig tableConfig, Runnable diskWriteGuard) {
+        return lookupRuntime.createLakeTableLookuper(
+                tablePath,
+                new LakeTableLookupRuntime.Context(
+                        paimonConfig, tablePath.toString(), tableConfig, diskWriteGuard));
+    }
+
+    private static Set<java.nio.file.Path> regularFiles(File directory) throws IOException {
+        if (!directory.exists()) {
+            return new HashSet<>();
+        }
+        try (Stream<java.nio.file.Path> paths = Files.walk(directory.toPath())) {
+            return paths.filter(Files::isRegularFile).collect(Collectors.toSet());
+        }
     }
 
     private static Schema pkSchema() {

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/lookup/SharedLookupFileCacheTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/lookup/SharedLookupFileCacheTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.paimon.lookup;
+
+import org.apache.paimon.lookup.LookupStoreReader;
+import org.apache.paimon.mergetree.LookupFile;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.time.Duration;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SharedLookupFileCache}. */
+class SharedLookupFileCacheTest {
+
+    @TempDir private File tempDir;
+
+    @Test
+    void testNamespaceIsolationAndGlobalLimit() throws Exception {
+        File firstFile = lookupFile("first.lookup");
+        File secondFile = lookupFile("second.lookup");
+        File thirdFile = lookupFile("third.lookup");
+
+        try (SharedLookupFileCache sharedCache =
+                new SharedLookupFileCache(Duration.ofHours(1), MemorySize.ofKibiBytes(2))) {
+            Cache<String, LookupFile> firstNamespace = sharedCache.namespaced("first");
+            Cache<String, LookupFile> secondNamespace = sharedCache.namespaced("second");
+            LookupFile firstLookupFile = lookupFile(firstFile);
+            LookupFile secondLookupFile = lookupFile(secondFile);
+
+            firstNamespace.put("same-file-name", firstLookupFile);
+            secondNamespace.put("same-file-name", secondLookupFile);
+            assertThat(firstNamespace.getIfPresent("same-file-name")).isSameAs(firstLookupFile);
+            assertThat(secondNamespace.getIfPresent("same-file-name")).isSameAs(secondLookupFile);
+
+            firstNamespace.invalidateAll();
+            assertThat(firstFile).doesNotExist();
+            assertThat(secondFile).exists();
+
+            sharedCache.updateMaxDiskSize(MemorySize.ofKibiBytes(1));
+            secondNamespace.put("third-file", lookupFile(thirdFile));
+            assertThat(Arrays.asList(secondFile, thirdFile).stream().filter(File::exists).count())
+                    .isLessThanOrEqualTo(1L);
+        }
+
+        assertThat(secondFile).doesNotExist();
+        assertThat(thirdFile).doesNotExist();
+    }
+
+    private File lookupFile(String name) throws IOException {
+        File file = new File(tempDir, name);
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw")) {
+            randomAccessFile.setLength(1024L);
+        }
+        return file;
+    }
+
+    private static LookupFile lookupFile(File file) {
+        return new LookupFile(file, 1, 0L, "v1", new NoOpLookupStoreReader(), () -> {});
+    }
+
+    private static final class NoOpLookupStoreReader implements LookupStoreReader {
+        @Override
+        public byte[] lookup(byte[] key) {
+            return null;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/historical/HistoricalLakeLookupManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/historical/HistoricalLakeLookupManager.java
@@ -26,6 +26,7 @@ import org.apache.fluss.exception.LakeStorageNotConfiguredException;
 import org.apache.fluss.lake.lakestorage.LakeStorage;
 import org.apache.fluss.lake.lakestorage.LakeStoragePlugin;
 import org.apache.fluss.lake.lakestorage.LakeStoragePluginSetUp;
+import org.apache.fluss.lake.lakestorage.LakeTableLookupRuntime;
 import org.apache.fluss.lake.lakestorage.LakeTableLookuper;
 import org.apache.fluss.metadata.DataLakeFormat;
 import org.apache.fluss.metadata.ResolvedPartitionSpec;
@@ -65,6 +66,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import static org.apache.fluss.server.utils.LakeStorageUtils.extractLakeProperties;
@@ -82,8 +84,12 @@ import static org.apache.fluss.utils.Preconditions.checkState;
  * the current request. Active lookups can finish on the old lookuper, which is closed after its
  * last lookup releases it.
  *
- * <p>Up to ten table lookupers are cached. Each lookuper receives one tenth of the server-level
- * disk budget, and Caffeine evicts lookupers when the table limit is exceeded.
+ * <p>One lake-format-specific lookup runtime is initialized with this manager, or when Paimon is
+ * configured dynamically, and shared by all table lookupers. The runtime owns TabletServer-scoped
+ * resources such as Paimon's I/O manager.
+ *
+ * <p>Up to ten table lookupers are cached. Their lookup files share one server-level disk budget,
+ * and Caffeine evicts lookupers when the table limit is exceeded.
  *
  * <p>Historical lookup cache I/O participates in TabletServer disk write protection. Existing cache
  * hits remain available when the data disk is write-locked, while lookups that need to download new
@@ -103,15 +109,14 @@ class HistoricalLakeLookupManager implements AutoCloseable {
     private static final String LOOKUP_CACHE_DISK_SIZE_TASK_NAME =
             "historical-lookup-cache-disk-size";
     private static final Duration LOOKUP_CACHE_DISK_SIZE_CHECK_INTERVAL = Duration.ofMinutes(3);
-    // TODO: Share one Paimon IOManager disk budget across all table lookupers and evict cached
-    // entries by data file instead of reserving fixed per-table capacity. See
-    // https://github.com/apache/fluss/issues/3955.
     private static final int MAX_CACHED_TABLES = 10;
 
     private volatile Configuration conf;
     private volatile long lakeConfigVersion;
     private final @Nullable PluginManager pluginManager;
+    private volatile @Nullable LakeTableLookupRuntime lookupRuntime;
     private final Counter capacityEvictions;
+    private final AtomicLong lookuperIdSequence;
     private final Cache<Long, CachedLakeTableLookuper> lakeTableLookupers;
     private final ConcurrentMap<Long, Long> requiredLakeSnapshotIds = new ConcurrentHashMap<>();
     private final File historicalLookupCacheRootDir;
@@ -121,7 +126,7 @@ class HistoricalLakeLookupManager implements AutoCloseable {
     // the cache to grow back to the maximum ratio after disk usage recovers.
     private final Runnable diskWriteGuard;
 
-    private volatile long lookupCacheMaxDiskBytesPerTable;
+    private volatile long lookupCacheMaxDiskBytes;
     private volatile long lookupCacheDiskSize;
 
     private volatile boolean started;
@@ -162,8 +167,8 @@ class HistoricalLakeLookupManager implements AutoCloseable {
         checkArgument(dataDirVolumeBytes > 0, "dataDirVolumeBytes must be greater than 0.");
         this.dataDirVolumeBytes = dataDirVolumeBytes;
         this.diskWriteGuard = checkNotNull(diskWriteGuard, "diskWriteGuard must not be null.");
-        this.lookupCacheMaxDiskBytesPerTable =
-                cacheBytesPerTable(
+        this.lookupCacheMaxDiskBytes =
+                cacheBytes(
                         conf.get(
                                 ConfigOptions
                                         .SERVER_HISTORICAL_PARTITION_LOOKUP_CACHE_MAX_DISK_RATIO));
@@ -180,6 +185,8 @@ class HistoricalLakeLookupManager implements AutoCloseable {
                         .executor(Runnable::run)
                         .removalListener(this::onLookuperRemoved)
                         .build();
+        this.lookuperIdSequence = new AtomicLong();
+        this.lookupRuntime = createLookupRuntime(conf);
     }
 
     private static com.github.benmanes.caffeine.cache.Scheduler createCacheScheduler(
@@ -264,6 +271,12 @@ class HistoricalLakeLookupManager implements AutoCloseable {
         lakeTableLookupers.invalidateAll();
         lakeTableLookupers.cleanUp();
         requiredLakeSnapshotIds.clear();
+        LakeTableLookupRuntime runtime;
+        synchronized (this) {
+            runtime = lookupRuntime;
+            lookupRuntime = null;
+        }
+        IOUtils.closeQuietly(runtime, "historical lake lookup runtime");
     }
 
     /** Invalidates the cached lake lookuper for the given table. */
@@ -287,6 +300,16 @@ class HistoricalLakeLookupManager implements AutoCloseable {
         return capacityEvictions;
     }
 
+    @VisibleForTesting
+    boolean hasLookupRuntime() {
+        return lookupRuntime != null;
+    }
+
+    @VisibleForTesting
+    long lookupCacheMaxDiskBytes() {
+        return lookupCacheMaxDiskBytes;
+    }
+
     /** Applies dynamic historical lookup configuration changes. */
     void reconfigure(Configuration newConf) {
         checkNotNull(newConf, "newConf must not be null.");
@@ -298,13 +321,13 @@ class HistoricalLakeLookupManager implements AutoCloseable {
                         ConfigOptions
                                 .SERVER_HISTORICAL_PARTITION_LOOKUPER_CACHE_EXPIRE_AFTER_ACCESS);
         synchronized (this) {
-            long newMaxBytesPerTable =
-                    cacheBytesPerTable(
+            long newMaxDiskBytes =
+                    cacheBytes(
                             newConf.get(
                                     ConfigOptions
                                             .SERVER_HISTORICAL_PARTITION_LOOKUP_CACHE_MAX_DISK_RATIO));
-            cacheLimitChanged = newMaxBytesPerTable != lookupCacheMaxDiskBytesPerTable;
-            lookupCacheMaxDiskBytesPerTable = newMaxBytesPerTable;
+            cacheLimitChanged = newMaxDiskBytes != lookupCacheMaxDiskBytes;
+            lookupCacheMaxDiskBytes = newMaxDiskBytes;
 
             lakeConfigChanged = hasLakeConfigChanged(conf, newConf);
             expirationChanged =
@@ -312,6 +335,12 @@ class HistoricalLakeLookupManager implements AutoCloseable {
                             conf.get(
                                     ConfigOptions
                                             .SERVER_HISTORICAL_PARTITION_LOOKUPER_CACHE_EXPIRE_AFTER_ACCESS));
+            if (lakeConfigChanged && lookupRuntime == null) {
+                lookupRuntime = createLookupRuntime(newConf);
+            }
+            if (cacheLimitChanged && lookupRuntime != null) {
+                lookupRuntime.updateLookupCacheMaxDiskBytes(newMaxDiskBytes);
+            }
             // Publish the configuration before its version. A lookup that observes the new version
             // must also observe the matching configuration snapshot.
             conf = newConf;
@@ -326,12 +355,11 @@ class HistoricalLakeLookupManager implements AutoCloseable {
                     .get()
                     .setExpiresAfter(newExpiration.toMillis(), TimeUnit.MILLISECONDS);
         }
-        if (lakeConfigChanged || cacheLimitChanged) {
+        if (lakeConfigChanged) {
             // Do not invalidate while holding this monitor: lookuper creation holds a cache key
             // lock before preparing the lookup directory under the same monitor. Invalidation
             // closes inactive lookupers immediately and active lookupers after their last lookup
-            // releases them. After a cache limit change, the next lookup creates a Paimon lookuper
-            // with the updated per-table limit.
+            // releases them.
             lakeTableLookupers.invalidateAll();
             lakeTableLookupers.cleanUp();
         }
@@ -374,9 +402,8 @@ class HistoricalLakeLookupManager implements AutoCloseable {
 
     LakeTableLookuper createLakeTableLookuper(
             TablePath tablePath,
-            String ioTmpDir,
             TableConfig tableConfig,
-            long cacheSizeBytes,
+            String cacheNamespace,
             Configuration clusterConf) {
         DataLakeFormat dataLakeFormat = clusterConf.get(ConfigOptions.DATALAKE_FORMAT);
         if (dataLakeFormat == null) {
@@ -396,14 +423,32 @@ class HistoricalLakeLookupManager implements AutoCloseable {
                     "Historical lookup requires cluster lake storage properties to be configured.");
         }
 
+        LakeTableLookupRuntime runtime = lookupRuntime;
+        if (runtime == null) {
+            throw new LakeStorageNotConfiguredException(
+                    "Historical lake lookup runtime has not been initialized.");
+        }
+        return runtime.createLakeTableLookuper(
+                tablePath,
+                new LakeTableLookupRuntime.Context(
+                        Configuration.fromMap(lakeProperties),
+                        cacheNamespace,
+                        tableConfig,
+                        diskWriteGuard));
+    }
+
+    private @Nullable LakeTableLookupRuntime createLookupRuntime(Configuration configuration) {
+        DataLakeFormat dataLakeFormat = configuration.get(ConfigOptions.DATALAKE_FORMAT);
+        Map<String, String> lakeProperties = extractLakeProperties(configuration);
+        if (dataLakeFormat != DataLakeFormat.PAIMON || lakeProperties == null) {
+            return null;
+        }
         LakeStoragePlugin lakeStoragePlugin =
                 LakeStoragePluginSetUp.fromDataLakeFormat(dataLakeFormat.toString(), pluginManager);
         LakeStorage lakeStorage =
                 lakeStoragePlugin.createLakeStorage(Configuration.fromMap(lakeProperties));
-        return lakeStorage.createLakeTableLookuper(
-                tablePath,
-                new LakeStorage.LookuperContext(
-                        ioTmpDir, tableConfig, cacheSizeBytes, diskWriteGuard));
+        return lakeStorage.createLakeTableLookupRuntime(
+                historicalLookupCacheRootDir.getAbsolutePath(), lookupCacheMaxDiskBytes);
     }
 
     private static boolean hasLakeConfigChanged(Configuration currentConf, Configuration newConf) {
@@ -413,11 +458,16 @@ class HistoricalLakeLookupManager implements AutoCloseable {
                         extractLakeProperties(currentConf), extractLakeProperties(newConf));
     }
 
-    private long cacheBytesPerTable(double ratio) {
+    private long cacheBytes(double ratio) {
         checkArgument(ratio > 0.0 && ratio <= 1.0, "ratio must be within (0.0, 1.0].");
         long totalCacheBytes =
                 Math.min(dataDirVolumeBytes, (long) Math.ceil(dataDirVolumeBytes * ratio));
-        return Math.max(1L, totalCacheBytes / MAX_CACHED_TABLES);
+        return Math.max(1L, totalCacheBytes);
+    }
+
+    private static String cacheNamespace(
+            long tableId, int schemaId, long lakeConfigVersion, long lookuperId) {
+        return tableId + "-" + schemaId + "-" + lakeConfigVersion + "-" + lookuperId;
     }
 
     /** Returns the most recently sampled historical lookup cache footprint, in bytes. */
@@ -453,34 +503,12 @@ class HistoricalLakeLookupManager implements AutoCloseable {
     }
 
     private static void closeLookuper(CachedLakeTableLookuper cachedLookuper) {
-        closeLookuper(cachedLookuper.lookuper, cachedLookuper.tableLookupDir);
-    }
-
-    private static void closeLookuper(LakeTableLookuper lookuper, File tableLookupDir) {
-        try {
-            IOUtils.closeQuietly(lookuper, "historical lake table lookuper");
-        } finally {
-            deleteTableLookupDirIfEmpty(tableLookupDir);
-        }
-    }
-
-    private static void deleteTableLookupDirIfEmpty(File tableLookupDir) {
-        if (FileUtils.isDirectoryEmpty(tableLookupDir)) {
-            try {
-                Files.deleteIfExists(tableLookupDir.toPath());
-            } catch (IOException e) {
-                LOG.debug(
-                        "Failed to delete empty historical lookup directory {}.",
-                        tableLookupDir,
-                        e);
-            }
-        }
+        IOUtils.closeQuietly(cachedLookuper.lookuper, "historical lake table lookuper");
     }
 
     private CachedLakeTableLookuper acquireLookuper(LookupContext context, TableInfo tableInfo) {
         long currentLakeConfigVersion = lakeConfigVersion;
         Configuration currentConf = conf;
-        long cacheSizeBytes = lookupCacheMaxDiskBytesPerTable;
         Long requiredLakeSnapshotId = requiredLakeSnapshotIds.get(context.tableId);
         return lakeTableLookupers
                 .asMap()
@@ -489,28 +517,24 @@ class HistoricalLakeLookupManager implements AutoCloseable {
                         (ignored, currentLookuper) -> {
                             CachedLakeTableLookuper selectedLookuper = currentLookuper;
                             // Create the lookuper lazily, and recreate it after schema,
-                            // lake configuration, or server cache size changes so it
-                            // reloads lake table/query state and uses the current
-                            // settings.
+                            // lake configuration, or required lake snapshot changes so it reloads
+                            // lake table/query state and uses the current settings.
                             if (selectedLookuper == null
                                     || selectedLookuper.schemaId != context.schemaId
                                     || selectedLookuper.lakeConfigVersion
                                             != currentLakeConfigVersion
-                                    || selectedLookuper.cacheSizeBytes != cacheSizeBytes
                                     || !Objects.equals(
                                             selectedLookuper.lakeSnapshotId,
                                             requiredLakeSnapshotId)) {
-                                File tableLookupDir =
-                                        FlussPaths.historicalLookupTableDir(
-                                                historicalLookupCacheRootDir,
-                                                context.tablePath,
-                                                context.tableId);
                                 LakeTableLookuper lookuper =
                                         createLakeTableLookuper(
                                                 context.tablePath,
-                                                tableLookupDir.getAbsolutePath(),
                                                 tableInfo.getTableConfig(),
-                                                cacheSizeBytes,
+                                                cacheNamespace(
+                                                        context.tableId,
+                                                        context.schemaId,
+                                                        currentLakeConfigVersion,
+                                                        lookuperIdSequence.getAndIncrement()),
                                                 currentConf);
                                 selectedLookuper =
                                         new CachedLakeTableLookuper(
@@ -518,9 +542,7 @@ class HistoricalLakeLookupManager implements AutoCloseable {
                                                 context.tablePath,
                                                 context.schemaId,
                                                 currentLakeConfigVersion,
-                                                cacheSizeBytes,
                                                 requiredLakeSnapshotId,
-                                                tableLookupDir,
                                                 lookuper);
                             }
                             // Pin the lookuper before leaving the atomic cache update.
@@ -554,11 +576,9 @@ class HistoricalLakeLookupManager implements AutoCloseable {
         private final TablePath tablePath;
         private final int schemaId;
         private final long lakeConfigVersion;
-        private final long cacheSizeBytes;
         /** The required opaque lake snapshot ID when this lookuper was created, or null if none. */
         private final @Nullable Long lakeSnapshotId;
 
-        private final File tableLookupDir;
         private final LakeTableLookuper lookuper;
         private int activeLookups;
         private boolean invalidated;
@@ -569,17 +589,13 @@ class HistoricalLakeLookupManager implements AutoCloseable {
                 TablePath tablePath,
                 int schemaId,
                 long lakeConfigVersion,
-                long cacheSizeBytes,
                 @Nullable Long lakeSnapshotId,
-                File tableLookupDir,
                 LakeTableLookuper lookuper) {
             this.tableId = tableId;
             this.tablePath = tablePath;
             this.schemaId = schemaId;
             this.lakeConfigVersion = lakeConfigVersion;
-            this.cacheSizeBytes = cacheSizeBytes;
             this.lakeSnapshotId = lakeSnapshotId;
-            this.tableLookupDir = tableLookupDir;
             this.lookuper = lookuper;
         }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/lakehouse/TestingPaimonStoragePlugin.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/lakehouse/TestingPaimonStoragePlugin.java
@@ -28,6 +28,8 @@ import org.apache.fluss.lake.committer.LakeCommitter;
 import org.apache.fluss.lake.lakestorage.LakeCatalog;
 import org.apache.fluss.lake.lakestorage.LakeStorage;
 import org.apache.fluss.lake.lakestorage.LakeStoragePlugin;
+import org.apache.fluss.lake.lakestorage.LakeTableLookupRuntime;
+import org.apache.fluss.lake.lakestorage.LakeTableLookuper;
 import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
 import org.apache.fluss.lake.source.LakeSource;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
@@ -85,6 +87,24 @@ public class TestingPaimonStoragePlugin implements LakeStoragePlugin {
         @Override
         public LakeSource<?> createLakeSource(TablePath tablePath) {
             throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public LakeTableLookupRuntime createLakeTableLookupRuntime(
+                String ioTmpDir, long lookupCacheMaxDiskBytes) {
+            return new LakeTableLookupRuntime() {
+                @Override
+                public LakeTableLookuper createLakeTableLookuper(
+                        TablePath tablePath, Context context) {
+                    throw new UnsupportedOperationException("Not implemented");
+                }
+
+                @Override
+                public void updateLookupCacheMaxDiskBytes(long lookupCacheMaxDiskBytes) {}
+
+                @Override
+                public void close() {}
+            };
         }
     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/historical/HistoricalLakeLookupManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/historical/HistoricalLakeLookupManagerTest.java
@@ -81,7 +81,6 @@ class HistoricalLakeLookupManagerTest {
         assertThat(staleLookupFile).doesNotExist();
         assertThat(serverLookupDir).isDirectory();
         lookup(manager, PARTITION_TABLE_INFO);
-        assertThat(manager.createdIoTmpDirs.get(0)).startsWith(serverLookupDir.getAbsolutePath());
 
         File liveLookupFile = new File(serverLookupDir, "live-lookup-file");
         assertThat(liveLookupFile.createNewFile()).isTrue();
@@ -263,9 +262,35 @@ class HistoricalLakeLookupManagerTest {
 
         assertThat(manager.createdLookupers).hasSize(11);
         assertThat(manager.createdLookupers).filteredOn(lookuper -> lookuper.closed).hasSize(1);
-        assertThat(manager.createdCacheSizes).containsOnly(2L);
+        assertThat(manager.createdCacheNamespaces).doesNotHaveDuplicates();
+        assertThat(manager.lookupCacheMaxDiskBytes()).isEqualTo(20L);
         assertThat(manager.cachedTableCount()).isEqualTo(10);
         assertThat(manager.capacityEvictions().getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testUpdatesSharedCacheLimitWithoutReplacingLookuper() throws Exception {
+        Configuration initialConf = conf();
+        initialConf.set(
+                ConfigOptions.SERVER_HISTORICAL_PARTITION_LOOKUP_CACHE_MAX_DISK_RATIO, 0.10);
+        TestingHistoricalLakeLookupManager manager =
+                new TestingHistoricalLakeLookupManager(
+                        initialConf,
+                        Ticker.systemTicker(),
+                        Scheduler.disabledScheduler(),
+                        100L,
+                        0L);
+        manager.startup(NO_OP_SCHEDULER);
+        lookup(manager, PARTITION_TABLE_INFO);
+        TestingLakeTableLookuper lookuper = manager.createdLookupers.get(0);
+
+        Configuration newConf = new Configuration(initialConf);
+        newConf.set(ConfigOptions.SERVER_HISTORICAL_PARTITION_LOOKUP_CACHE_MAX_DISK_RATIO, 0.20);
+        manager.reconfigure(newConf);
+
+        assertThat(manager.lookupCacheMaxDiskBytes()).isEqualTo(20L);
+        assertThat(lookuper.closed).isFalse();
+        assertThat(manager.cachedTableCount()).isOne();
     }
 
     @Test
@@ -275,6 +300,7 @@ class HistoricalLakeLookupManagerTest {
         initialConf.setString("datalake.paimon.warehouse", "old-warehouse");
         TestingHistoricalLakeLookupManager manager =
                 new TestingHistoricalLakeLookupManager(initialConf);
+        assertThat(manager.hasLookupRuntime()).isTrue();
         manager.startup(NO_OP_SCHEDULER);
 
         lookup(manager, PARTITION_TABLE_INFO);
@@ -350,9 +376,8 @@ class HistoricalLakeLookupManagerTest {
     private static final class TestingHistoricalLakeLookupManager
             extends HistoricalLakeLookupManager {
         private final List<TestingLakeTableLookuper> createdLookupers = new ArrayList<>();
-        private final List<String> createdIoTmpDirs = new ArrayList<>();
         private final List<TableConfig> createdTableConfigs = new ArrayList<>();
-        private final List<Long> createdCacheSizes = new ArrayList<>();
+        private final List<String> createdCacheNamespaces = new ArrayList<>();
         private final List<Configuration> createdClusterConfigs = new ArrayList<>();
         private final long lookupCacheFileBytes;
 
@@ -401,16 +426,17 @@ class HistoricalLakeLookupManagerTest {
         @Override
         LakeTableLookuper createLakeTableLookuper(
                 TablePath tablePath,
-                String ioTmpDir,
                 TableConfig tableConfig,
-                long cacheSizeBytes,
+                String cacheNamespace,
                 Configuration clusterConf) {
             TestingLakeTableLookuper lookuper =
-                    new TestingLakeTableLookuper(new File(ioTmpDir), lookupCacheFileBytes);
+                    new TestingLakeTableLookuper(
+                            FlussPaths.historicalLookupRootDir(
+                                    new File(clusterConf.get(ConfigOptions.DATA_DIR))),
+                            lookupCacheFileBytes);
             createdLookupers.add(lookuper);
-            createdIoTmpDirs.add(ioTmpDir);
             createdTableConfigs.add(tableConfig);
-            createdCacheSizes.add(cacheSizeBytes);
+            createdCacheNamespaces.add(cacheNamespace);
             createdClusterConfigs.add(clusterConf);
             return lookuper;
         }


### PR DESCRIPTION
### Purpose

Linked issue: close #3955 

This PR depends on the https://github.com/apache/fluss/pull/4050 . 

### Brief change log

As discussed in [#3955](https://github.com/apache/fluss/issues/3955), sharing the file cache across multiple table lookups requires maintaining a Fluss-side fork of Paimon’s LocalTableQuery, adapted to use the shared cache.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
