### PR TITLE
[rust] Preserve highest_field_id during Schema JSON deserialization

### DIFF
--- a/fluss-rust/crates/fluss/src/metadata/json_serde.rs
+++ b/fluss-rust/crates/fluss/src/metadata/json_serde.rs
@@ -543,6 +543,23 @@ impl JsonSerde for Schema {
             }
         }
 
+        if let Some(highest_field_id_node) = node.get(Self::HIGHEST_FIELD_ID) {
+            let highest_field_id =
+                highest_field_id_node
+                    .as_i64()
+                    .ok_or_else(|| Error::JsonSerdeError {
+                        message: format!("{} must be an integer", Self::HIGHEST_FIELD_ID),
+                    })?;
+            let highest_field_id =
+                i32::try_from(highest_field_id).map_err(|_| Error::JsonSerdeError {
+                    message: format!(
+                        "{} value {highest_field_id} does not fit in i32",
+                        Self::HIGHEST_FIELD_ID
+                    ),
+                })?;
+            schema_builder = schema_builder.highest_field_id(highest_field_id);
+        }
+
         schema_builder.build()
     }
 }
@@ -982,6 +999,41 @@ mod tests {
             vec![0, 1],
         );
         assert_eq!(round_tripped, original);
+    }
+
+    #[test]
+    fn schema_deserialization_preserves_highest_field_id_above_maximum() {
+        let json = json!({
+            "version": 1,
+            "columns": [
+                {"name": "id", "data_type": {"type": "INTEGER"}, "id": 0},
+                {"name": "name", "data_type": {"type": "STRING"}, "id": 1}
+            ],
+            "highest_field_id": 10
+        });
+
+        let schema = Schema::deserialize_json(&json).unwrap();
+        assert_eq!(schema.highest_field_id(), 10);
+    }
+
+    #[test]
+    fn schema_deserialization_rejects_highest_field_id_below_maximum() {
+        let json = json!({
+            "version": 1,
+            "columns": [
+                {"name": "id", "data_type": {"type": "INTEGER"}, "id": 0},
+                {"name": "name", "data_type": {"type": "STRING"}, "id": 1}
+            ],
+            "highest_field_id": 0
+        });
+
+        let error = Schema::deserialize_json(&json).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("must be greater than or equal to the maximum field id (1)"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/fluss-rust/crates/fluss/src/metadata/json_serde.rs
+++ b/fluss-rust/crates/fluss/src/metadata/json_serde.rs
@@ -1017,7 +1017,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_deserialization_rejects_highest_field_id_below_maximum() {
+    fn schema_deserialization_clamps_highest_field_id_to_computed_minimum() {
         let json = json!({
             "version": 1,
             "columns": [
@@ -1027,13 +1027,16 @@ mod tests {
             "highest_field_id": 0
         });
 
-        let error = Schema::deserialize_json(&json).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("must be greater than or equal to the maximum field id (1)"),
-            "{error}"
-        );
+        let schema = Schema::deserialize_json(&json).unwrap();
+        assert_eq!(schema.highest_field_id(), 1);
+
+        let empty_json = json!({
+            "version": 1,
+            "columns": [],
+            "highest_field_id": -3
+        });
+        let empty_schema = Schema::deserialize_json(&empty_json).unwrap();
+        assert_eq!(empty_schema.highest_field_id(), -1);
     }
 
     #[test]

--- a/fluss-rust/crates/fluss/src/metadata/table.rs
+++ b/fluss-rust/crates/fluss/src/metadata/table.rs
@@ -253,6 +253,7 @@ pub struct SchemaBuilder {
     columns: Vec<Column>,
     primary_key: Option<PrimaryKey>,
     auto_increment_col_names: Vec<String>,
+    highest_field_id: Option<i32>,
 }
 
 impl SchemaBuilder {
@@ -330,9 +331,23 @@ impl SchemaBuilder {
         Ok(self)
     }
 
+    pub(crate) fn highest_field_id(mut self, highest_field_id: i32) -> Self {
+        self.highest_field_id = Some(highest_field_id);
+        self
+    }
+
     pub fn build(&self) -> Result<Schema> {
         let columns = Self::normalize_columns(&self.columns, self.primary_key.as_ref())?;
-        let (columns_with_ids, highest_field_id) = Self::assign_all_field_ids(columns)?;
+        let (columns_with_ids, maximum_field_id) = Self::assign_all_field_ids(columns)?;
+        let highest_field_id = self.highest_field_id.unwrap_or(maximum_field_id);
+
+        if !columns_with_ids.is_empty() && highest_field_id < maximum_field_id {
+            return Err(IllegalArgument {
+                message: format!(
+                    "Highest field id ({highest_field_id}) must be greater than or equal to the maximum field id ({maximum_field_id})"
+                ),
+            });
+        }
 
         if !self.auto_increment_col_names.is_empty() && self.primary_key.is_none() {
             return Err(IllegalArgument {

--- a/fluss-rust/crates/fluss/src/metadata/table.rs
+++ b/fluss-rust/crates/fluss/src/metadata/table.rs
@@ -339,15 +339,10 @@ impl SchemaBuilder {
     pub fn build(&self) -> Result<Schema> {
         let columns = Self::normalize_columns(&self.columns, self.primary_key.as_ref())?;
         let (columns_with_ids, maximum_field_id) = Self::assign_all_field_ids(columns)?;
-        let highest_field_id = self.highest_field_id.unwrap_or(maximum_field_id);
-
-        if !columns_with_ids.is_empty() && highest_field_id < maximum_field_id {
-            return Err(IllegalArgument {
-                message: format!(
-                    "Highest field id ({highest_field_id}) must be greater than or equal to the maximum field id ({maximum_field_id})"
-                ),
-            });
-        }
+        let highest_field_id = self
+            .highest_field_id
+            .unwrap_or(maximum_field_id)
+            .max(maximum_field_id);
 
         if !self.auto_increment_col_names.is_empty() && self.primary_key.is_none() {
             return Err(IllegalArgument {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4181

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
