### PR TITLE
[coordinator] Withhold leader from UpdateMetadataRequest until NotifyLeaderAndIsr is acked

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorContext.java
@@ -260,7 +260,13 @@ public class CoordinatorContext {
         return offlineReplicas;
     }
 
-    // ---- Pending leader activation tracking (for Cluster Health API) ----
+    // ---- Pending leader activation tracking ----
+    // Also gates leader visibility in UpdateMetadataRequest (see
+    // CoordinatorRequestBatch#addUpdateMetadataRequestForTabletServers): a bucket must not be
+    // advertised to clients as having an active leader until the target tablet server has
+    // actually admitted the replica (NotifyLeaderAndIsrRequest acked), otherwise a client can
+    // observe "server N is leader" before server N's own ReplicaManager agrees, and any request
+    // sent to server N in that window is rejected with NotLeaderOrFollowerException.
 
     public void addPendingLeaderActivation(TableBucket bucket) {
         pendingLeaderActivationBuckets.add(bucket);
@@ -272,6 +278,10 @@ public class CoordinatorContext {
 
     public void clearPendingLeaderActivation(TableBucket bucket) {
         pendingLeaderActivationBuckets.remove(bucket);
+    }
+
+    public boolean isPendingLeaderActivation(TableBucket bucket) {
+        return pendingLeaderActivationBuckets.contains(bucket);
     }
 
     /**

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -1199,11 +1199,36 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 succeededBuckets.add(notifyLeaderAndIsrResultForBucket.getTableBucket());
             }
         }
+        Set<TableBucket> reactivatedBuckets = new HashSet<>();
         for (TableBucket tb : succeededBuckets) {
             Optional<LeaderAndIsr> laiOpt = coordinatorContext.getBucketLeaderAndIsr(tb);
             if (laiOpt.isPresent() && laiOpt.get().leader() == serverId) {
                 coordinatorContext.clearPendingLeaderActivation(tb);
+                reactivatedBuckets.add(tb);
             }
+        }
+        if (!reactivatedBuckets.isEmpty()) {
+            // The earlier UpdateMetadataRequest that accompanied this NotifyLeaderAndIsrRequest
+            // withheld these buckets' leader (see
+            // CoordinatorRequestBatch#addUpdateMetadataRequestForTabletServers) because activation
+            // was still pending. Now that server N has acked the replica as Online, push a
+            // follow-up UpdateMetadataRequest so clients see the real leader without having to
+            // wait for some unrelated cluster event to trigger the next broadcast.
+            updateTabletServerMetadataCache(
+                    new HashSet<>(coordinatorContext.getLiveTabletServers().values()),
+                    null,
+                    null,
+                    reactivatedBuckets);
+        }
+        // A bucket whose NotifyLeaderAndIsrRequest came back with a per-bucket error (e.g. fenced
+        // epoch) never reaches the succeededBuckets branch above, so its pending-activation mark
+        // would otherwise never be cleared here. onReplicaBecomeOffline below re-elects a leader
+        // via TableBucketStateMachine, which does not go through
+        // CoordinatorRequestBatch#sendNotifyLeaderAndIsrRequest and therefore never re-marks the
+        // bucket as pending either — so a stale mark left in place would permanently withhold this
+        // bucket's leader from UpdateMetadataRequest even after a successful re-election.
+        for (TableBucketReplica offlineReplica : offlineReplicas) {
+            coordinatorContext.clearPendingLeaderActivation(offlineReplica.getTableBucket());
         }
         if (!offlineReplicas.isEmpty()) {
             // trigger replicas to offline

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatch.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatch.java
@@ -35,7 +35,6 @@ import org.apache.fluss.rpc.messages.PbStopReplicaRespForBucket;
 import org.apache.fluss.rpc.messages.StopReplicaRequest;
 import org.apache.fluss.rpc.messages.UpdateMetadataRequest;
 import org.apache.fluss.rpc.protocol.ApiError;
-import org.apache.fluss.server.coordinator.event.AccessContextEvent;
 import org.apache.fluss.server.coordinator.event.DeleteReplicaResponseReceivedEvent;
 import org.apache.fluss.server.coordinator.event.EventManager;
 import org.apache.fluss.server.coordinator.event.NotifyLeaderAndIsrResponseReceivedEvent;
@@ -311,6 +310,23 @@ public class CoordinatorRequestBatch {
                         .put(partitionId, Collections.emptyList());
             } else {
                 // case3, case4, case10, case 11
+                // If this table already has non-empty bucket data queued in the same batch
+                // (added via the tableId==null branch below), this put() silently discards it
+                // since it's a plain Map.put overwrite, not a merge. Only known to happen during
+                // coordinator's own startup batch; log it so a real occurrence is not silent.
+                List<BucketMetadata> existingBucketData =
+                        updateMetadataRequestBucketMap.get(tableId);
+                if (existingBucketData != null && !existingBucketData.isEmpty()) {
+                    LOG.warn(
+                            "Discarding {} already-queued bucket entries for tableId={} in favor "
+                                    + "of an empty bucket list from the same UpdateMetadataRequest "
+                                    + "batch; buckets discarded: {}",
+                            existingBucketData.size(),
+                            tableId,
+                            existingBucketData.stream()
+                                    .map(BucketMetadata::getBucketId)
+                                    .collect(Collectors.toList()));
+                }
                 updateMetadataRequestBucketMap.put(tableId, Collections.emptyList());
             }
         } else {
@@ -323,7 +339,19 @@ public class CoordinatorRequestBatch {
                         coordinatorContext.getBucketLeaderAndIsr(tableBucket);
                 Integer leaderEpoch =
                         bucketLeaderAndIsr.map(LeaderAndIsr::leaderEpoch).orElse(null);
-                Integer leader = bucketLeaderAndIsr.map(LeaderAndIsr::leader).orElse(null);
+                // Withhold the leader from clients until the target tablet server has actually
+                // activated the replica (i.e. processed its NotifyLeaderAndIsrRequest and moved
+                // the local replica from NoneReplica to OnlineReplica). sendRequestToTabletServers
+                // sends NotifyLeaderAndIsrRequest (which populates pendingLeaderActivationBuckets)
+                // strictly before UpdateMetadataRequest, so this check always sees the bucket as
+                // pending for the very same activation round that this metadata push accompanies.
+                // Without this, a client can learn "server N is leader for bucket X" from metadata
+                // before server N's own ReplicaManager has admitted the replica, and any fetchLog
+                // sent to server N in that window is rejected with NotLeaderOrFollowerException.
+                Integer leader =
+                        coordinatorContext.isPendingLeaderActivation(tableBucket)
+                                ? null
+                                : bucketLeaderAndIsr.map(LeaderAndIsr::leader).orElse(null);
                 if (currentPartitionId == null) {
                     Map<Integer, List<Integer>> tableAssignment =
                             coordinatorContext.getTableAssignment(currentTableId);
@@ -416,15 +444,11 @@ public class CoordinatorRequestBatch {
                     makeNotifyLeaderAndIsrRequest(
                             coordinatorEpoch, notifyRequestEntry.getValue().values());
 
-            // Track exactly which buckets THIS request marked as pending leader activation. Only
-            // those entries (where leader == serverId) need to be cleared if the request fails
-            Set<TableBucket> addedToPendingLeaderActivation = new HashSet<>();
             for (Map.Entry<TableBucket, PbNotifyLeaderAndIsrReqForBucket> entry :
                     notifyRequestEntry.getValue().entrySet()) {
                 int leader = entry.getValue().getLeader();
                 if (leader == serverId) {
                     coordinatorContext.addPendingLeaderActivation(entry.getKey());
-                    addedToPendingLeaderActivation.add(entry.getKey());
                 }
             }
 
@@ -444,20 +468,23 @@ public class CoordinatorRequestBatch {
                             // replica in the tablet server as offline. so, in here, if encounter
                             // any error, we just ignore it.
 
-                            // Clear pending state so the health API does not report stale
-                            // RED. The coordinator will detect actual server death via
-                            // heartbeat timeout and trigger re-election separately.
-                            if (!addedToPendingLeaderActivation.isEmpty()) {
-                                eventManager.put(
-                                        new AccessContextEvent<Void>(
-                                                ctx -> {
-                                                    for (TableBucket tb :
-                                                            addedToPendingLeaderActivation) {
-                                                        ctx.clearPendingLeaderActivation(tb);
-                                                    }
-                                                    return null;
-                                                }));
-                            }
+                            // Deliberately leave pendingLeaderActivationBuckets untouched here.
+                            // This request never reached serverId (or its response never came
+                            // back), so serverId's own ReplicaManager has NOT admitted these
+                            // replicas. Clearing the pending mark here would let
+                            // addUpdateMetadataRequestForTabletServers advertise serverId as
+                            // leader to clients despite serverId itself still treating the bucket
+                            // as NoneReplica, reproducing the exact race this mechanism exists to
+                            // prevent: a client could learn "serverId is leader" from metadata
+                            // before serverId's own ReplicaManager agrees, and any request sent to
+                            // serverId in that window would be rejected with
+                            // NotLeaderOrFollowerException until some unrelated coordinator event
+                            // happened to trigger the next broadcast. The mark is only cleared once
+                            // processNotifyLeaderAndIsrResponseReceivedEvent sees a real ack from
+                            // serverId, or once onReplicaBecomeOffline runs during
+                            // heartbeat-timeout-triggered re-election. A transient GetClusterHealth
+                            // RED during this window is expected and reflects genuine uncertainty,
+                            // not a bug.
                             return;
                         }
                         // put the response receive event into the event manager

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatchTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/CoordinatorRequestBatchTest.java
@@ -23,7 +23,6 @@ import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.rpc.messages.NotifyLeaderAndIsrRequest;
 import org.apache.fluss.rpc.messages.NotifyLeaderAndIsrResponse;
-import org.apache.fluss.server.coordinator.event.AccessContextEvent;
 import org.apache.fluss.server.coordinator.event.EventManager;
 import org.apache.fluss.server.zk.ZkEpoch;
 import org.apache.fluss.server.zk.data.LeaderAndIsr;
@@ -49,11 +48,18 @@ class CoordinatorRequestBatchTest {
 
     /**
      * When the NotifyLeaderAndIsr request to the actual leader (leader == serverId) fails, the
-     * pending leader activation entry that this request added must be cleared via an
-     * AccessContextEvent dispatched on the event manager.
+     * pending leader activation entry that this request added must be LEFT IN PLACE. The request
+     * never reached serverId (or its response never came back), so serverId's own ReplicaManager
+     * has not admitted the replica; clearing the mark here would let
+     * addUpdateMetadataRequestForTabletServers advertise serverId as leader to clients despite
+     * serverId itself still treating the bucket as NoneReplica (observed in production 2026-08-29:
+     * rolling-restart RPC failures cleared pending state early and NotLeaderOrFollowerException
+     * kept recurring for ~20min). The mark is only cleared by a real ack in
+     * processNotifyLeaderAndIsrResponseReceivedEvent, or by onReplicaBecomeOffline during
+     * heartbeat-timeout-triggered re-election.
      */
     @Test
-    void testNotifyLeaderAndIsrSendFailureClearsLeaderPending() {
+    void testNotifyLeaderAndIsrSendFailureLeavesLeaderPending() {
         long tableId = 100L;
         TableBucket tb = new TableBucket(tableId, 0);
         TablePath tablePath = TablePath.of("db1", "t1");
@@ -67,7 +73,7 @@ class CoordinatorRequestBatchTest {
         coordinatorContext.putBucketLeaderAndIsr(tb, leaderAndIsr);
 
         TestCoordinatorChannelManager failingChannel = newAlwaysFailingChannelManager();
-        EventManager eventManager = newSynchronousAccessContextEventManager();
+        EventManager eventManager = newNoopEventManager();
 
         CoordinatorRequestBatch batch =
                 new CoordinatorRequestBatch(failingChannel, eventManager, coordinatorContext);
@@ -81,13 +87,13 @@ class CoordinatorRequestBatchTest {
 
         batch.sendRequestToTabletServers(0);
 
-        // The failure callback must clear the pending entry that this request added.
-        assertThat(coordinatorContext.getPendingLeaderActivationBuckets()).isEmpty();
+        // The failure callback must leave the pending entry untouched.
+        assertThat(coordinatorContext.getPendingLeaderActivationBuckets()).containsExactly(tb);
     }
 
     /**
      * When the NotifyLeaderAndIsr request to a follower (leader != serverId) fails, the failure
-     * callback must NOT clear any pending leader activation entry. Specifically, it must not remove
+     * callback must NOT touch any pending leader activation entry. Specifically, it must not remove
      * entries added by another in-flight sender targeting the actual leader.
      */
     @Test
@@ -111,13 +117,13 @@ class CoordinatorRequestBatchTest {
         coordinatorContext.addPendingLeaderActivation(otherLeaderTb);
 
         TestCoordinatorChannelManager failingChannel = newAlwaysFailingChannelManager();
-        EventManager eventManager = newSynchronousAccessContextEventManager();
+        EventManager eventManager = newNoopEventManager();
 
         CoordinatorRequestBatch batch =
                 new CoordinatorRequestBatch(failingChannel, eventManager, coordinatorContext);
         // Send to server 1, which is a follower for followerTb (leader is 0). Because
         // leader != serverId, this request does NOT add followerTb to pending, so the failure
-        // callback must short-circuit without dispatching an AccessContextEvent.
+        // callback must be a pure no-op.
         batch.addNotifyLeaderRequestForTabletServers(
                 Collections.singleton(1),
                 PhysicalTablePath.of(tablePath),
@@ -146,15 +152,11 @@ class CoordinatorRequestBatchTest {
     }
 
     /**
-     * Returns an EventManager that synchronously executes {@link AccessContextEvent}s against the
-     * test's CoordinatorContext, mimicking the serial event-thread semantics.
+     * Returns an EventManager that drops every event. The failure callback under test no longer
+     * dispatches anything (see {@link CoordinatorRequestBatch#sendNotifyLeaderAndIsrRequest}), so
+     * these tests only need a valid EventManager instance to construct the batch.
      */
-    private EventManager newSynchronousAccessContextEventManager() {
-        return event -> {
-            if (event instanceof AccessContextEvent) {
-                AccessContextEvent<?> accessContextEvent = (AccessContextEvent<?>) event;
-                accessContextEvent.getAccessFunction().apply(coordinatorContext);
-            }
-        };
+    private EventManager newNoopEventManager() {
+        return event -> {};
     }
 }


### PR DESCRIPTION
<!--
Generated-by: Claude Code (Sonnet) following the guidelines at https://github.com/apache/fluss/blob/main/AGENTS.md
-->

### Purpose

Linked issue: close #4149

The coordinator maintains two independently-updated views of replica state: `TabletServerMetadataCache` (pushed via `UpdateMetadataRequest`, determines what leader info clients see) and `ReplicaManager.allReplicas` (activated via `NotifyLeaderAndIsrRequest`, determines whether a tablet server can actually serve `fetchLog`/`putKv` for a bucket). These are sent as two separate RPCs (`CoordinatorRequestBatch#sendRequestToTabletServers`) with no atomicity guarantee between them.

Under normal conditions the window between "coordinator decided who the leader is" and "the target tablet server has admitted the replica" is milliseconds and rarely observable. For large tables, however, a restarting tablet server can take minutes to complete local log recovery before it processes `NotifyLeaderAndIsrRequest`, while `UpdateMetadataRequest` can be broadcast well before that (e.g. via `CoordinatorEventProcessor#processNewTabletServer` when the server re-registers). A client that picks up the new leader from metadata during this window sends requests to a server whose `ReplicaManager` still treats the bucket as `NoneReplica`, and is rejected with `NotLeaderOrFollowerException`/`LeaderNotAvailableException` in a tight retry loop until the server finally catches up (observed: single-digit minutes to over ten minutes for a large 12-bucket table). See #4149 for full details and reproduction steps.

### Brief change log

- `CoordinatorContext`: expose `isPendingLeaderActivation(TableBucket)` on the existing (previously read-only, health-API-only) `pendingLeaderActivationBuckets` tracking.
- `CoordinatorRequestBatch#addUpdateMetadataRequestForTabletServers`: withhold a bucket's leader from `UpdateMetadataRequest` for as long as `isPendingLeaderActivation` is true. `sendNotifyLeaderAndIsrRequest` already runs strictly before `sendUpdateMetadataRequest` in the same batch, so the pending mark set for an activation round is always visible to the accompanying metadata push.
- `CoordinatorEventProcessor#processNotifyLeaderAndIsrResponseReceivedEvent`: when a pending bucket's activation is genuinely acknowledged, clear the mark and proactively push a follow-up `UpdateMetadataRequest` (rather than waiting for some unrelated coordinator event to trigger the next broadcast). Also clear the mark for buckets that go offline via `onReplicaBecomeOffline`, since a bucket whose `NotifyLeaderAndIsrRequest` comes back with a per-bucket error never reaches the ack path and would otherwise be stuck pending forever, permanently withholding its leader even after a successful re-election.
- `CoordinatorRequestBatch#sendNotifyLeaderAndIsrRequest`: on RPC send failure, deliberately leave the pending mark untouched (see "Notable subtlety" below).
- Also fixes an unrelated but adjacent plain `Map.put` overwrite in the same method (case3/4/10/11) that could silently discard already-queued non-empty bucket data for the same table within one `UpdateMetadataRequest` batch — now logged instead of silent.

**Notable subtlety:** an earlier iteration of this change also cleared the pending mark when the `NotifyLeaderAndIsrRequest` RPC itself failed to send (e.g. target server not yet reachable during a rolling restart), reasoning that this avoided a stale RED in the health API. That turned out to reintroduce the exact race being fixed here, just triggered by RPC failure instead of by slow log recovery: clearing the mark let the leader be advertised to clients while the target server's `ReplicaManager` had never actually admitted the replica. The current version keeps the mark untouched on send failure; a transient `GetClusterHealth` RED during this window is expected and reflects genuine uncertainty, not a bug.

### Tests

- `mvn -pl fluss-server -am test -Dtest='org.apache.fluss.server.coordinator.**'`: 352/353 passing. The sole unrelated failure (`CoordinatorServerITCase#testRunServerUsingProcess`) reproduces identically on an unmodified checkout and is a local-environment issue spawning a separate JVM process, not a regression from this change.
- `CoordinatorRequestBatchTest#testNotifyLeaderAndIsrSendFailureLeavesLeaderPending` (renamed/inverted from a prior version that asserted the opposite, now-incorrect, behavior): asserts the pending mark survives an RPC send failure.
- `CoordinatorRequestBatchTest#testNotifyLeaderAndIsrSendFailureToFollowerDoesNotClearOtherPending`: asserts a follower-send failure doesn't touch an unrelated bucket's pending mark.
- `CoordinatorEventProcessorTest` (existing `testSchemaChange`/`testTableRegistrationChange` etc.): exercise the proactive follow-up `UpdateMetadataRequest` push after a pending mark is cleared.
- Manually reproduced and verified against a real cluster: rolling-restarted three tablet servers hosting a large table (including one requiring ~11 minutes of local log recovery), with a client continuously reading from the affected buckets throughout. Before this fix, `NotLeaderOrFollowerException`/`LeaderNotAvailableException` recurred for minutes after all tablet servers reported ready. After this fix, the client's cumulative error count did not increase at all across the full rolling-restart window plus an additional 10-minute observation period.

### API and Format

No public API or on-disk/wire format change. Behavior change is purely in when a bucket's leader becomes visible via `UpdateMetadataRequest`/`metadata()` — it is delayed until the leader is actually able to serve requests, never advertised earlier than before.

### Documentation

No new user-facing feature; no documentation change needed.

### Generative AI disclosure

- [x] Yes (tool: Claude Code, Claude Sonnet model)

Root-cause investigation, code changes, and this PR/issue writeup were produced with Claude Code assistance. All changes were reviewed by a human, verified with the automated test suite, and independently validated against a live cluster (real rolling-restart reproduction described in the Tests section above) before submission.
