### PR TITLE
[metrics] Expire stale histogram samples

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/metrics/ScannerMetricGroup.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/metrics/ScannerMetricGroup.java
@@ -75,7 +75,8 @@ public class ScannerMetricGroup extends AbstractMetricGroup {
         bytesPerRequest =
                 histogram(
                         MetricNames.SCANNER_BYTES_PER_REQUEST,
-                        new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                        new DescriptiveStatisticsHistogram(
+                                WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
 
         gauge(MetricNames.SCANNER_TIME_MS_BETWEEN_POLL, () -> timeMsBetweenPoll);
         gauge(MetricNames.SCANNER_LAST_POLL_SECONDS_AGO, this::lastPollSecondsAgo);

--- a/fluss-client/src/main/java/org/apache/fluss/client/metrics/WriterMetricGroup.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/metrics/WriterMetricGroup.java
@@ -87,11 +87,13 @@ public class WriterMetricGroup extends AbstractMetricGroup {
         bytesPerBatch =
                 histogram(
                         MetricNames.WRITER_BYTES_PER_BATCH,
-                        new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                        new DescriptiveStatisticsHistogram(
+                                WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
         recordPerBatch =
                 histogram(
                         MetricNames.WRITER_RECORDS_PER_BATCH,
-                        new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                        new DescriptiveStatisticsHistogram(
+                                WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
     }
 
     public void setBatchQueueTimeMs(long batchQueueTimeMs) {

--- a/fluss-common/src/main/java/org/apache/fluss/metrics/DescriptiveStatisticsHistogram.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/DescriptiveStatisticsHistogram.java
@@ -17,7 +17,13 @@
 
 package org.apache.fluss.metrics;
 
+import org.apache.fluss.annotation.VisibleForTesting;
+import org.apache.fluss.utils.clock.Clock;
+import org.apache.fluss.utils.clock.SystemClock;
+
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+
+import java.time.Duration;
 
 /**
  * The {@link DescriptiveStatisticsHistogram} use a DescriptiveStatistics {@link
@@ -25,10 +31,31 @@ import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
  */
 public class DescriptiveStatisticsHistogram implements Histogram {
 
+    /** Default maximum age for samples collected by Fluss metric groups. */
+    public static final Duration DEFAULT_MAX_AGE = Duration.ofMinutes(5);
+
     private final CircularDoubleArray descriptiveStatistics;
 
     public DescriptiveStatisticsHistogram(int windowSize) {
         this.descriptiveStatistics = new CircularDoubleArray(windowSize);
+    }
+
+    /**
+     * Creates a histogram that retains samples for at most the given age.
+     *
+     * @param windowSize maximum number of retained samples
+     * @param maxAge maximum age of retained samples
+     */
+    public DescriptiveStatisticsHistogram(int windowSize, Duration maxAge) {
+        this(windowSize, maxAge, SystemClock.getInstance());
+    }
+
+    @VisibleForTesting
+    DescriptiveStatisticsHistogram(int windowSize, Duration maxAge, Clock clock) {
+        if (maxAge.isZero() || maxAge.isNegative() || maxAge.toMillis() == 0) {
+            throw new IllegalArgumentException("Maximum sample age must be positive.");
+        }
+        this.descriptiveStatistics = new CircularDoubleArray(windowSize, maxAge.toMillis(), clock);
     }
 
     @Override
@@ -49,16 +76,29 @@ public class DescriptiveStatisticsHistogram implements Histogram {
     /** Fixed-size array that wraps around at the end and has a dynamic start position. */
     static class CircularDoubleArray {
         private final double[] backingArray;
+        private final long[] timestamps;
+        private final long maxAgeMillis;
+        private final Clock clock;
         private int nextPos = 0;
         private boolean fullSize = false;
         private long elementsSeen = 0;
 
         CircularDoubleArray(int windowSize) {
+            this(windowSize, Long.MAX_VALUE, SystemClock.getInstance());
+        }
+
+        CircularDoubleArray(int windowSize, long maxAgeMillis, Clock clock) {
             this.backingArray = new double[windowSize];
+            this.timestamps = new long[windowSize];
+            this.maxAgeMillis = maxAgeMillis;
+            this.clock = clock;
         }
 
         synchronized void addValue(double value) {
+            long now = clock.milliseconds();
+            evictExpired(now);
             backingArray[nextPos] = value;
+            timestamps[nextPos] = now;
             ++elementsSeen;
             ++nextPos;
             if (nextPos == backingArray.length) {
@@ -68,10 +108,32 @@ public class DescriptiveStatisticsHistogram implements Histogram {
         }
 
         synchronized double[] toUnsortedArray() {
-            final int size = getSize();
-            double[] result = new double[size];
+            evictExpired(clock.milliseconds());
+            double[] result = new double[getSize()];
             System.arraycopy(backingArray, 0, result, 0, result.length);
             return result;
+        }
+
+        private void evictExpired(long now) {
+            int size = getSize();
+            int activeSize = 0;
+            boolean expired = false;
+            for (int i = 0; i < size; i++) {
+                if (now - timestamps[i] < maxAgeMillis) {
+                    backingArray[activeSize] = backingArray[i];
+                    timestamps[activeSize++] = timestamps[i];
+                } else {
+                    expired = true;
+                }
+            }
+            if (!expired) {
+                return;
+            }
+            nextPos = activeSize;
+            fullSize = activeSize == backingArray.length;
+            if (fullSize) {
+                nextPos = 0;
+            }
         }
 
         private synchronized int getSize() {

--- a/fluss-common/src/test/java/org/apache/fluss/metrics/DescriptiveStatisticsHistogramTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/metrics/DescriptiveStatisticsHistogramTest.java
@@ -17,8 +17,12 @@
 
 package org.apache.fluss.metrics;
 
+import org.apache.fluss.utils.clock.ManualClock;
+
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
@@ -48,6 +52,29 @@ class DescriptiveStatisticsHistogramTest {
 
         final DescriptiveStatisticsHistogramStatistics.CommonMetricsSnapshot copy = original.copy();
         assertOperations(copy);
+    }
+
+    @Test
+    void testExpiredSamplesAreRemovedWhenStatisticsAreCollected() {
+        ManualClock clock = new ManualClock();
+        DescriptiveStatisticsHistogram histogram =
+                new DescriptiveStatisticsHistogram(10, Duration.ofMinutes(5), clock);
+
+        histogram.update(100);
+        histogram.update(200);
+
+        assertThat(histogram.getStatistics().getValues()).containsExactly(100, 200);
+        assertThat(histogram.getCount()).isEqualTo(2);
+
+        clock.advanceTime(Duration.ofMinutes(5));
+
+        assertThat(histogram.getStatistics().size()).isZero();
+        assertThat(histogram.getCount()).isEqualTo(2);
+
+        histogram.update(10);
+
+        assertThat(histogram.getStatistics().getValues()).containsExactly(10);
+        assertThat(histogram.getCount()).isEqualTo(3);
     }
 
     private static void assertOperations(

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/RequestsMetrics.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/server/RequestsMetrics.java
@@ -148,23 +148,28 @@ public class RequestsMetrics {
             requestBytes =
                     metricGroup.histogram(
                             MetricNames.REQUEST_BYTES,
-                            new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                            new DescriptiveStatisticsHistogram(
+                                    WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
             requestQueueTimeMs =
                     metricGroup.histogram(
                             MetricNames.REQUEST_QUEUE_TIME_MS,
-                            new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                            new DescriptiveStatisticsHistogram(
+                                    WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
             requestProcessTimeMs =
                     metricGroup.histogram(
                             MetricNames.REQUEST_PROCESS_TIME_MS,
-                            new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                            new DescriptiveStatisticsHistogram(
+                                    WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
             responseSendTimeMs =
                     metricGroup.histogram(
                             MetricNames.RESPONSE_SEND_TIME_MS,
-                            new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                            new DescriptiveStatisticsHistogram(
+                                    WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
             totalTimeMs =
                     metricGroup.histogram(
                             MetricNames.REQUEST_TOTAL_TIME_MS,
-                            new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                            new DescriptiveStatisticsHistogram(
+                                    WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
         }
 
         public Counter getRequestsCount() {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/CoordinatorEventManager.java
@@ -93,7 +93,8 @@ public final class CoordinatorEventManager implements EventManager {
         eventQueueTime =
                 coordinatorMetricGroup.histogram(
                         MetricNames.EVENT_QUEUE_TIME_MS,
-                        new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                        new DescriptiveStatisticsHistogram(
+                                WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
 
         // Register coordinator metrics
         coordinatorMetricGroup.gauge(MetricNames.ACTIVE_COORDINATOR_COUNT, () -> 1);

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/CoordinatorEventMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/CoordinatorEventMetricGroup.java
@@ -51,7 +51,8 @@ public class CoordinatorEventMetricGroup extends AbstractMetricGroup {
         this.eventProcessingTime =
                 histogram(
                         MetricNames.EVENT_PROCESSING_TIME_MS,
-                        new DescriptiveStatisticsHistogram(100));
+                        new DescriptiveStatisticsHistogram(
+                                100, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
         this.queuedEventCount =
                 counter(MetricNames.EVENT_QUEUE_SIZE, new ThreadSafeSimpleCounter());
     }

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TableMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TableMetricGroup.java
@@ -705,7 +705,8 @@ public class TableMetricGroup extends AbstractMetricGroup {
             lakeLookupTimeMs =
                     histogram(
                             MetricNames.LAKE_LOOKUP_TIME_MS,
-                            new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+                            new DescriptiveStatisticsHistogram(
+                                    WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE));
         }
 
         private void recordLookup(long lookupTimeNanos) {

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
@@ -109,13 +109,17 @@ public class TabletServerMetricGroup extends AbstractMetricGroup {
         // about flush
         logFlushCount = new SimpleCounter();
         meter(MetricNames.LOG_FLUSH_RATE, new MeterView(logFlushCount));
-        logFlushLatencyHistogram = new DescriptiveStatisticsHistogram(WINDOW_SIZE);
+        logFlushLatencyHistogram =
+                new DescriptiveStatisticsHistogram(
+                        WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE);
         histogram(MetricNames.LOG_FLUSH_LATENCY_MS, logFlushLatencyHistogram);
 
         // about pre-write buffer.
         kvFlushCount = new SimpleCounter();
         meter(MetricNames.KV_FLUSH_RATE, new MeterView(kvFlushCount));
-        kvFlushLatencyHistogram = new DescriptiveStatisticsHistogram(WINDOW_SIZE);
+        kvFlushLatencyHistogram =
+                new DescriptiveStatisticsHistogram(
+                        WINDOW_SIZE, DescriptiveStatisticsHistogram.DEFAULT_MAX_AGE);
         histogram(MetricNames.KV_FLUSH_LATENCY_MS, kvFlushLatencyHistogram);
         kvTruncateAsDuplicatedCount = new SimpleCounter();
         meter(


### PR DESCRIPTION
## Summary
- Add an optional maximum age to `DescriptiveStatisticsHistogram` samples.
- Enable a five-minute sample lifetime for Fluss internal metric groups while retaining the existing unbounded single-argument constructor.
- Keep `getCount()` cumulative and cover expiration after an idle period with a deterministic clock-based test.

Fixes #4139

## Validation
- `mvn test -Dtest=DescriptiveStatisticsHistogramTest -pl fluss-common`
- `mvn install -DskipTests -pl fluss-protogen,fluss-rpc,fluss-server,fluss-client -am`
- `mvn spotless:check -pl fluss-common,fluss-client,fluss-rpc,fluss-server`

AI-assisted changes; validated with the commands above.