### PR TITLE
[rust] Stop retrying writes after a cached table is dropped

### DIFF
--- a/fluss-gateway/src/backend/client.rs
+++ b/fluss-gateway/src/backend/client.rs
@@ -153,7 +153,6 @@ impl NativeFlussBackend {
 
         let deadline = ctx.deadline();
         for (index, future) in pending {
-            // TODO: Surface dropped tables as table_not_found after fluss-rust fixes #4136.
             let error = match tokio::time::timeout_at(deadline.into(), future).await {
                 Ok(Ok(())) => continue,
                 Ok(Err(error)) => classify_unknown(error),
@@ -391,7 +390,11 @@ fn classify_rejected(error: FlussClientError) -> GatewayError {
 fn classify_unknown(error: FlussClientError) -> GatewayError {
     if matches!(
         error.api_error(),
-        Some(FlussError::StorageBackpressureException | FlussError::AuthorizationException)
+        Some(
+            FlussError::StorageBackpressureException
+                | FlussError::AuthorizationException
+                | FlussError::TableNotExist
+        )
     ) {
         return classify_rejected(error);
     }
@@ -466,6 +469,7 @@ mod tests {
         for error in [
             FlussError::StorageBackpressureException,
             FlussError::AuthorizationException,
+            FlussError::TableNotExist,
         ] {
             assert!(
                 !classify_unknown(api_failure(error))

--- a/fluss-rust/crates/fluss/src/client/metadata.rs
+++ b/fluss-rust/crates/fluss/src/client/metadata.rs
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::PartitionId;
 use crate::cluster::{Cluster, ServerNode, ServerType};
 use crate::error::{Error, FlussError, Result};
 use crate::metadata::{PhysicalTablePath, TableBucket, TablePath};
 use crate::proto::MetadataResponse;
-use crate::rpc::message::UpdateMetadataRequest;
+use crate::rpc::message::{GetTableRequest, UpdateMetadataRequest};
 use crate::rpc::{RpcClient, ServerConnection};
+use crate::{PartitionId, TableId};
 use log::{info, warn};
 use parking_lot::RwLock;
 use std::collections::HashSet;
@@ -267,6 +267,39 @@ impl Metadata {
             let mut cluster_guard = self.cluster.write();
             let updated_cluster =
                 cluster_guard.invalidate_physical_table_meta(physical_tables_to_invalid);
+            *cluster_guard = Arc::new(updated_cluster);
+        }
+        self.notify_cluster_changed();
+    }
+
+    /// Fetches the table id from the cluster, bypassing the local cache.
+    /// Returns `Ok(None)` when the table does not exist. Unlike the metadata
+    /// refresh, which wraps a missing table in a generic server error, this
+    /// reports `TableNotExist` so callers can tell a dropped table apart from
+    /// a transient failure.
+    pub async fn fetch_table_id(&self, table_path: &TablePath) -> Result<Option<TableId>> {
+        let maybe_server = {
+            let guard = self.cluster.read();
+            guard.get_one_available_server().cloned()
+        };
+        let server = maybe_server.ok_or_else(|| Error::UnexpectedError {
+            message: "No available server to fetch table metadata".to_string(),
+            source: None,
+        })?;
+
+        let conn = self.connections.get_connection(&server).await?;
+        match conn.request(GetTableRequest::new(table_path)).await {
+            Ok(response) => Ok(Some(response.table_id)),
+            Err(e) if e.api_error() == Some(FlussError::TableNotExist) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Drops the cached id, info, partitions and bucket locations of `table_path`.
+    pub fn evict_table_metadata(&self, table_path: &TablePath) {
+        {
+            let mut cluster_guard = self.cluster.write();
+            let updated_cluster = cluster_guard.evict_table(table_path);
             *cluster_guard = Arc::new(updated_cluster);
         }
         self.notify_cluster_changed();
@@ -625,6 +658,18 @@ mod tests {
         metadata.invalidate_server(&1, vec![1]);
         let cluster = metadata.get_cluster();
         assert!(cluster.get_tablet_server(1).is_none());
+    }
+
+    #[test]
+    fn evict_table_metadata_purges_cluster() {
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let cluster = build_cluster_arc(&table_path, 1, 1);
+        let metadata = Metadata::new_for_test(cluster);
+        metadata.evict_table_metadata(&table_path);
+        let cluster = metadata.get_cluster();
+        assert!(cluster.get_table_id(&table_path).is_none());
+        assert!(cluster.opt_get_table(&table_path).is_none());
+        assert!(cluster.leader_for(&TableBucket::new(1, 0)).is_none());
     }
 
     #[test]

--- a/fluss-rust/crates/fluss/src/client/write/accumulator.rs
+++ b/fluss-rust/crates/fluss/src/client/write/accumulator.rs
@@ -24,8 +24,8 @@ use crate::client::{LogWriteRecord, Record, ResultHandle, WriteRecord};
 use crate::cluster::{BucketLocation, Cluster, ServerNode};
 use crate::compression::ArrowCompressionRatioEstimator;
 use crate::config::Config;
-use crate::error::{Error, Result};
-use crate::metadata::{PhysicalTablePath, TableBucket};
+use crate::error::{Error, FlussError, Result};
+use crate::metadata::{PhysicalTablePath, TableBucket, TablePath};
 use crate::record::{ArrowBatchConfig, NO_BATCH_SEQUENCE, NO_WRITER_ID};
 use crate::util::current_time_ms;
 use crate::{BucketId, PartitionId, TableId};
@@ -254,6 +254,10 @@ impl RecordAccumulator {
     ) -> Result<Option<RecordAppendResult>> {
         let dq_size = dq.len();
         if let Some(last_batch) = dq.back_mut() {
+            // A recreated path shares one queue, so keep table instances apart.
+            if last_batch.table_id() != record.table_info.table_id {
+                return Ok(None);
+            }
             return if let Some(result_handle) = last_batch.try_append(record)? {
                 Ok(Some(RecordAppendResult::new(
                     result_handle,
@@ -299,6 +303,7 @@ impl RecordAccumulator {
             Record::Log(_) => ArrowLog(ArrowLogWriteBatch::new(
                 self.batch_id.fetch_add(1, Ordering::Relaxed),
                 Arc::clone(physical_table_path),
+                record.table_info.table_id,
                 ArrowBatchConfig {
                     schema_id,
                     row_type: row_type.clone(),
@@ -313,6 +318,7 @@ impl RecordAccumulator {
             Record::Kv(kv_record) => Kv(KvWriteBatch::new(
                 self.batch_id.fetch_add(1, Ordering::Relaxed),
                 Arc::clone(physical_table_path),
+                record.table_info.table_id,
                 schema_id,
                 alloc_size,
                 record.write_format.to_kv_format()?,
@@ -364,12 +370,7 @@ impl RecordAccumulator {
                 .write_batches
                 .entry(Arc::clone(physical_table_path))
                 .or_insert_with(|| {
-                    BucketAndWriteBatches::new(
-                        table_info.table_id,
-                        is_partitioned_table,
-                        partition_id,
-                        &self.config,
-                    )
+                    BucketAndWriteBatches::new(is_partitioned_table, partition_id, &self.config)
                 });
             let bucket_and_batches = binding.value_mut();
             let dq = bucket_and_batches
@@ -519,7 +520,11 @@ impl RecordAccumulator {
             let waited_time_ms = batch.waited_time_ms(current_time_ms());
             let deque_size = batch_guard.len();
             let full = deque_size > 1 || batch.is_closed();
-            let table_bucket = cluster.get_table_bucket(physical_table_path, bucket_id)?;
+            // An evicted table must not stall the check every table shares.
+            let Ok(table_bucket) = cluster.get_table_bucket(physical_table_path, bucket_id) else {
+                unknown_leader_tables.insert(Arc::clone(physical_table_path));
+                return Ok(next_delay);
+            };
             if let Some(expiry) = self.throttle_expiry_ms.get(&table_bucket).map(|e| *e) {
                 let remaining = expiry.saturating_sub(current_time_ms());
                 if remaining > 0 {
@@ -711,32 +716,58 @@ impl RecordAccumulator {
 
             if let Some(deque) = deque {
                 let mut maybe_batch = None;
+                let mut stale_batches = Vec::new();
                 {
                     let mut batch_lock = deque.lock();
-                    if !batch_lock.is_empty() {
-                        let first_batch = batch_lock.front().unwrap();
-
-                        if size + first_batch.estimated_size_in_bytes() > max_size as usize
-                            && !ready.is_empty()
-                        {
-                            // there is a rare case that a single batch size is larger than the request size
-                            // due to compression; in this case we will still eventually send this batch in
-                            // a single request.
-                            break;
-                        }
-
-                        // Improvement: `continue` instead of `break` to skip
-                        // only this bucket, not all buckets for the node.
-                        if self.should_stop_drain_batches_for_bucket(first_batch, &table_bucket) {
+                    let head_table_id = batch_lock.front().map(|batch| batch.table_id());
+                    if let Some(head_table_id) = head_table_id {
+                        if head_table_id < table_bucket.table_id() {
+                            // Table ids only ever grow, so a lower one means these belong to
+                            // a dropped table. Take every consecutive stale head batch in one
+                            // pass, ahead of the checks that gate batches actually being sent.
+                            while batch_lock
+                                .front()
+                                .is_some_and(|batch| batch.table_id() == head_table_id)
+                            {
+                                stale_batches.push(batch_lock.pop_front().unwrap());
+                            }
+                        } else if head_table_id > table_bucket.table_id() {
+                            // This snapshot predates a recreate the appender already saw.
+                            // Sending under the old id would write to the dropped table, so
+                            // leave the batch for a cycle with fresher metadata.
                             if current_index == start {
                                 break;
                             }
                             continue;
-                        }
+                        } else {
+                            let first_batch = batch_lock.front().unwrap();
 
-                        maybe_batch = Some(batch_lock.pop_front().unwrap());
+                            if size + first_batch.estimated_size_in_bytes() > max_size as usize
+                                && !ready.is_empty()
+                            {
+                                // there is a rare case that a single batch size is larger than the request size
+                                // due to compression; in this case we will still eventually send this batch in
+                                // a single request.
+                                break;
+                            }
+
+                            // Improvement: `continue` instead of `break` to skip
+                            // only this bucket, not all buckets for the node.
+                            if self.should_stop_drain_batches_for_bucket(first_batch, &table_bucket)
+                            {
+                                if current_index == start {
+                                    break;
+                                }
+                                continue;
+                            }
+
+                            maybe_batch = Some(batch_lock.pop_front().unwrap());
+                        }
                     }
                 }
+
+                // Outside the deque lock, so waking a writer never runs under it.
+                self.fail_stale_batches(table_path, &table_bucket, stale_batches);
 
                 if let Some(ref mut batch) = maybe_batch {
                     // Assign writer state to fresh batches (matching Java's drain loop)
@@ -911,7 +942,6 @@ impl RecordAccumulator {
     ) -> Arc<Mutex<VecDeque<WriteBatch>>> {
         let physical_table_path = ready_write_batch.write_batch.physical_table_path();
         let bucket_id = ready_write_batch.table_bucket.bucket_id();
-        let table_id = ready_write_batch.table_bucket.table_id();
         let partition_id = ready_write_batch.table_bucket.partition_id();
         let is_partitioned_table = partition_id.is_some();
 
@@ -919,12 +949,7 @@ impl RecordAccumulator {
             .write_batches
             .entry(Arc::clone(physical_table_path))
             .or_insert_with(|| {
-                BucketAndWriteBatches::new(
-                    table_id,
-                    is_partitioned_table,
-                    partition_id,
-                    &self.config,
-                )
+                BucketAndWriteBatches::new(is_partitioned_table, partition_id, &self.config)
             });
         let bucket_and_batches = binding.value_mut();
         bucket_and_batches
@@ -965,6 +990,102 @@ impl RecordAccumulator {
             handle.fail(error.clone());
         }
         incomplete.clear();
+    }
+
+    /// Fails the queued batches of `table_path` that were appended under
+    /// `table_id`, so a dropped table's pending writes complete instead of
+    /// waiting on a leader that never arrives. Batches belonging to another
+    /// table instance of the same path are kept, in order, since a drop and
+    /// recreate leaves both sharing one queue. In-flight batches are failed by
+    /// the sender. The map entries are kept, as in `abort_batches`, so a
+    /// concurrent `append` cannot strand a batch in a deque nothing owns.
+    pub fn fail_batches_for_table(
+        &self,
+        table_path: &TablePath,
+        table_id: TableId,
+        error: broadcast::Error,
+    ) {
+        let mut completed_batch_ids = Vec::new();
+        for mut entry in self
+            .write_batches
+            .iter_mut()
+            .filter(|entry| entry.key().get_table_path() == table_path)
+        {
+            for deque in entry.value_mut().batches.values_mut() {
+                let stale: Vec<WriteBatch> = {
+                    let mut dq = deque.lock();
+                    let mut kept = VecDeque::with_capacity(dq.len());
+                    let mut stale = Vec::new();
+                    while let Some(batch) = dq.pop_front() {
+                        if batch.table_id() == table_id {
+                            stale.push(batch);
+                        } else {
+                            kept.push_back(batch);
+                        }
+                    }
+                    *dq = kept;
+                    stale
+                };
+                // Outside the deque lock, as the Java accumulator does, so waking
+                // a writer never runs under it.
+                for batch in stale {
+                    completed_batch_ids.push(batch.batch_id());
+                    batch.complete(Err(error.clone()));
+                    self.release_idempotence_slot(&batch);
+                }
+            }
+        }
+
+        // Drop the completed batches' handles and memory permits.
+        let mut incomplete = self.incomplete_batches.write();
+        for batch_id in completed_batch_ids {
+            incomplete.remove(&batch_id);
+        }
+    }
+
+    /// Fails batches whose table instance no longer matches the bucket they would
+    /// be sent to. Call outside the deque lock.
+    fn fail_stale_batches(
+        &self,
+        table_path: &Arc<PhysicalTablePath>,
+        table_bucket: &TableBucket,
+        stale_batches: Vec<WriteBatch>,
+    ) {
+        let Some(stale_table_id) = stale_batches.first().map(|batch| batch.table_id()) else {
+            return;
+        };
+        log::warn!(
+            "Table {} was dropped and re-created with a new table id. Old id: {}, new id: {}. Failing {} pending batches for the old table instance.",
+            table_path.as_ref(),
+            stale_table_id,
+            table_bucket.table_id(),
+            stale_batches.len()
+        );
+        let error = broadcast::Error::WriteFailed {
+            code: FlussError::TableNotExist.code(),
+            message: format!(
+                "Table {} now resolves to table_id={}, so this write to table_id={} was not sent.",
+                table_path.as_ref(),
+                table_bucket.table_id(),
+                stale_table_id
+            ),
+        };
+        for batch in stale_batches {
+            if batch.complete(Err(error.clone())) {
+                self.release_idempotence_slot(&batch);
+                self.incomplete_batches.write().remove(&batch.batch_id());
+            }
+        }
+    }
+
+    /// Releases the in-flight slot a batch failed here still holds. A batch that
+    /// was never drained has no sequence and holds none.
+    fn release_idempotence_slot(&self, batch: &WriteBatch) {
+        if !self.idempotence_manager.is_enabled() || !batch.has_batch_sequence() {
+            return;
+        }
+        self.idempotence_manager
+            .remove_in_flight_batch_by_id(batch.batch_id());
     }
 
     pub fn has_incomplete(&self) -> bool {
@@ -1064,9 +1185,9 @@ impl ReadyWriteBatch {
     }
 }
 
-#[allow(dead_code)]
 struct BucketAndWriteBatches {
-    table_id: TableId,
+    // Kept for symmetry with the Java accumulator; `ready` derives this from the path.
+    #[allow(dead_code)]
     is_partitioned_table: bool,
     partition_id: Option<PartitionId>,
     batches: HashMap<BucketId, Arc<Mutex<VecDeque<WriteBatch>>>>,
@@ -1077,12 +1198,7 @@ struct BucketAndWriteBatches {
 }
 
 impl BucketAndWriteBatches {
-    fn new(
-        table_id: TableId,
-        is_partitioned_table: bool,
-        partition_id: Option<PartitionId>,
-        config: &Config,
-    ) -> Self {
+    fn new(is_partitioned_table: bool, partition_id: Option<PartitionId>, config: &Config) -> Self {
         let dynamic_batch_size = config.writer_dynamic_batch_size_enabled.then(|| {
             DynamicWriteBatchSizeEstimator::new(
                 config.writer_dynamic_batch_size_min as usize,
@@ -1090,7 +1206,6 @@ impl BucketAndWriteBatches {
             )
         });
         Self {
-            table_id,
             is_partitioned_table,
             partition_id,
             batches: Default::default(),
@@ -1508,6 +1623,410 @@ mod tests {
             batch_result,
             Err(broadcast::Error::Client { message }) if message == "test abort"
         ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fail_batches_for_table_only_fails_target_table() -> Result<()> {
+        let idempotence = disabled_idempotence();
+        let config = Config::default();
+        let accumulator = RecordAccumulator::new(config, Arc::clone(&idempotence));
+        let row = GenericRow {
+            values: vec![Datum::Int32(1)],
+        };
+
+        let table_path_a = TablePath::new("db".to_string(), "tbl_a".to_string());
+        let physical_path_a = Arc::new(PhysicalTablePath::of(Arc::new(table_path_a.clone())));
+        let table_info_a = Arc::new(build_table_info(table_path_a.clone(), 1, 1));
+        let cluster_a = Arc::new(build_cluster(&table_path_a, 1, 1));
+        let record_a = WriteRecord::for_append(table_info_a, physical_path_a, 1, &row);
+        let result_a = accumulator.append(&record_a, 0, &cluster_a, false)?;
+        let handle_a = result_a.result_handle.expect("handle");
+
+        let table_path_b = TablePath::new("db".to_string(), "tbl_b".to_string());
+        let physical_path_b = Arc::new(PhysicalTablePath::of(Arc::new(table_path_b.clone())));
+        let table_info_b = Arc::new(build_table_info(table_path_b.clone(), 2, 1));
+        let cluster_b = Arc::new(build_cluster(&table_path_b, 2, 1));
+        let record_b = WriteRecord::for_append(table_info_b, physical_path_b, 1, &row);
+        accumulator.append(&record_b, 0, &cluster_b, false)?;
+
+        accumulator.fail_batches_for_table(
+            &table_path_a,
+            1,
+            broadcast::Error::WriteFailed {
+                code: 7,
+                message: "table dropped".to_string(),
+            },
+        );
+
+        // The target table's handle receives the error.
+        let batch_result = tokio::time::timeout(Duration::from_secs(10), handle_a.wait())
+            .await
+            .expect("the swept write must be failed, not left pending")?;
+        assert!(matches!(
+            batch_result,
+            Err(broadcast::Error::WriteFailed { code, .. }) if code == 7
+        ));
+
+        // The other table's batch is untouched and still drains.
+        assert!(accumulator.has_incomplete());
+        assert!(accumulator.has_undrained());
+        let server = cluster_b.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let mut batches = accumulator.drain(cluster_b, &nodes, 1024 * 1024)?;
+        let drained = batches.remove(&1).expect("drained");
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].table_bucket.table_id(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fail_batches_for_table_releases_the_idempotence_slot() -> Result<()> {
+        let idempotence = enabled_idempotence();
+        idempotence.set_writer_id(42);
+        let accumulator = RecordAccumulator::new(Config::default(), Arc::clone(&idempotence));
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let cluster = Arc::new(build_cluster(&table_path, 1, 1));
+
+        // Only a drained batch holds a slot, so drain it and put it back.
+        let batch = append_and_drain(&accumulator, &cluster, &table_path, 0)?;
+        let table_bucket = batch.table_bucket.clone();
+        accumulator.re_enqueue(batch);
+        assert_eq!(idempotence.in_flight_count(&table_bucket), 1);
+
+        accumulator.fail_batches_for_table(
+            &table_path,
+            1,
+            broadcast::Error::WriteFailed {
+                code: FlussError::TableNotExist.code(),
+                message: "table dropped".to_string(),
+            },
+        );
+
+        assert_eq!(
+            idempotence.in_flight_count(&table_bucket),
+            0,
+            "the swept batch must not leave its in-flight slot behind"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fail_batches_for_table_spares_a_newer_table_instance() -> Result<()> {
+        let idempotence = disabled_idempotence();
+        let config = Config::default();
+        let accumulator = RecordAccumulator::new(config, Arc::clone(&idempotence));
+        let row = GenericRow {
+            values: vec![Datum::Int32(1)],
+        };
+
+        // Dropped and recreated: queued batches are id 2, the sweep is id 1.
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let physical_path = Arc::new(PhysicalTablePath::of(Arc::new(table_path.clone())));
+        let table_info = Arc::new(build_table_info(table_path.clone(), 2, 1));
+        let cluster = Arc::new(build_cluster(&table_path, 2, 1));
+        let record = WriteRecord::for_append(table_info, physical_path, 1, &row);
+        accumulator.append(&record, 0, &cluster, false)?;
+
+        accumulator.fail_batches_for_table(
+            &table_path,
+            1,
+            broadcast::Error::WriteFailed {
+                code: 7,
+                message: "table dropped".to_string(),
+            },
+        );
+
+        // The recreated table's batch survives and still drains.
+        assert!(accumulator.has_incomplete());
+        let server = cluster.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let mut batches = accumulator.drain(cluster, &nodes, 1024 * 1024)?;
+        let drained = batches.remove(&1).expect("drained");
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].table_bucket.table_id(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fail_batches_for_table_splits_a_shared_queue_by_table_instance() -> Result<()> {
+        let idempotence = disabled_idempotence();
+        let config = Config::default();
+        let accumulator = RecordAccumulator::new(config, Arc::clone(&idempotence));
+        let row = GenericRow {
+            values: vec![Datum::Int32(1)],
+        };
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let physical_path = Arc::new(PhysicalTablePath::of(Arc::new(table_path.clone())));
+
+        // One record per table instance, both in the same bucket deque.
+        let cluster_old = Arc::new(build_cluster(&table_path, 1, 1));
+        let record_old = WriteRecord::for_append(
+            Arc::new(build_table_info(table_path.clone(), 1, 1)),
+            Arc::clone(&physical_path),
+            1,
+            &row,
+        );
+        let old_handle = accumulator
+            .append(&record_old, 0, &cluster_old, false)?
+            .result_handle
+            .expect("old handle");
+
+        let cluster_new = Arc::new(build_cluster(&table_path, 2, 1));
+        let record_new = WriteRecord::for_append(
+            Arc::new(build_table_info(table_path.clone(), 2, 1)),
+            physical_path,
+            1,
+            &row,
+        );
+        let new_handle = accumulator
+            .append(&record_new, 0, &cluster_new, false)?
+            .result_handle
+            .expect("new handle");
+
+        accumulator.fail_batches_for_table(
+            &table_path,
+            1,
+            broadcast::Error::WriteFailed {
+                code: 7,
+                message: "table dropped".to_string(),
+            },
+        );
+
+        // The dropped table instance's record is failed, not carried over.
+        let old_result = tokio::time::timeout(Duration::from_secs(10), old_handle.wait())
+            .await
+            .expect("the dropped table instance's write must be failed")?;
+        assert!(matches!(
+            old_result,
+            Err(broadcast::Error::WriteFailed { code, .. }) if code == 7
+        ));
+
+        // The recreated table's record is untouched and still drains.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), new_handle.wait())
+                .await
+                .is_err(),
+            "the recreated table's write must survive the stale sweep"
+        );
+        let server = cluster_new.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let mut batches = accumulator.drain(cluster_new, &nodes, 1024 * 1024)?;
+        let drained = batches.remove(&1).expect("drained");
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].write_batch.table_id(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_drain_fails_every_stale_batch_in_one_pass() -> Result<()> {
+        let accumulator = RecordAccumulator::new(Config::default(), disabled_idempotence());
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let cluster_old = Arc::new(build_cluster(&table_path, 1, 1));
+
+        // Two batches queued under table id 1, drained and put back.
+        let first = append_and_drain(&accumulator, &cluster_old, &table_path, 0)?;
+        let second = append_and_drain(&accumulator, &cluster_old, &table_path, 0)?;
+        accumulator.re_enqueue(second);
+        accumulator.re_enqueue(first);
+
+        let cluster_new = Arc::new(build_cluster(&table_path, 2, 1));
+        let server = cluster_new.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let batches = accumulator.drain(cluster_new, &nodes, 1024 * 1024)?;
+
+        assert!(batches.values().all(|drained| drained.is_empty()));
+        let physical_path = PhysicalTablePath::of(Arc::new(table_path));
+        let entry = accumulator
+            .write_batches
+            .get(&physical_path)
+            .expect("entry");
+        let remaining = entry.batches.get(&0).expect("deque").lock().len();
+        assert_eq!(
+            remaining, 0,
+            "a single drain must clear every consecutive stale batch, not just the head"
+        );
+        assert!(!accumulator.has_incomplete());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_drain_keeps_a_batch_newer_than_the_cluster_snapshot() -> Result<()> {
+        let accumulator = RecordAccumulator::new(Config::default(), disabled_idempotence());
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+
+        // Appended against the recreated table while the sender still holds a
+        // snapshot pinned before the recreate.
+        let cluster_new = Arc::new(build_cluster(&table_path, 2, 1));
+        let row = GenericRow {
+            values: vec![Datum::Int32(1)],
+        };
+        let record = WriteRecord::for_append(
+            Arc::new(build_table_info(table_path.clone(), 2, 1)),
+            Arc::new(PhysicalTablePath::of(Arc::new(table_path.clone()))),
+            1,
+            &row,
+        );
+        let handle = accumulator
+            .append(&record, 0, &cluster_new, false)?
+            .result_handle
+            .expect("handle");
+
+        let cluster_old = Arc::new(build_cluster(&table_path, 1, 1));
+        let server = cluster_old.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let batches = accumulator.drain(cluster_old, &nodes, 1024 * 1024)?;
+
+        // Neither sent under the stale id nor failed as though it were dropped.
+        assert!(batches.values().all(|drained| drained.is_empty()));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), handle.wait())
+                .await
+                .is_err(),
+            "a batch newer than the snapshot must wait, not be failed"
+        );
+        assert!(accumulator.has_incomplete());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_drain_fails_a_batch_whose_table_instance_is_gone() -> Result<()> {
+        let idempotence = disabled_idempotence();
+        let config = Config::default();
+        let accumulator = RecordAccumulator::new(config, Arc::clone(&idempotence));
+        let row = GenericRow {
+            values: vec![Datum::Int32(1)],
+        };
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+
+        // Queued under table id 1, but the cache now resolves the path to 2.
+        let cluster_old = Arc::new(build_cluster(&table_path, 1, 1));
+        let record = WriteRecord::for_append(
+            Arc::new(build_table_info(table_path.clone(), 1, 1)),
+            Arc::new(PhysicalTablePath::of(Arc::new(table_path.clone()))),
+            1,
+            &row,
+        );
+        let handle = accumulator
+            .append(&record, 0, &cluster_old, false)?
+            .result_handle
+            .expect("handle");
+
+        let cluster_new = Arc::new(build_cluster(&table_path, 2, 1));
+        let server = cluster_new.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let batches = accumulator.drain(cluster_new, &nodes, 1024 * 1024)?;
+
+        // The batch is failed rather than written into the new table instance.
+        assert!(batches.values().all(|drained| drained.is_empty()));
+        let result = tokio::time::timeout(Duration::from_secs(10), handle.wait())
+            .await
+            .expect("the stale batch must be failed at drain")?;
+        assert!(matches!(
+            result,
+            Err(broadcast::Error::WriteFailed { code, .. })
+                if code == FlussError::TableNotExist.code()
+        ));
+        assert!(!accumulator.has_incomplete());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ready_skips_a_table_whose_metadata_was_evicted() -> Result<()> {
+        let idempotence = disabled_idempotence();
+        let config = Config::default();
+        let accumulator = RecordAccumulator::new(config, Arc::clone(&idempotence));
+        let row = GenericRow {
+            values: vec![Datum::Int32(1)],
+        };
+
+        let evicted_path = TablePath::new("db".to_string(), "evicted".to_string());
+        let evicted_cluster = Arc::new(build_cluster(&evicted_path, 1, 1));
+        let record_evicted = WriteRecord::for_append(
+            Arc::new(build_table_info(evicted_path.clone(), 1, 1)),
+            Arc::new(PhysicalTablePath::of(Arc::new(evicted_path.clone()))),
+            1,
+            &row,
+        );
+        accumulator.append(&record_evicted, 0, &evicted_cluster, false)?;
+
+        let live_path = TablePath::new("db".to_string(), "live".to_string());
+        let live_cluster = Arc::new(build_cluster(&live_path, 2, 1));
+        let record_live = WriteRecord::for_append(
+            Arc::new(build_table_info(live_path.clone(), 2, 1)),
+            Arc::new(PhysicalTablePath::of(Arc::new(live_path.clone()))),
+            1,
+            &row,
+        );
+        accumulator.append(&record_live, 0, &live_cluster, false)?;
+
+        // Only the live table is known, as after an eviction.
+        let result = accumulator.ready(&live_cluster)?;
+        assert!(
+            result
+                .unknown_leader_tables
+                .iter()
+                .any(|path| path.get_table_path() == &evicted_path)
+        );
+        assert!(
+            !result
+                .unknown_leader_tables
+                .iter()
+                .any(|path| path.get_table_path() == &live_path),
+            "the live table must still be checked normally"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_reenqueue_does_not_expose_newer_table_instance_to_stale_sweep() -> Result<()> {
+        let idempotence = disabled_idempotence();
+        let config = Config::default();
+        let accumulator = RecordAccumulator::new(config, Arc::clone(&idempotence));
+        let row = GenericRow {
+            values: vec![Datum::Int32(1)],
+        };
+        let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+        let physical_path = Arc::new(PhysicalTablePath::of(Arc::new(table_path.clone())));
+
+        // Drained under id 1, before the drop and recreate.
+        let cluster_old = Arc::new(build_cluster(&table_path, 1, 1));
+        let table_info_old = Arc::new(build_table_info(table_path.clone(), 1, 1));
+        let record_old =
+            WriteRecord::for_append(table_info_old, Arc::clone(&physical_path), 1, &row);
+        accumulator.append(&record_old, 0, &cluster_old, false)?;
+        let server_old = cluster_old.get_tablet_server(1).expect("server");
+        let nodes_old = HashSet::from([server_old.clone()]);
+        let mut drained = accumulator.drain(cluster_old, &nodes_old, 1024 * 1024)?;
+        let old_batch = drained.remove(&1).expect("drained").pop().expect("batch");
+        assert_eq!(old_batch.table_bucket.table_id(), 1);
+
+        // The path is recreated as table id 2 and a new record is queued.
+        let cluster_new = Arc::new(build_cluster(&table_path, 2, 1));
+        let table_info_new = Arc::new(build_table_info(table_path.clone(), 2, 1));
+        let record_new = WriteRecord::for_append(table_info_new, physical_path, 1, &row);
+        let result_new = accumulator.append(&record_new, 0, &cluster_new, false)?;
+        let handle_new = result_new.result_handle.expect("handle");
+
+        // The stale batch is retried after the recreate.
+        accumulator.re_enqueue(old_batch);
+
+        accumulator.fail_batches_for_table(
+            &table_path,
+            1,
+            broadcast::Error::WriteFailed {
+                code: 7,
+                message: "table dropped".to_string(),
+            },
+        );
+
+        // The recreated table's write is untouched by the stale sweep.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), handle_new.wait())
+                .await
+                .is_err(),
+            "a write to the recreated table must not be failed by the stale sweep"
+        );
         Ok(())
     }
 

--- a/fluss-rust/crates/fluss/src/client/write/batch.rs
+++ b/fluss-rust/crates/fluss/src/client/write/batch.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::TableId;
 use crate::client::broadcast::{BatchWriteResult, BroadcastOnce};
 use crate::client::{Record, ResultHandle, WriteRecord};
 use crate::error::{Error, Result};
@@ -30,6 +31,7 @@ use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 pub struct InnerWriteBatch {
     batch_id: i64,
     physical_table_path: Arc<PhysicalTablePath>,
+    table_id: TableId,
     create_ms: i64,
     results: BroadcastOnce<BatchWriteResult>,
     completed: AtomicBool,
@@ -40,10 +42,16 @@ pub struct InnerWriteBatch {
 }
 
 impl InnerWriteBatch {
-    fn new(batch_id: i64, physical_table_path: Arc<PhysicalTablePath>, create_ms: i64) -> Self {
+    fn new(
+        batch_id: i64,
+        physical_table_path: Arc<PhysicalTablePath>,
+        table_id: TableId,
+        create_ms: i64,
+    ) -> Self {
         InnerWriteBatch {
             batch_id,
             physical_table_path,
+            table_id,
             create_ms,
             results: Default::default(),
             completed: AtomicBool::new(false),
@@ -96,6 +104,10 @@ impl InnerWriteBatch {
 
     fn physical_table_path(&self) -> &Arc<PhysicalTablePath> {
         &self.physical_table_path
+    }
+
+    fn table_id(&self) -> TableId {
+        self.table_id
     }
 
     fn attempts(&self) -> i32 {
@@ -203,6 +215,10 @@ impl WriteBatch {
         self.inner_batch().physical_table_path()
     }
 
+    pub fn table_id(&self) -> TableId {
+        self.inner_batch().table_id()
+    }
+
     pub fn attempts(&self) -> i32 {
         self.inner_batch().attempts()
     }
@@ -245,11 +261,12 @@ impl ArrowLogWriteBatch {
     pub(crate) fn new(
         batch_id: i64,
         physical_table_path: Arc<PhysicalTablePath>,
+        table_id: TableId,
         config: ArrowBatchConfig,
         create_ms: i64,
         to_append_record_batch: bool,
     ) -> Result<Self> {
-        let base = InnerWriteBatch::new(batch_id, physical_table_path, create_ms);
+        let base = InnerWriteBatch::new(batch_id, physical_table_path, table_id, create_ms);
         Ok(Self {
             write_batch: base,
             arrow_builder: MemoryLogRecordsArrowBuilder::new(config, to_append_record_batch)?,
@@ -325,13 +342,14 @@ impl KvWriteBatch {
     pub fn new(
         batch_id: i64,
         physical_table_path: Arc<PhysicalTablePath>,
+        table_id: TableId,
         schema_id: i32,
         write_limit: usize,
         kv_format: KvFormat,
         target_columns: Option<Arc<Vec<usize>>>,
         create_ms: i64,
     ) -> Self {
-        let base = InnerWriteBatch::new(batch_id, physical_table_path, create_ms);
+        let base = InnerWriteBatch::new(batch_id, physical_table_path, table_id, create_ms);
         Self {
             write_batch: base,
             kv_batch_builder: KvRecordBatchBuilder::new(schema_id, write_limit, kv_format),
@@ -440,7 +458,7 @@ mod tests {
     fn complete_only_once() {
         let table_path = TablePath::new("db".to_string(), "tbl".to_string());
         let physical_path = PhysicalTablePath::of(Arc::new(table_path));
-        let batch = InnerWriteBatch::new(1, Arc::new(physical_path), 0);
+        let batch = InnerWriteBatch::new(1, Arc::new(physical_path), 1, 0);
         assert!(batch.complete(Ok(())));
         assert!(!batch.complete(Err(crate::client::broadcast::Error::Dropped)));
     }
@@ -449,7 +467,7 @@ mod tests {
     fn attempts_increment_on_reenqueue() {
         let table_path = TablePath::new("db".to_string(), "tbl".to_string());
         let physical_path = PhysicalTablePath::of(Arc::new(table_path));
-        let batch = InnerWriteBatch::new(1, Arc::new(physical_path), 0);
+        let batch = InnerWriteBatch::new(1, Arc::new(physical_path), 1, 0);
         assert_eq!(batch.attempts(), 0);
         batch.re_enqueued();
         assert_eq!(batch.attempts(), 1);
@@ -459,7 +477,7 @@ mod tests {
     fn queue_time_ms_is_drained_minus_create() {
         let table_path = TablePath::new("db".to_string(), "tbl".to_string());
         let physical_path = PhysicalTablePath::of(Arc::new(table_path));
-        let mut batch = InnerWriteBatch::new(1, Arc::new(physical_path), 1_000);
+        let mut batch = InnerWriteBatch::new(1, Arc::new(physical_path), 1, 1_000);
         // Not drained yet -> 0 (drained_ms == -1).
         assert_eq!(batch.queue_time_ms(), 0);
         batch.drained(1_150);
@@ -487,6 +505,7 @@ mod tests {
         let arrow_batch = ArrowLogWriteBatch::new(
             1,
             Arc::clone(&physical_table_path),
+            1,
             uncompressed_config(&row_type, 2 * 1024 * 1024),
             0,
             false,
@@ -521,6 +540,7 @@ mod tests {
         let mut batch = WriteBatch::Kv(KvWriteBatch::new(
             1,
             Arc::clone(&physical_path),
+            1,
             1,
             64 * 1024,
             KvFormat::COMPACTED,
@@ -566,6 +586,7 @@ mod tests {
             let mut batch = ArrowLogWriteBatch::new(
                 1,
                 Arc::clone(&physical_table_path),
+                1,
                 uncompressed_config(&row_type, 2 * 1024 * 1024),
                 0,
                 false,
@@ -605,6 +626,7 @@ mod tests {
             let mut batch = ArrowLogWriteBatch::new(
                 1,
                 physical_table_path.clone(),
+                1,
                 uncompressed_config(&row_type, 2 * 1024 * 1024),
                 0,
                 true,
@@ -658,6 +680,7 @@ mod tests {
         let mut batch = KvWriteBatch::new(
             1,
             Arc::clone(&physical_path),
+            1,
             1,
             256,
             KvFormat::COMPACTED,
@@ -716,6 +739,7 @@ mod tests {
         let mut batch = ArrowLogWriteBatch::new(
             1,
             Arc::clone(&physical_table_path),
+            1,
             uncompressed_config(&row_type, write_limit),
             0,
             false,
@@ -759,6 +783,7 @@ mod tests {
         let mut batch = ArrowLogWriteBatch::new(
             2,
             Arc::clone(&physical_table_path),
+            1,
             uncompressed_config(&row_type_small, 2 * 1024 * 1024),
             0,
             false,
@@ -796,6 +821,7 @@ mod tests {
         let mut batch1 = ArrowLogWriteBatch::new(
             3,
             Arc::clone(&physical_table_path),
+            1,
             ArrowBatchConfig {
                 schema_id: 1,
                 row_type: row_type.clone(),
@@ -836,6 +862,7 @@ mod tests {
         let mut batch2 = ArrowLogWriteBatch::new(
             4,
             Arc::clone(&physical_table_path),
+            1,
             ArrowBatchConfig {
                 schema_id: 1,
                 row_type: row_type.clone(),

--- a/fluss-rust/crates/fluss/src/client/write/idempotence.rs
+++ b/fluss-rust/crates/fluss/src/client/write/idempotence.rs
@@ -245,6 +245,16 @@ impl IdempotenceManager {
         }
     }
 
+    /// Drops a batch's in-flight entry by id, which is unique across buckets, so
+    /// the caller needs no key. Leaves sequences and the writer id alone, for
+    /// buckets with no ordering left to preserve such as a dropped table.
+    pub fn remove_in_flight_batch_by_id(&self, batch_id: i64) {
+        let mut entries = self.bucket_entries.lock();
+        for entry in entries.values_mut() {
+            entry.in_flight.retain(|batch| batch.batch_id != batch_id);
+        }
+    }
+
     #[cfg(test)]
     pub fn remove_in_flight_batch(&self, bucket: &TableBucket, batch_id: i64) {
         let mut entries = self.bucket_entries.lock();

--- a/fluss-rust/crates/fluss/src/client/write/sender.rs
+++ b/fluss-rust/crates/fluss/src/client/write/sender.rs
@@ -509,6 +509,7 @@ impl Sender {
     ) -> Result<()> {
         let mut invalid_metadata_tables: HashSet<TablePath> = HashSet::new();
         let mut invalid_physical_table_paths: HashSet<Arc<PhysicalTablePath>> = HashSet::new();
+        let mut deferred_unknown_table_batches: Vec<ReadyWriteBatch> = Vec::new();
         let mut pending_buckets: HashSet<TableBucket> = request_buckets.iter().cloned().collect();
 
         for bucket_resp in response.buckets_resp() {
@@ -532,9 +533,12 @@ impl Sender {
                         .error_message()
                         .cloned()
                         .unwrap_or_else(|| error.message().to_string());
-                    if let Some(physical_table_path) =
-                        self.handle_write_batch_error(ready_batch, error, message)?
-                    {
+                    if let Some(physical_table_path) = self.handle_write_batch_error(
+                        ready_batch,
+                        error,
+                        message,
+                        &mut deferred_unknown_table_batches,
+                    )? {
                         invalid_metadata_tables
                             .insert(physical_table_path.get_table_path().clone());
                         invalid_physical_table_paths.insert(physical_table_path);
@@ -550,6 +554,7 @@ impl Sender {
                     ready_batch,
                     FlussError::UnknownServerError,
                     format!("Missing response for table bucket {bucket}"),
+                    &mut deferred_unknown_table_batches,
                 )? {
                     invalid_metadata_tables.insert(physical_table_path.get_table_path().clone());
                     invalid_physical_table_paths.insert(physical_table_path);
@@ -558,6 +563,8 @@ impl Sender {
         }
 
         self.update_metadata_if_needed(invalid_metadata_tables, invalid_physical_table_paths)
+            .await;
+        self.resolve_unknown_table_batches(deferred_unknown_table_batches)
             .await;
         Ok(())
     }
@@ -616,16 +623,22 @@ impl Sender {
     ) -> Result<()> {
         let mut invalid_metadata_tables: HashSet<TablePath> = HashSet::new();
         let mut invalid_physical_table_paths: HashSet<Arc<PhysicalTablePath>> = HashSet::new();
+        let mut deferred_unknown_table_batches: Vec<ReadyWriteBatch> = Vec::new();
 
         for batch in batches {
-            if let Some(physical_table_path) =
-                self.handle_write_batch_error(batch, error, message.clone())?
-            {
+            if let Some(physical_table_path) = self.handle_write_batch_error(
+                batch,
+                error,
+                message.clone(),
+                &mut deferred_unknown_table_batches,
+            )? {
                 invalid_metadata_tables.insert(physical_table_path.get_table_path().clone());
                 invalid_physical_table_paths.insert(physical_table_path);
             }
         }
         self.update_metadata_if_needed(invalid_metadata_tables, invalid_physical_table_paths)
+            .await;
+        self.resolve_unknown_table_batches(deferred_unknown_table_batches)
             .await;
         Ok(())
     }
@@ -655,6 +668,7 @@ impl Sender {
         ready_write_batch: ReadyWriteBatch,
         error: FlussError,
         message: String,
+        deferred_unknown_table_batches: &mut Vec<ReadyWriteBatch>,
     ) -> Result<Option<Arc<PhysicalTablePath>>> {
         let physical_table_path = Arc::clone(ready_write_batch.write_batch.physical_table_path());
 
@@ -730,7 +744,12 @@ impl Sender {
                 }
             }
 
-            self.re_enqueue_batch(ready_write_batch);
+            if error == FlussError::UnknownTableOrBucketException {
+                // Table may be dropped, defer until the identity check runs.
+                deferred_unknown_table_batches.push(ready_write_batch);
+            } else {
+                self.re_enqueue_batch(ready_write_batch);
+            }
             return Ok(Self::is_invalid_metadata_error(error).then_some(physical_table_path));
         }
 
@@ -826,6 +845,110 @@ impl Sender {
             .await
         {
             warn!("Failed to update metadata after write error: {e:?}");
+        }
+    }
+
+    /// Decides the fate of batches that failed with UnknownTableOrBucketException
+    /// by comparing the cluster's current table id with the id they were sent
+    /// under, so a dropped or recreated table stops retrying.
+    async fn resolve_unknown_table_batches(&self, deferred: Vec<ReadyWriteBatch>) {
+        if deferred.is_empty() {
+            return;
+        }
+
+        // Keyed by id too, so a recreated path resolves per table instance.
+        let mut batches_by_table: HashMap<(TablePath, TableId), Vec<ReadyWriteBatch>> =
+            HashMap::new();
+        for batch in deferred {
+            let table_path = batch
+                .write_batch
+                .physical_table_path()
+                .get_table_path()
+                .clone();
+            let table_id = batch.table_bucket.table_id();
+            batches_by_table
+                .entry((table_path, table_id))
+                .or_default()
+                .push(batch);
+        }
+
+        for ((table_path, expected_table_id), batches) in batches_by_table {
+            match self.check_table_gone(&table_path, expected_table_id).await {
+                Some(reason) => {
+                    warn!("Failing pending writes for {table_path}: {reason}");
+                    self.metadata.evict_table_metadata(&table_path);
+                    let error = broadcast::Error::WriteFailed {
+                        code: FlussError::TableNotExist.code(),
+                        message: reason,
+                    };
+                    for batch in batches {
+                        self.fail_batch(
+                            batch,
+                            error.clone(),
+                            Some(FlussError::TableNotExist),
+                            false,
+                        );
+                    }
+                    // Queued batches would otherwise await a leader forever.
+                    self.accumulator
+                        .fail_batches_for_table(&table_path, expected_table_id, error);
+                }
+                None => {
+                    for batch in batches {
+                        self.re_enqueue_checked_batch(batch);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Re-enqueues a deferred batch, re-checking the writer id first. The
+    /// identity check awaits, so the writer state can have been reset in the
+    /// meantime and the caller's earlier check no longer holds.
+    fn re_enqueue_checked_batch(&self, ready_write_batch: ReadyWriteBatch) {
+        if self.idempotence_manager.is_enabled() {
+            let batch_writer_id = ready_write_batch.write_batch.writer_id();
+            let current_writer_id = self.idempotence_manager.writer_id();
+            if batch_writer_id != NO_WRITER_ID && current_writer_id != batch_writer_id {
+                warn!(
+                    "Writer ID changed from {batch_writer_id} to {current_writer_id} while the table identity was checked, failing instead of retrying"
+                );
+                self.fail_batch(
+                    ready_write_batch,
+                    broadcast::Error::WriteFailed {
+                        code: FlussError::UnknownWriterIdException.code(),
+                        message: format!(
+                            "Attempted to retry sending a batch but the writer id has changed from {batch_writer_id} to {current_writer_id}. This batch will be dropped."
+                        ),
+                    },
+                    Some(FlussError::UnknownWriterIdException),
+                    false,
+                );
+                return;
+            }
+        }
+        self.re_enqueue_batch(ready_write_batch);
+    }
+
+    /// Returns Some(reason) when the table was dropped or recreated under a new
+    /// table id, None when the batches should be retried normally.
+    async fn check_table_gone(
+        &self,
+        table_path: &TablePath,
+        expected_table_id: TableId,
+    ) -> Option<String> {
+        match self.metadata.fetch_table_id(table_path).await {
+            Ok(None) => Some(format!(
+                "Table {table_path} (table_id={expected_table_id}) no longer exists."
+            )),
+            Ok(Some(table_id)) if table_id == expected_table_id => None,
+            Ok(Some(new_table_id)) => Some(format!(
+                "Table {table_path} (table_id={expected_table_id}) was dropped and recreated with table_id={new_table_id}."
+            )),
+            Err(e) => {
+                warn!("Table identity check for {table_path} failed, keeping normal retry: {e:?}");
+                None
+            }
         }
     }
 
@@ -1098,6 +1221,7 @@ mod tests {
     use crate::test_utils::{build_cluster_arc, build_cluster_arc_with_port, build_table_info};
     use prost::Message;
     use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::AtomicUsize;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
@@ -1162,6 +1286,7 @@ mod tests {
             batch,
             FlussError::RequestTimeOut,
             "timeout".to_string(),
+            &mut Vec::new(),
         )?;
 
         let server = cluster.get_tablet_server(1).expect("server");
@@ -1231,6 +1356,7 @@ mod tests {
             batch,
             FlussError::StorageBackpressureException,
             "backpressure".to_string(),
+            &mut Vec::new(),
         )?;
 
         assert!(accumulator.is_throttled(&tb));
@@ -1288,6 +1414,7 @@ mod tests {
                 batch,
                 FlussError::RequestTimeOut,
                 "timeout".to_string(),
+                &mut Vec::new(),
             )?;
             Ok(())
         });
@@ -1616,6 +1743,7 @@ mod tests {
             batch,
             FlussError::InvalidTableException,
             "invalid".to_string(),
+            &mut Vec::new(),
         )?;
 
         let batch_result = handle.wait().await?;
@@ -1702,6 +1830,7 @@ mod tests {
             batch,
             FlussError::UnknownWriterIdException,
             "unknown writer".to_string(),
+            &mut Vec::new(),
         )?;
 
         // Writer ID should be reset
@@ -1749,6 +1878,7 @@ mod tests {
             batch,
             FlussError::OutOfOrderSequenceException,
             "out of order".to_string(),
+            &mut Vec::new(),
         )?;
 
         // Writer ID should be reset (matching Java behavior)
@@ -1803,6 +1933,7 @@ mod tests {
             batch,
             FlussError::NetworkException,
             "connection reset".to_string(),
+            &mut Vec::new(),
         )?;
 
         // Batch should be failed (not retried) because writer ID is stale
@@ -1888,6 +2019,574 @@ mod tests {
             idempotence.next_sequence_and_increment(&ready_batch.table_bucket),
             1
         );
+        Ok(())
+    }
+
+    /// How the mock server answers a GetTable request.
+    #[derive(Clone, Copy)]
+    enum GetTableReply {
+        /// The table is gone, answered as TableNotExist.
+        Dropped,
+        /// The path currently resolves to this table id.
+        Exists(TableId),
+        /// The request failed for an unrelated reason.
+        ServerError,
+    }
+
+    /// Mock tablet server answering ApiVersions and GetTable, the latter per
+    /// `reply`. The returned counter tracks how many GetTable requests it
+    /// served, so tests can assert the identity check actually ran.
+    fn spawn_get_table_server(
+        listener: TcpListener,
+        reply: GetTableReply,
+    ) -> (tokio::task::JoinHandle<()>, Arc<AtomicUsize>) {
+        let get_table_requests = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&get_table_requests);
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let counter = Arc::clone(&counter);
+                tokio::spawn(async move {
+                    loop {
+                        let mut len_buf = [0u8; 4];
+                        if stream.read_exact(&mut len_buf).await.is_err() {
+                            return;
+                        }
+                        let len = i32::from_be_bytes(len_buf) as usize;
+                        let mut payload = vec![0u8; len];
+                        if stream.read_exact(&mut payload).await.is_err() {
+                            return;
+                        }
+
+                        // Header layout: api_key(2) + api_version(2) + request_id(4)
+                        let api_key = i16::from_be_bytes([payload[0], payload[1]]);
+                        let request_id =
+                            i32::from_be_bytes([payload[4], payload[5], payload[6], payload[7]]);
+                        if api_key == 1007 {
+                            counter.fetch_add(1, Ordering::SeqCst);
+                        }
+
+                        let mut body = Vec::new();
+                        let response_type = match (api_key, reply) {
+                            // ApiVersions, advertising the keys the sender needs.
+                            (1000, _) => {
+                                ApiVersionsResponse {
+                                    api_versions: vec![
+                                        PbApiVersion {
+                                            api_key: 1000, // ApiVersion
+                                            min_version: 0,
+                                            max_version: 0,
+                                        },
+                                        PbApiVersion {
+                                            api_key: 1007, // GetTable
+                                            min_version: 0,
+                                            max_version: 0,
+                                        },
+                                        PbApiVersion {
+                                            api_key: 1012, // MetaData
+                                            min_version: 0,
+                                            max_version: 0,
+                                        },
+                                    ],
+                                    server_type: Some(ServerType::TabletServer.to_type_id()),
+                                }
+                                .encode(&mut body)
+                                .expect("encode ApiVersionsResponse");
+                                0u8
+                            }
+                            // GetTable for a table that still exists.
+                            (1007, GetTableReply::Exists(table_id)) => {
+                                crate::proto::GetTableInfoResponse {
+                                    table_id,
+                                    schema_id: 1,
+                                    table_json: Vec::new(),
+                                    created_time: 0,
+                                    modified_time: 0,
+                                    remote_data_dir: None,
+                                }
+                                .encode(&mut body)
+                                .expect("encode GetTableInfoResponse");
+                                0u8
+                            }
+                            // GetTable for a dropped table.
+                            (1007, GetTableReply::Dropped) => {
+                                crate::proto::ErrorResponse {
+                                    error_code: FlussError::TableNotExist.code(),
+                                    error_message: Some("table does not exist".to_string()),
+                                }
+                                .encode(&mut body)
+                                .expect("encode ErrorResponse");
+                                1u8
+                            }
+                            _ => {
+                                crate::proto::ErrorResponse {
+                                    error_code: FlussError::UnknownServerError.code(),
+                                    error_message: Some("mock error".to_string()),
+                                }
+                                .encode(&mut body)
+                                .expect("encode ErrorResponse");
+                                1u8
+                            }
+                        };
+
+                        let mut resp = Vec::with_capacity(5 + body.len());
+                        resp.push(response_type);
+                        resp.extend_from_slice(&request_id.to_be_bytes());
+                        resp.extend_from_slice(&body);
+
+                        let resp_len = (resp.len() as i32).to_be_bytes();
+                        if stream.write_all(&resp_len).await.is_err()
+                            || stream.write_all(&resp).await.is_err()
+                            || stream.flush().await.is_err()
+                        {
+                            return;
+                        }
+                    }
+                });
+            }
+        });
+        (handle, get_table_requests)
+    }
+
+    #[tokio::test]
+    async fn unknown_table_error_fails_batch_when_table_dropped() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        // The identity check answers TableNotExist: the table was dropped.
+        let (server_task, get_table_requests) =
+            spawn_get_table_server(listener, GetTableReply::Dropped);
+
+        let table_path = Arc::new(TablePath::new("db".to_string(), "tbl".to_string()));
+        let cluster = build_cluster_arc_with_port(table_path.as_ref(), 1, 1, port as u32);
+        let metadata = Arc::new(Metadata::new_for_test(cluster.clone()));
+        let idempotence = disabled_idempotence();
+        let accumulator = Arc::new(RecordAccumulator::new(
+            Config::default(),
+            Arc::clone(&idempotence),
+        ));
+        let sender = Sender::new(
+            metadata.clone(),
+            accumulator.clone(),
+            1024 * 1024,
+            1000,
+            1,
+            100,
+            idempotence,
+            Arc::new(crate::metrics::WriterMetrics::new()),
+        );
+
+        let (batch, handle) =
+            build_ready_batch(accumulator.as_ref(), cluster.clone(), table_path.clone())?;
+
+        // A second record stays queued, so the sweep has something to fail.
+        let queued_row = GenericRow {
+            values: vec![Datum::Int32(2)],
+        };
+        let queued_record = WriteRecord::for_append(
+            Arc::new(build_table_info(table_path.as_ref().clone(), 1, 1)),
+            Arc::new(PhysicalTablePath::of(Arc::clone(&table_path))),
+            1,
+            &queued_row,
+        );
+        let queued_handle = accumulator
+            .append(&queued_record, 0, &cluster, false)?
+            .result_handle
+            .expect("queued handle");
+
+        let tb = batch.table_bucket.clone();
+        let mut records_by_bucket = HashMap::new();
+        records_by_bucket.insert(tb.clone(), batch);
+        let request_buckets = vec![tb.clone()];
+
+        let response = ProduceLogResponse {
+            buckets_resp: vec![PbProduceLogRespForBucket {
+                bucket_id: tb.bucket_id(),
+                error_code: Some(FlussError::UnknownTableOrBucketException.code()),
+                error_message: Some("unknown table or bucket".to_string()),
+                ..Default::default()
+            }],
+        };
+        sender
+            .handle_write_response(
+                tb.table_id(),
+                &request_buckets,
+                &mut records_by_bucket,
+                response,
+            )
+            .await?;
+
+        // The table identity was checked against the cluster.
+        assert_eq!(get_table_requests.load(Ordering::SeqCst), 1);
+        // The queued batch is failed by the sweep.
+        let queued_result = tokio::time::timeout(Duration::from_secs(10), queued_handle.wait())
+            .await
+            .expect("the queued write must be failed by the sweep")?;
+        assert!(matches!(
+            queued_result,
+            Err(broadcast::Error::WriteFailed { code, .. })
+                if code == FlussError::TableNotExist.code()
+        ));
+        // The stale table metadata is evicted.
+        assert!(
+            metadata
+                .get_cluster()
+                .get_table_id(table_path.as_ref())
+                .is_none()
+        );
+        // The pending write completes with TableNotExist instead of retrying.
+        let batch_result = tokio::time::timeout(Duration::from_secs(10), handle.wait())
+            .await
+            .expect("write must be completed, not left retrying")?;
+        assert!(matches!(
+            batch_result,
+            Err(broadcast::Error::WriteFailed { code, .. })
+                if code == FlussError::TableNotExist.code()
+        ));
+        // Nothing is left to retry.
+        assert!(!accumulator.has_incomplete());
+        let server = cluster.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let batches = accumulator.drain(cluster, &nodes, 1024 * 1024)?;
+        assert!(batches.is_empty());
+
+        server_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unknown_table_error_fails_batch_when_table_recreated() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        // The path resolves to a different id: dropped and recreated.
+        let (server_task, get_table_requests) =
+            spawn_get_table_server(listener, GetTableReply::Exists(2));
+
+        let table_path = Arc::new(TablePath::new("db".to_string(), "tbl".to_string()));
+        let cluster = build_cluster_arc_with_port(table_path.as_ref(), 1, 1, port as u32);
+        let metadata = Arc::new(Metadata::new_for_test(cluster.clone()));
+        let idempotence = disabled_idempotence();
+        let accumulator = Arc::new(RecordAccumulator::new(
+            Config::default(),
+            Arc::clone(&idempotence),
+        ));
+        let sender = Sender::new(
+            metadata.clone(),
+            accumulator.clone(),
+            1024 * 1024,
+            1000,
+            1,
+            100,
+            idempotence,
+            Arc::new(crate::metrics::WriterMetrics::new()),
+        );
+
+        let (batch, handle) =
+            build_ready_batch(accumulator.as_ref(), cluster.clone(), table_path.clone())?;
+        let tb = batch.table_bucket.clone();
+        let mut records_by_bucket = HashMap::new();
+        records_by_bucket.insert(tb.clone(), batch);
+        let request_buckets = vec![tb.clone()];
+
+        let response = ProduceLogResponse {
+            buckets_resp: vec![PbProduceLogRespForBucket {
+                bucket_id: tb.bucket_id(),
+                error_code: Some(FlussError::UnknownTableOrBucketException.code()),
+                error_message: Some("unknown table or bucket".to_string()),
+                ..Default::default()
+            }],
+        };
+        sender
+            .handle_write_response(
+                tb.table_id(),
+                &request_buckets,
+                &mut records_by_bucket,
+                response,
+            )
+            .await?;
+
+        assert_eq!(get_table_requests.load(Ordering::SeqCst), 1);
+        assert!(
+            metadata
+                .get_cluster()
+                .get_table_id(table_path.as_ref())
+                .is_none()
+        );
+        let batch_result = tokio::time::timeout(Duration::from_secs(10), handle.wait())
+            .await
+            .expect("write must be completed, not left retrying")?;
+        assert!(matches!(
+            batch_result,
+            Err(broadcast::Error::WriteFailed { code, .. })
+                if code == FlussError::TableNotExist.code()
+        ));
+
+        server_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unknown_table_error_reenqueues_when_table_is_unchanged() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        // Same id, so the error is transient and the retry continues.
+        let (server_task, get_table_requests) =
+            spawn_get_table_server(listener, GetTableReply::Exists(1));
+
+        let table_path = Arc::new(TablePath::new("db".to_string(), "tbl".to_string()));
+        let cluster = build_cluster_arc_with_port(table_path.as_ref(), 1, 1, port as u32);
+        let metadata = Arc::new(Metadata::new_for_test(cluster.clone()));
+        let idempotence = disabled_idempotence();
+        let accumulator = Arc::new(RecordAccumulator::new(
+            Config::default(),
+            Arc::clone(&idempotence),
+        ));
+        let sender = Sender::new(
+            metadata.clone(),
+            accumulator.clone(),
+            1024 * 1024,
+            1000,
+            1,
+            100,
+            idempotence,
+            Arc::new(crate::metrics::WriterMetrics::new()),
+        );
+
+        let (batch, _handle) =
+            build_ready_batch(accumulator.as_ref(), cluster.clone(), table_path.clone())?;
+        let tb = batch.table_bucket.clone();
+        let mut records_by_bucket = HashMap::new();
+        records_by_bucket.insert(tb.clone(), batch);
+        let request_buckets = vec![tb.clone()];
+
+        let response = ProduceLogResponse {
+            buckets_resp: vec![PbProduceLogRespForBucket {
+                bucket_id: tb.bucket_id(),
+                error_code: Some(FlussError::UnknownTableOrBucketException.code()),
+                error_message: Some("unknown table or bucket".to_string()),
+                ..Default::default()
+            }],
+        };
+        sender
+            .handle_write_response(
+                tb.table_id(),
+                &request_buckets,
+                &mut records_by_bucket,
+                response,
+            )
+            .await?;
+
+        // Unchanged, so the metadata stays cached and the batch retries.
+        assert_eq!(get_table_requests.load(Ordering::SeqCst), 1);
+        assert!(
+            metadata
+                .get_cluster()
+                .get_table_id(table_path.as_ref())
+                .is_some()
+        );
+        let server = cluster.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let mut batches = accumulator.drain(cluster, &nodes, 1024 * 1024)?;
+        let batch = batches
+            .remove(&1)
+            .expect("drained batches")
+            .pop()
+            .expect("batch");
+        assert_eq!(batch.write_batch.attempts(), 1);
+
+        server_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deferred_batch_is_not_reenqueued_with_a_stale_writer_id() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        // The table is unchanged, so the batch would normally be retried.
+        let (server_task, _) = spawn_get_table_server(listener, GetTableReply::Exists(1));
+
+        let table_path = Arc::new(TablePath::new("db".to_string(), "tbl".to_string()));
+        let cluster = build_cluster_arc_with_port(table_path.as_ref(), 1, 1, port as u32);
+        let metadata = Arc::new(Metadata::new_for_test(cluster.clone()));
+        let idempotence = enabled_idempotence();
+        let accumulator = Arc::new(RecordAccumulator::new(
+            Config::default(),
+            Arc::clone(&idempotence),
+        ));
+        idempotence.set_writer_id(42);
+        let sender = Sender::new(
+            metadata,
+            accumulator.clone(),
+            1024 * 1024,
+            1000,
+            1,
+            100,
+            Arc::clone(&idempotence),
+            Arc::new(crate::metrics::WriterMetrics::new()),
+        );
+
+        let (batch, handle) =
+            build_ready_batch(accumulator.as_ref(), cluster.clone(), table_path.clone())?;
+        assert_eq!(batch.write_batch.writer_id(), 42);
+
+        // The reset lands after the caller's own check, while the identity
+        // check is awaiting, so only a re-check at the point of use sees it.
+        idempotence.set_writer_id(99);
+        sender.resolve_unknown_table_batches(vec![batch]).await;
+
+        let batch_result = tokio::time::timeout(Duration::from_secs(10), handle.wait())
+            .await
+            .expect("the batch must be failed, not re-enqueued with stale state")?;
+        assert!(matches!(
+            batch_result,
+            Err(broadcast::Error::WriteFailed { code, .. })
+                if code == FlussError::UnknownWriterIdException.code()
+        ));
+
+        server_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unknown_table_error_reenqueues_when_check_returns_server_error() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        // Only TableNotExist means gone, so this must retry.
+        let (server_task, get_table_requests) =
+            spawn_get_table_server(listener, GetTableReply::ServerError);
+
+        let table_path = Arc::new(TablePath::new("db".to_string(), "tbl".to_string()));
+        let cluster = build_cluster_arc_with_port(table_path.as_ref(), 1, 1, port as u32);
+        let metadata = Arc::new(Metadata::new_for_test(cluster.clone()));
+        let idempotence = disabled_idempotence();
+        let accumulator = Arc::new(RecordAccumulator::new(
+            Config::default(),
+            Arc::clone(&idempotence),
+        ));
+        let sender = Sender::new(
+            metadata.clone(),
+            accumulator.clone(),
+            1024 * 1024,
+            1000,
+            1,
+            100,
+            idempotence,
+            Arc::new(crate::metrics::WriterMetrics::new()),
+        );
+
+        let (batch, _handle) =
+            build_ready_batch(accumulator.as_ref(), cluster.clone(), table_path.clone())?;
+        let tb = batch.table_bucket.clone();
+        let mut records_by_bucket = HashMap::new();
+        records_by_bucket.insert(tb.clone(), batch);
+        let request_buckets = vec![tb.clone()];
+
+        let response = ProduceLogResponse {
+            buckets_resp: vec![PbProduceLogRespForBucket {
+                bucket_id: tb.bucket_id(),
+                error_code: Some(FlussError::UnknownTableOrBucketException.code()),
+                error_message: Some("unknown table or bucket".to_string()),
+                ..Default::default()
+            }],
+        };
+        sender
+            .handle_write_response(
+                tb.table_id(),
+                &request_buckets,
+                &mut records_by_bucket,
+                response,
+            )
+            .await?;
+
+        assert_eq!(get_table_requests.load(Ordering::SeqCst), 1);
+        // The metadata stays cached and the batch is retried.
+        assert!(
+            metadata
+                .get_cluster()
+                .get_table_id(table_path.as_ref())
+                .is_some()
+        );
+        let server = cluster.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let mut batches = accumulator.drain(cluster, &nodes, 1024 * 1024)?;
+        let batch = batches
+            .remove(&1)
+            .expect("drained batches")
+            .pop()
+            .expect("batch");
+        assert_eq!(batch.write_batch.attempts(), 1);
+
+        server_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unknown_table_error_reenqueues_when_check_fails_transiently() -> Result<()> {
+        // Nothing listening, so the check fails with a connection error.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        drop(listener);
+
+        let table_path = Arc::new(TablePath::new("db".to_string(), "tbl".to_string()));
+        let cluster = build_cluster_arc_with_port(table_path.as_ref(), 1, 1, port as u32);
+        let metadata = Arc::new(Metadata::new_for_test(cluster.clone()));
+        let idempotence = disabled_idempotence();
+        let accumulator = Arc::new(RecordAccumulator::new(
+            Config::default(),
+            Arc::clone(&idempotence),
+        ));
+        let sender = Sender::new(
+            metadata.clone(),
+            accumulator.clone(),
+            1024 * 1024,
+            1000,
+            1,
+            100,
+            idempotence,
+            Arc::new(crate::metrics::WriterMetrics::new()),
+        );
+
+        let (batch, _handle) =
+            build_ready_batch(accumulator.as_ref(), cluster.clone(), table_path.clone())?;
+        let tb = batch.table_bucket.clone();
+        let mut records_by_bucket = HashMap::new();
+        records_by_bucket.insert(tb.clone(), batch);
+        let request_buckets = vec![tb.clone()];
+
+        let response = ProduceLogResponse {
+            buckets_resp: vec![PbProduceLogRespForBucket {
+                bucket_id: tb.bucket_id(),
+                error_code: Some(FlussError::UnknownTableOrBucketException.code()),
+                error_message: Some("unknown table or bucket".to_string()),
+                ..Default::default()
+            }],
+        };
+        sender
+            .handle_write_response(
+                tb.table_id(),
+                &request_buckets,
+                &mut records_by_bucket,
+                response,
+            )
+            .await?;
+
+        // Unchecked, so the batch retries and the metadata stays cached.
+        assert!(
+            metadata
+                .get_cluster()
+                .get_table_id(table_path.as_ref())
+                .is_some()
+        );
+        let server = cluster.get_tablet_server(1).expect("server");
+        let nodes = HashSet::from([server.clone()]);
+        let mut batches = accumulator.drain(cluster, &nodes, 1024 * 1024)?;
+        let batch = batches
+            .remove(&1)
+            .expect("drained batches")
+            .pop()
+            .expect("batch");
+        assert_eq!(batch.write_batch.attempts(), 1);
         Ok(())
     }
 }

--- a/fluss-rust/crates/fluss/src/client/write/writer_client.rs
+++ b/fluss-rust/crates/fluss/src/client/write/writer_client.rs
@@ -25,9 +25,10 @@ use crate::client::write::bucket_assigner::{
 };
 use crate::client::write::sender::Sender;
 use crate::client::{RecordAccumulator, ResultHandle, WriteRecord};
+use crate::cluster::Cluster;
 use crate::config::Config;
 use crate::config::NoKeyAssigner;
-use crate::error::{Error, Result};
+use crate::error::{Error, FlussError, Result};
 use crate::metadata::{PhysicalTablePath, TableInfo};
 use crate::metrics::WriterMetrics;
 use bytes::Bytes;
@@ -119,10 +120,24 @@ impl WriterClient {
         }
         let physical_table_path = &record.physical_table_path;
         let cluster = self.metadata.get_cluster();
+        // A dropped table is missing here once its metadata is evicted. Report the
+        // same error its pending writes got, before the bucket assigner panics.
+        let table_path = physical_table_path.get_table_path();
+        cluster.get_table(table_path).map_err(|e| {
+            if e.api_error() == Some(FlussError::InvalidTableException) {
+                Error::table_not_exist(format!("Table not found: {table_path}"))
+            } else {
+                e
+            }
+        })?;
         let bucket_key = record.bucket_key.as_ref();
 
-        let (bucket_assigner, bucket_id) =
-            self.assign_bucket(&record.table_info, bucket_key, physical_table_path)?;
+        let (bucket_assigner, bucket_id) = self.assign_bucket(
+            &record.table_info,
+            bucket_key,
+            physical_table_path,
+            &cluster,
+        )?;
 
         let mut result = self.accumulate.append(
             record,
@@ -149,8 +164,8 @@ impl WriterClient {
         table_info: &Arc<TableInfo>,
         bucket_key: Option<&Bytes>,
         table_path: &Arc<PhysicalTablePath>,
+        cluster: &Arc<Cluster>,
     ) -> Result<(Arc<dyn BucketAssigner>, BucketId)> {
-        let cluster = self.metadata.get_cluster();
         let bucket_assigner = {
             if let Some(assigner) = self.bucket_assigners.get(table_path) {
                 assigner.clone()
@@ -162,7 +177,7 @@ impl WriterClient {
                 assigner
             }
         };
-        let bucket_id = bucket_assigner.assign_bucket(bucket_key, &cluster)?;
+        let bucket_id = bucket_assigner.assign_bucket(bucket_key, cluster)?;
         Ok((bucket_assigner, bucket_id))
     }
 

--- a/fluss-rust/crates/fluss/src/cluster/cluster.rs
+++ b/fluss-rust/crates/fluss/src/cluster/cluster.rs
@@ -122,6 +122,45 @@ impl Cluster {
         )
     }
 
+    /// Returns a copy without `table_path`'s id, info, partitions and bucket
+    /// locations. Used once the table is known to be dropped or recreated.
+    pub fn evict_table(&self, table_path: &TablePath) -> Self {
+        let table_paths = HashSet::from([table_path]);
+        let (available_locations_by_path, available_locations_by_bucket) =
+            self.filter_bucket_locations_by_path(&table_paths);
+
+        let table_id_by_path = self
+            .table_id_by_path
+            .iter()
+            .filter(|&(path, _)| path != table_path)
+            .map(|(path, table_id)| (path.clone(), *table_id))
+            .collect();
+
+        let table_info_by_path = self
+            .table_info_by_path
+            .iter()
+            .filter(|&(path, _)| path != table_path)
+            .map(|(path, table_info)| (path.clone(), table_info.clone()))
+            .collect();
+
+        let partitions_id_by_path = self
+            .partitions_id_by_path
+            .iter()
+            .filter(|&(path, _)| path.get_table_path() != table_path)
+            .map(|(path, partition_id)| (Arc::clone(path), *partition_id))
+            .collect();
+
+        Cluster::new(
+            self.coordinator_server.clone(),
+            self.alive_tablet_servers_by_id.clone(),
+            available_locations_by_path,
+            available_locations_by_bucket,
+            table_id_by_path,
+            table_info_by_path,
+            partitions_id_by_path,
+        )
+    }
+
     pub fn update(&mut self, cluster: Cluster) {
         let Cluster {
             coordinator_server,
@@ -618,6 +657,97 @@ mod tests {
         assert_eq!(
             updated_cluster
                 .get_available_buckets_for_table_path(partition_2.as_ref())
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_evict_table_removes_all_table_state() {
+        let table_path_a = Arc::new(TablePath::new("db", "table_a"));
+        let table_path_b = Arc::new(TablePath::new("db", "table_b"));
+        let partition_a = Arc::new(PhysicalTablePath::of_partitioned(
+            Arc::clone(&table_path_a),
+            Some("p1".to_string()),
+        ));
+        let physical_b = Arc::new(PhysicalTablePath::of(Arc::clone(&table_path_b)));
+        let bucket_a = TableBucket::new_with_partition(1, Some(10), 0);
+        let bucket_b = TableBucket::new(2, 0);
+        let leader = ServerNode::new(1, "ts1-host".to_string(), 9124, ServerType::TabletServer);
+        let location_a = BucketLocation::new(
+            bucket_a.clone(),
+            Some(leader.clone()),
+            Arc::clone(&partition_a),
+        );
+        let location_b = BucketLocation::new(
+            bucket_b.clone(),
+            Some(leader.clone()),
+            Arc::clone(&physical_b),
+        );
+        let cluster = Cluster::new(
+            None,
+            HashMap::from([(leader.id(), leader)]),
+            HashMap::from([
+                (Arc::clone(&partition_a), vec![location_a.clone()]),
+                (Arc::clone(&physical_b), vec![location_b.clone()]),
+            ]),
+            HashMap::from([
+                (bucket_a.clone(), location_a),
+                (bucket_b.clone(), location_b),
+            ]),
+            HashMap::from([
+                (table_path_a.as_ref().clone(), 1),
+                (table_path_b.as_ref().clone(), 2),
+            ]),
+            HashMap::from([
+                (
+                    table_path_a.as_ref().clone(),
+                    crate::test_utils::build_table_info(table_path_a.as_ref().clone(), 1, 1),
+                ),
+                (
+                    table_path_b.as_ref().clone(),
+                    crate::test_utils::build_table_info(table_path_b.as_ref().clone(), 2, 1),
+                ),
+            ]),
+            HashMap::from([(Arc::clone(&partition_a), 10)]),
+        );
+
+        let updated_cluster = cluster.evict_table(table_path_a.as_ref());
+
+        assert!(
+            updated_cluster
+                .get_table_id(table_path_a.as_ref())
+                .is_none()
+        );
+        assert!(
+            updated_cluster
+                .opt_get_table(table_path_a.as_ref())
+                .is_none()
+        );
+        assert!(updated_cluster.get_table_path_by_id(1).is_none());
+        assert!(
+            updated_cluster
+                .get_partition_id(partition_a.as_ref())
+                .is_none()
+        );
+        assert!(updated_cluster.get_partition_name(10).is_none());
+        assert!(updated_cluster.leader_for(&bucket_a).is_none());
+        assert!(
+            updated_cluster
+                .get_available_buckets_for_table_path(partition_a.as_ref())
+                .is_empty()
+        );
+
+        assert_eq!(updated_cluster.get_table_id(table_path_b.as_ref()), Some(2));
+        assert!(
+            updated_cluster
+                .opt_get_table(table_path_b.as_ref())
+                .is_some()
+        );
+        assert!(updated_cluster.leader_for(&bucket_b).is_some());
+        assert_eq!(
+            updated_cluster
+                .get_available_buckets_for_table_path(physical_b.as_ref())
                 .len(),
             1
         );

--- a/fluss-rust/crates/fluss/tests/integration/log_table.rs
+++ b/fluss-rust/crates/fluss/tests/integration/log_table.rs
@@ -3633,4 +3633,211 @@ mod table_test {
 
         admin.drop_table(&table_path, false).await.expect("drop");
     }
+
+    /// A pending write to a dropped table must complete with TableNotExist
+    /// instead of retrying UnknownTableOrBucketException forever, and the
+    /// stale table metadata must be evicted so later writes fail fast.
+    #[tokio::test]
+    async fn write_after_drop_completes_with_table_not_exist() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("admin");
+
+        let table_path = TablePath::new("fluss", "test_log_write_after_drop");
+        let descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("c1", DataTypes::int())
+                    .build()
+                    .expect("schema"),
+            )
+            .distributed_by(Some(1), vec![])
+            .build()
+            .expect("descriptor");
+        create_table(&admin, &table_path, &descriptor).await;
+        wait_for_table_ready(&admin, &table_path).await;
+
+        let table = connection.get_table(&table_path).await.expect("table");
+        let writer = table
+            .new_append()
+            .expect("append")
+            .create_writer()
+            .expect("writer");
+
+        // Warm the metadata cache with a successful write.
+        let mut row = GenericRow::new(1);
+        row.set_field(0, 1);
+        writer
+            .append(&row)
+            .expect("append")
+            .await
+            .expect("first write");
+
+        admin.drop_table(&table_path, false).await.expect("drop");
+
+        // Append until a write observes the drop, tolerating writes that still
+        // succeed while the drop propagates to the tablet servers. Every write
+        // shares one budget, so a write left retrying trips the timeout instead
+        // of running until the caller's own deadline.
+        let deadline = std::time::Instant::now() + DEFAULT_POLL_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "writes kept succeeding after the table was dropped"
+            );
+            let result = match writer.append(&row) {
+                Ok(write_future) => tokio::time::timeout(remaining, write_future)
+                    .await
+                    .expect("write must settle promptly instead of retrying until the deadline"),
+                Err(error) => Err(error),
+            };
+            match result {
+                Ok(()) => tokio::time::sleep(Duration::from_millis(500)).await,
+                Err(error) => {
+                    assert_eq!(
+                        error.api_error(),
+                        Some(FlussError::TableNotExist),
+                        "Expected TableNotExist error, got {:?}",
+                        error
+                    );
+                    break;
+                }
+            }
+        }
+
+        // The stale metadata is evicted, so the next append fails fast rather
+        // than hanging or panicking in the bucket assigner, and it reports the
+        // same error as the write that observed the drop.
+        let error = writer
+            .append(&row)
+            .expect_err("append after eviction must fail");
+        assert_eq!(
+            error.api_error(),
+            Some(FlussError::TableNotExist),
+            "Expected TableNotExist error, got {:?}",
+            error
+        );
+    }
+
+    /// Drives real rows through a live cluster across a drop and a recreate of
+    /// the same path, covering both table instance behaviours end to end.
+    #[tokio::test]
+    async fn real_data_survives_drop_and_recreate_of_the_same_path() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let admin = connection.get_admin().expect("admin");
+
+        let table_path = TablePath::new("fluss", "test_real_data_drop_recreate");
+        let descriptor = TableDescriptor::builder()
+            .schema(
+                Schema::builder()
+                    .column("c1", DataTypes::int())
+                    .column("c2", DataTypes::string())
+                    .build()
+                    .expect("schema"),
+            )
+            .distributed_by(Some(3), vec!["c1".to_string()])
+            .build()
+            .expect("descriptor");
+        create_table(&admin, &table_path, &descriptor).await;
+        wait_for_table_buckets_ready(&admin, &table_path, &[0, 1, 2]).await;
+
+        // Real rows across all three buckets must persist before the drop.
+        let table = connection.get_table(&table_path).await.expect("table");
+        let writer = table
+            .new_append()
+            .expect("append")
+            .create_writer()
+            .expect("writer");
+        let batch = record_batch!(
+            ("c1", Int32, [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            ("c2", Utf8, ["a", "b", "c", "d", "e", "f", "g", "h", "i"])
+        )
+        .unwrap();
+        writer.append_arrow_batch(batch).expect("append batch");
+        writer.flush().await.expect("flush");
+        let offsets = admin
+            .list_offsets(&table_path, &[0, 1, 2], OffsetSpec::Latest)
+            .await
+            .expect("list offsets");
+        let total: i64 = offsets.values().sum();
+        assert_eq!(total, 9, "all rows must persist, got {offsets:?}");
+
+        admin.drop_table(&table_path, false).await.expect("drop");
+
+        // Writes settle with TableNotExist instead of retrying to the deadline.
+        let mut row = GenericRow::new(2);
+        row.set_field(0, 42);
+        row.set_field(1, "after-drop");
+        let deadline = std::time::Instant::now() + DEFAULT_POLL_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "writes kept succeeding after the drop"
+            );
+            let result = match writer.append(&row) {
+                Ok(write_future) => tokio::time::timeout(remaining, write_future)
+                    .await
+                    .expect("write must settle, not retry to the deadline"),
+                Err(error) => Err(error),
+            };
+            match result {
+                Ok(()) => tokio::time::sleep(Duration::from_millis(500)).await,
+                Err(error) => {
+                    assert_eq!(
+                        error.api_error(),
+                        Some(FlussError::TableNotExist),
+                        "Expected TableNotExist, got {:?}",
+                        error
+                    );
+                    break;
+                }
+            }
+        }
+
+        // The writer sees the drop before the coordinator finishes clearing it,
+        // so wait for the server side to settle before recreating the path.
+        let deadline = std::time::Instant::now() + DEFAULT_POLL_TIMEOUT;
+        while admin.table_exists(&table_path).await.unwrap_or(true) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the dropped table never disappeared server side"
+            );
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+
+        // The recreated path must hold only rows written to the new table instance.
+        create_table(&admin, &table_path, &descriptor).await;
+        wait_for_table_buckets_ready(&admin, &table_path, &[0, 1, 2]).await;
+
+        let fresh_table = connection.get_table(&table_path).await.expect("table");
+        let fresh_writer = fresh_table
+            .new_append()
+            .expect("append")
+            .create_writer()
+            .expect("writer");
+        let batch2 = record_batch!(
+            ("c1", Int32, [10, 11, 12, 13]),
+            ("c2", Utf8, ["j", "k", "l", "m"])
+        )
+        .unwrap();
+        fresh_writer
+            .append_arrow_batch(batch2)
+            .expect("append batch");
+        fresh_writer.flush().await.expect("flush");
+
+        let offsets = admin
+            .list_offsets(&table_path, &[0, 1, 2], OffsetSpec::Latest)
+            .await
+            .expect("list offsets");
+        let total: i64 = offsets.values().sum();
+        assert_eq!(
+            total, 4,
+            "the recreated table must hold only its own rows, got {offsets:?}"
+        );
+
+        admin.drop_table(&table_path, false).await.expect("drop");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #4136.

Writes to a table dropped after its metadata was cached kept retrying `UnknownTableOrBucketException` until the
caller's deadline instead of failing with `TableNotExist`.

**Detecting the drop.** The sender now defers a batch that fails with `UnknownTableOrBucketException` and resolves it
by fetching the table's current id with the `GetTable` RPC, comparing it against the id the batch was sent under. The
metadata refresh cannot be used here, because `MetadataManager.getTables` throws `TableNotExistException` inside a
`try` with a blanket `catch` that rewraps it, so a missing table reaches the client as a generic
`UNKNOWN_SERVER_ERROR`. Deferred batches are grouped by `(table path, table id)`, so two table instances of a
recreated path resolve independently.

**Acting on it.** When the table is gone, or was recreated under a different id, the cached metadata is evicted and
both the pending and the queued writes complete with `TableNotExist`. An unchanged id, or a check that fails for any
other reason, keeps the existing retry behaviour. The re-enqueue re-reads the writer id, because the identity check
awaits and the caller's earlier check can have gone stale.

**Keeping table instances apart.** A drop and recreate of the same path share one queue, so each `WriteBatch` records
the table id it was appended under. `try_append` refuses to put two table instances in one batch, the sweep fails only
the batches of the dropped table instance, and drain refuses to send a batch whose id no longer matches the bucket it
would go to. Without that last guard, a write queued under the old table was sent with whatever id the cache held at
drain time, landing its rows in the recreated table and acking `Ok`. Table ids only ever grow, so the guard compares
direction: a lower id means the batch belongs to a dropped table and is failed, while a higher one means the sender's
snapshot predates a recreate the appender already saw, so that batch waits for fresher metadata rather than being sent
under the old id. Every consecutive stale batch is taken in one pass, and they are failed outside the deque lock.

**Reporting it consistently.** `WriterClient::send` raises `TableNotExist` for a table missing from the cluster, so
the write that observes the drop and every append after the eviction report the same error. That guard also replaces a
panic in the bucket assigner.

**Elsewhere.** Missing table metadata in the accumulator ready check skips that table instead of stalling draining for
every table, and the gateway's `classify_unknown` treats `TableNotExist` as a definite rejection rather than an
indeterminate write, so a dropped table is no longer reported as a row that a retry may duplicate.


🤖 AI-assisted changes - reviewed by human developer

