### PR TITLE
[rust] Avoid copying the Arrow payload when decoding a batch

### DIFF
--- a/fluss-rust/crates/fluss/src/record/arrow.rs
+++ b/fluss-rust/crates/fluss/src/record/arrow.rs
@@ -53,6 +53,7 @@ use super::log_record_batch::*;
 use crate::error::Error::IllegalArgument;
 use crate::record::statistics::{estimated_serialized_size, serialize_statistics};
 use arrow::ipc::writer::IpcWriteOptions;
+use bytes::Bytes;
 
 pub const BUILDER_DEFAULT_OFFSET: i64 = 0;
 
@@ -631,7 +632,7 @@ pub trait ToArrow {
 /// Returns `Err(arrow_error)` on errors
 /// - `arrow_error`: Error details e.g. malformed, too short or bad continuation marker.
 fn parse_ipc_message(
-    data: &[u8],
+    data: &Bytes,
 ) -> Result<(
     arrow::ipc::RecordBatch<'_>,
     Buffer,
@@ -668,8 +669,8 @@ fn parse_ipc_message(
 
     let metadata_padded_size = (metadata_size + 7) & !7;
     let body_start = 8 + metadata_padded_size;
-    let body_data = &data[body_start..];
-    let body_buffer = Buffer::from(body_data);
+    // Slicing the `Bytes` bumps a refcount; `Buffer::from(&[u8])` would copy.
+    let body_buffer = Buffer::from(data.slice(body_start..));
 
     Ok((batch_metadata, body_buffer, message.version()))
 }
@@ -1426,8 +1427,8 @@ impl ReadContext {
             .map(|p| p.ordered_fields.as_slice())
     }
 
-    pub fn record_batch(&self, data: &[u8]) -> Result<RecordBatch> {
-        let (batch_metadata, body_buffer, version) = parse_ipc_message(data)?;
+    pub(crate) fn record_batch(&self, data: Bytes) -> Result<RecordBatch> {
+        let (batch_metadata, body_buffer, version) = parse_ipc_message(&data)?;
 
         let resolve_schema = {
             // if from remote, no projection, need to use full schema
@@ -1495,8 +1496,8 @@ impl ReadContext {
         Ok(record_batch)
     }
 
-    pub fn record_batch_for_remote_log(&self, data: &[u8]) -> Result<Option<RecordBatch>> {
-        let (batch_metadata, body_buffer, version) = parse_ipc_message(data)?;
+    pub(crate) fn record_batch_for_remote_log(&self, data: Bytes) -> Result<Option<RecordBatch>> {
+        let (batch_metadata, body_buffer, version) = parse_ipc_message(&data)?;
 
         let record_batch = read_record_batch(
             &body_buffer,
@@ -2462,8 +2463,8 @@ mod tests {
 
     #[test]
     fn test_parse_ipc_message() {
-        let empty_body: &[u8] = &le_bytes(&[0xFFFFFFFF, 0x00000000]);
-        let result = parse_ipc_message(empty_body);
+        let empty_body = Bytes::from(le_bytes(&[0xFFFFFFFF, 0x00000000]));
+        let result = parse_ipc_message(&empty_body);
         assert_eq!(
             result.unwrap_err().to_string(),
             String::from(
@@ -2471,17 +2472,17 @@ mod tests {
             )
         );
 
-        let invalid_data = &[];
+        let invalid_data = Bytes::new();
         assert_eq!(
-            parse_ipc_message(invalid_data).unwrap_err().to_string(),
+            parse_ipc_message(&invalid_data).unwrap_err().to_string(),
             String::from(
                 "Fluss hitting Arrow error Parser error: Invalid data length: 0: ParseError(\"Invalid data length: 0\")."
             )
         );
 
-        let data_with_invalid_continuation: &[u8] = &le_bytes(&[0x00000001, 0x00000000]);
+        let data_with_invalid_continuation = Bytes::from(le_bytes(&[0x00000001, 0x00000000]));
         assert_eq!(
-            parse_ipc_message(data_with_invalid_continuation)
+            parse_ipc_message(&data_with_invalid_continuation)
                 .unwrap_err()
                 .to_string(),
             String::from(
@@ -2489,9 +2490,9 @@ mod tests {
             )
         );
 
-        let data_with_invalid_length: &[u8] = &le_bytes(&[0xFFFFFFFF, 0x00000001]);
+        let data_with_invalid_length = Bytes::from(le_bytes(&[0xFFFFFFFF, 0x00000001]));
         assert_eq!(
-            parse_ipc_message(data_with_invalid_length)
+            parse_ipc_message(&data_with_invalid_length)
                 .unwrap_err()
                 .to_string(),
             String::from(
@@ -2499,9 +2500,9 @@ mod tests {
             )
         );
 
-        let data_with_invalid_length = &le_bytes(&[0xFFFFFFFF, 0x00000004, 0x00000000]);
+        let data_with_invalid_length = Bytes::from(le_bytes(&[0xFFFFFFFF, 0x00000004, 0x00000000]));
         assert_eq!(
-            parse_ipc_message(data_with_invalid_length)
+            parse_ipc_message(&data_with_invalid_length)
                 .unwrap_err()
                 .to_string(),
             String::from(

--- a/fluss-rust/crates/fluss/src/record/log_record_batch.rs
+++ b/fluss-rust/crates/fluss/src/record/log_record_batch.rs
@@ -631,7 +631,7 @@ impl LogRecordBatch {
 
     /// Splits the batch body into its per-record change types and the trailing
     /// Arrow IPC payload (see [`APPEND_ONLY_FLAG_MASK`] for the layout).
-    fn decode_change_types(&self) -> Result<(BatchChangeTypes, &[u8])> {
+    fn decode_change_types(&self) -> Result<(BatchChangeTypes, Bytes)> {
         let records_offset = self.records_data_offset()?;
         let body = self
             .data
@@ -645,7 +645,10 @@ impl LogRecordBatch {
             })?;
 
         if self.is_append_only() {
-            return Ok((BatchChangeTypes::Uniform(ChangeType::AppendOnly), body));
+            return Ok((
+                BatchChangeTypes::Uniform(ChangeType::AppendOnly),
+                self.data.slice(records_offset..),
+            ));
         }
 
         let record_count = self.record_count();
@@ -656,7 +659,7 @@ impl LogRecordBatch {
             });
         }
         let record_count = record_count as usize;
-        let (change_type_bytes, arrow_data) =
+        let (change_type_bytes, _) =
             body.split_at_checked(record_count)
                 .ok_or_else(|| Error::UnexpectedError {
                     message: format!(
@@ -666,6 +669,7 @@ impl LogRecordBatch {
                     ),
                     source: None,
                 })?;
+        let arrow_data = self.data.slice(records_offset + record_count..);
 
         let mut change_types = Vec::with_capacity(record_count);
         for &byte in change_type_bytes {
@@ -1294,5 +1298,35 @@ mod tests {
             .err()
             .expect("a statistics length past the batch end must be rejected");
         assert!(err.to_string().contains("records offset"));
+    }
+    /// Changelog batches put a record_count-byte change-type vector before the
+    /// Arrow payload, so the payload's offset - and its alignment - shifts with
+    /// the record count. Decode every count from 1..=16 to cover each residue.
+    #[test]
+    fn decodes_changelog_at_every_payload_alignment() -> Result<()> {
+        for n in 1usize..=16 {
+            let rows: Vec<(i32, String)> = (0..n).map(|i| (i as i32, format!("v{i}"))).collect();
+            let row_refs: Vec<(i32, &str)> = rows.iter().map(|(i, s)| (*i, s.as_str())).collect();
+            let (row_type, append_only) = build_append_only_batch(&row_refs);
+            let change_types = vec![ChangeType::Insert; n];
+            let changelog = splice_change_type_vector(&append_only, &change_types);
+
+            let batch = LogRecordsBatches::new(changelog)
+                .next()
+                .expect("changelog batch")?;
+            let read_context =
+                ReadContext::new(to_arrow_schema(&row_type)?, Arc::new(row_type), false);
+
+            let decoded = batch.record_batch(&read_context)?;
+            assert_eq!(decoded.num_rows(), n, "row count for {n} records");
+
+            let ids: Vec<i32> = batch
+                .records(&read_context)?
+                .map(|r| r.row().get_int(0).expect("id"))
+                .collect();
+            let expected: Vec<i32> = (0..n as i32).collect();
+            assert_eq!(ids, expected, "values for {n} records");
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/4153

parse_ipc_message wraps the Arrow body with Buffer::from(&[u8]), which copies the payload. LogRecordBatch already holds the batch as Bytes, so slicing it gives the reader the same allocation for a refcount bump.

decode_change_types returns Bytes instead of a borrow, and record_batch/record_batch_for_remote_log take Bytes.