### PR TITLE
[rust] Filter pushdown documentation and example

### DIFF
--- a/fluss-rust/crates/examples/Cargo.toml
+++ b/fluss-rust/crates/examples/Cargo.toml
@@ -60,3 +60,7 @@ path = "src/example_partitioned_prefix_lookup.rs"
 [[example]]
 name = "example-prometheus-metrics"
 path = "src/example_prometheus_metrics.rs"
+
+[[example]]
+name = "example-filter-pushdown"
+path = "src/example_filter_pushdown.rs"

--- a/fluss-rust/crates/examples/src/example_filter_pushdown.rs
+++ b/fluss-rust/crates/examples/src/example_filter_pushdown.rs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use clap::Parser;
+use fluss::client::{EARLIEST_OFFSET, FlussConnection};
+use fluss::config::Config;
+use fluss::error::Result;
+use fluss::metadata::{DataTypes, Schema, TableDescriptor, TablePath};
+use fluss::predicate::col;
+use fluss::row::{DataGetters, GenericRow};
+use std::time::Duration;
+
+#[tokio::main]
+pub async fn main() -> Result<()> {
+    let mut config = Config::parse();
+    config.bootstrap_servers = "127.0.0.1:9123".to_string();
+
+    let conn = FlussConnection::new(config).await?;
+    let admin = conn.get_admin()?;
+
+    let table_path = TablePath::new("fluss", "rust_filter_pushdown");
+    let descriptor = TableDescriptor::builder()
+        .schema(
+            Schema::builder()
+                .column("id", DataTypes::int())
+                .column("name", DataTypes::string())
+                .build()?,
+        )
+        // Collect per-batch column statistics; without them nothing is pruned.
+        .property("table.statistics.columns", "*")
+        .build()?;
+    admin.create_table(&table_path, &descriptor, true).await?;
+
+    let table = conn.get_table(&table_path).await?;
+    let writer = table.new_append()?.create_writer()?;
+
+    // Two flushes produce two batches with disjoint id ranges.
+    for id in 1..=3 {
+        let mut row = GenericRow::new(2);
+        row.set_field(0, id);
+        row.set_field(1, format!("low-{id}"));
+        writer.append(&row)?;
+    }
+    writer.flush().await?;
+    for id in 101..=103 {
+        let mut row = GenericRow::new(2);
+        row.set_field(0, id);
+        row.set_field(1, format!("high-{id}"));
+        writer.append(&row)?;
+    }
+    writer.flush().await?;
+
+    // The server skips the first batch: its statistics say max(id) is 3.
+    let scanner = table
+        .new_scan()
+        .filter(col("id").gt(100))?
+        .create_log_scanner()?;
+    scanner.subscribe(0, EARLIEST_OFFSET).await?;
+
+    let mut received = 0;
+    while received < 3 {
+        let records = scanner.poll(Duration::from_secs(10)).await?;
+        for record in records {
+            let row = record.row();
+            println!(
+                "id={}, name={} @ offset={}",
+                row.get_int(0)?,
+                row.get_string(1)?,
+                record.offset()
+            );
+            received += 1;
+        }
+    }
+
+    admin.drop_table(&table_path, false).await?;
+    Ok(())
+}

--- a/fluss-rust/crates/fluss/tests/integration/log_table.rs
+++ b/fluss-rust/crates/fluss/tests/integration/log_table.rs
@@ -840,7 +840,8 @@ mod table_test {
     }
 
     /// Pruning across the statistics encodings: spilled string bounds, compact
-    /// and non-compact decimals and timestamps, time, and null counts.
+    /// and non-compact decimals and timestamps, time with seconds-to-millis
+    /// scaling, and null counts.
     #[tokio::test]
     async fn filter_pushdown_prunes_across_column_types() {
         let cluster = get_shared_cluster();
@@ -857,7 +858,7 @@ mod table_test {
                     .column("big", DataTypes::decimal(22, 5))
                     .column("ts3", DataTypes::timestamp_with_precision(3))
                     .column("ts6", DataTypes::timestamp_with_precision(6))
-                    .column("t", DataTypes::time_with_precision(3))
+                    .column("t", DataTypes::time_with_precision(0))
                     .column("opt", DataTypes::int())
                     .build()
                     .expect("Failed to build schema"),
@@ -901,7 +902,7 @@ mod table_test {
                 5,
                 TimestampNtz::from_millis_nanos(1_600_000_000_000 + id as i64, 123_000).unwrap(),
             );
-            row.set_field(6, Time::new(32_400_000 + id));
+            row.set_field(6, Time::new(32_400_000 + id * 1_000));
             row.set_field(7, Datum::Null);
             writer.append(&row).expect("Failed to append low row");
         }
@@ -931,7 +932,7 @@ mod table_test {
                 5,
                 TimestampNtz::from_millis_nanos(1_900_000_000_000 + id as i64, 456_000).unwrap(),
             );
-            row.set_field(6, Time::new(72_000_000 + id));
+            row.set_field(6, Time::new(72_000_000 + id * 1_000));
             row.set_field(7, id);
             writer.append(&row).expect("Failed to append high row");
         }

--- a/fluss-rust/website/docs/user-guide/rust/api-reference.md
+++ b/fluss-rust/website/docs/user-guide/rust/api-reference.md
@@ -146,6 +146,7 @@ series are shared by `AppendWriter` (log tables) and `UpsertWriter` (PK tables).
 | `fn project(self, indices: &[usize]) -> Result<Self>`                       | Project columns by index                |
 | `fn project_by_name(self, names: &[&str]) -> Result<Self>`                  | Project columns by name                 |
 | `fn limit(self, n: i32) -> Result<Self>`                                    | Set a row limit (enables `create_bucket_batch_scanner`; rejected by log scanners) |
+| `fn filter(self, predicate: Predicate) -> Result<Self>`                     | Push a predicate down to log scanners; whole batches are pruned by statistics, and returned batches can still hold non-matching rows (see [Filter Pushdown](example/filter-pushdown.md); rejected by `create_bucket_batch_scanner`) |
 | `fn create_log_scanner(self) -> Result<LogScanner>`                         | Create a record-based log scanner; on a primary-key table, subscribes to its CDC changelog (per-record `ChangeType`) |
 | `fn create_record_batch_log_scanner(self) -> Result<RecordBatchLogScanner>` | Create an Arrow batch-based log scanner (log tables only — no per-record change types) |
 | `fn create_bucket_batch_scanner(self, bucket: TableBucket) -> Result<LimitBatchScanner>` | Bounded scan of one bucket (requires `limit`; runs on first `next_batch`) |

--- a/fluss-rust/website/docs/user-guide/rust/example/filter-pushdown.md
+++ b/fluss-rust/website/docs/user-guide/rust/example/filter-pushdown.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 8
+---
+# Filter Pushdown
+
+Log scans can push a predicate down to the server, which uses per-batch column
+statistics to skip whole Arrow record batches that cannot contain matching rows.
+This reduces network transfer and decoding work, but it is not exact row
+filtering: pruning works on whole batches, so the scan returns every batch that
+may contain a matching record — including the non-matching rows in those
+batches. Apply the filter again client-side when exact results are required.
+
+## Requirements
+
+- The table uses the ARROW log format (the default).
+- Column statistics are enabled via the `table.statistics.columns` table
+  property; without statistics no batches can be pruned.
+- A Fluss v1.0+ cluster (older servers reject the property, and older consumers
+  cannot parse the extended batch format it enables).
+
+```rust
+let descriptor = TableDescriptor::builder()
+    .schema(/* ... */)
+    // "*" collects statistics for all supported columns;
+    // a comma-separated list like "id,name" restricts collection.
+    .property("table.statistics.columns", "*")
+    .build()?;
+```
+
+Statistics are collected for BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
+FLOAT, DOUBLE, STRING, CHAR, DECIMAL, DATE, TIME, TIMESTAMP, and TIMESTAMP_LTZ
+columns.
+
+## Building Predicates
+
+Predicates are built from column references created with
+`fluss::predicate::col`:
+
+```rust
+use fluss::predicate::col;
+
+// Comparisons: eq, ne, lt, le, gt, ge
+let p = col("id").gt(100);
+let p = col("name").eq("alice");
+
+// Null checks
+let p = col("opt").is_null();
+let p = col("opt").is_not_null();
+
+// Set membership
+let p = col("id").is_in([1, 2, 3]);
+let p = col("id").not_in([4, 5]);
+
+// String matching
+let p = col("name").starts_with("a");
+let p = col("name").ends_with("z");
+let p = col("name").contains("mid");
+
+// Boolean combinations
+let p = col("id").gt(100).and(col("name").starts_with("a"));
+let p = col("id").lt(10).or(col("id").gt(100));
+```
+
+Literals convert from the natural Rust types (`i32`, `i64`, `f64`, `&str`,
+`Decimal`, `TimestampNtz`, `TimestampLtz`, ...). `Literal::Date` holds epoch
+days and `Literal::Time` milliseconds of day, matching Fluss's internal
+encoding. The protocol has no negation node; negate with `ne` and `not_in`.
+
+## Attaching a Filter to a Scan
+
+```rust
+use fluss::client::EARLIEST_OFFSET;
+use fluss::predicate::col;
+use std::time::Duration;
+
+let scanner = table
+    .new_scan()
+    .filter(col("id").gt(100))?
+    .create_log_scanner()?;
+scanner.subscribe(0, EARLIEST_OFFSET).await?;
+let records = scanner.poll(Duration::from_secs(5)).await?;
+```
+
+`filter` resolves the predicate against the table schema and errors on unknown
+columns or literals the column's type cannot represent exactly. It is supported
+by `create_log_scanner` and `create_record_batch_log_scanner`; the bounded
+`create_bucket_batch_scanner` rejects it.
+
+A runnable end-to-end example is in
+[`crates/examples/src/example_filter_pushdown.rs`](https://github.com/apache/fluss/blob/main/fluss-rust/crates/examples/src/example_filter_pushdown.rs).

--- a/fluss-rust/website/docs/user-guide/rust/example/log-tables.md
+++ b/fluss-rust/website/docs/user-guide/rust/example/log-tables.md
@@ -154,6 +154,22 @@ let scanner = table.new_scan()
     .create_log_scanner()?;
 ```
 
+## Filter Pushdown
+
+```rust
+use fluss::predicate::col;
+
+let scanner = table
+    .new_scan()
+    .filter(col("event_id").gt(100))?
+    .create_log_scanner()?;
+```
+
+The server skips whole record batches whose statistics cannot match; batches
+with any matching record are returned in full, so non-matching records can
+still appear. Requires column statistics via the `table.statistics.columns`
+table property; see [Filter Pushdown](./filter-pushdown.md).
+
 ## Limit Scan
 
 For a bounded read of up to `n` rows from a single bucket, use a batch scanner


### PR DESCRIPTION
## Summary
- Adds a filter pushdown page to the Rust user guide covering requirements (`table.statistics.columns`, ARROW log format), predicate building, and batch-pruning semantics, with cross-links from the log tables page and API reference.
- Adds a runnable end-to-end example (`example-filter-pushdown`).
- Switches the stats pruning test's time column to TIME(0) to cover the seconds-to-millis statistics scaling, per review feedback on #4109.
- Closes #3848

## Test Plan
- Ran `example-filter-pushdown` against a local 1.0 cluster; the low batch is pruned and only matching-batch rows return.
- Ran the filter pushdown integration tests (4) with the TIME(0) change against the same cluster.

🤖 AI-assisted changes - reviewed by human developer