### PR TITLE
[lake/paimon] Prevent concurrent local lookup false misses

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuper.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuper.java
@@ -357,6 +357,10 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
             int bucket,
             org.apache.paimon.data.InternalRow key)
             throws IOException {
+        // TODO: Remove this lock once https://github.com/apache/paimon/issues/9483 is fixed in the
+        // Paimon version used by Fluss. If concurrent lookup is needed sooner, bring Paimon's
+        // LocalTableQuery implementation into Fluss and make it thread-safe, following the approach
+        // in https://github.com/apache/fluss/pull/4113.
         synchronized (paimonLookupLock) {
             return localTableQuery.lookup(partition, bucket, key);
         }

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuper.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuper.java
@@ -87,9 +87,8 @@ import static org.apache.fluss.utils.Preconditions.checkNotNull;
  * lookup I/O failure refreshes that partition-bucket with the files from the latest snapshot and
  * retries once.
  *
- * <p>Lookup concurrency is delegated to {@link LocalTableQuery}. Older Paimon versions may
- * serialize lookups internally, while Paimon 2.0 supports concurrent lookups without an additional
- * Fluss-level lock.
+ * <p>Calls to {@link LocalTableQuery#lookup} are serialized because Paimon 2.0 shares mutable
+ * lookup-store comparator state across local lookup files.
  *
  * <p>Close is expected only after the owner has drained active lookups. It is synchronized with
  * lazy initialization, but deliberately does not add a lifecycle lock to every lookup.
@@ -104,6 +103,7 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
     private final Runnable diskWriteGuard;
 
     private final ThreadLocal<Boolean> lookupFileDownloaded;
+    private final Object paimonLookupLock;
     private final Object initializationLock;
     private final Map<PaimonPartitionBucket, List<DataFileMeta>> registeredFiles;
 
@@ -137,6 +137,7 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
         this.lookupCacheMaxDiskBytes = lookupCacheMaxDiskBytes;
         this.diskWriteGuard = checkNotNull(diskWriteGuard, "diskWriteGuard must not be null.");
         this.lookupFileDownloaded = new ThreadLocal<>();
+        this.paimonLookupLock = new Object();
         this.initializationLock = new Object();
         this.registeredFiles = new ConcurrentHashMap<>();
     }
@@ -339,15 +340,25 @@ public class PaimonLakeTableLookuper implements LakeTableLookuper {
             throws IOException {
         List<DataFileMeta> filesBeforeLookup = initializeFiles(partition, bucket);
         try {
-            return localTableQuery.lookup(partition, bucket, key);
+            return lookupLocalTable(partition, bucket, key);
         } catch (IOException firstError) {
             refreshFilesIfUnchanged(partition, bucket, filesBeforeLookup);
             try {
-                return localTableQuery.lookup(partition, bucket, key);
+                return lookupLocalTable(partition, bucket, key);
             } catch (IOException retryError) {
                 retryError.addSuppressed(firstError);
                 throw retryError;
             }
+        }
+    }
+
+    private @Nullable org.apache.paimon.data.InternalRow lookupLocalTable(
+            org.apache.paimon.data.BinaryRow partition,
+            int bucket,
+            org.apache.paimon.data.InternalRow key)
+            throws IOException {
+        synchronized (paimonLookupLock) {
+            return localTableQuery.lookup(partition, bucket, key);
         }
     }
 

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuperTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/lookup/PaimonLakeTableLookuperTest.java
@@ -165,6 +165,73 @@ class PaimonLakeTableLookuperTest {
     }
 
     @Test
+    void testConcurrentFirstLookupsForDifferentPartitions() throws Exception {
+        TablePath tablePath = TablePath.of(DB, "concurrent_first_lookups");
+        Schema schema = pkSchema();
+        FileStoreTable table = createPaimonTable(tablePath, partitionedPkDescriptor(schema));
+        writeAndCommitData(
+                table,
+                Collections.singletonMap(
+                        0,
+                        Arrays.asList(
+                                paimonRow(1, "20240101", "Alice"),
+                                paimonRow(2, "20240102", "Bob"))));
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            // Recreate the local query so every attempt submits two cold-cache lookups together.
+            for (int attempt = 0; attempt < 10; attempt++) {
+                CountDownLatch downloadsStarted = new CountDownLatch(2);
+                Runnable diskWriteGuard =
+                        () -> {
+                            downloadsStarted.countDown();
+                            try {
+                                // Without Fluss-level serialization, both downloads reach this
+                                // guard and continue together, exercising Paimon's shared mutable
+                                // lookup-store comparator. With serialization, the short wait
+                                // expires and the downloads proceed one at a time.
+                                downloadsStarted.await(100, TimeUnit.MILLISECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new RuntimeException(e);
+                            }
+                        };
+
+                try (LakeTableLookuper lookuper =
+                        new PaimonLakeTableLookuper(
+                                paimonConfig,
+                                tablePath,
+                                tempWarehouseDir.getAbsolutePath(),
+                                tableConfig(KvFormat.COMPACTED),
+                                LOOKUP_CACHE_MAX_DISK_BYTES,
+                                diskWriteGuard)) {
+                    Future<byte[]> firstLookup =
+                            executor.submit(
+                                    () ->
+                                            lookuper.lookup(
+                                                    paimonKey(schema, 1, "20240101"),
+                                                    lookupContext(
+                                                            schema, "20240101", 0, SCHEMA_ID)));
+                    Future<byte[]> secondLookup =
+                            executor.submit(
+                                    () ->
+                                            lookuper.lookup(
+                                                    paimonKey(schema, 2, "20240102"),
+                                                    lookupContext(
+                                                            schema, "20240102", 0, SCHEMA_ID)));
+
+                    BinaryValue firstValue = decodeValue(firstLookup.get(), SCHEMA_ID, schema);
+                    BinaryValue secondValue = decodeValue(secondLookup.get(), SCHEMA_ID, schema);
+                    assertRow(firstValue.row, 1, "20240101", "Alice");
+                    assertRow(secondValue.row, 2, "20240102", "Bob");
+                }
+            }
+        } finally {
+            ExecutorUtils.gracefulShutdown(30, TimeUnit.SECONDS, executor);
+        }
+    }
+
+    @Test
     void testDiskWriteLockBlocksOnlyLookupFileDownloads() throws Exception {
         TablePath tablePath = TablePath.of(DB, "disk_write_lock");
         Schema schema = pkSchema();
@@ -434,22 +501,6 @@ class PaimonLakeTableLookuperTest {
         List<DataFileMeta> filesBeforeCompaction = dataFiles(table, partition, 0);
         assertThat(filesBeforeCompaction).hasSize(5);
 
-        AtomicBoolean blockDownloads = new AtomicBoolean();
-        CountDownLatch downloadStarted = new CountDownLatch(1);
-        CountDownLatch continueDownload = new CountDownLatch(1);
-        Runnable diskWriteGuard =
-                () -> {
-                    if (blockDownloads.get()) {
-                        downloadStarted.countDown();
-                        try {
-                            continueDownload.await();
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            throw new RuntimeException(e);
-                        }
-                    }
-                };
-
         try (LakeTableLookuper lookuper =
                 new PaimonLakeTableLookuper(
                         paimonConfig,
@@ -457,7 +508,7 @@ class PaimonLakeTableLookuperTest {
                         tempWarehouseDir.getAbsolutePath(),
                         tableConfig(KvFormat.COMPACTED),
                         LOOKUP_CACHE_MAX_DISK_BYTES,
-                        diskWriteGuard)) {
+                        NO_OP_DISK_WRITE_GUARD)) {
             assertThat(
                             lookuper.lookup(
                                     paimonKey(schema, 5, "20240101"),
@@ -513,34 +564,19 @@ class PaimonLakeTableLookuperTest {
                             SCHEMA_ID,
                             (lookupTimeNanos, lookupFileDownloaded) ->
                                     cachedLookupDownloads.add(lookupFileDownloaded));
-            ExecutorService executor = Executors.newFixedThreadPool(2);
-            blockDownloads.set(true);
-            try {
-                Future<byte[]> refreshedLookup =
-                        executor.submit(
-                                () ->
-                                        lookuper.lookup(
-                                                paimonKey(schema, 1, "20240101"),
-                                                refreshedContext));
-                assertThat(downloadStarted.await(30, TimeUnit.SECONDS)).isTrue();
+            BinaryValue refreshedValue =
+                    decodeValue(
+                            lookuper.lookup(paimonKey(schema, 1, "20240101"), refreshedContext),
+                            SCHEMA_ID,
+                            schema);
+            assertRow(refreshedValue.row, 1, "20240101", "name-1");
 
-                Future<byte[]> cachedLookup =
-                        executor.submit(
-                                () ->
-                                        lookuper.lookup(
-                                                paimonKey(schema, 6, "20240102"), cachedContext));
-                BinaryValue cachedValue =
-                        decodeValue(cachedLookup.get(30, TimeUnit.SECONDS), SCHEMA_ID, schema);
-                assertRow(cachedValue.row, 6, "20240102", "name-6");
-
-                continueDownload.countDown();
-                BinaryValue refreshedValue =
-                        decodeValue(refreshedLookup.get(30, TimeUnit.SECONDS), SCHEMA_ID, schema);
-                assertRow(refreshedValue.row, 1, "20240101", "name-1");
-            } finally {
-                continueDownload.countDown();
-                ExecutorUtils.gracefulShutdown(30, TimeUnit.SECONDS, executor);
-            }
+            BinaryValue cachedValue =
+                    decodeValue(
+                            lookuper.lookup(paimonKey(schema, 6, "20240102"), cachedContext),
+                            SCHEMA_ID,
+                            schema);
+            assertRow(cachedValue.row, 6, "20240102", "name-6");
 
             assertThat(refreshedLookupDownloads).containsExactly(true);
             assertThat(cachedLookupDownloads).containsExactly(false);


### PR DESCRIPTION
<!--
Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: [apache/paimon#9483](https://github.com/apache/paimon/issues/9483)

Paimon 2.0 allows lookups for different partition-buckets to run concurrently, but their local lookup-store readers share a comparator with mutable reader state. Concurrent lookups against different files can therefore return `null` for existing keys.

This PR adds a Fluss-side correctness workaround while the problem is addressed upstream. Calls to one `LocalTableQuery` are serialized, including the retry after refreshing stale files. Consequently, a cache hit waits while another lookup on the same table is downloading a local lookup file.

### Brief change log

- Serialize calls to `LocalTableQuery.lookup` with a dedicated per-lookuper lock.
- Add a regression test that submits cold-cache lookups for two different partitions concurrently.
- Update the compaction and snapshot-expiration test so it no longer assumes that a cache hit bypasses an in-progress lookup-file download.

### Tests

- `./mvnw -pl fluss-lake/fluss-lake-paimon -Dtest=PaimonLakeTableLookuperTest test`
  - 11 tests passed.
  - Checkstyle reported 0 violations.
  - Spotless check passed.
- `./mvnw install -DskipTests -pl fluss-lake/fluss-lake-paimon -am`

### API and Format

No API or storage format changes.

### Documentation

No documentation changes. This is a correctness workaround for an upstream concurrency issue.
