### PR TITLE
[lake/paimon] Maintain lakestream.enabled with lake acceleration state

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
@@ -210,10 +210,7 @@ public class PaimonConversions {
                 schemaChanges.add(SchemaChange.removeOption(key));
                 // #4102: resetting datalake.enabled is equivalent to disabling acceleration.
                 maybeSyncLakeStreamOption(
-                        resetOption.getKey(),
-                        null,
-                        paimonIncludingSystemColumns,
-                        schemaChanges);
+                        resetOption.getKey(), null, paimonIncludingSystemColumns, schemaChanges);
             } else if (tableChange instanceof TableChange.AddColumn) {
                 TableChange.AddColumn addColumn = (TableChange.AddColumn) tableChange;
 
@@ -380,10 +377,7 @@ public class PaimonConversions {
      * @param out the schema-change list to append to
      */
     private static void maybeSyncLakeStreamOption(
-            String flussKey,
-            @Nullable String value,
-            boolean legacyTable,
-            List<SchemaChange> out) {
+            String flussKey, @Nullable String value, boolean legacyTable, List<SchemaChange> out) {
         if (!TABLE_DATALAKE_ENABLED.key().equals(flussKey)) {
             return;
         }
@@ -392,9 +386,7 @@ public class PaimonConversions {
             return;
         }
         if (Boolean.parseBoolean(value)) {
-            out.add(
-                    SchemaChange.setOption(
-                            LAKESTREAM_ENABLED_OPTION_KEY, Boolean.TRUE.toString()));
+            out.add(SchemaChange.setOption(LAKESTREAM_ENABLED_OPTION_KEY, Boolean.TRUE.toString()));
         } else {
             // Disabling (SetOption "false") or resetting removes the option entirely.
             out.add(SchemaChange.removeOption(LAKESTREAM_ENABLED_OPTION_KEY));

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
@@ -43,8 +43,6 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 
-import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -198,9 +196,9 @@ public class PaimonConversions {
                 validateAlterPaimonOptions(key);
                 schemaChanges.add(SchemaChange.setOption(key, setOption.getValue()));
                 // #4102: keep lakestream.enabled in sync with datalake acceleration state.
-                maybeSyncLakeStreamOption(
+                appendLakeStreamOptionChange(
                         setOption.getKey(),
-                        setOption.getValue(),
+                        Boolean.parseBoolean(setOption.getValue()),
                         paimonIncludingSystemColumns,
                         schemaChanges);
             } else if (tableChange instanceof TableChange.ResetOption) {
@@ -209,8 +207,8 @@ public class PaimonConversions {
                 validateAlterPaimonOptions(key);
                 schemaChanges.add(SchemaChange.removeOption(key));
                 // #4102: resetting datalake.enabled is equivalent to disabling acceleration.
-                maybeSyncLakeStreamOption(
-                        resetOption.getKey(), null, paimonIncludingSystemColumns, schemaChanges);
+                appendLakeStreamOptionChange(
+                        resetOption.getKey(), false, paimonIncludingSystemColumns, schemaChanges);
             } else if (tableChange instanceof TableChange.AddColumn) {
                 TableChange.AddColumn addColumn = (TableChange.AddColumn) tableChange;
 
@@ -372,12 +370,15 @@ public class PaimonConversions {
      * instead of persisting {@code false}.
      *
      * @param flussKey the original (un-prefixed) Fluss change key
-     * @param value the option value for a SetOption change, or {@code null} for a ResetOption
+     * @param lakeStreamEnabled whether datalake acceleration is enabled after this change
      * @param legacyTable whether the Paimon table uses the legacy system-column layout
      * @param out the schema-change list to append to
      */
-    private static void maybeSyncLakeStreamOption(
-            String flussKey, @Nullable String value, boolean legacyTable, List<SchemaChange> out) {
+    private static void appendLakeStreamOptionChange(
+            String flussKey,
+            boolean lakeStreamEnabled,
+            boolean legacyTable,
+            List<SchemaChange> out) {
         if (!TABLE_DATALAKE_ENABLED.key().equals(flussKey)) {
             return;
         }
@@ -385,7 +386,7 @@ public class PaimonConversions {
         if (legacyTable) {
             return;
         }
-        if (Boolean.parseBoolean(value)) {
+        if (lakeStreamEnabled) {
             out.add(SchemaChange.setOption(LAKESTREAM_ENABLED_OPTION_KEY, Boolean.TRUE.toString()));
         } else {
             // Disabling (SetOption "false") or resetting removes the option entirely.

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
@@ -195,20 +195,23 @@ public class PaimonConversions {
                 String key = convertFlussPropertyKeyToPaimon(setOption.getKey());
                 validateAlterPaimonOptions(key);
                 schemaChanges.add(SchemaChange.setOption(key, setOption.getValue()));
-                // #4102: keep lakestream.enabled in sync with datalake acceleration state.
-                appendLakeStreamOptionChange(
-                        setOption.getKey(),
-                        Boolean.parseBoolean(setOption.getValue()),
-                        paimonIncludingSystemColumns,
-                        schemaChanges);
+                if (TABLE_DATALAKE_ENABLED.key().equals(setOption.getKey())) {
+                    // #4102: keep lakestream.enabled in sync with datalake acceleration state.
+                    appendLakeStreamOptionChange(
+                            Boolean.parseBoolean(setOption.getValue()),
+                            paimonIncludingSystemColumns,
+                            schemaChanges);
+                }
             } else if (tableChange instanceof TableChange.ResetOption) {
                 TableChange.ResetOption resetOption = (TableChange.ResetOption) tableChange;
                 String key = convertFlussPropertyKeyToPaimon(resetOption.getKey());
                 validateAlterPaimonOptions(key);
                 schemaChanges.add(SchemaChange.removeOption(key));
-                // #4102: resetting datalake.enabled is equivalent to disabling acceleration.
-                appendLakeStreamOptionChange(
-                        resetOption.getKey(), false, paimonIncludingSystemColumns, schemaChanges);
+                if (TABLE_DATALAKE_ENABLED.key().equals(resetOption.getKey())) {
+                    // #4102: resetting datalake.enabled is equivalent to disabling acceleration.
+                    appendLakeStreamOptionChange(
+                            false, paimonIncludingSystemColumns, schemaChanges);
+                }
             } else if (tableChange instanceof TableChange.AddColumn) {
                 TableChange.AddColumn addColumn = (TableChange.AddColumn) tableChange;
 
@@ -369,19 +372,12 @@ public class PaimonConversions {
      * that still carry the Fluss system columns are left untouched. Disabling removes the option
      * instead of persisting {@code false}.
      *
-     * @param flussKey the original (un-prefixed) Fluss change key
      * @param lakeStreamEnabled whether datalake acceleration is enabled after this change
      * @param legacyTable whether the Paimon table uses the legacy system-column layout
      * @param out the schema-change list to append to
      */
     private static void appendLakeStreamOptionChange(
-            String flussKey,
-            boolean lakeStreamEnabled,
-            boolean legacyTable,
-            List<SchemaChange> out) {
-        if (!TABLE_DATALAKE_ENABLED.key().equals(flussKey)) {
-            return;
-        }
+            boolean lakeStreamEnabled, boolean legacyTable, List<SchemaChange> out) {
         // Old-layout tables are outside the scope of this option.
         if (legacyTable) {
             return;

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
@@ -43,6 +43,8 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -51,6 +53,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import static org.apache.fluss.config.ConfigOptions.TABLE_DATALAKE_ENABLED;
 import static org.apache.fluss.lake.paimon.PaimonLakeCatalog.LEGACY_SYSTEM_COLUMNS;
 import static org.apache.fluss.utils.Preconditions.checkState;
 
@@ -64,6 +67,14 @@ public class PaimonConversions {
     // again
     /** Option controlling whether Paimon uses legacy partition value encoding. */
     public static final String PARTITION_GENERATE_LEGACY_NAME_OPTION_KEY = "partition.legacy-name";
+
+    /**
+     * Native Paimon table option maintained by Fluss to mark whether the (clean-layout) Paimon
+     * table is currently accelerated by Fluss LakeStream. Managed only for new-layout tables that
+     * do not carry the Fluss system columns; legacy tables are left untouched. Disabling lake
+     * acceleration removes the option instead of persisting {@code false}.
+     */
+    public static final String LAKESTREAM_ENABLED_OPTION_KEY = "lakestream.enabled";
 
     // for fluss config
     public static final String FLUSS_CONF_PREFIX = "fluss.";
@@ -186,11 +197,23 @@ public class PaimonConversions {
                 String key = convertFlussPropertyKeyToPaimon(setOption.getKey());
                 validateAlterPaimonOptions(key);
                 schemaChanges.add(SchemaChange.setOption(key, setOption.getValue()));
+                // #4102: keep lakestream.enabled in sync with datalake acceleration state.
+                maybeSyncLakeStreamOption(
+                        setOption.getKey(),
+                        setOption.getValue(),
+                        paimonIncludingSystemColumns,
+                        schemaChanges);
             } else if (tableChange instanceof TableChange.ResetOption) {
                 TableChange.ResetOption resetOption = (TableChange.ResetOption) tableChange;
                 String key = convertFlussPropertyKeyToPaimon(resetOption.getKey());
                 validateAlterPaimonOptions(key);
                 schemaChanges.add(SchemaChange.removeOption(key));
+                // #4102: resetting datalake.enabled is equivalent to disabling acceleration.
+                maybeSyncLakeStreamOption(
+                        resetOption.getKey(),
+                        null,
+                        paimonIncludingSystemColumns,
+                        schemaChanges);
             } else if (tableChange instanceof TableChange.AddColumn) {
                 TableChange.AddColumn addColumn = (TableChange.AddColumn) tableChange;
 
@@ -306,6 +329,13 @@ public class PaimonConversions {
         tableDescriptor
                 .getCustomProperties()
                 .forEach((k, v) -> setFlussPropertyToPaimon(k, v, options));
+
+        // #4102: newly created lake tables are always clean (system columns are rejected above), so
+        // a lake-enabled table must advertise its LakeStream state to Paimon.
+        if (isDataLakeEnabled(tableDescriptor)) {
+            options.set(LAKESTREAM_ENABLED_OPTION_KEY, Boolean.TRUE.toString());
+        }
+
         schemaBuilder.options(options.toMap());
 
         // currently we only support string type, todo
@@ -331,6 +361,44 @@ public class PaimonConversions {
         tableDescriptor.getComment().ifPresent(schemaBuilder::comment);
 
         return schemaBuilder.build();
+    }
+
+    private static boolean isDataLakeEnabled(TableDescriptor tableDescriptor) {
+        return Boolean.parseBoolean(
+                tableDescriptor.getProperties().get(TABLE_DATALAKE_ENABLED.key()));
+    }
+
+    /**
+     * Maintains the {@code lakestream.enabled} Paimon option together with the {@code
+     * table.datalake.enabled} lifecycle. Only new-layout (clean) tables are managed; legacy tables
+     * that still carry the Fluss system columns are left untouched. Disabling removes the option
+     * instead of persisting {@code false}.
+     *
+     * @param flussKey the original (un-prefixed) Fluss change key
+     * @param value the option value for a SetOption change, or {@code null} for a ResetOption
+     * @param legacyTable whether the Paimon table uses the legacy system-column layout
+     * @param out the schema-change list to append to
+     */
+    private static void maybeSyncLakeStreamOption(
+            String flussKey,
+            @Nullable String value,
+            boolean legacyTable,
+            List<SchemaChange> out) {
+        if (!TABLE_DATALAKE_ENABLED.key().equals(flussKey)) {
+            return;
+        }
+        // Old-layout tables are outside the scope of this option.
+        if (legacyTable) {
+            return;
+        }
+        if (Boolean.parseBoolean(value)) {
+            out.add(
+                    SchemaChange.setOption(
+                            LAKESTREAM_ENABLED_OPTION_KEY, Boolean.TRUE.toString()));
+        } else {
+            // Disabling (SetOption "false") or resetting removes the option entirely.
+            out.add(SchemaChange.removeOption(LAKESTREAM_ENABLED_OPTION_KEY));
+        }
     }
 
     private static void validatePaimonOptions(Map<String, String> properties) {

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/LakeEnabledTableCreateITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/LakeEnabledTableCreateITCase.java
@@ -74,6 +74,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.apache.fluss.lake.paimon.testutils.PaimonTestUtils.adjustToLegacyV1Table;
+import static org.apache.fluss.lake.paimon.utils.PaimonConversions.LAKESTREAM_ENABLED_OPTION_KEY;
 import static org.apache.fluss.lake.paimon.utils.PaimonConversions.PAIMON_UNSETTABLE_OPTIONS;
 import static org.apache.fluss.metadata.TableDescriptor.BUCKET_COLUMN_NAME;
 import static org.apache.fluss.metadata.TableDescriptor.OFFSET_COLUMN_NAME;
@@ -177,6 +178,7 @@ class LakeEnabledTableCreateITCase {
                         new String[] {"log_c1", "log_c2"}),
                 "log_c1,log_c2",
                 BUCKET_NUM);
+        assertThat(paimonLogTable.options()).containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
 
         TableDescriptor logNoBucketKeyTable =
                 TableDescriptor.builder()
@@ -234,6 +236,7 @@ class LakeEnabledTableCreateITCase {
                         new String[] {"pk_c1", "pk_c2"}),
                 "pk_c1",
                 BUCKET_NUM);
+        assertThat(paimonPkTable.options()).containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
 
         // test partitioned table
         TablePath partitionedTablePath = TablePath.of(DATABASE, "partitioned_table");
@@ -708,6 +711,9 @@ class LakeEnabledTableCreateITCase {
 
         Identifier paimonTablePath = Identifier.create(DATABASE, logTablePath.getTableName());
         Table enabledPaimonLogTable = paimonCatalog.getTable(paimonTablePath);
+        // enabling lake acceleration on a clean table sets lakestream.enabled=true
+        assertThat(enabledPaimonLogTable.options())
+                .containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
 
         Map<String, String> updatedProperties = new HashMap<>();
         updatedProperties.put(ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "true");
@@ -735,6 +741,9 @@ class LakeEnabledTableCreateITCase {
 
         // verify LogTablet datalake status is disabled
         verifyLogTabletDataLakeEnabled(tableId, false);
+        // disabling lake acceleration removes lakestream.enabled instead of storing false
+        assertThat(paimonCatalog.getTable(paimonTablePath).options())
+                .doesNotContainKey(LAKESTREAM_ENABLED_OPTION_KEY);
 
         // try to enable lake table again
         enableLake = TableChange.set(ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "true");
@@ -743,6 +752,9 @@ class LakeEnabledTableCreateITCase {
 
         // verify LogTablet datalake status is enabled again
         verifyLogTabletDataLakeEnabled(tableId, true);
+        // re-enabling lake acceleration adds lakestream.enabled=true again
+        assertThat(paimonCatalog.getTable(paimonTablePath).options())
+                .containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
 
         // write some data to the lake table
         writeData(paimonCatalog.getTable(paimonTablePath));
@@ -763,6 +775,119 @@ class LakeEnabledTableCreateITCase {
 
         // verify LogTablet datalake status is enabled
         verifyLogTabletDataLakeEnabled(tableId, true);
+    }
+
+    @Test
+    void testAlterLakeEnabledPrimaryKeyTable() throws Exception {
+        // create pk table with lake disabled
+        TableDescriptor pkTable =
+                TableDescriptor.builder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("pk_c1", DataTypes.INT())
+                                        .column("pk_c2", DataTypes.STRING())
+                                        .primaryKey("pk_c1")
+                                        .build())
+                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, false)
+                        .distributedBy(BUCKET_NUM)
+                        .build();
+        TablePath pkTablePath = TablePath.of(DATABASE, "pk_table_alter");
+        admin.createTable(pkTablePath, pkTable, false).get();
+        Identifier paimonTablePath = Identifier.create(DATABASE, pkTablePath.getTableName());
+
+        // lake table not created yet while lake is disabled
+        assertThatThrownBy(() -> paimonCatalog.getTable(paimonTablePath))
+                .isInstanceOf(Catalog.TableNotExistException.class);
+
+        // enable lake acceleration sets lakestream.enabled=true
+        admin.alterTable(
+                        pkTablePath,
+                        Collections.singletonList(
+                                TableChange.set(
+                                        ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "true")),
+                        false)
+                .get();
+        assertThat(paimonCatalog.getTable(paimonTablePath).options())
+                .containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
+
+        // disable lake acceleration removes lakestream.enabled instead of storing false
+        admin.alterTable(
+                        pkTablePath,
+                        Collections.singletonList(
+                                TableChange.set(
+                                        ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "false")),
+                        false)
+                .get();
+        assertThat(paimonCatalog.getTable(paimonTablePath).options())
+                .doesNotContainKey(LAKESTREAM_ENABLED_OPTION_KEY);
+
+        // re-enable lake acceleration adds lakestream.enabled=true again
+        admin.alterTable(
+                        pkTablePath,
+                        Collections.singletonList(
+                                TableChange.set(
+                                        ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "true")),
+                        false)
+                .get();
+        assertThat(paimonCatalog.getTable(paimonTablePath).options())
+                .containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
+    }
+
+    @Test
+    void testLegacyTableLakeStreamOptionUntouched() throws Exception {
+        // create a clean, lake-enabled table, then turn it into a legacy table carrying the three
+        // system columns. Old-layout tables are outside the scope of lakestream.enabled: altering
+        // datalake.enabled must not add or remove the option on them.
+        TablePath tablePath = TablePath.of(DATABASE, "legacy_lakestream_table");
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("c1", DataTypes.INT())
+                                        .column("c2", DataTypes.STRING())
+                                        .build())
+                        .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
+                        .distributedBy(BUCKET_NUM, "c1")
+                        .build();
+        admin.createTable(tablePath, tableDescriptor, false).get();
+        Identifier paimonTablePath = Identifier.create(DATABASE, tablePath.getTableName());
+
+        adjustToLegacyV1Table(tablePath, paimonCatalog);
+        String lakeStreamValueBeforeAlter =
+                paimonCatalog
+                        .getTable(paimonTablePath)
+                        .options()
+                        .get(LAKESTREAM_ENABLED_OPTION_KEY);
+
+        // disable lake acceleration on a legacy table leaves the option untouched
+        admin.alterTable(
+                        tablePath,
+                        Collections.singletonList(
+                                TableChange.set(
+                                        ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "false")),
+                        false)
+                .get();
+        assertThat(
+                        paimonCatalog
+                                .getTable(paimonTablePath)
+                                .options()
+                                .get(LAKESTREAM_ENABLED_OPTION_KEY))
+                .isEqualTo(lakeStreamValueBeforeAlter);
+
+        // re-enable lake acceleration on a legacy table also leaves the option untouched
+        admin.alterTable(
+                        tablePath,
+                        Collections.singletonList(
+                                TableChange.set(
+                                        ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "true")),
+                        false)
+                .get();
+        assertThat(
+                        paimonCatalog
+                                .getTable(paimonTablePath)
+                                .options()
+                                .get(LAKESTREAM_ENABLED_OPTION_KEY))
+                .isEqualTo(lakeStreamValueBeforeAlter);
     }
 
     @Test

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/LakeEnabledTableCreateITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/LakeEnabledTableCreateITCase.java
@@ -831,6 +831,30 @@ class LakeEnabledTableCreateITCase {
                 .get();
         assertThat(paimonCatalog.getTable(paimonTablePath).options())
                 .containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
+
+        // resetting datalake.enabled is equivalent to disabling acceleration, and removes the
+        // key from the table descriptor entirely (unlike SetOption "false")
+        admin.alterTable(
+                        pkTablePath,
+                        Collections.singletonList(
+                                TableChange.reset(ConfigOptions.TABLE_DATALAKE_ENABLED.key())),
+                        false)
+                .get();
+        assertThat(paimonCatalog.getTable(paimonTablePath).options())
+                .doesNotContainKey(LAKESTREAM_ENABLED_OPTION_KEY);
+
+        // re-enabling after a reset must still sync lakestream.enabled=true: since the reset
+        // removed the key from the descriptor, MetadataManager must not rely solely on "the old
+        // descriptor already had the key" to decide whether to sync to the lake table
+        admin.alterTable(
+                        pkTablePath,
+                        Collections.singletonList(
+                                TableChange.set(
+                                        ConfigOptions.TABLE_DATALAKE_ENABLED.key(), "true")),
+                        false)
+                .get();
+        assertThat(paimonCatalog.getTable(paimonTablePath).options())
+                .containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
     }
 
     @Test

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/PaimonLakeCatalogTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/PaimonLakeCatalogTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 
 import static org.apache.fluss.config.ConfigOptions.TABLE_DATALAKE_ENABLED;
 import static org.apache.fluss.config.ConfigOptions.TABLE_DATALAKE_FORMAT;
+import static org.apache.fluss.lake.paimon.utils.PaimonConversions.LAKESTREAM_ENABLED_OPTION_KEY;
 import static org.apache.fluss.lake.paimon.utils.PaimonConversions.PARTITION_GENERATE_LEGACY_NAME_OPTION_KEY;
 import static org.apache.fluss.lake.paimon.utils.PaimonConversions.toPaimon;
 import static org.apache.fluss.lake.paimon.utils.PaimonTableValidation.isPaimonSchemaCompatible;
@@ -472,6 +473,78 @@ class PaimonLakeCatalogTest {
                         String.format(
                                 "therefore you need to add the diff columns all at once, rather than applying other table changes: %s.",
                                 changes));
+    }
+
+    @Test
+    void testCreateTableSetsLakeStreamEnabledForCleanTable() throws Exception {
+        String database = "test_create_lakestream_db";
+        String tableName = "test_create_lakestream_table";
+        TablePath tablePath = TablePath.of(database, tableName);
+        Identifier identifier = Identifier.create(database, tableName);
+
+        // getTableDescriptor sets table.datalake.enabled=true, so the clean table advertises its
+        // LakeStream state to Paimon
+        flussPaimonCatalog.createTable(
+                tablePath, getTableDescriptor(FLUSS_SCHEMA), LAKE_CATALOG_CONTEXT);
+
+        Table table = flussPaimonCatalog.getPaimonCatalog().getTable(identifier);
+        assertThat(table.options()).containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
+    }
+
+    @Test
+    void testCreateTableWithoutDataLakeEnabledHasNoLakeStreamOption() throws Exception {
+        String database = "test_create_no_lakestream_db";
+        String tableName = "test_create_no_lakestream_table";
+        TablePath tablePath = TablePath.of(database, tableName);
+        Identifier identifier = Identifier.create(database, tableName);
+
+        TableDescriptor tableDescriptor =
+                TableDescriptor.builder()
+                        .schema(FLUSS_SCHEMA)
+                        .property(TABLE_DATALAKE_ENABLED.key(), "false")
+                        .property(TABLE_DATALAKE_FORMAT.key(), "paimon")
+                        .property(
+                                "table.datalake.paimon.warehouse",
+                                tempWarehouseDir.toURI().toString())
+                        .distributedBy(3)
+                        .build();
+        flussPaimonCatalog.createTable(tablePath, tableDescriptor, LAKE_CATALOG_CONTEXT);
+
+        Table table = flussPaimonCatalog.getPaimonCatalog().getTable(identifier);
+        assertThat(table.options()).doesNotContainKey(LAKESTREAM_ENABLED_OPTION_KEY);
+    }
+
+    @Test
+    void testAlterDataLakeEnabledMaintainsLakeStreamOptionForCleanTable() throws Exception {
+        String database = "test_alter_lakestream_db";
+        String tableName = "test_alter_lakestream_table";
+        TablePath tablePath = TablePath.of(database, tableName);
+        Identifier identifier = Identifier.create(database, tableName);
+        createTable(database, tableName);
+
+        // disable lake acceleration removes lakestream.enabled instead of storing false
+        flussPaimonCatalog.alterTable(
+                tablePath,
+                Collections.singletonList(TableChange.set(TABLE_DATALAKE_ENABLED.key(), "false")),
+                LAKE_CATALOG_CONTEXT);
+        Table table = flussPaimonCatalog.getPaimonCatalog().getTable(identifier);
+        assertThat(table.options()).doesNotContainKey(LAKESTREAM_ENABLED_OPTION_KEY);
+
+        // re-enable lake acceleration adds lakestream.enabled=true again
+        flussPaimonCatalog.alterTable(
+                tablePath,
+                Collections.singletonList(TableChange.set(TABLE_DATALAKE_ENABLED.key(), "true")),
+                LAKE_CATALOG_CONTEXT);
+        table = flussPaimonCatalog.getPaimonCatalog().getTable(identifier);
+        assertThat(table.options()).containsEntry(LAKESTREAM_ENABLED_OPTION_KEY, "true");
+
+        // resetting datalake.enabled is equivalent to disabling acceleration
+        flussPaimonCatalog.alterTable(
+                tablePath,
+                Collections.singletonList(TableChange.reset(TABLE_DATALAKE_ENABLED.key())),
+                LAKE_CATALOG_CONTEXT);
+        table = flussPaimonCatalog.getPaimonCatalog().getTable(identifier);
+        assertThat(table.options()).doesNotContainKey(LAKESTREAM_ENABLED_OPTION_KEY);
     }
 
     private org.apache.paimon.schema.Schema createPaimonSchema(

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
@@ -618,12 +618,18 @@ public class MetadataManager {
         // We should always alter lake table even though datalake is disabled.
         // Otherwise, if user alter the fluss table when datalake is disabled, then enable datalake
         // again, the lake table will mismatch.
-        // Only sync to lake if this table has ever opted into datalake (key present regardless of
-        // value).
+        // Sync to lake if this table has ever opted into datalake (key present regardless of
+        // value), or if this change is enabling datalake now. The latter is needed because
+        // resetting table.datalake.enabled removes the key entirely (see
+        // #getUpdatedTableDescriptor), so a later re-enable would otherwise see an old descriptor
+        // without the key and skip the alterTable call that re-applies lakestream.enabled.
+        boolean enablingDataLake =
+                isDataLakeEnabled(newDescriptor) && !isDataLakeEnabled(tableDescriptor);
         if (lakeCatalog != null
-                && tableDescriptor
-                        .getProperties()
-                        .containsKey(ConfigOptions.TABLE_DATALAKE_ENABLED.key())) {
+                && (enablingDataLake
+                        || tableDescriptor
+                                .getProperties()
+                                .containsKey(ConfigOptions.TABLE_DATALAKE_ENABLED.key()))) {
             try {
                 lakeCatalog.alterTable(tablePath, tableChanges, lakeCatalogContext);
             } catch (TableNotExistException e) {


### PR DESCRIPTION
### Purpose

Linked issue: close #4102

Follow-up to FIP-27 (*clean Paimon lake table schema*, umbrella #2411). Under FIP-27 newly created Paimon lake tables use a **clean** physical layout without the Fluss system columns (`__bucket`, `__offset`, `__timestamp`), while pre-FIP-27 **legacy** tables still carry them.

Paimon needs an explicit signal to know whether a table is currently accelerated by Fluss LakeStream. Today Fluss drives the lake-acceleration lifecycle but leaves Paimon unaware of the table's LakeStream state. This PR makes Fluss maintain a native Paimon table option `lakestream.enabled` in lock-step with that lifecycle.

Scope is limited to **new-layout (clean)** tables. Legacy tables that still carry the system columns are out of scope and keep their current behavior untouched.

Option lifecycle:

| Operation | Paimon option change |
| --- | --- |
| Create a new lake-enabled Paimon table | set `lakestream.enabled=true` |
| Enable lake acceleration for a clean table | set `lakestream.enabled=true` |
| Disable lake acceleration for a clean table | **remove** `lakestream.enabled` |
| Re-enable lake acceleration | set `lakestream.enabled=true` again |

Disabling **removes** the option rather than storing `lakestream.enabled=false`.

### Brief change log

All changes are in `PaimonConversions` (the Paimon conversion layer); the upstream coordination layer
is untouched.

- **New option key:** add `LAKESTREAM_ENABLED_OPTION_KEY = "lakestream.enabled"`, written as a **native** Paimon option (it does not go through the `fluss.` property-prefix path).
- **Create path (`toPaimonSchema`):** when the table descriptor is lake-enabled, set `lakestream.enabled=true` on the generated Paimon options. Newly created tables are always clean (system columns are rejected earlier in this method), so no layout check is needed here.
- **Alter path (`toPaimonSchemaChanges`):** the method already resolves the target layout via  `PaimonUtils.isLegacyTable(rowType)`. A new helper `maybeSyncLakeStreamOption(...)` is invoked from both the `SetOption` and `ResetOption` branches:
  - only new-layout (clean) tables are managed; legacy tables are short-circuited and left untouched;
  - `table.datalake.enabled=true` -> append `SchemaChange.setOption("lakestream.enabled","true")`;
  - `table.datalake.enabled=false` or a reset of the key -> append `SchemaChange.removeOption("lakestream.enabled")`.
- The existing `table.datalake.enabled` property handling is unchanged; `lakestream.enabled` is maintained **in addition**, not as a replacement.

**Why the conversion layer (not the coordinator):** only this layer holds the Paimon physical schema, which is required to distinguish clean vs. legacy tables. Verified that `PaimonTableValidation.isPaimonSchemaCompatible` does **not** compare `lakestream.enabled`, so injecting it in `toPaimonSchema` (which is reused during the alter compatibility check) does not
affect re-enable schema compatibility.

### Tests

- `PaimonLakeCatalogTest` (unit, no cluster):
  - a lake-enabled clean table gets `lakestream.enabled=true` on create;
  - a non-lake table has no `lakestream.enabled`;
  - enable/disable/reset of `table.datalake.enabled` on a clean table sets / removes / removes the option respectively.
- `LakeEnabledTableCreateITCase` (integration):
  - `testCreateLakeEnabledTable` -- assert `lakestream.enabled=true` on created **log** and  **primary-key** tables;
  - `testAlterLakeEnabledLogTable` -- assert set on enable, **removed** on disable, set again on re-enable;
  - new `testAlterLakeEnabledPrimaryKeyTable` -- same enable -> disable -> re-enable lifecycle for a primary-key table;
  - new `testLegacyTableLakeStreamOptionUntouched` -- a legacy table (built via `adjustToLegacyV1Table`) keeps its `lakestream.enabled` unchanged across disable/enable.
- Covers both primary-key and log tables, as required by the acceptance criteria.
- Local run (Maven 3.8.6 + JBR 21, source level 8):
  - `PaimonLakeCatalogTest` -- 12 tests passed;
  - `LakeEnabledTableCreateITCase` -- 16 tests passed.
  - `spotless:check` could not run locally (google-java-format 1.15.0 is incompatible with JDK 21); formatting was verified manually (`git diff --check` clean, import order, line width). Full `mvn clean verify` should run in CI on JDK 11.

### API and Format

No public API change. This adds a native Paimon table option `lakestream.enabled` on **new-layout (clean)** Paimon lake tables, maintained together with the lake-acceleration lifecycle.
Legacy tables carrying the Fluss system columns are not affected. Fluss's own storage format is unchanged.

### Documentation

No documentation change. This is an internal Paimon table option maintained by Fluss; it introduces no user-facing configuration or feature surface.