### PR TITLE
[rust] Return error for invalid table metadata JSON

### DIFF
--- a/fluss-rust/crates/fluss/src/client/admin.rs
+++ b/fluss-rust/crates/fluss/src/client/admin.rs
@@ -50,6 +50,13 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 
+fn parse_table_descriptor(bytes: &[u8]) -> Result<TableDescriptor> {
+    let node = serde_json::from_slice(bytes).map_err(|e| Error::JsonSerdeError {
+        message: format!("Failed to parse table_json: {e}"),
+    })?;
+    TableDescriptor::deserialize_json(&node)
+}
+
 pub struct FlussAdmin {
     metadata: Arc<Metadata>,
     rpc_client: Arc<RpcClient>,
@@ -165,9 +172,7 @@ impl FlussAdmin {
             modified_time,
             ..
         } = response;
-        let v: &[u8] = &table_json[..];
-        let table_descriptor =
-            TableDescriptor::deserialize_json(&serde_json::from_slice(v).unwrap())?;
+        let table_descriptor = parse_table_descriptor(&table_json)?;
         Ok(TableInfo::of(
             table_path.clone(),
             table_id,
@@ -879,5 +884,22 @@ impl FlussAdmin {
             .request(DropKvSnapshotLeaseRequest::new(lease_id))
             .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_table_descriptor;
+    use crate::error::Error;
+
+    #[test]
+    fn test_parse_table_descriptor_rejects_malformed_json() {
+        let error = parse_table_descriptor(b"{not valid json").unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::JsonSerdeError { message }
+                if message.starts_with("Failed to parse table_json:")
+        ));
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: closes #4145

`FlussAdmin::get_table_info()` currently uses `unwrap()` when parsing the `table_json` returned by the coordinator. A malformed response therefore causes the Rust client to panic instead of returning an error.

This PR makes the parsing failure return `Error::JsonSerdeError`, consistent with the error handling in `FlussAdmin::get_table_schema()`.

### Brief change log

- Add a private helper for parsing `table_json` into a `TableDescriptor`.

### Tests

Added unit test:

- `client::admin::tests::test_parse_table_descriptor_rejects_malformed_json`

### API and Format

No.

### Documentation

No.