### PR TITLE
[rust] Return error when table descriptor schema is missing.

### DIFF
--- a/fluss-rust/crates/fluss/src/metadata/table.rs
+++ b/fluss-rust/crates/fluss/src/metadata/table.rs
@@ -643,7 +643,9 @@ impl TableDescriptorBuilder {
     }
 
     pub fn build(self) -> Result<TableDescriptor> {
-        let schema = self.schema.expect("Schema must be set");
+        let schema = self.schema.ok_or_else(|| IllegalArgument {
+            message: "Schema must be set".to_string(),
+        })?;
         let table_distribution = TableDescriptor::normalize_distribution(
             &schema,
             &self.partition_keys,
@@ -1766,6 +1768,16 @@ mod tests {
             0,
         );
         assert!(table_info.is_auto_partitioned());
+    }
+
+    #[test]
+    fn table_descriptor_builder_requires_schema() {
+        let result = TableDescriptor::builder().build();
+
+        assert!(matches!(
+            result,
+            Err(Error::IllegalArgument { message }) if message == "Schema must be set"
+        ));
     }
 
     fn stats_table(property: Option<&str>) -> TableInfo {


### PR DESCRIPTION
### Purpose

Linked issue: close #4173

`TableDescriptorBuilder::build()` returns a `Result<TableDescriptor>`, but currently panics when the required schema is not set.

This change makes the builder return `Error::IllegalArgument` instead, allowing callers to handle the invalid builder state through the existing `Result` API.

### Brief change log

- Replace the `expect()` call in `TableDescriptorBuilder::build()` with an `IllegalArgument` error.
- Add a unit test verifying that building a table descriptor without a schema returns the expected error.
- Preserve the existing public method signature and successful build behavior.

### Tests

- Added `metadata::table::tests::table_descriptor_builder_requires_schema`.

### API and Format

No.

### Documentation

No.