### PR TITLE
[build] Relocate third-party classes leaking from uber-jars

### DIFF
--- a/fluss-client/pom.xml
+++ b/fluss-client/pom.xml
@@ -131,6 +131,28 @@
                                     <include>*:*</include>
                                 </includes>
                             </artifactSet>
+                            <relocations>
+                                <!-- commons-lang3 and commons-math3 are compile dependencies of
+                                     fluss-common, so they land in this uber-jar at their original
+                                     package. On an engine classpath they shadow the engine's own
+                                     copies; #3960 fixed exactly that for the filesystem plugins
+                                     after Spark hit NoSuchMethodError on a shadowed commons class.
+
+                                     Named individually rather than as org.apache.commons: the
+                                     shade plugin rewrites every reference matching a pattern,
+                                     including ones to classes this jar does not bundle. Only
+                                     lang3 and math3 are bundled; commons-codec and
+                                     commons-logging are referenced but come from elsewhere, and
+                                     relocating them would leave links that resolve nowhere. -->
+                                <relocation>
+                                    <pattern>org.apache.commons.lang3</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.lang3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.math3</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.math3</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/fluss-filesystems/fluss-fs-azure/pom.xml
+++ b/fluss-filesystems/fluss-fs-azure/pom.xml
@@ -275,6 +275,21 @@
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.azure.io.netty
+                                    </shadedPattern>
+                                    <excludes>
+                                        <!-- netty-tcnative is a JNI wrapper around OpenSSL and its
+                                             native symbols bind to the io.netty.internal.tcnative
+                                             package name, so renaming it would break them. It is
+                                             referenced here but supplied from elsewhere, if at all;
+                                             leaving it alone keeps OpenSSL usable when the host
+                                             provides it and avoids references resolving nowhere. -->
+                                        <exclude>io.netty.internal.tcnative.**</exclude>
+                                    </excludes>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/fluss-filesystems/fluss-fs-azure/pom.xml
+++ b/fluss-filesystems/fluss-fs-azure/pom.xml
@@ -237,6 +237,40 @@
                                 </filter>
                             </filters>
                             <relocations>
+                                <!-- relocate the third-party packages bundled from
+                                     Hadoop and the cloud SDK so they cannot shadow a
+                                     downstream application's own copies, mirroring
+                                     fluss-fs-hadoop-shaded and fluss-fs-s3 -->
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.azure.com.google
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.htrace</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.azure.org.apache.htrace
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.azure.com.fasterxml
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.azure.org.codehaus
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.ctc</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.azure.com.ctc
+                                    </shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>

--- a/fluss-filesystems/fluss-fs-cos/pom.xml
+++ b/fluss-filesystems/fluss-fs-cos/pom.xml
@@ -295,6 +295,21 @@
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.cos.io.netty
+                                    </shadedPattern>
+                                    <excludes>
+                                        <!-- netty-tcnative is a JNI wrapper around OpenSSL and its
+                                             native symbols bind to the io.netty.internal.tcnative
+                                             package name, so renaming it would break them. It is
+                                             referenced here but supplied from elsewhere, if at all;
+                                             leaving it alone keeps OpenSSL usable when the host
+                                             provides it and avoids references resolving nowhere. -->
+                                        <exclude>io.netty.internal.tcnative.**</exclude>
+                                    </excludes>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/fluss-filesystems/fluss-fs-cos/pom.xml
+++ b/fluss-filesystems/fluss-fs-cos/pom.xml
@@ -257,6 +257,40 @@
                                 </filter>
                             </filters>
                             <relocations>
+                                <!-- relocate the third-party packages bundled from
+                                     Hadoop and the cloud SDK so they cannot shadow a
+                                     downstream application's own copies, mirroring
+                                     fluss-fs-hadoop-shaded and fluss-fs-s3 -->
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.cos.com.google
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.htrace</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.cos.org.apache.htrace
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.cos.com.fasterxml
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.cos.org.codehaus
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.ctc</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.cos.com.ctc
+                                    </shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>

--- a/fluss-filesystems/fluss-fs-gs/pom.xml
+++ b/fluss-filesystems/fluss-fs-gs/pom.xml
@@ -424,6 +424,46 @@
                                 </filter>
                             </filters>
                             <relocations>
+                                <!-- relocate the third-party packages bundled from
+                                     Hadoop and the cloud SDK so they cannot shadow a
+                                     downstream application's own copies, mirroring
+                                     fluss-fs-hadoop-shaded and fluss-fs-s3 -->
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.gs.com.google.common
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.re2j</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.gs.com.google.re2j
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.htrace</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.gs.org.apache.htrace
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.gs.com.fasterxml
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.gs.org.codehaus
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.ctc</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.gs.com.ctc
+                                    </shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>

--- a/fluss-filesystems/fluss-fs-hadoop-shaded/pom.xml
+++ b/fluss-filesystems/fluss-fs-hadoop-shaded/pom.xml
@@ -226,12 +226,77 @@
                                 </includes>
                             </artifactSet>
                             <relocations>
-                                <!-- we shade only the parts that are internal to Hadoop and not used / exposed downstream -->
+                                <!-- Shade the third-party packages Hadoop drags in, so they cannot
+                                     shadow a downstream application's own copies. org.apache.hadoop
+                                     itself is deliberately left alone: the FileSystem SPI resolves
+                                     implementations by class name from configuration. -->
+                                <!-- These patterns name individual packages rather than the
+                                     com.google / org.apache.commons prefixes on purpose. The shade
+                                     plugin rewrites every reference matching a pattern, including
+                                     references to classes this jar does not bundle, which would
+                                     leave dangling links. Hadoop here references but does not
+                                     bundle com.google.protobuf, com.google.gson, commons-cli,
+                                     commons-codec, commons-math3 and commons-net; relocating those
+                                     prefixes wholesale breaks the NameNode at runtime. Only
+                                     packages actually present below. -->
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.hadoop3.com.google.common
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.j2objc</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.hadoop3.com.google.j2objc
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.thirdparty</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.hadoop3.com.google.thirdparty
+                                    </shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>com.google.re2j</pattern>
                                     <shadedPattern>
                                         org.apache.fluss.fs.shaded.hadoop3.com.google.re2j
                                     </shadedPattern>
+                                </relocation>
+                                <!-- commons packages that are bundled here. The shaded target
+                                     matches what the filesystem plugins already use, so a plugin
+                                     bundling this jar ends up with one copy rather than two. -->
+                                <relocation>
+                                    <pattern>org.apache.commons.beanutils</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.beanutils</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.collections</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.collections</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.compress</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.compress</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.configuration2</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.configuration2</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.io</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.io</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.lang3</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.lang3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.logging</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.logging</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.text</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.text</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.htrace</pattern>

--- a/fluss-filesystems/fluss-fs-hdfs/pom.xml
+++ b/fluss-filesystems/fluss-fs-hdfs/pom.xml
@@ -213,6 +213,40 @@
                                 </filter>
                             </filters>
                             <relocations>
+                                <!-- relocate the third-party packages bundled from
+                                     Hadoop and the cloud SDK so they cannot shadow a
+                                     downstream application's own copies, mirroring
+                                     fluss-fs-hadoop-shaded and fluss-fs-s3 -->
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.hdfs.com.google
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.htrace</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.hdfs.org.apache.htrace
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.hdfs.com.fasterxml
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.hdfs.org.codehaus
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.ctc</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.hdfs.com.ctc
+                                    </shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>

--- a/fluss-filesystems/fluss-fs-obs/pom.xml
+++ b/fluss-filesystems/fluss-fs-obs/pom.xml
@@ -282,6 +282,21 @@
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.obs.io.netty
+                                    </shadedPattern>
+                                    <excludes>
+                                        <!-- netty-tcnative is a JNI wrapper around OpenSSL and its
+                                             native symbols bind to the io.netty.internal.tcnative
+                                             package name, so renaming it would break them. It is
+                                             referenced here but supplied from elsewhere, if at all;
+                                             leaving it alone keeps OpenSSL usable when the host
+                                             provides it and avoids references resolving nowhere. -->
+                                        <exclude>io.netty.internal.tcnative.**</exclude>
+                                    </excludes>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/fluss-filesystems/fluss-fs-obs/pom.xml
+++ b/fluss-filesystems/fluss-fs-obs/pom.xml
@@ -244,6 +244,40 @@
                                 </filter>
                             </filters>
                             <relocations>
+                                <!-- relocate the third-party packages bundled from
+                                     Hadoop and the cloud SDK so they cannot shadow a
+                                     downstream application's own copies, mirroring
+                                     fluss-fs-hadoop-shaded and fluss-fs-s3 -->
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.obs.com.google
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.htrace</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.obs.org.apache.htrace
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.obs.com.fasterxml
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.obs.org.codehaus
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.ctc</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.obs.com.ctc
+                                    </shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>

--- a/fluss-filesystems/fluss-fs-oss/pom.xml
+++ b/fluss-filesystems/fluss-fs-oss/pom.xml
@@ -266,6 +266,21 @@
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.oss.io.netty
+                                    </shadedPattern>
+                                    <excludes>
+                                        <!-- netty-tcnative is a JNI wrapper around OpenSSL and its
+                                             native symbols bind to the io.netty.internal.tcnative
+                                             package name, so renaming it would break them. It is
+                                             referenced here but supplied from elsewhere, if at all;
+                                             leaving it alone keeps OpenSSL usable when the host
+                                             provides it and avoids references resolving nowhere. -->
+                                        <exclude>io.netty.internal.tcnative.**</exclude>
+                                    </excludes>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/fluss-filesystems/fluss-fs-oss/pom.xml
+++ b/fluss-filesystems/fluss-fs-oss/pom.xml
@@ -228,6 +228,40 @@
                                 </filter>
                             </filters>
                             <relocations>
+                                <!-- relocate the third-party packages bundled from
+                                     Hadoop and the cloud SDK so they cannot shadow a
+                                     downstream application's own copies, mirroring
+                                     fluss-fs-hadoop-shaded and fluss-fs-s3 -->
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.oss.com.google
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.htrace</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.oss.org.apache.htrace
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.oss.com.fasterxml
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.oss.org.codehaus
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.ctc</pattern>
+                                    <shadedPattern>
+                                        org.apache.fluss.fs.shaded.oss.com.ctc
+                                    </shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.apache.fluss.shaded.org.apache.commons</shadedPattern>

--- a/fluss-lake/fluss-lake-iceberg/pom.xml
+++ b/fluss-lake/fluss-lake-iceberg/pom.xml
@@ -327,6 +327,25 @@
                                     <pattern>org.apache.parquet</pattern>
                                     <shadedPattern>org.apache.iceberg.shaded.org.apache.parquet</shadedPattern>
                                 </relocation>
+                                <!-- Named individually rather than as org.apache.commons: the
+                                     shade plugin rewrites every reference matching a pattern,
+                                     including ones to classes this jar does not bundle. Only
+                                     compress, lang3 and pool are bundled here; commons-io and
+                                     commons-lang (2.x) are referenced but supplied from
+                                     elsewhere, and relocating them would leave links that
+                                     resolve nowhere. -->
+                                <relocation>
+                                    <pattern>org.apache.commons.compress</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.compress</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.lang3</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.lang3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.pool</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.pool</shadedPattern>
+                                </relocation>
                             </relocations>
                             <filters>
                                 <filter>

--- a/fluss-lake/fluss-lake-lance/pom.xml
+++ b/fluss-lake/fluss-lake-lance/pom.xml
@@ -208,6 +208,34 @@
                                     <include>*:*</include>
                                 </includes>
                             </artifactSet>
+                            <relocations>
+                                <!-- jackson is bundled whole here: every package referenced
+                                     (annotation, core, databind, datatype) is also present. -->
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                                <!-- commons named individually: only codec and lang3 are
+                                     bundled. commons-logging is referenced but supplied from
+                                     elsewhere, so relocating org.apache.commons wholesale would
+                                     leave links that resolve nowhere. -->
+                                <relocation>
+                                    <pattern>org.apache.commons.codec</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.codec</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.lang3</pattern>
+                                    <shadedPattern>org.apache.fluss.shaded.org.apache.commons.lang3</shadedPattern>
+                                </relocation>
+                                <!-- org.apache.arrow is deliberately NOT relocated. The bundled
+                                     libarrow_cdata_jni native exports JNI symbols that embed the
+                                     Java package name, e.g.
+                                     Java_org_apache_arrow_c_jni_JniWrapper_exportArray. Renaming
+                                     the package would make the JVM look for a symbol the library
+                                     does not export, failing with UnsatisfiedLinkError at
+                                     runtime. io.netty is left alone for the same reason in
+                                     spirit: it is Arrow's allocator layer, tied to Arrow. -->
+                            </relocations>
                             <filters>
                                 <filter>
                                     <artifact>*</artifact>

--- a/tools/ci/check_shaded_jars.py
+++ b/tools/ci/check_shaded_jars.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""
+Shaded jar leak checker for Apache Fluss.
+
+Verifies that uber-jars do not ship third-party classes at their original
+package paths, where they can shadow a downstream application's own copy of the
+same library at runtime.
+
+Two leak shapes are detected:
+
+1. Base-path leaks -- e.g. ``com/fasterxml/jackson/core/JsonToken.class``
+   sitting next to the relocated copy because no ``<relocation>`` was
+   configured for the bundling module.
+
+2. Multi-Release JAR leaks -- the same classes under
+   ``META-INF/versions/<n>/``. The Maven Shade Plugin relocates base-path
+   classes but *not* MRJ entries, so these survive relocation and must be
+   excluded by a shade ``<filter>`` instead.
+
+A rule passes only when the forbidden prefix is absent AND its relocated
+counterpart is present, or when the package is absent from the jar entirely.
+Absent-and-not-relocated is reported as a failure: that combination is what a
+silently discarded ``<relocations>`` block looks like, since a global MRJ
+filter will strip the classes rather than relocate them.
+
+Usage::
+
+    # fail on any leak
+    python3 tools/ci/check_shaded_jars.py path/to/*.jar
+
+    # record a baseline, then compare a later build against it
+    python3 tools/ci/check_shaded_jars.py --baseline before.json path/to/*.jar
+    python3 tools/ci/check_shaded_jars.py --compare  before.json path/to/*.jar
+
+Exit codes: 0 = clean, 1 = violations found, 2 = usage or I/O error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+import zipfile
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+# Entries of the form META-INF/versions/<n>/<real path>. The Shade Plugin does
+# not rewrite these, which is the whole reason this checker exists.
+MRJ_PREFIX = re.compile(r"^META-INF/versions/\d+/")
+
+# Packages that must never appear at their original path in a Fluss uber-jar,
+# each paired with a regex matching where the relocated copy should live.
+#
+# The relocated patterns are deliberately loose about the middle segment: Fluss
+# uses several shading namespaces (org.apache.fluss.shaded.*,
+# org.apache.fluss.fs.shaded.s3.*, org.apache.fluss.fs.shaded.hadoop3.*) and
+# this checker only cares that the classes ended up somewhere under
+# org/apache/fluss/, not which namespace was chosen.
+RULES: Sequence[Tuple[str, str]] = (
+    ("com/fasterxml/", r"^org/apache/fluss/.*/com/fasterxml/"),
+    ("org/codehaus/", r"^org/apache/fluss/.*/org/codehaus/"),
+    ("com/ctc/", r"^org/apache/fluss/.*/com/ctc/"),
+    ("org/apache/htrace/", r"^org/apache/fluss/.*/org/apache/htrace/"),
+    ("com/google/re2j/", r"^org/apache/fluss/.*/com/google/re2j/"),
+    ("org/apache/commons/", r"^org/apache/fluss/.*/org/apache/commons/"),
+)
+
+# Prefixes that are legitimately present unshaded.
+#
+# org/apache/hadoop is the notable one: it is deliberately never relocated
+# anywhere in this repository. fluss-fs-hadoop-shaded relocates only re2j,
+# htrace, fasterxml, codehaus and ctc, leaving Hadoop itself at its real
+# package because the Hadoop FileSystem SPI resolves implementations by class
+# name. Its entries are still counted and reported so that a change in the
+# footprint is visible, but they never fail the check.
+ALLOWED_PREFIXES: Sequence[str] = (
+    "org/apache/fluss/",
+    "org/apache/hadoop/",
+    "com/amazonaws/",
+    "java/",
+    "javax/",
+    "jdk/",
+    "sun/",
+)
+
+# Reported alongside the rules so drift is visible in --compare, never fatal.
+TRACKED_PREFIXES: Sequence[str] = ("org/apache/hadoop/",)
+
+# Leaks that already exist on main and are out of scope for the change being
+# validated. They are still detected and printed, but as WARN rather than FAIL,
+# so the checker stays usable as a gate. --compare still fails if one of these
+# grows. Entries are (jar filename prefix, forbidden package prefix).
+#
+# fluss-client bundles commons-lang3 at its original path. #3960 relocated
+# org.apache.commons in the S3/GS/Azure filesystem plugins only; the client
+# uber-jar was never covered. Tracked upstream separately from #3553 / #4072.
+KNOWN_EXCEPTIONS: Sequence[Tuple[str, str]] = (
+    ("fluss-client", "org/apache/commons/"),
+)
+
+
+def is_known_exception(jar_path: str, prefix: str) -> bool:
+    name = jar_path.rsplit("/", 1)[-1]
+    return any(
+        name.startswith(jar_prefix) and prefix == pkg
+        for jar_prefix, pkg in KNOWN_EXCEPTIONS
+    )
+
+
+class JarReport:
+    """Per-jar scan result: leak counts, relocated counts, sample entries."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.total_entries = 0
+        self.total_classes = 0
+        # forbidden prefix -> counts
+        self.leaked: Dict[str, int] = {p: 0 for p, _ in RULES}
+        self.leaked_mrj: Dict[str, int] = {p: 0 for p, _ in RULES}
+        self.relocated: Dict[str, int] = {p: 0 for p, _ in RULES}
+        self.tracked: Dict[str, int] = {p: 0 for p in TRACKED_PREFIXES}
+        # forbidden prefix -> first few offending entry names
+        self.samples: Dict[str, List[str]] = {p: [] for p, _ in RULES}
+        # non-jackson MRJ entries, so we can prove unrelated MRJ content survived
+        self.mrj_other = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "total_entries": self.total_entries,
+            "total_classes": self.total_classes,
+            "leaked": self.leaked,
+            "leaked_mrj": self.leaked_mrj,
+            "relocated": self.relocated,
+            "tracked": self.tracked,
+            "mrj_other": self.mrj_other,
+        }
+
+    def violations(self) -> Tuple[List[str], List[str]]:
+        """Return (fatal, warnings) as human-readable reasons.
+
+        Warnings are leaks listed in KNOWN_EXCEPTIONS: real, but pre-existing
+        and out of scope, so they are reported without failing the gate.
+        """
+        fatal: List[str] = []
+        warnings: List[str] = []
+        for prefix, _ in RULES:
+            sink = warnings if is_known_exception(self.path, prefix) else fatal
+            base = self.leaked[prefix]
+            mrj = self.leaked_mrj[prefix]
+            if base:
+                sink.append(
+                    "{} unshaded entries at {} (base path)".format(base, prefix)
+                )
+            if mrj:
+                sink.append(
+                    "{} unshaded entries at META-INF/versions/*/{}".format(mrj, prefix)
+                )
+        return fatal, warnings
+
+
+def _classify(name: str, report: JarReport, relocated_res: Sequence[re.Pattern]) -> None:
+    mrj_match = MRJ_PREFIX.match(name)
+    logical = name[mrj_match.end():] if mrj_match else name
+
+    if mrj_match and logical:
+        if not any(logical.startswith(p) for p, _ in RULES):
+            report.mrj_other += 1
+
+    for prefix in TRACKED_PREFIXES:
+        if logical.startswith(prefix):
+            report.tracked[prefix] += 1
+
+    for idx, (prefix, _) in enumerate(RULES):
+        if logical.startswith(prefix):
+            bucket = report.leaked_mrj if mrj_match else report.leaked
+            bucket[prefix] += 1
+            if len(report.samples[prefix]) < 5:
+                report.samples[prefix].append(name)
+            return
+        if relocated_res[idx].match(logical):
+            report.relocated[prefix] += 1
+            return
+
+
+def scan_jar(path: str) -> JarReport:
+    report = JarReport(path)
+    relocated_res = [re.compile(pat) for _, pat in RULES]
+    with zipfile.ZipFile(path) as zf:
+        for name in zf.namelist():
+            report.total_entries += 1
+            if not name.endswith(".class"):
+                continue
+            report.total_classes += 1
+            _classify(name, report, relocated_res)
+    return report
+
+
+def format_report(report: JarReport) -> str:
+    lines = [
+        "",
+        report.path,
+        "  {} entries, {} classes".format(report.total_entries, report.total_classes),
+    ]
+    header = "  {:<22} {:>8} {:>8} {:>10}".format(
+        "package", "leaked", "mrj", "relocated"
+    )
+    lines.append(header)
+    lines.append("  " + "-" * (len(header) - 2))
+    for prefix, _ in RULES:
+        base = report.leaked[prefix]
+        mrj = report.leaked_mrj[prefix]
+        reloc = report.relocated[prefix]
+        if not (base or mrj or reloc):
+            continue
+        flag = "  LEAK" if (base or mrj) else ""
+        lines.append(
+            "  {:<22} {:>8} {:>8} {:>10}{}".format(
+                prefix.rstrip("/"), base, mrj, reloc, flag
+            )
+        )
+    for prefix in TRACKED_PREFIXES:
+        lines.append(
+            "  {:<22} {:>8} {:>8} {:>10}  (tracked, never fatal)".format(
+                prefix.rstrip("/"), report.tracked[prefix], "-", "-"
+            )
+        )
+    lines.append(
+        "  {:<22} {:>8}".format("other MRJ entries", report.mrj_other)
+    )
+    for prefix, _ in RULES:
+        for sample in report.samples[prefix]:
+            lines.append("    e.g. {}".format(sample))
+    return "\n".join(lines)
+
+
+def compare_reports(
+    baseline: Sequence[dict], current: Sequence[JarReport]
+) -> Tuple[List[str], List[str]]:
+    """Diff current reports against a baseline. Returns (regressions, notes)."""
+    by_name = {}
+    for entry in baseline:
+        by_name[entry["path"].rsplit("/", 1)[-1]] = entry
+
+    regressions: List[str] = []
+    notes: List[str] = []
+    for report in current:
+        key = report.path.rsplit("/", 1)[-1]
+        before = by_name.get(key)
+        if before is None:
+            notes.append("{}: no baseline entry, skipped comparison".format(key))
+            continue
+        for prefix, _ in RULES:
+            for field, label in (("leaked", "base"), ("leaked_mrj", "mrj")):
+                was = before[field].get(prefix, 0)
+                now = getattr(report, field)[prefix]
+                if now > was:
+                    regressions.append(
+                        "{}: {} {} leaks rose {} -> {}".format(
+                            key, prefix, label, was, now
+                        )
+                    )
+                elif now < was:
+                    notes.append(
+                        "{}: {} {} leaks fell {} -> {}".format(
+                            key, prefix, label, was, now
+                        )
+                    )
+            # A base-path leak that disappeared should reappear as relocated
+            # classes. If it did not, the classes were stripped by a filter
+            # rather than rewritten -- the signature of a <relocations> block
+            # that Maven silently discarded. Losing the classes outright breaks
+            # the bundled library at runtime, so this is fatal.
+            was_leaked = before["leaked"].get(prefix, 0)
+            was_reloc = before["relocated"].get(prefix, 0)
+            now_reloc = report.relocated[prefix]
+            if was_leaked > 0 and report.leaked[prefix] == 0:
+                gained = now_reloc - was_reloc
+                if gained < was_leaked * 0.9:
+                    regressions.append(
+                        "{}: {} lost {} unshaded entries but gained only {} "
+                        "relocated -- classes were stripped, not relocated".format(
+                            key, prefix, was_leaked, gained
+                        )
+                    )
+        for prefix in TRACKED_PREFIXES:
+            was = before.get("tracked", {}).get(prefix, 0)
+            now = report.tracked[prefix]
+            if was != now:
+                notes.append(
+                    "{}: {} count changed {} -> {} (tracked, not fatal)".format(
+                        key, prefix, was, now
+                    )
+                )
+        was_mrj = before.get("mrj_other", 0)
+        if report.mrj_other < was_mrj:
+            regressions.append(
+                "{}: unrelated MRJ entries dropped {} -> {} "
+                "(a filter is too broad)".format(key, was_mrj, report.mrj_other)
+            )
+    return regressions, notes
+
+
+def expand(patterns: Iterable[str]) -> List[str]:
+    paths: List[str] = []
+    for pattern in patterns:
+        matches = sorted(glob.glob(pattern))
+        if matches:
+            paths.extend(matches)
+        else:
+            paths.append(pattern)
+    # a shaded build leaves original-* and dependency-reduced artifacts around
+    return [p for p in paths if not p.rsplit("/", 1)[-1].startswith("original-")]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check Fluss uber-jars for unshaded third-party classes."
+    )
+    parser.add_argument("jars", nargs="+", help="jar paths or globs")
+    parser.add_argument(
+        "--baseline", metavar="FILE", help="write scan results to FILE and exit 0"
+    )
+    parser.add_argument(
+        "--compare", metavar="FILE", help="compare against a baseline written earlier"
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON to stdout")
+    args = parser.parse_args()
+
+    paths = expand(args.jars)
+    if not paths:
+        print("no jars matched", file=sys.stderr)
+        return 2
+
+    reports = []
+    for path in paths:
+        try:
+            reports.append(scan_jar(path))
+        except (OSError, zipfile.BadZipFile) as err:
+            print("cannot read {}: {}".format(path, err), file=sys.stderr)
+            return 2
+
+    if args.json:
+        print(json.dumps([r.to_dict() for r in reports], indent=2))
+    else:
+        for report in reports:
+            print(format_report(report))
+
+    if args.baseline:
+        with open(args.baseline, "w") as handle:
+            json.dump([r.to_dict() for r in reports], handle, indent=2)
+        print("\nbaseline written to {}".format(args.baseline))
+        return 0
+
+    failed = False
+
+    if args.compare:
+        try:
+            with open(args.compare) as handle:
+                baseline = json.load(handle)
+        except (OSError, ValueError) as err:
+            print("cannot read baseline: {}".format(err), file=sys.stderr)
+            return 2
+        regressions, notes = compare_reports(baseline, reports)
+        print("\n--- comparison against {} ---".format(args.compare))
+        for note in notes:
+            print("  ok   {}".format(note))
+        for regression in regressions:
+            print("  FAIL {}".format(regression))
+        if not notes and not regressions:
+            print("  no differences")
+        failed = failed or bool(regressions)
+
+    print("\n--- leak check ---")
+    for report in reports:
+        fatal, warnings = report.violations()
+        name = report.path.rsplit("/", 1)[-1]
+        if fatal:
+            failed = True
+            print("  FAIL {}".format(name))
+            for problem in fatal:
+                print("       {}".format(problem))
+        else:
+            print("  ok   {}".format(name))
+        for problem in warnings:
+            print("  WARN {}: {} (known pre-existing, not gating)".format(name, problem))
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci/check_shaded_jars.py
+++ b/tools/ci/check_shaded_jars.py
@@ -46,9 +46,22 @@ Usage::
     # fail on any leak
     python3 tools/ci/check_shaded_jars.py path/to/*.jar
 
+    # every uber-jar in the repo; quote the globs so this script expands them
+    python3 tools/ci/check_shaded_jars.py \
+        'fluss-*/target/*.jar' 'fluss-*/*/target/*.jar' 'tools/ci/*/target/*.jar'
+
     # record a baseline, then compare a later build against it
     python3 tools/ci/check_shaded_jars.py --baseline before.json path/to/*.jar
     python3 tools/ci/check_shaded_jars.py --compare  before.json path/to/*.jar
+
+Arguments are globbed by this script rather than the shell, and artifacts that
+are never worth scanning are dropped automatically: ``original-*`` pre-shade
+jars, ``-tests``/``-sources``/``-javadoc`` jars, ``target/temporary/`` build
+intermediates, and the ``target/*-bin/`` distribution tree whose plugin jars
+duplicate ones already scanned. The number skipped is printed, not hidden.
+
+Scan a clean build. An incremental build reuses already-relocated classes in
+``target/classes``, so a changed relocation pattern looks like it did nothing.
 
 Exit codes: 0 = clean, 1 = violations found, 2 = usage or I/O error.
 """
@@ -399,16 +412,49 @@ def compare_reports(
     return regressions, notes
 
 
-def expand(patterns: Iterable[str]) -> List[str]:
+# Artifacts a Maven build leaves in target/ that are never worth scanning.
+# Filtering here rather than in the caller's shell means a plain glob such as
+# 'fluss-*/*/target/*.jar' is already correct.
+SKIP_SUFFIXES: Sequence[str] = ("-tests.jar", "-sources.jar", "-javadoc.jar")
+
+# original-<artifact>.jar is the pre-shade input the plugin renames aside; it
+# still holds every unshaded class and would report leaks the real jar does not
+# have.
+SKIP_PREFIXES: Sequence[str] = ("original-",)
+
+# target/temporary/ holds unpacked build intermediates (the fs plugins stage
+# jaxb-api there). target/<name>-bin/ is the assembled distribution, which
+# duplicates plugin jars already scanned in their own module directories.
+SKIP_PATH_RE = re.compile(r"/target/(temporary/|[^/]*-bin/)")
+
+
+def _is_scannable(path: str) -> bool:
+    name = path.rsplit("/", 1)[-1]
+    if any(name.startswith(p) for p in SKIP_PREFIXES):
+        return False
+    if any(name.endswith(s) for s in SKIP_SUFFIXES):
+        return False
+    return not SKIP_PATH_RE.search(path)
+
+
+def expand(patterns: Iterable[str]) -> Tuple[List[str], int]:
+    """Resolve globs to jar paths, dropping artifacts not worth scanning.
+
+    Returns (paths, skipped_count). The count is reported rather than dropped
+    silently, so a run that quietly scanned nothing is visible.
+    """
     paths: List[str] = []
+    seen = set()
     for pattern in patterns:
         matches = sorted(glob.glob(pattern))
-        if matches:
-            paths.extend(matches)
-        else:
-            paths.append(pattern)
-    # a shaded build leaves original-* and dependency-reduced artifacts around
-    return [p for p in paths if not p.rsplit("/", 1)[-1].startswith("original-")]
+        # a literal path that does not exist is kept so the caller gets a clear
+        # "cannot read" error rather than silently scanning nothing
+        for path in matches or [pattern]:
+            if path not in seen:
+                seen.add(path)
+                paths.append(path)
+    scannable = [p for p in paths if _is_scannable(p)]
+    return scannable, len(paths) - len(scannable)
 
 
 def main() -> int:
@@ -445,10 +491,15 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    paths = expand(args.jars)
+    paths, skipped = expand(args.jars)
     if not paths:
         print("no jars matched", file=sys.stderr)
         return 2
+    if skipped:
+        print(
+            "scanning {} jars ({} skipped: original-/tests/sources/javadoc, "
+            "build intermediates, distribution copies)".format(len(paths), skipped)
+        )
 
     if args.dangling:
         failed = False

--- a/tools/ci/check_shaded_jars.py
+++ b/tools/ci/check_shaded_jars.py
@@ -110,11 +110,13 @@ TRACKED_PREFIXES: Sequence[str] = ("org/apache/hadoop/",)
 # so the checker stays usable as a gate. --compare still fails if one of these
 # grows. Entries are (jar filename prefix, forbidden package prefix).
 #
-# fluss-client bundles commons-lang3 at its original path. #3960 relocated
-# org.apache.commons in the S3/GS/Azure filesystem plugins only; the client
-# uber-jar was never covered. Tracked upstream separately from #3553 / #4072.
+# fluss-client bundles commons-lang3 at its original path, and the Flink
+# connector uber-jars inherit it. #3960 relocated org.apache.commons in the
+# S3/GS/Azure filesystem plugins only; the client was never covered. Separate
+# pre-existing issue from #3553 / #4072.
 KNOWN_EXCEPTIONS: Sequence[Tuple[str, str]] = (
     ("fluss-client", "org/apache/commons/"),
+    ("fluss-flink-", "org/apache/commons/"),
 )
 
 

--- a/tools/ci/check_shaded_jars.py
+++ b/tools/ci/check_shaded_jars.py
@@ -134,18 +134,15 @@ TRACKED_PREFIXES: Sequence[str] = ("org/apache/hadoop/",)
 # so the checker stays usable as a gate. --compare still fails if one of these
 # grows. Entries are (jar filename prefix, forbidden package prefix).
 #
-# fluss-client bundles commons-math3 (1386 classes) and commons-lang3 (431) at
-# their original paths, and the Flink and Spark uber-jars inherit both. #3960
-# relocated org.apache.commons in the S3/GS/Azure filesystem plugins only; the
-# client was never covered. Separate pre-existing issue from #3553 / #4072.
+# Currently empty. fluss-client, the Flink connectors and the Spark connectors
+# used to be listed here for commons-math3/commons-lang3; that leak is fixed,
+# so the entries are gone rather than left behind where they would mask a
+# regression.
 #
-# fluss-lake-iceberg leaks commons too but from different libraries
-# (commons-compress 602, lang3 431, commons-pool 57), so it is a distinct
-# problem and is deliberately NOT excepted here.
-KNOWN_EXCEPTIONS: Sequence[Tuple[str, str]] = (
-    ("fluss-client", "org/apache/commons/"),
-    ("fluss-flink-", "org/apache/commons/"),
-)
+# fluss-lake-iceberg still leaks commons, but from different libraries
+# (commons-compress 602, lang3 431, commons-pool 57). It is deliberately NOT
+# excepted: it is a real unfixed problem, not an accepted one.
+KNOWN_EXCEPTIONS: Sequence[Tuple[str, str]] = ()
 
 
 # Packages holding only annotations. A missing or duplicated annotation class

--- a/tools/ci/check_shaded_jars.py
+++ b/tools/ci/check_shaded_jars.py
@@ -85,10 +85,14 @@ RULES: Sequence[Tuple[str, str]] = (
     ("org/apache/commons/", r"^org/apache/fluss/.*/org/apache/commons/"),
     # the libraries Fluss ships pre-shaded; see the forbidden-import list in
     # AGENTS.md. An unshaded copy in an uber-jar defeats that shading.
-    ("com/google/common/", r"^org/apache/fluss/shaded/guava\d*/com/google/common/"),
-    ("io/netty/", r"^org/apache/fluss/shaded/netty\d*/io/netty/"),
-    ("org/apache/arrow/", r"^org/apache/fluss/shaded/arrow/org/apache/arrow/"),
-    ("org/apache/zookeeper/", r"^org/apache/fluss/shaded/zookeeper\d*/org/apache/zookeeper/"),
+    # the relocated path is matched loosely on purpose: these land under
+    # org/apache/fluss/shaded/<lib>/ when they come from a fluss-shaded
+    # artifact, but under org/apache/fluss/fs/shaded/<plugin>/ when a
+    # filesystem plugin relocates its own bundled copy.
+    ("com/google/common/", r"^org/apache/fluss/.*/com/google/common/"),
+    ("io/netty/", r"^org/apache/fluss/.*/io/netty/"),
+    ("org/apache/arrow/", r"^org/apache/fluss/.*/org/apache/arrow/"),
+    ("org/apache/zookeeper/", r"^org/apache/fluss/.*/org/apache/zookeeper/"),
 )
 
 # Prefixes that are legitimately present unshaded.
@@ -237,6 +241,46 @@ def audit_packages(path: str, depth: int = 3) -> List[Tuple[str, int]]:
     return sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
 
 
+# A relocated class reference in a constant pool, e.g.
+# org/apache/fluss/fs/shaded/hadoop3/com/google/common/collect/ImmutableList
+RELOCATED_REF = re.compile(
+    rb"org/apache/fluss/(?:fs/)?shaded/[A-Za-z0-9_$/-]+"
+)
+
+
+def dangling_relocations(path: str, limit: int = 12) -> List[Tuple[str, int]]:
+    """Relocated class names referenced by the jar but not contained in it.
+
+    The shade plugin rewrites every reference matching a <relocation> pattern,
+    including references to classes the jar does not bundle. Relocating
+    org.apache.commons when only some commons artifacts are present therefore
+    leaves links to org/apache/fluss/shaded/org/apache/commons/cli/... that
+    resolve nowhere, and the failure only shows up at runtime.
+
+    Returns (missing class name, reference count), most referenced first.
+    """
+    missing: Dict[str, int] = {}
+    with zipfile.ZipFile(path) as zf:
+        names = set(zf.namelist())
+        for name in zf.namelist():
+            if not name.endswith(".class"):
+                continue
+            try:
+                blob = zf.read(name)
+            except (OSError, zipfile.BadZipFile):
+                continue
+            for raw in set(RELOCATED_REF.findall(blob)):
+                ref = raw.decode("utf-8", "replace")
+                # inner classes and array/descriptor noise resolve via the
+                # outer name; only flag when nothing plausible is present
+                if ref + ".class" in names:
+                    continue
+                if any(n.startswith(ref + "$") or n.startswith(ref + "/") for n in names):
+                    continue
+                missing[ref] = missing.get(ref, 0) + 1
+    return sorted(missing.items(), key=lambda kv: (-kv[1], kv[0]))[:limit]
+
+
 def scan_jar(path: str) -> JarReport:
     report = JarReport(path)
     relocated_res = [re.compile(pat) for _, pat in RULES]
@@ -380,6 +424,13 @@ def main() -> int:
     )
     parser.add_argument("--json", action="store_true", help="emit JSON to stdout")
     parser.add_argument(
+        "--dangling",
+        action="store_true",
+        help="report relocated class references the jar does not contain; "
+        "catches a <relocation> pattern that rewrote links to classes that "
+        "were never bundled",
+    )
+    parser.add_argument(
         "--audit",
         action="store_true",
         help="list every unshaded third-party package per jar and exit 0; "
@@ -398,6 +449,24 @@ def main() -> int:
     if not paths:
         print("no jars matched", file=sys.stderr)
         return 2
+
+    if args.dangling:
+        failed = False
+        for path in paths:
+            try:
+                missing = dangling_relocations(path)
+            except (OSError, zipfile.BadZipFile) as err:
+                print("cannot read {}: {}".format(path, err), file=sys.stderr)
+                return 2
+            name = path.rsplit("/", 1)[-1]
+            if missing:
+                failed = True
+                print("  FAIL {}".format(name))
+                for ref, count in missing:
+                    print("       missing {}  ({} refs)".format(ref, count))
+            else:
+                print("  ok   {}".format(name))
+        return 1 if failed else 0
 
     if args.audit:
         for path in paths:

--- a/tools/ci/check_shaded_jars.py
+++ b/tools/ci/check_shaded_jars.py
@@ -76,12 +76,19 @@ MRJ_PREFIX = re.compile(r"^META-INF/versions/\d+/")
 # this checker only cares that the classes ended up somewhere under
 # org/apache/fluss/, not which namespace was chosen.
 RULES: Sequence[Tuple[str, str]] = (
+    # the five relocated by fluss-fs-hadoop-shaded and fluss-fs-s3
     ("com/fasterxml/", r"^org/apache/fluss/.*/com/fasterxml/"),
     ("org/codehaus/", r"^org/apache/fluss/.*/org/codehaus/"),
     ("com/ctc/", r"^org/apache/fluss/.*/com/ctc/"),
     ("org/apache/htrace/", r"^org/apache/fluss/.*/org/apache/htrace/"),
     ("com/google/re2j/", r"^org/apache/fluss/.*/com/google/re2j/"),
     ("org/apache/commons/", r"^org/apache/fluss/.*/org/apache/commons/"),
+    # the libraries Fluss ships pre-shaded; see the forbidden-import list in
+    # AGENTS.md. An unshaded copy in an uber-jar defeats that shading.
+    ("com/google/common/", r"^org/apache/fluss/shaded/guava\d*/com/google/common/"),
+    ("io/netty/", r"^org/apache/fluss/shaded/netty\d*/io/netty/"),
+    ("org/apache/arrow/", r"^org/apache/fluss/shaded/arrow/org/apache/arrow/"),
+    ("org/apache/zookeeper/", r"^org/apache/fluss/shaded/zookeeper\d*/org/apache/zookeeper/"),
 )
 
 # Prefixes that are legitimately present unshaded.
@@ -202,6 +209,32 @@ def _classify(name: str, report: JarReport, relocated_res: Sequence[re.Pattern])
         if relocated_res[idx].match(logical):
             report.relocated[prefix] += 1
             return
+
+
+def audit_packages(path: str, depth: int = 3) -> List[Tuple[str, int]]:
+    """Every non-Fluss, non-JDK package shipped in the jar, largest first.
+
+    Discovery aid for the repo-wide sweep: RULES only covers packages we
+    already know about, so this answers "what else is in here". Entries are
+    grouped to `depth` path segments, and relocated classes under
+    org/apache/fluss are folded away since those are the shaded copies.
+    """
+    counts: Dict[str, int] = {}
+    jdk = ("java/", "javax/", "jdk/", "sun/", "META-INF/")
+    with zipfile.ZipFile(path) as zf:
+        for name in zf.namelist():
+            if not name.endswith(".class"):
+                continue
+            logical = MRJ_PREFIX.sub("", name)
+            if logical.startswith("org/apache/fluss/") or logical.startswith(jdk):
+                continue
+            parts = logical.split("/")
+            if len(parts) <= 1:
+                key = "(default package)"
+            else:
+                key = "/".join(parts[: min(depth, len(parts) - 1)])
+            counts[key] = counts.get(key, 0) + 1
+    return sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
 
 
 def scan_jar(path: str) -> JarReport:
@@ -346,12 +379,41 @@ def main() -> int:
         "--compare", metavar="FILE", help="compare against a baseline written earlier"
     )
     parser.add_argument("--json", action="store_true", help="emit JSON to stdout")
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="list every unshaded third-party package per jar and exit 0; "
+        "discovery mode, does not gate",
+    )
+    parser.add_argument(
+        "--audit-min",
+        type=int,
+        default=1,
+        metavar="N",
+        help="with --audit, hide packages with fewer than N classes",
+    )
     args = parser.parse_args()
 
     paths = expand(args.jars)
     if not paths:
         print("no jars matched", file=sys.stderr)
         return 2
+
+    if args.audit:
+        for path in paths:
+            try:
+                packages = audit_packages(path)
+            except (OSError, zipfile.BadZipFile) as err:
+                print("cannot read {}: {}".format(path, err), file=sys.stderr)
+                continue
+            shown = [(p, n) for p, n in packages if n >= args.audit_min]
+            total = sum(n for _, n in packages)
+            print("\n{}  ({} unshaded third-party classes)".format(path, total))
+            if not shown:
+                print("  none")
+            for package, count in shown:
+                print("  {:>7}  {}".format(count, package))
+        return 0
 
     reports = []
     for path in paths:

--- a/tools/ci/check_shaded_jars.py
+++ b/tools/ci/check_shaded_jars.py
@@ -134,14 +134,36 @@ TRACKED_PREFIXES: Sequence[str] = ("org/apache/hadoop/",)
 # so the checker stays usable as a gate. --compare still fails if one of these
 # grows. Entries are (jar filename prefix, forbidden package prefix).
 #
-# fluss-client bundles commons-lang3 at its original path, and the Flink
-# connector uber-jars inherit it. #3960 relocated org.apache.commons in the
-# S3/GS/Azure filesystem plugins only; the client was never covered. Separate
-# pre-existing issue from #3553 / #4072.
+# fluss-client bundles commons-math3 (1386 classes) and commons-lang3 (431) at
+# their original paths, and the Flink and Spark uber-jars inherit both. #3960
+# relocated org.apache.commons in the S3/GS/Azure filesystem plugins only; the
+# client was never covered. Separate pre-existing issue from #3553 / #4072.
+#
+# fluss-lake-iceberg leaks commons too but from different libraries
+# (commons-compress 602, lang3 431, commons-pool 57), so it is a distinct
+# problem and is deliberately NOT excepted here.
 KNOWN_EXCEPTIONS: Sequence[Tuple[str, str]] = (
     ("fluss-client", "org/apache/commons/"),
     ("fluss-flink-", "org/apache/commons/"),
 )
+
+
+# Packages holding only annotations. A missing or duplicated annotation class
+# is ignored by the JVM at class load, so an unshaded copy cannot shadow
+# anything that changes behaviour. Reported, never fatal -- otherwise a jar
+# fails the gate over something like a single
+# org/codehaus/mojo/animal_sniffer/IgnoreJRERequirement.class.
+ANNOTATION_ONLY: Sequence[str] = (
+    "org/codehaus/mojo/animal_sniffer/",
+    "com/google/errorprone/annotations/",
+    "com/google/j2objc/annotations/",
+    "org/checkerframework/",
+)
+
+
+def is_annotation_only(entry: str) -> bool:
+    logical = MRJ_PREFIX.sub("", entry)
+    return any(logical.startswith(p) for p in ANNOTATION_ONLY)
 
 
 def is_known_exception(jar_path: str, prefix: str) -> bool:
@@ -163,6 +185,8 @@ class JarReport:
         self.leaked: Dict[str, int] = {p: 0 for p, _ in RULES}
         self.leaked_mrj: Dict[str, int] = {p: 0 for p, _ in RULES}
         self.relocated: Dict[str, int] = {p: 0 for p, _ in RULES}
+        # unshaded but annotation-only: reported, never fatal
+        self.annotations: Dict[str, int] = {p: 0 for p, _ in RULES}
         self.tracked: Dict[str, int] = {p: 0 for p in TRACKED_PREFIXES}
         # forbidden prefix -> first few offending entry names
         self.samples: Dict[str, List[str]] = {p: [] for p, _ in RULES}
@@ -177,6 +201,7 @@ class JarReport:
             "leaked": self.leaked,
             "leaked_mrj": self.leaked_mrj,
             "relocated": self.relocated,
+            "annotations": self.annotations,
             "tracked": self.tracked,
             "mrj_other": self.mrj_other,
         }
@@ -218,6 +243,10 @@ def _classify(name: str, report: JarReport, relocated_res: Sequence[re.Pattern])
 
     for idx, (prefix, _) in enumerate(RULES):
         if logical.startswith(prefix):
+            if is_annotation_only(logical):
+                # counted and reported, but never a gate failure
+                report.annotations[prefix] += 1
+                return
             bucket = report.leaked_mrj if mrj_match else report.leaked
             bucket[prefix] += 1
             if len(report.samples[prefix]) < 5:
@@ -313,8 +342,8 @@ def format_report(report: JarReport) -> str:
         report.path,
         "  {} entries, {} classes".format(report.total_entries, report.total_classes),
     ]
-    header = "  {:<22} {:>8} {:>8} {:>10}".format(
-        "package", "leaked", "mrj", "relocated"
+    header = "  {:<22} {:>8} {:>8} {:>10} {:>7}".format(
+        "package", "leaked", "mrj", "relocated", "annot"
     )
     lines.append(header)
     lines.append("  " + "-" * (len(header) - 2))
@@ -322,26 +351,34 @@ def format_report(report: JarReport) -> str:
         base = report.leaked[prefix]
         mrj = report.leaked_mrj[prefix]
         reloc = report.relocated[prefix]
-        if not (base or mrj or reloc):
+        annot = report.annotations[prefix]
+        if not (base or mrj or reloc or annot):
             continue
         flag = "  LEAK" if (base or mrj) else ""
         lines.append(
-            "  {:<22} {:>8} {:>8} {:>10}{}".format(
-                prefix.rstrip("/"), base, mrj, reloc, flag
+            "  {:<22} {:>8} {:>8} {:>10} {:>7}{}".format(
+                prefix.rstrip("/"), base, mrj, reloc, annot, flag
             )
         )
     for prefix in TRACKED_PREFIXES:
         lines.append(
-            "  {:<22} {:>8} {:>8} {:>10}  (tracked, never fatal)".format(
-                prefix.rstrip("/"), report.tracked[prefix], "-", "-"
+            "  {:<22} {:>8} {:>8} {:>10} {:>7}  (tracked, never fatal)".format(
+                prefix.rstrip("/"), report.tracked[prefix], "-", "-", "-"
             )
         )
     lines.append(
         "  {:<22} {:>8}".format("other MRJ entries", report.mrj_other)
     )
+    # Group samples under a heading naming their package. Printed flat they
+    # trail the "other MRJ entries" row and read as if they were MRJ examples,
+    # which they are not -- they are examples of the leak in that package.
     for prefix, _ in RULES:
-        for sample in report.samples[prefix]:
-            lines.append("    e.g. {}".format(sample))
+        samples = report.samples[prefix]
+        if not samples:
+            continue
+        lines.append("  leaked from {}:".format(prefix.rstrip("/")))
+        for sample in samples:
+            lines.append("      {}".format(sample))
     return "\n".join(lines)
 
 
@@ -495,10 +532,15 @@ def main() -> int:
     if not paths:
         print("no jars matched", file=sys.stderr)
         return 2
+    # with --json, stdout carries only the JSON document; everything a human
+    # reads goes to stderr so the output stays pipeable into jq
+    out = sys.stderr if args.json else sys.stdout
+
     if skipped:
         print(
             "scanning {} jars ({} skipped: original-/tests/sources/javadoc, "
-            "build intermediates, distribution copies)".format(len(paths), skipped)
+            "build intermediates, distribution copies)".format(len(paths), skipped),
+            file=out,
         )
 
     if args.dangling:
@@ -552,7 +594,7 @@ def main() -> int:
     if args.baseline:
         with open(args.baseline, "w") as handle:
             json.dump([r.to_dict() for r in reports], handle, indent=2)
-        print("\nbaseline written to {}".format(args.baseline))
+        print("\nbaseline written to {}".format(args.baseline), file=out)
         return 0
 
     failed = False
@@ -565,28 +607,31 @@ def main() -> int:
             print("cannot read baseline: {}".format(err), file=sys.stderr)
             return 2
         regressions, notes = compare_reports(baseline, reports)
-        print("\n--- comparison against {} ---".format(args.compare))
+        print("\n--- comparison against {} ---".format(args.compare), file=out)
         for note in notes:
-            print("  ok   {}".format(note))
+            print("  ok   {}".format(note), file=out)
         for regression in regressions:
-            print("  FAIL {}".format(regression))
+            print("  FAIL {}".format(regression), file=out)
         if not notes and not regressions:
-            print("  no differences")
+            print("  no differences", file=out)
         failed = failed or bool(regressions)
 
-    print("\n--- leak check ---")
+    print("\n--- leak check ---", file=out)
     for report in reports:
         fatal, warnings = report.violations()
         name = report.path.rsplit("/", 1)[-1]
         if fatal:
             failed = True
-            print("  FAIL {}".format(name))
+            print("  FAIL {}".format(name), file=out)
             for problem in fatal:
-                print("       {}".format(problem))
+                print("       {}".format(problem), file=out)
         else:
-            print("  ok   {}".format(name))
+            print("  ok   {}".format(name), file=out)
         for problem in warnings:
-            print("  WARN {}: {} (known pre-existing, not gating)".format(name, problem))
+            print(
+                "  WARN {}: {} (known pre-existing, not gating)".format(name, problem),
+                file=out,
+            )
 
     return 1 if failed else 0
 

--- a/website/community/dev/building.md
+++ b/website/community/dev/building.md
@@ -54,6 +54,104 @@ mvn clean install -DskipTests -T 1C
 - For local testing, it's recommend to use directory `${project}/build-target` in project.
 - For deploying distributed cluster, it's recommend to use binary file named `fluss-xxx-bin.tgz`, the file is in directory `${project}/fluss-dist/target`.
 
+## Shaded dependencies
+
+Fluss relocates the third-party libraries it bundles into the
+`org.apache.fluss.shaded.*` namespace, and the filesystem plugins use a
+per-plugin namespace such as `org.apache.fluss.fs.shaded.oss.*`. An uber-jar
+that ships a library at its original package can shadow the copy belonging to
+the application or engine that loads it, which surfaces as `NoSuchMethodError`
+or `NoClassDefFoundError` at runtime rather than as a build failure.
+
+### Writing a relocation
+
+**Name the packages the jar actually bundles, not their common prefix.** The
+shade plugin rewrites *every* reference matching a `<relocation>` pattern,
+including references to classes the jar does not contain. Relocating
+`org.apache.commons` in a module that bundles only `commons-lang3` but
+*references* `commons-cli` rewrites the commons-cli references too, pointing
+them at a coordinate nothing can ever provide. That turns a soft dependency,
+resolvable from the surrounding classpath, into a guaranteed failure:
+
+```
+java.lang.NoClassDefFoundError: org/apache/fluss/shaded/org/apache/commons/cli/ParseException
+    at org.apache.hadoop.hdfs.server.namenode.NameNode.createNameNode(NameNode.java:1713)
+```
+
+**Leave packages bound to native code alone.** A JNI library exports symbols
+that embed the Java package name, so renaming the package breaks the binding:
+
+```
+$ nm -gU libarrow_cdata_jni.dylib | grep Java_org_apache_arrow
+Java_org_apache_arrow_c_jni_JniWrapper_exportArray
+```
+
+For this reason `org.apache.arrow` is not relocated in `fluss-lake-lance`, and
+`io.netty.internal.tcnative` is excluded from the netty relocation in the
+filesystem plugins. `org.apache.hadoop` is likewise never relocated anywhere in
+the repository, because the Hadoop `FileSystem` SPI resolves implementations by
+class name from configuration.
+
+**Run `mvn clean`.** An incremental build reuses already-relocated classes in
+`target/classes`, so a changed relocation pattern appears to have no effect
+until the module is cleaned.
+
+### Checking a build for leaks
+
+`tools/ci/check_shaded_jars.py` scans built jars for classes sitting at a
+forbidden package path. It needs only Python 3 and the standard library.
+
+```bash
+# one jar
+python3 tools/ci/check_shaded_jars.py fluss-client/target/fluss-client-*.jar
+
+# every uber-jar in the repo; quote the globs, the script expands them and
+# skips original-/tests/sources/javadoc jars and distribution copies itself
+python3 tools/ci/check_shaded_jars.py \
+    'fluss-*/target/*.jar' 'fluss-*/*/target/*.jar' 'tools/ci/*/target/*.jar'
+```
+
+Each jar gets a table of per-package counts:
+
+```
+  package                  leaked      mrj  relocated   annot
+  com/fasterxml                 0        0       2066       0
+  io/netty                   1698        0          0       0  LEAK
+  org/apache/hadoop          5912        -          -       -  (tracked, never fatal)
+```
+
+`leaked` counts classes at the original package path and `mrj` counts them under
+`META-INF/versions/`, which the shade plugin does not relocate and which
+therefore need a `<filter>` exclusion rather than a rename. `relocated` should
+be non-zero wherever a package is bundled: zero in both `leaked` and
+`relocated` means a `<relocations>` block was silently discarded and the classes
+were dropped instead of renamed. `annot` counts annotation-only packages, which
+are reported but never fail the check since the JVM ignores an annotation class
+it cannot resolve.
+
+Exit code is 0 when clean and 1 when a leak is found. Three other modes help
+when changing shade configuration:
+
+```bash
+# every unshaded third-party package, not just the ones on the rule list --
+# use this to discover leaks the rules do not yet cover
+python3 tools/ci/check_shaded_jars.py --audit --audit-min 50 path/to/uber.jar
+
+# relocated references the jar does not contain, i.e. a pattern that rewrote
+# links to classes that were never bundled
+python3 tools/ci/check_shaded_jars.py --dangling path/to/uber.jar
+
+# compare a build against one recorded earlier, so an expected-but-unshaded
+# package such as org.apache.hadoop can be checked for drift rather than zero
+python3 tools/ci/check_shaded_jars.py --baseline before.json path/to/*.jar
+python3 tools/ci/check_shaded_jars.py --compare  before.json path/to/*.jar
+```
+
+`--compare` also fails when a leak disappears without a matching rise in
+relocated classes, which catches classes being stripped rather than renamed.
+`--json` writes the report to stdout for use in CI, with all human-readable
+output on stderr.
+
 ## Building the Rust client (fluss-rust)
 
 The Rust client, language bindings, and examples live under `fluss-rust/` and build with Cargo. You need **Rust** (the toolchain pinned in `fluss-rust/rust-toolchain.toml`, currently 1.85+). The code generated from the canonical `fluss-rpc/src/main/proto/FlussApi.proto` is checked in, so **protoc** is only needed when the proto changes — run `fluss-rust/crates/fluss/regen.sh` and commit the result.


### PR DESCRIPTION
### Purpose

Linked issue: close #4143

Uber-jars across the client, connectors, lake modules and filesystem plugins ship third-party libraries at their original package paths, where they shadow the copy belonging to the application or engine that loads them. #3960 already fixed one instance of this after Spark hit `NoSuchMethodError` on a shadowed commons class; this PR covers the modules that were never reached.

Independent of the two open PRs on the same problem: #3884 (jackson MRJ entries) and #4073 (`fluss-fs-s3`) are untouched here and remain to be merged separately.

### Brief change log

- **`fluss-client`** — relocate `commons-lang3` and `commons-math3`. The Flink and Spark connector uber-jars inherit the fix.
- **`fluss-fs-hadoop-shaded`** — relocate guava and the eight bundled commons packages. Every filesystem plugin bundles this module, so the leak propagated to all of them.
- **`fluss-fs-azure` / `cos` / `gs` / `hdfs` / `obs` / `oss`** — relocate the jackson, codehaus, ctc, re2j and guava that Hadoop and the cloud SDKs bring in, each under its own `org.apache.fluss.fs.shaded.<plugin>` namespace.
- **`fluss-fs-azure` / `cos` / `obs` / `oss`** — relocate netty, excluding `io.netty.internal.tcnative`.
- **`fluss-lake-iceberg`** — relocate `commons-compress`, `commons-lang3`, `commons-pool`.
- **`fluss-lake-lance`** — relocate jackson, `commons-codec`, `commons-lang3`.
- **`tools/ci/check_shaded_jars.py`** — new checker; there is currently no jar shading verification anywhere in the repo or CI, which is why these accumulated.
- **`website/community/dev/building.md`** — document the two rules that make a relocation correct, and how to run the checker.

### Two constraints the patterns follow

**Name the packages the jar bundles, not their prefix.** The shade plugin rewrites *every* reference matching a pattern, including references to classes the jar does not contain, turning a soft dependency into a coordinate nothing can provide. A broad `org.apache.commons` in `fluss-fs-hadoop-shaded` produced:

```
java.lang.NoClassDefFoundError: org/apache/fluss/shaded/org/apache/commons/cli/ParseException
    at org.apache.hadoop.hdfs.server.namenode.NameNode.createNameNode(NameNode.java:1713)
```

**Leave packages bound to native code alone.** JNI symbols embed the Java package name:

```
$ nm -gU libarrow_cdata_jni.dylib | grep Java_org_apache_arrow
Java_org_apache_arrow_c_jni_JniWrapper_exportArray
```

So `org.apache.arrow` in `fluss-lake-lance` is deliberately not relocated, and `io.netty.internal.tcnative` is excluded from the netty relocation — verified in the built jar as 0 references to a shaded tcnative and 73 to the original.

### Tests

Full clean build of every module on `main` and on this branch, then `tools/ci/check_shaded_jars.py` over all 43 produced jars. Full output for both runs: https://gist.github.com/binary-signal/200be0c79785a3fde84d119dc8b8a66b

Leaked classes by package:

| package | before | after | delta |
| --- | ---: | ---: | ---: |
| `org/apache/commons` | 17489 | 0 | **−17489** |
| `com/google/common` | 15803 | 1954 | **−13849** |
| `com/fasterxml` | 8616 | 1247 | **−7369** |
| `io/netty` | 7432 | 640 | **−6792** |
| `org/codehaus` | 1555 | 124 | **−1431** |
| `com/ctc` | 1230 | 205 | **−1025** |
| `com/google/re2j` | 282 | 47 | **−235** |
| `org/apache/arrow` | 941 | 941 | 0 |
| **total** | **53348** | **5158** | **−48190** |

17 jars carry fewer leaked classes.

### Why the report still lists 18 failing jars

The AFTER run still shows 18 jars failing on `10 unshaded entries at META-INF/versions/*/com/fasterxml/`, and `fluss-fs-s3` still failing on base-path jackson. **Neither is a regression, and neither is fixable from this PR.**

Those 18 jars are not 18 separate problems. They are one bug — #3553 — visible in 18 places, and its fix is the single `<exclude>` line in **PR #3884**:

```diff
+++ b/pom.xml
+    <exclude>META-INF/versions/**/com/fasterxml/**</exclude>
```

Because that goes in the *root* pom under `<filters combine.children="append">`, it cascades to every module at once. Adding it here would mean shipping another contributor's change and conflicting with their PR on the same file, so this branch leaves it alone.

The same applies to `fluss-fs-s3`, whose base-path leak is #4072, fixed by **PR #4073**.

The three changes are complementary, and I verified that by measurement rather than assumption. Building this branch with #3884 and #4073 applied on top gives:

| fix | scope | clears |
| --- | --- | ---: |
| #3884 — one line, root pom | jackson MRJ entries | 18 jars, 197 entries |
| #4073 | `fluss-fs-s3` base path | 1 jar, 3380 classes |
| **this PR** | everything else | **17 jars, 48190 classes** |
| — | `fluss-lake-lance` arrow + netty | not fixable, see above |

The combined result is **1 failing jar and 42 clean**, the single failure being `fluss-lake-lance`'s deliberate arrow and netty. Restricting the comparison to the modules this PR actually touches, base-path jackson goes 7369 → 0 and commons 17489 → 0.

Unit tests pass for every module touched: 264 across the filesystem modules, 320 across `fluss-client` / `fluss-flink-1.20` / `fluss-spark-3.5`, 161 across the two lake modules.

<details>
<summary>Checker verdicts, before and after</summary>

### BEFORE — on `main`

```
  FAIL fluss-client-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       1714 unshaded entries at org/apache/commons/ (base path)
  FAIL fluss-server-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-fs-azure-1.0-SNAPSHOT.jar
       1033 unshaded entries at com/fasterxml/ (base path)
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       794 unshaded entries at org/codehaus/ (base path)
       205 unshaded entries at com/ctc/ (base path)
       47 unshaded entries at com/google/re2j/ (base path)
       1954 unshaded entries at com/google/common/ (base path)
       1698 unshaded entries at io/netty/ (base path)
  FAIL fluss-fs-cos-1.0-SNAPSHOT.jar
       1033 unshaded entries at com/fasterxml/ (base path)
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       171 unshaded entries at org/codehaus/ (base path)
       205 unshaded entries at com/ctc/ (base path)
       47 unshaded entries at com/google/re2j/ (base path)
       1954 unshaded entries at com/google/common/ (base path)
       1698 unshaded entries at io/netty/ (base path)
  FAIL fluss-fs-gs-1.0-SNAPSHOT.jar
       1033 unshaded entries at com/fasterxml/ (base path)
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       124 unshaded entries at org/codehaus/ (base path)
       205 unshaded entries at com/ctc/ (base path)
       47 unshaded entries at com/google/re2j/ (base path)
       2125 unshaded entries at com/google/common/ (base path)
  FAIL fluss-fs-hadoop-shaded-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       2228 unshaded entries at org/apache/commons/ (base path)
       1954 unshaded entries at com/google/common/ (base path)
  FAIL fluss-fs-hdfs-1.0-SNAPSHOT.jar
       1033 unshaded entries at com/fasterxml/ (base path)
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       1954 unshaded entries at com/google/common/ (base path)
  FAIL fluss-fs-obs-1.0-SNAPSHOT.jar
       1113 unshaded entries at com/fasterxml/ (base path)
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       171 unshaded entries at org/codehaus/ (base path)
       205 unshaded entries at com/ctc/ (base path)
       47 unshaded entries at com/google/re2j/ (base path)
       1954 unshaded entries at com/google/common/ (base path)
       1698 unshaded entries at io/netty/ (base path)
  FAIL fluss-fs-oss-1.0-SNAPSHOT.jar
       1033 unshaded entries at com/fasterxml/ (base path)
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       171 unshaded entries at org/codehaus/ (base path)
       205 unshaded entries at com/ctc/ (base path)
       47 unshaded entries at com/google/re2j/ (base path)
       1954 unshaded entries at com/google/common/ (base path)
       1698 unshaded entries at io/netty/ (base path)
  FAIL fluss-fs-s3-1.0-SNAPSHOT.jar
       1050 unshaded entries at com/fasterxml/ (base path)
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       124 unshaded entries at org/codehaus/ (base path)
       205 unshaded entries at com/ctc/ (base path)
       47 unshaded entries at com/google/re2j/ (base path)
       1954 unshaded entries at com/google/common/ (base path)
  FAIL fluss-flink-1.18-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       1714 unshaded entries at org/apache/commons/ (base path)
  FAIL fluss-flink-1.19-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       1714 unshaded entries at org/apache/commons/ (base path)
  FAIL fluss-flink-1.20-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       1714 unshaded entries at org/apache/commons/ (base path)
  FAIL fluss-flink-2.2-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       1714 unshaded entries at org/apache/commons/ (base path)
  FAIL fluss-flink-2.3-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       1714 unshaded entries at org/apache/commons/ (base path)
  FAIL fluss-lake-iceberg-1.0-SNAPSHOT.jar
       7 unshaded entries at META-INF/versions/*/com/fasterxml/
       1030 unshaded entries at org/apache/commons/ (base path)
  FAIL fluss-lake-lance-1.0-SNAPSHOT.jar
       1091 unshaded entries at com/fasterxml/ (base path)
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       519 unshaded entries at org/apache/commons/ (base path)
       640 unshaded entries at io/netty/ (base path)
       941 unshaded entries at org/apache/arrow/ (base path)
  FAIL fluss-metrics-influxdb-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-spark-3.4_2.12-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       1714 unshaded entries at org/apache/commons/ (base path)
  FAIL fluss-spark-3.5_2.12-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       1714 unshaded entries at org/apache/commons/ (base path)
```

### AFTER — on this branch

```
  FAIL fluss-client-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-server-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-fs-azure-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-fs-cos-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-fs-gs-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-fs-hadoop-shaded-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-fs-hdfs-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-fs-obs-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-fs-oss-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-fs-s3-1.0-SNAPSHOT.jar
       1050 unshaded entries at com/fasterxml/ (base path)
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       124 unshaded entries at org/codehaus/ (base path)
       205 unshaded entries at com/ctc/ (base path)
       47 unshaded entries at com/google/re2j/ (base path)
       1954 unshaded entries at com/google/common/ (base path)
  FAIL fluss-flink-1.18-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-flink-1.19-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-flink-1.20-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-flink-2.2-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-flink-2.3-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-lake-iceberg-1.0-SNAPSHOT.jar
       7 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-lake-lance-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
       640 unshaded entries at io/netty/ (base path)
       941 unshaded entries at org/apache/arrow/ (base path)
  FAIL fluss-metrics-influxdb-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-spark-3.4_2.12-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
  FAIL fluss-spark-3.5_2.12-1.0-SNAPSHOT.jar
       10 unshaded entries at META-INF/versions/*/com/fasterxml/
```

</details>

### API and Format

No API or storage format changes. Only the internal shading layout of the affected uber-jars changes.

### Documentation

`website/community/dev/building.md` gains a "Shaded dependencies" section covering the relocation rules and the checker.


  - **Generative AI disclosure:** 
    - [x ] Yes (Claude Opus 5) and reviewed by a human
