### PR TITLE
[client] Recover Admin writes after coordinator failover

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/admin/FlussAdmin.java
@@ -35,6 +35,7 @@ import org.apache.fluss.config.cluster.ConfigEntry;
 import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.exception.LeaderNotAvailableException;
 import org.apache.fluss.exception.NotCoordinatorLeaderException;
+import org.apache.fluss.exception.RetriableException;
 import org.apache.fluss.metadata.DatabaseChange;
 import org.apache.fluss.metadata.DatabaseDescriptor;
 import org.apache.fluss.metadata.DatabaseInfo;
@@ -161,14 +162,17 @@ public class FlussAdmin implements Admin {
         AdminGateway rawGateway =
                 GatewayClientProxy.createGatewayProxy(
                         metadataUpdater::getCoordinatorServer, client, AdminGateway.class);
-        // Retrying generic network errors is unsafe for non-idempotent writes because the request
-        // may already have succeeded. NotCoordinatorLeaderException is safe because the standby
-        // rejects the request before invoking the coordinator API.
+        // Refresh metadata for recoverable failures, but don't retry generic network errors because
+        // a non-idempotent write may already have succeeded. NotCoordinatorLeaderException is safe
+        // to retry because the standby rejects the request before invoking the coordinator API.
         this.gateway =
                 RetryableGatewayClientProxy.createRetryableGatewayProxy(
                         rawGateway,
                         () -> refreshCoordinatorMetadata(client, metadataUpdater),
                         refreshExecutor,
+                        cause ->
+                                cause instanceof NotCoordinatorLeaderException
+                                        || cause instanceof RetriableException,
                         NotCoordinatorLeaderException.class::isInstance,
                         AdminGateway.class);
         AdminGateway rawReadOnlyGateway =

--- a/fluss-client/src/main/java/org/apache/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/admin/FlussAdmin.java
@@ -34,6 +34,7 @@ import org.apache.fluss.config.cluster.AlterConfig;
 import org.apache.fluss.config.cluster.ConfigEntry;
 import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.exception.LeaderNotAvailableException;
+import org.apache.fluss.exception.NotCoordinatorLeaderException;
 import org.apache.fluss.metadata.DatabaseChange;
 import org.apache.fluss.metadata.DatabaseDescriptor;
 import org.apache.fluss.metadata.DatabaseInfo;
@@ -157,15 +158,19 @@ public class FlussAdmin implements Admin {
                     1, new ExecutorThreadFactory("fluss-admin-metadata-refresh"));
 
     public FlussAdmin(RpcClient client, MetadataUpdater metadataUpdater) {
-        // TODO: AdminGateway includes non-idempotent write operations (createTable, dropTable,
-        //  createDatabase, etc.). Wrapping it with RetryableGatewayClientProxy is unsafe because
-        //  a request may succeed on the server while the response is lost (surfacing as a
-        //  RetriableException), causing a duplicate mutation on retry. A future phase should
-        //  introduce idempotent retry semantics (e.g., request-id deduplication) before enabling
-        //  retry on the write gateway.
-        this.gateway =
+        AdminGateway rawGateway =
                 GatewayClientProxy.createGatewayProxy(
                         metadataUpdater::getCoordinatorServer, client, AdminGateway.class);
+        // Retrying generic network errors is unsafe for non-idempotent writes because the request
+        // may already have succeeded. NotCoordinatorLeaderException is safe because the standby
+        // rejects the request before invoking the coordinator API.
+        this.gateway =
+                RetryableGatewayClientProxy.createRetryableGatewayProxy(
+                        rawGateway,
+                        () -> refreshCoordinatorMetadata(client, metadataUpdater),
+                        refreshExecutor,
+                        NotCoordinatorLeaderException.class::isInstance,
+                        AdminGateway.class);
         AdminGateway rawReadOnlyGateway =
                 GatewayClientProxy.createGatewayProxy(
                         metadataUpdater::getRandomTabletServer, client, AdminGateway.class);
@@ -176,6 +181,17 @@ public class FlussAdmin implements Admin {
                         refreshExecutor,
                         AdminGateway.class);
         this.metadataUpdater = metadataUpdater;
+    }
+
+    private static void refreshCoordinatorMetadata(
+            RpcClient client, MetadataUpdater metadataUpdater) {
+        metadataUpdater.refreshClusterUntilAvailable();
+        ServerNode coordinator = metadataUpdater.getCoordinatorServer();
+        if (coordinator != null) {
+            // Coordinator nodes share the same cs-0 UID. Discard the connection that returned
+            // NotCoordinatorLeaderException so the retry opens one to the refreshed endpoint.
+            client.disconnect(coordinator.uid()).join();
+        }
     }
 
     @Override

--- a/fluss-client/src/main/java/org/apache/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/admin/FlussAdmin.java
@@ -33,6 +33,7 @@ import org.apache.fluss.cluster.rebalance.ServerTag;
 import org.apache.fluss.config.cluster.AlterConfig;
 import org.apache.fluss.config.cluster.ConfigEntry;
 import org.apache.fluss.exception.FlussRuntimeException;
+import org.apache.fluss.exception.InvalidServerTypeException;
 import org.apache.fluss.exception.LeaderNotAvailableException;
 import org.apache.fluss.exception.NotCoordinatorLeaderException;
 import org.apache.fluss.exception.RetriableException;
@@ -164,7 +165,8 @@ public class FlussAdmin implements Admin {
                         metadataUpdater::getCoordinatorServer, client, AdminGateway.class);
         // Refresh metadata for recoverable failures, but don't retry generic network errors because
         // a non-idempotent write may already have succeeded. NotCoordinatorLeaderException is safe
-        // to retry because the standby rejects the request before invoking the coordinator API.
+        // to retry because the standby rejects the request before invoking the coordinator API,
+        // and InvalidServerTypeException is raised during the handshake before sending the request.
         this.gateway =
                 RetryableGatewayClientProxy.createRetryableGatewayProxy(
                         rawGateway,
@@ -173,7 +175,9 @@ public class FlussAdmin implements Admin {
                         cause ->
                                 cause instanceof NotCoordinatorLeaderException
                                         || cause instanceof RetriableException,
-                        NotCoordinatorLeaderException.class::isInstance,
+                        cause ->
+                                cause instanceof NotCoordinatorLeaderException
+                                        || cause instanceof InvalidServerTypeException,
                         AdminGateway.class);
         AdminGateway rawReadOnlyGateway =
                 GatewayClientProxy.createGatewayProxy(

--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/CustomFlussClusterITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/CustomFlussClusterITCase.java
@@ -26,6 +26,8 @@ import org.apache.fluss.client.table.scanner.ScanRecord;
 import org.apache.fluss.client.table.scanner.log.LogScanner;
 import org.apache.fluss.client.table.scanner.log.ScanRecords;
 import org.apache.fluss.client.table.writer.UpsertWriter;
+import org.apache.fluss.cluster.Endpoint;
+import org.apache.fluss.cluster.ServerNode;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.MemorySize;
@@ -37,18 +39,26 @@ import org.apache.fluss.metadata.TableDescriptor;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.record.ChangeType;
 import org.apache.fluss.row.InternalRow;
+import org.apache.fluss.server.coordinator.CoordinatorServer;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
 import org.apache.fluss.server.zk.ZooKeeperClient;
+import org.apache.fluss.server.zk.data.CoordinatorAddress;
+import org.apache.fluss.shaded.curator5.org.apache.curator.framework.CuratorFramework;
+import org.apache.fluss.shaded.zookeeper3.org.apache.zookeeper.Watcher;
+import org.apache.fluss.shaded.zookeeper3.org.apache.zookeeper.ZooKeeper;
 import org.apache.fluss.types.RowType;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -60,10 +70,106 @@ import static org.apache.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR_PK;
 import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.apache.fluss.testutils.InternalRowAssert.assertThatRow;
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
+import static org.apache.fluss.testutils.common.CommonTestUtils.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT case for tests that require manual cluster management. */
 class CustomFlussClusterITCase {
+
+    @Test
+    void testAdminWriteRecoversAfterCoordinatorFailover(@TempDir Path tempDir) throws Exception {
+        final FlussClusterExtension flussClusterExtension =
+                FlussClusterExtension.builder().setNumOfTabletServers(1).build();
+        CoordinatorServer standbyCoordinator = null;
+        try {
+            flussClusterExtension.start();
+            CoordinatorServer firstLeader = flussClusterExtension.getCoordinatorServer();
+            String zooKeeperConnectString =
+                    firstLeader
+                            .getZooKeeperClient()
+                            .getCuratorClient()
+                            .getZookeeperClient()
+                            .getCurrentConnectionString();
+
+            Configuration standbyConf = new Configuration();
+            standbyConf.setString(ConfigOptions.ZOOKEEPER_ADDRESS, zooKeeperConnectString);
+            standbyConf.setString(ConfigOptions.BIND_LISTENERS, "FLUSS://localhost:0");
+            standbyConf.set(
+                    ConfigOptions.REMOTE_DATA_DIR,
+                    tempDir.resolve("standby-remote-data").toString());
+            standbyCoordinator = new CoordinatorServer(standbyConf);
+            standbyCoordinator.start();
+
+            waitUntil(
+                    () ->
+                            flussClusterExtension
+                                            .getZooKeeperClient()
+                                            .getCoordinatorServerList()
+                                            .size()
+                                    == 2,
+                    Duration.ofSeconds(30),
+                    "Standby coordinator did not register");
+
+            try (Connection connection =
+                            ConnectionFactory.createConnection(
+                                    flussClusterExtension.getClientConfig());
+                    Admin admin = connection.getAdmin()) {
+                String databaseName = "test_admin_write_after_coordinator_failover";
+                admin.createDatabase(databaseName, DatabaseDescriptor.EMPTY, false).get();
+                assertThat(admin.listDatabases().get()).contains(databaseName);
+
+                killZooKeeperSession(firstLeader, zooKeeperConnectString);
+                CoordinatorServer newLeader = standbyCoordinator;
+                waitUntil(
+                        () -> {
+                            CoordinatorAddress leaderAddress =
+                                    flussClusterExtension
+                                            .getZooKeeperClient()
+                                            .getCoordinatorLeaderAddress()
+                                            .orElse(null);
+                            return leaderAddress != null
+                                    && leaderAddress.getId().equals(newLeader.getServerId())
+                                    && newLeader.getCoordinatorService().isLeader();
+                        },
+                        Duration.ofMinutes(1),
+                        "Standby coordinator did not become leader");
+
+                Endpoint newLeaderEndpoint =
+                        newLeader.getRpcServer().getBindEndpoints().stream()
+                                .filter(
+                                        endpoint ->
+                                                endpoint.getListenerName()
+                                                        .equals(
+                                                                ConfigOptions.INTERNAL_LISTENER_NAME
+                                                                        .defaultValue()))
+                                .findFirst()
+                                .orElseThrow(IllegalStateException::new);
+                waitUntil(
+                        () -> {
+                            ServerNode cachedCoordinator =
+                                    flussClusterExtension
+                                            .getTabletServerById(0)
+                                            .getMetadataCache()
+                                            .getCoordinatorServer(
+                                                    ConfigOptions.INTERNAL_LISTENER_NAME
+                                                            .defaultValue());
+                            return cachedCoordinator != null
+                                    && cachedCoordinator.host().equals(newLeaderEndpoint.getHost())
+                                    && cachedCoordinator.port() == newLeaderEndpoint.getPort();
+                        },
+                        Duration.ofSeconds(30),
+                        "Tablet server did not learn the new coordinator leader");
+
+                admin.dropDatabase(databaseName, false, false).get();
+                assertThat(admin.listDatabases().get()).doesNotContain(databaseName);
+            }
+        } finally {
+            if (standbyCoordinator != null) {
+                standbyCoordinator.close();
+            }
+            flussClusterExtension.close();
+        }
+    }
 
     @Test
     void testProjectionPushdownWithEmptyBatches() throws Exception {
@@ -325,5 +431,28 @@ class CustomFlussClusterITCase {
 
         conf.set(ConfigOptions.NETTY_CLIENT_NUM_NETWORK_THREADS, 1);
         return conf;
+    }
+
+    private static void killZooKeeperSession(
+            CoordinatorServer server, String zooKeeperConnectString) throws Exception {
+        CuratorFramework curatorClient = server.getZooKeeperClient().getCuratorClient();
+        ZooKeeper zooKeeper = curatorClient.getZookeeperClient().getZooKeeper();
+        CountDownLatch connectedLatch = new CountDownLatch(1);
+        ZooKeeper duplicateSession =
+                new ZooKeeper(
+                        zooKeeperConnectString,
+                        1000,
+                        event -> {
+                            if (event.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                                connectedLatch.countDown();
+                            }
+                        },
+                        zooKeeper.getSessionId(),
+                        zooKeeper.getSessionPasswd());
+        if (!connectedLatch.await(10, TimeUnit.SECONDS)) {
+            duplicateSession.close();
+            throw new IllegalStateException("Failed to connect duplicate ZooKeeper session");
+        }
+        duplicateSession.close();
     }
 }

--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/CustomFlussClusterITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/CustomFlussClusterITCase.java
@@ -26,8 +26,6 @@ import org.apache.fluss.client.table.scanner.ScanRecord;
 import org.apache.fluss.client.table.scanner.log.LogScanner;
 import org.apache.fluss.client.table.scanner.log.ScanRecords;
 import org.apache.fluss.client.table.writer.UpsertWriter;
-import org.apache.fluss.cluster.Endpoint;
-import org.apache.fluss.cluster.ServerNode;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.config.MemorySize;
@@ -39,26 +37,18 @@ import org.apache.fluss.metadata.TableDescriptor;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.record.ChangeType;
 import org.apache.fluss.row.InternalRow;
-import org.apache.fluss.server.coordinator.CoordinatorServer;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
 import org.apache.fluss.server.zk.ZooKeeperClient;
-import org.apache.fluss.server.zk.data.CoordinatorAddress;
-import org.apache.fluss.shaded.curator5.org.apache.curator.framework.CuratorFramework;
-import org.apache.fluss.shaded.zookeeper3.org.apache.zookeeper.Watcher;
-import org.apache.fluss.shaded.zookeeper3.org.apache.zookeeper.ZooKeeper;
 import org.apache.fluss.types.RowType;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -70,106 +60,10 @@ import static org.apache.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR_PK;
 import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.apache.fluss.testutils.InternalRowAssert.assertThatRow;
 import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
-import static org.apache.fluss.testutils.common.CommonTestUtils.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT case for tests that require manual cluster management. */
 class CustomFlussClusterITCase {
-
-    @Test
-    void testAdminWriteRecoversAfterCoordinatorFailover(@TempDir Path tempDir) throws Exception {
-        final FlussClusterExtension flussClusterExtension =
-                FlussClusterExtension.builder().setNumOfTabletServers(1).build();
-        CoordinatorServer standbyCoordinator = null;
-        try {
-            flussClusterExtension.start();
-            CoordinatorServer firstLeader = flussClusterExtension.getCoordinatorServer();
-            String zooKeeperConnectString =
-                    firstLeader
-                            .getZooKeeperClient()
-                            .getCuratorClient()
-                            .getZookeeperClient()
-                            .getCurrentConnectionString();
-
-            Configuration standbyConf = new Configuration();
-            standbyConf.setString(ConfigOptions.ZOOKEEPER_ADDRESS, zooKeeperConnectString);
-            standbyConf.setString(ConfigOptions.BIND_LISTENERS, "FLUSS://localhost:0");
-            standbyConf.set(
-                    ConfigOptions.REMOTE_DATA_DIR,
-                    tempDir.resolve("standby-remote-data").toString());
-            standbyCoordinator = new CoordinatorServer(standbyConf);
-            standbyCoordinator.start();
-
-            waitUntil(
-                    () ->
-                            flussClusterExtension
-                                            .getZooKeeperClient()
-                                            .getCoordinatorServerList()
-                                            .size()
-                                    == 2,
-                    Duration.ofSeconds(30),
-                    "Standby coordinator did not register");
-
-            try (Connection connection =
-                            ConnectionFactory.createConnection(
-                                    flussClusterExtension.getClientConfig());
-                    Admin admin = connection.getAdmin()) {
-                String databaseName = "test_admin_write_after_coordinator_failover";
-                admin.createDatabase(databaseName, DatabaseDescriptor.EMPTY, false).get();
-                assertThat(admin.listDatabases().get()).contains(databaseName);
-
-                killZooKeeperSession(firstLeader, zooKeeperConnectString);
-                CoordinatorServer newLeader = standbyCoordinator;
-                waitUntil(
-                        () -> {
-                            CoordinatorAddress leaderAddress =
-                                    flussClusterExtension
-                                            .getZooKeeperClient()
-                                            .getCoordinatorLeaderAddress()
-                                            .orElse(null);
-                            return leaderAddress != null
-                                    && leaderAddress.getId().equals(newLeader.getServerId())
-                                    && newLeader.getCoordinatorService().isLeader();
-                        },
-                        Duration.ofMinutes(1),
-                        "Standby coordinator did not become leader");
-
-                Endpoint newLeaderEndpoint =
-                        newLeader.getRpcServer().getBindEndpoints().stream()
-                                .filter(
-                                        endpoint ->
-                                                endpoint.getListenerName()
-                                                        .equals(
-                                                                ConfigOptions.INTERNAL_LISTENER_NAME
-                                                                        .defaultValue()))
-                                .findFirst()
-                                .orElseThrow(IllegalStateException::new);
-                waitUntil(
-                        () -> {
-                            ServerNode cachedCoordinator =
-                                    flussClusterExtension
-                                            .getTabletServerById(0)
-                                            .getMetadataCache()
-                                            .getCoordinatorServer(
-                                                    ConfigOptions.INTERNAL_LISTENER_NAME
-                                                            .defaultValue());
-                            return cachedCoordinator != null
-                                    && cachedCoordinator.host().equals(newLeaderEndpoint.getHost())
-                                    && cachedCoordinator.port() == newLeaderEndpoint.getPort();
-                        },
-                        Duration.ofSeconds(30),
-                        "Tablet server did not learn the new coordinator leader");
-
-                admin.dropDatabase(databaseName, false, false).get();
-                assertThat(admin.listDatabases().get()).doesNotContain(databaseName);
-            }
-        } finally {
-            if (standbyCoordinator != null) {
-                standbyCoordinator.close();
-            }
-            flussClusterExtension.close();
-        }
-    }
 
     @Test
     void testProjectionPushdownWithEmptyBatches() throws Exception {
@@ -431,28 +325,5 @@ class CustomFlussClusterITCase {
 
         conf.set(ConfigOptions.NETTY_CLIENT_NUM_NETWORK_THREADS, 1);
         return conf;
-    }
-
-    private static void killZooKeeperSession(
-            CoordinatorServer server, String zooKeeperConnectString) throws Exception {
-        CuratorFramework curatorClient = server.getZooKeeperClient().getCuratorClient();
-        ZooKeeper zooKeeper = curatorClient.getZookeeperClient().getZooKeeper();
-        CountDownLatch connectedLatch = new CountDownLatch(1);
-        ZooKeeper duplicateSession =
-                new ZooKeeper(
-                        zooKeeperConnectString,
-                        1000,
-                        event -> {
-                            if (event.getState() == Watcher.Event.KeeperState.SyncConnected) {
-                                connectedLatch.countDown();
-                            }
-                        },
-                        zooKeeper.getSessionId(),
-                        zooKeeper.getSessionPasswd());
-        if (!connectedLatch.await(10, TimeUnit.SECONDS)) {
-            duplicateSession.close();
-            throw new IllegalStateException("Failed to connect duplicate ZooKeeper session");
-        }
-        duplicateSession.close();
     }
 }

--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
@@ -85,6 +85,9 @@ import org.apache.fluss.server.metadata.ServerInfo;
 import org.apache.fluss.server.replica.Replica;
 import org.apache.fluss.server.tablet.TestTabletServerGateway;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
+import org.apache.fluss.server.testutils.TestingServerRestartUtils;
+import org.apache.fluss.server.testutils.TestingServerRestartUtils.RestartScenario;
+import org.apache.fluss.server.testutils.TestingServerRestartUtils.RestartTarget;
 import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.data.ServerTags;
 import org.apache.fluss.types.DataTypeChecks;
@@ -92,6 +95,8 @@ import org.apache.fluss.types.DataTypes;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.annotation.Nullable;
 
@@ -1211,8 +1216,37 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         }
     }
 
-    @Test
-    void testListPartitionInfosAfterTabletServerRestart() throws Exception {
+    @ParameterizedTest
+    @EnumSource(RestartScenario.class)
+    void testCreateTableAfterCoordinatorServerRestart(RestartScenario restartScenario)
+            throws Exception {
+        TablePath tablePath =
+                TablePath.of(
+                        DEFAULT_TABLE_PATH.getDatabaseName(),
+                        "test_create_table_after_coordinator_server_restart");
+        ZooKeeperClient zkClient = FLUSS_CLUSTER_EXTENSION.getZooKeeperClient();
+
+        TestingServerRestartUtils.restartServers(
+                FLUSS_CLUSTER_EXTENSION, RestartTarget.COORDINATOR, restartScenario);
+
+        if (restartScenario == RestartScenario.NEW_PORT) {
+            assertThatThrownBy(
+                            () ->
+                                    admin.createTable(tablePath, DEFAULT_TABLE_DESCRIPTOR, false)
+                                            .get())
+                    .isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(NetworkException.class);
+            assertThat(zkClient.tableExist(tablePath)).isFalse();
+        }
+
+        admin.createTable(tablePath, DEFAULT_TABLE_DESCRIPTOR, true).get();
+        assertThat(zkClient.tableExist(tablePath)).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(RestartScenario.class)
+    void testListPartitionInfosAfterTabletServerRestart(RestartScenario restartScenario)
+            throws Exception {
         String dbName = DEFAULT_TABLE_PATH.getDatabaseName();
         TablePath partitionedTablePath = TablePath.of(dbName, "test_retry_partitioned_table");
         admin.createTable(partitionedTablePath, DATA1_PARTITIONED_TABLE_DESCRIPTOR, true).get();
@@ -1223,12 +1257,8 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
                 admin.listPartitionInfos(partitionedTablePath).get();
         assertThat(partitionInfosBefore).isNotEmpty();
 
-        // Restart all tablet servers (they bind to new ports, making cached addresses stale).
-        for (int i = 0; i < FLUSS_CLUSTER_EXTENSION.getTabletServerNodes().size(); i++) {
-            FLUSS_CLUSTER_EXTENSION.stopTabletServer(i);
-            FLUSS_CLUSTER_EXTENSION.startTabletServer(i);
-        }
-        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
+        TestingServerRestartUtils.restartServers(
+                FLUSS_CLUSTER_EXTENSION, RestartTarget.TABLET_SERVERS, restartScenario);
 
         // Second query using the same admin client should succeed after retry with metadata
         // refresh (verifies RetryableGatewayClientProxy convergence on stale addresses).
@@ -1237,22 +1267,28 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         assertThat(partitionInfosAfter).hasSize(partitionInfosBefore.size());
     }
 
-    @Test
-    void testKvSnapshotLeaseAfterCoordinatorServerRestart() throws Exception {
+    @ParameterizedTest
+    @EnumSource(RestartScenario.class)
+    void testKvSnapshotLeaseAfterCoordinatorServerRestart(RestartScenario restartScenario)
+            throws Exception {
         long tableId = admin.getTableInfo(DEFAULT_TABLE_PATH).get().getTableId();
         TableBucket tableBucket = new TableBucket(tableId, 0);
         Map<TableBucket, Long> snapshots = Collections.singletonMap(tableBucket, 0L);
-        KvSnapshotLease lease = admin.createKvSnapshotLease("test-retry-kv-snapshot-lease", 60000L);
+        KvSnapshotLease lease =
+                admin.createKvSnapshotLease(
+                        "test-retry-kv-snapshot-lease-" + restartScenario.name(), 60000L);
         ZooKeeperClient zkClient = FLUSS_CLUSTER_EXTENSION.getZooKeeperClient();
 
         // Restart the coordinator server so that the lease uses a stale cached address.
-        restartCoordinatorServer(zkClient);
+        TestingServerRestartUtils.restartServers(
+                FLUSS_CLUSTER_EXTENSION, RestartTarget.COORDINATOR, restartScenario);
 
         lease.acquireSnapshots(snapshots).get();
         assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isPresent();
 
         // Verify that release also refreshes metadata and retries against the new coordinator.
-        restartCoordinatorServer(zkClient);
+        TestingServerRestartUtils.restartServers(
+                FLUSS_CLUSTER_EXTENSION, RestartTarget.COORDINATOR, restartScenario);
 
         lease.releaseSnapshots(Collections.singleton(tableBucket)).get();
         assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isNotPresent();
@@ -1261,20 +1297,11 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         lease.acquireSnapshots(snapshots).get();
         assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isPresent();
 
-        restartCoordinatorServer(zkClient);
-        FLUSS_CLUSTER_EXTENSION.waitUntilAllGatewayHasSameMetadata();
+        TestingServerRestartUtils.restartServers(
+                FLUSS_CLUSTER_EXTENSION, RestartTarget.COORDINATOR, restartScenario);
 
         lease.dropLease().get();
         assertThat(zkClient.getKvSnapshotLeaseMetadata(lease.leaseId())).isNotPresent();
-    }
-
-    private void restartCoordinatorServer(ZooKeeperClient zkClient) throws Exception {
-        FLUSS_CLUSTER_EXTENSION.stopCoordinatorServer();
-        waitUntil(
-                () -> !zkClient.getCoordinatorLeaderAddress().isPresent(),
-                Duration.ofMinutes(1),
-                "Coordinator server node still exists in ZooKeeper");
-        FLUSS_CLUSTER_EXTENSION.startCoordinatorServer();
     }
 
     @Test

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/RetryableGatewayClientProxy.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/RetryableGatewayClientProxy.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Proxy;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
 /**
  * A proxy that wraps an existing {@link RpcGateway} proxy and adds automatic retry with metadata
@@ -68,6 +69,7 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
     private final Object delegate;
     private final Runnable metadataRefreshAction;
     private final Executor refreshExecutor;
+    private final Predicate<Throwable> retryPredicate;
 
     /**
      * Holds the currently in-flight metadata refresh, if any. Concurrent retriers piggyback on this
@@ -78,10 +80,14 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
             new AtomicReference<>();
 
     RetryableGatewayClientProxy(
-            Object delegate, Runnable metadataRefreshAction, Executor refreshExecutor) {
+            Object delegate,
+            Runnable metadataRefreshAction,
+            Executor refreshExecutor,
+            Predicate<Throwable> retryPredicate) {
         this.delegate = delegate;
         this.metadataRefreshAction = metadataRefreshAction;
         this.refreshExecutor = refreshExecutor;
+        this.retryPredicate = retryPredicate;
     }
 
     /**
@@ -102,6 +108,33 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
             Runnable metadataRefreshAction,
             Executor refreshExecutor,
             Class<T> gatewayClass) {
+        return createRetryableGatewayProxy(
+                delegate,
+                metadataRefreshAction,
+                refreshExecutor,
+                RetriableException.class::isInstance,
+                gatewayClass);
+    }
+
+    /**
+     * Creates a retryable proxy wrapping an existing gateway proxy. When an error matches {@code
+     * retryPredicate}, the proxy will invoke {@code metadataRefreshAction} and retry the failed RPC
+     * call once.
+     *
+     * @param delegate the underlying gateway proxy to wrap
+     * @param metadataRefreshAction callback to refresh metadata (e.g., update cluster info)
+     * @param refreshExecutor executor on which {@code metadataRefreshAction} is run
+     * @param retryPredicate predicate that selects errors safe to retry
+     * @param gatewayClass the gateway interface class
+     * @param <T> the gateway type
+     * @return a retryable gateway proxy
+     */
+    public static <T extends RpcGateway> T createRetryableGatewayProxy(
+            T delegate,
+            Runnable metadataRefreshAction,
+            Executor refreshExecutor,
+            Predicate<Throwable> retryPredicate,
+            Class<T> gatewayClass) {
         ClassLoader classLoader = gatewayClass.getClassLoader();
 
         @SuppressWarnings("unchecked")
@@ -111,7 +144,10 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
                                 classLoader,
                                 new Class<?>[] {gatewayClass},
                                 new RetryableGatewayClientProxy(
-                                        delegate, metadataRefreshAction, refreshExecutor));
+                                        delegate,
+                                        metadataRefreshAction,
+                                        refreshExecutor,
+                                        retryPredicate));
         return proxy;
     }
 
@@ -143,7 +179,7 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
                         return;
                     }
                     Throwable cause = ExceptionUtils.stripCompletionException(throwable);
-                    if (!(cause instanceof RetriableException) || !retry) {
+                    if (!retry || !retryPredicate.test(cause)) {
                         resultFuture.completeExceptionally(cause);
                         return;
                     }

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/RetryableGatewayClientProxy.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/RetryableGatewayClientProxy.java
@@ -69,6 +69,7 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
     private final Object delegate;
     private final Runnable metadataRefreshAction;
     private final Executor refreshExecutor;
+    private final Predicate<Throwable> refreshPredicate;
     private final Predicate<Throwable> retryPredicate;
 
     /**
@@ -83,10 +84,12 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
             Object delegate,
             Runnable metadataRefreshAction,
             Executor refreshExecutor,
+            Predicate<Throwable> refreshPredicate,
             Predicate<Throwable> retryPredicate) {
         this.delegate = delegate;
         this.metadataRefreshAction = metadataRefreshAction;
         this.refreshExecutor = refreshExecutor;
+        this.refreshPredicate = refreshPredicate;
         this.retryPredicate = retryPredicate;
     }
 
@@ -113,17 +116,18 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
                 metadataRefreshAction,
                 refreshExecutor,
                 RetriableException.class::isInstance,
+                RetriableException.class::isInstance,
                 gatewayClass);
     }
 
     /**
-     * Creates a retryable proxy wrapping an existing gateway proxy. When an error matches {@code
-     * retryPredicate}, the proxy will invoke {@code metadataRefreshAction} and retry the failed RPC
-     * call once.
+     * Creates a retryable proxy wrapping an existing gateway proxy. Matching errors refresh
+     * metadata, and errors that also match {@code retryPredicate} retry the failed RPC call once.
      *
      * @param delegate the underlying gateway proxy to wrap
      * @param metadataRefreshAction callback to refresh metadata (e.g., update cluster info)
      * @param refreshExecutor executor on which {@code metadataRefreshAction} is run
+     * @param refreshPredicate predicate that selects errors which require a metadata refresh
      * @param retryPredicate predicate that selects errors safe to retry
      * @param gatewayClass the gateway interface class
      * @param <T> the gateway type
@@ -133,6 +137,7 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
             T delegate,
             Runnable metadataRefreshAction,
             Executor refreshExecutor,
+            Predicate<Throwable> refreshPredicate,
             Predicate<Throwable> retryPredicate,
             Class<T> gatewayClass) {
         ClassLoader classLoader = gatewayClass.getClassLoader();
@@ -147,6 +152,7 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
                                         delegate,
                                         metadataRefreshAction,
                                         refreshExecutor,
+                                        refreshPredicate,
                                         retryPredicate));
         return proxy;
     }
@@ -179,22 +185,30 @@ public class RetryableGatewayClientProxy implements InvocationHandler {
                         return;
                     }
                     Throwable cause = ExceptionUtils.stripCompletionException(throwable);
-                    if (!retry || !retryPredicate.test(cause)) {
+                    if (!retry) {
+                        resultFuture.completeExceptionally(cause);
+                        return;
+                    }
+                    boolean shouldRetry = retryPredicate.test(cause);
+                    boolean shouldRefresh = shouldRetry || refreshPredicate.test(cause);
+                    if (!shouldRefresh) {
                         resultFuture.completeExceptionally(cause);
                         return;
                     }
                     LOG.warn(
-                            "RPC call {} failed with retriable error, "
-                                    + "refreshing metadata and retrying once.",
+                            "RPC call {} failed, refreshing metadata{}.",
                             method.getName(),
+                            shouldRetry ? " and retrying once" : " without retrying",
                             cause);
                     // Coalesce concurrent refreshes so N parallel failing calls trigger only one
                     // metadata refresh (and one round of MetadataUpdater lock contention).
                     coalescedRefresh()
                             .thenCompose(
                                     ignored ->
-                                            RetryableGatewayClientProxy.this.<T>invokeWithRetry(
-                                                    method, args, false))
+                                            shouldRetry
+                                                    ? RetryableGatewayClientProxy.this
+                                                            .<T>invokeWithRetry(method, args, false)
+                                                    : future)
                             .whenComplete(
                                     (retryResult, retryError) -> {
                                         if (retryError != null) {

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/RetryableGatewayClientProxyTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/RetryableGatewayClientProxyTest.java
@@ -150,7 +150,7 @@ class RetryableGatewayClientProxyTest {
     }
 
     @Test
-    void testCustomRetryPredicateExcludesNetworkErrors() {
+    void testCustomPredicatesRefreshWithoutRetryingNetworkError() throws Exception {
         AtomicInteger callCount = new AtomicInteger(0);
         AtomicInteger refreshCount = new AtomicInteger(0);
 
@@ -160,6 +160,7 @@ class RetryableGatewayClientProxyTest {
                         delegate,
                         refreshCount::incrementAndGet,
                         REFRESH_EXECUTOR,
+                        NetworkException.class::isInstance,
                         NotCoordinatorLeaderException.class::isInstance,
                         RpcGateway.class);
 
@@ -169,7 +170,44 @@ class RetryableGatewayClientProxyTest {
                 .rootCause()
                 .isInstanceOf(NetworkException.class);
         assertThat(callCount.get()).isEqualTo(1);
-        assertThat(refreshCount.get()).isEqualTo(0);
+        assertThat(refreshCount.get()).isEqualTo(1);
+
+        assertThat(proxy.apiVersions(new ApiVersionsRequest()).get()).isNotNull();
+        assertThat(callCount.get()).isEqualTo(2);
+        assertThat(refreshCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void testCustomPredicatesRetryNotCoordinatorLeader() throws Exception {
+        AtomicInteger callCount = new AtomicInteger(0);
+        AtomicInteger refreshCount = new AtomicInteger(0);
+        RpcGateway delegate =
+                new TestRpcGateway() {
+                    @Override
+                    public CompletableFuture<ApiVersionsResponse> apiVersions(
+                            ApiVersionsRequest request) {
+                        if (callCount.incrementAndGet() == 1) {
+                            CompletableFuture<ApiVersionsResponse> failed =
+                                    new CompletableFuture<>();
+                            failed.completeExceptionally(
+                                    new NotCoordinatorLeaderException("not coordinator leader"));
+                            return failed;
+                        }
+                        return CompletableFuture.completedFuture(new ApiVersionsResponse());
+                    }
+                };
+        RpcGateway proxy =
+                RetryableGatewayClientProxy.createRetryableGatewayProxy(
+                        delegate,
+                        refreshCount::incrementAndGet,
+                        REFRESH_EXECUTOR,
+                        NotCoordinatorLeaderException.class::isInstance,
+                        NotCoordinatorLeaderException.class::isInstance,
+                        RpcGateway.class);
+
+        assertThat(proxy.apiVersions(new ApiVersionsRequest()).get()).isNotNull();
+        assertThat(callCount.get()).isEqualTo(2);
+        assertThat(refreshCount.get()).isEqualTo(1);
     }
 
     @Test

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/RetryableGatewayClientProxyTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/RetryableGatewayClientProxyTest.java
@@ -18,6 +18,7 @@
 package org.apache.fluss.rpc;
 
 import org.apache.fluss.exception.NetworkException;
+import org.apache.fluss.exception.NotCoordinatorLeaderException;
 import org.apache.fluss.exception.TableNotExistException;
 import org.apache.fluss.rpc.messages.ApiVersionsRequest;
 import org.apache.fluss.rpc.messages.ApiVersionsResponse;
@@ -144,6 +145,29 @@ class RetryableGatewayClientProxyTest {
                 .isInstanceOf(TableNotExistException.class)
                 .hasMessageContaining("table does not exist");
         // Should only be called once - no retries for non-retriable exceptions
+        assertThat(callCount.get()).isEqualTo(1);
+        assertThat(refreshCount.get()).isEqualTo(0);
+    }
+
+    @Test
+    void testCustomRetryPredicateExcludesNetworkErrors() {
+        AtomicInteger callCount = new AtomicInteger(0);
+        AtomicInteger refreshCount = new AtomicInteger(0);
+
+        RpcGateway delegate = createGateway(callCount, 1);
+        RpcGateway proxy =
+                RetryableGatewayClientProxy.createRetryableGatewayProxy(
+                        delegate,
+                        refreshCount::incrementAndGet,
+                        REFRESH_EXECUTOR,
+                        NotCoordinatorLeaderException.class::isInstance,
+                        RpcGateway.class);
+
+        CompletableFuture<ApiVersionsResponse> result = proxy.apiVersions(new ApiVersionsRequest());
+        assertThatThrownBy(result::get)
+                .isInstanceOf(ExecutionException.class)
+                .rootCause()
+                .isInstanceOf(NetworkException.class);
         assertThat(callCount.get()).isEqualTo(1);
         assertThat(refreshCount.get()).isEqualTo(0);
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/FlussClusterExtension.java
@@ -263,11 +263,16 @@ public final class FlussClusterExtension
 
     /** Start a coordinator server. start a new one if no coordinator server exists. */
     public void startCoordinatorServer() throws Exception {
+        startCoordinatorServer(coordinatorServerListeners);
+    }
+
+    /** Start a coordinator server with the given listeners. */
+    public void startCoordinatorServer(String bindListeners) throws Exception {
         if (coordinatorServer == null) {
             // if no coordinator server exists, create a new coordinator server and start
             Configuration conf = new Configuration(clusterConf);
             conf.setString(ConfigOptions.ZOOKEEPER_ADDRESS, zooKeeperServer.getConnectString());
-            conf.setString(ConfigOptions.BIND_LISTENERS, coordinatorServerListeners);
+            conf.setString(ConfigOptions.BIND_LISTENERS, bindListeners);
             setRemoteDataDir(conf);
             setRemoteDataDirs(conf);
             coordinatorServer = new CoordinatorServer(conf, clock);
@@ -310,6 +315,16 @@ public final class FlussClusterExtension
         startTabletServer(serverId, false);
     }
 
+    /** Start a new tablet server with the given listeners. */
+    public void startTabletServer(int serverId, String bindListeners) throws Exception {
+        if (tabletServers.containsKey(serverId)) {
+            throw new IllegalArgumentException("Tablet server " + serverId + " already exists.");
+        }
+        Configuration overwriteConfig = new Configuration();
+        overwriteConfig.setString(ConfigOptions.BIND_LISTENERS, bindListeners);
+        startTabletServer(serverId, overwriteConfig);
+    }
+
     public void startTabletServer(int serverId, boolean forceStartIfExists) throws Exception {
         if (tabletServers.containsKey(serverId)) {
             if (!forceStartIfExists) {
@@ -317,7 +332,7 @@ public final class FlussClusterExtension
                         "Tablet server " + serverId + " already exists.");
             }
         }
-        startTabletServer(serverId, null);
+        startTabletServer(serverId, (Configuration) null);
     }
 
     private void startTabletServer(int serverId, @Nullable Configuration overwriteConfig)

--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/TestingServerRestartUtils.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/TestingServerRestartUtils.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.testutils;
+
+import org.apache.fluss.cluster.ServerNode;
+import org.apache.fluss.server.coordinator.CoordinatorServer;
+import org.apache.fluss.server.zk.ZooKeeperClient;
+import org.apache.fluss.utils.IOUtils;
+import org.apache.fluss.utils.NetUtils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.fluss.testutils.common.CommonTestUtils.waitUntil;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Utilities for restarting testing servers with deterministic endpoint changes. */
+public final class TestingServerRestartUtils {
+
+    /** Endpoint topology used when restarting testing servers. */
+    public enum RestartScenario {
+        NEW_PORT,
+        SWAPPED_COORDINATOR_AND_TABLET_SERVER_PORTS
+    }
+
+    /** Server group targeted by a {@link RestartScenario#NEW_PORT} restart. */
+    public enum RestartTarget {
+        COORDINATOR,
+        TABLET_SERVERS
+    }
+
+    private TestingServerRestartUtils() {}
+
+    /**
+     * Restarts testing servers with deterministic endpoint changes and waits for ZooKeeper and
+     * server metadata to converge.
+     */
+    public static void restartServers(
+            FlussClusterExtension extension,
+            RestartTarget restartTarget,
+            RestartScenario restartScenario)
+            throws Exception {
+        ZooKeeperClient zkClient = extension.getZooKeeperClient();
+        switch (restartScenario) {
+            case NEW_PORT:
+                if (restartTarget == RestartTarget.COORDINATOR) {
+                    restartCoordinatorServerWithNewPort(extension, zkClient);
+                } else {
+                    restartTabletServersWithNewPorts(extension);
+                }
+                break;
+            case SWAPPED_COORDINATOR_AND_TABLET_SERVER_PORTS:
+                restartCoordinatorAndTabletServersWithSwappedPorts(extension, zkClient);
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported restart scenario: " + restartScenario);
+        }
+    }
+
+    private static void restartCoordinatorServerWithNewPort(
+            FlussClusterExtension extension, ZooKeeperClient zkClient) throws Exception {
+        CoordinatorServer previousServer = extension.getCoordinatorServer();
+        ServerNode previousNode = extension.getCoordinatorServerNode();
+        try (NetUtils.Port newPort = NetUtils.getAvailablePort()) {
+            stopCoordinatorServer(extension, zkClient);
+            extension.startCoordinatorServer(bindListener(newPort.getPort()));
+
+            ServerNode restartedNode = extension.getCoordinatorServerNode();
+            assertThat(extension.getCoordinatorServer()).isNotSameAs(previousServer);
+            assertThat(restartedNode.uid()).isEqualTo(previousNode.uid());
+            assertThat(restartedNode.host()).isEqualTo(previousNode.host());
+            assertThat(restartedNode.port())
+                    .isEqualTo(newPort.getPort())
+                    .isNotEqualTo(previousNode.port());
+        }
+        extension.waitUntilAllGatewayHasSameMetadata();
+    }
+
+    private static void restartTabletServersWithNewPorts(FlussClusterExtension extension)
+            throws Exception {
+        List<ServerNode> previousNodes = extension.getTabletServerNodes();
+        List<NetUtils.Port> newPorts = reservePorts(previousNodes.size());
+        try {
+            for (int i = 0; i < previousNodes.size(); i++) {
+                ServerNode previousNode = previousNodes.get(i);
+                extension.stopTabletServer(previousNode.id());
+                extension.startTabletServer(
+                        previousNode.id(), bindListener(newPorts.get(i).getPort()));
+            }
+            extension.waitUntilAllGatewayHasSameMetadata();
+
+            for (int i = 0; i < previousNodes.size(); i++) {
+                ServerNode previousNode = previousNodes.get(i);
+                ServerNode restartedNode = getTabletServerNode(extension, previousNode.id());
+                assertThat(restartedNode.uid()).isEqualTo(previousNode.uid());
+                assertThat(restartedNode.host()).isEqualTo(previousNode.host());
+                assertThat(restartedNode.port())
+                        .isEqualTo(newPorts.get(i).getPort())
+                        .isNotEqualTo(previousNode.port());
+            }
+        } finally {
+            IOUtils.closeAllQuietly(newPorts);
+        }
+    }
+
+    private static void restartCoordinatorAndTabletServersWithSwappedPorts(
+            FlussClusterExtension extension, ZooKeeperClient zkClient) throws Exception {
+        CoordinatorServer previousCoordinatorServer = extension.getCoordinatorServer();
+        ServerNode previousCoordinator = extension.getCoordinatorServerNode();
+        List<ServerNode> previousTabletServers = extension.getTabletServerNodes();
+        ServerNode swappedTabletServer =
+                previousTabletServers.stream()
+                        .filter(tabletServer -> tabletServer.id() == 0)
+                        .findFirst()
+                        .orElseThrow(
+                                () -> new IllegalStateException("Tablet server 0 does not exist."));
+        List<NetUtils.Port> otherTabletServerPorts = reservePorts(previousTabletServers.size() - 1);
+
+        try {
+            // Stop tablet servers while the coordinator is still available for controlled
+            // shutdown, then stop the coordinator before reusing their ports.
+            for (ServerNode tabletServer : previousTabletServers) {
+                extension.stopTabletServer(tabletServer.id());
+            }
+            waitUntil(
+                    () -> zkClient.getSortedTabletServerList().length == 0,
+                    Duration.ofMinutes(1),
+                    "Tablet server nodes still exist in ZooKeeper");
+            stopCoordinatorServer(extension, zkClient);
+
+            extension.startCoordinatorServer(bindListener(swappedTabletServer.port()));
+            extension.startTabletServer(
+                    swappedTabletServer.id(), bindListener(previousCoordinator.port()));
+            int newPortIndex = 0;
+            for (ServerNode tabletServer : previousTabletServers) {
+                if (tabletServer.id() != swappedTabletServer.id()) {
+                    extension.startTabletServer(
+                            tabletServer.id(),
+                            bindListener(otherTabletServerPorts.get(newPortIndex).getPort()));
+                    newPortIndex++;
+                }
+            }
+            extension.waitUntilAllGatewayHasSameMetadata();
+
+            ServerNode restartedCoordinator = extension.getCoordinatorServerNode();
+            ServerNode restartedTabletServer =
+                    getTabletServerNode(extension, swappedTabletServer.id());
+            assertThat(extension.getCoordinatorServer()).isNotSameAs(previousCoordinatorServer);
+            assertThat(restartedCoordinator.uid()).isEqualTo(previousCoordinator.uid());
+            assertThat(restartedCoordinator.host()).isEqualTo(swappedTabletServer.host());
+            assertThat(restartedCoordinator.port())
+                    .isEqualTo(swappedTabletServer.port())
+                    .isNotEqualTo(previousCoordinator.port());
+            assertThat(restartedTabletServer.uid()).isEqualTo(swappedTabletServer.uid());
+            assertThat(restartedTabletServer.host()).isEqualTo(previousCoordinator.host());
+            assertThat(restartedTabletServer.port())
+                    .isEqualTo(previousCoordinator.port())
+                    .isNotEqualTo(swappedTabletServer.port());
+
+            newPortIndex = 0;
+            for (ServerNode tabletServer : previousTabletServers) {
+                if (tabletServer.id() != swappedTabletServer.id()) {
+                    ServerNode restartedNode = getTabletServerNode(extension, tabletServer.id());
+                    assertThat(restartedNode.uid()).isEqualTo(tabletServer.uid());
+                    assertThat(restartedNode.host()).isEqualTo(tabletServer.host());
+                    assertThat(restartedNode.port())
+                            .isEqualTo(otherTabletServerPorts.get(newPortIndex).getPort())
+                            .isNotEqualTo(tabletServer.port());
+                    newPortIndex++;
+                }
+            }
+        } finally {
+            IOUtils.closeAllQuietly(otherTabletServerPorts);
+        }
+    }
+
+    private static void stopCoordinatorServer(
+            FlussClusterExtension extension, ZooKeeperClient zkClient) throws Exception {
+        extension.stopCoordinatorServer();
+        waitUntil(
+                () -> !zkClient.getCoordinatorLeaderAddress().isPresent(),
+                Duration.ofMinutes(1),
+                "Coordinator server node still exists in ZooKeeper");
+    }
+
+    private static List<NetUtils.Port> reservePorts(int portCount) {
+        List<NetUtils.Port> ports = new ArrayList<>(portCount);
+        try {
+            for (int i = 0; i < portCount; i++) {
+                ports.add(NetUtils.getAvailablePort());
+            }
+            return ports;
+        } catch (RuntimeException e) {
+            IOUtils.closeAllQuietly(ports);
+            throw e;
+        }
+    }
+
+    private static ServerNode getTabletServerNode(FlussClusterExtension extension, int serverId) {
+        return extension.getTabletServerNodes().stream()
+                .filter(serverNode -> serverNode.id() == serverId)
+                .findFirst()
+                .orElseThrow(
+                        () ->
+                                new IllegalArgumentException(
+                                        "Tablet server " + serverId + " does not exist."));
+    }
+
+    private static String bindListener(int port) {
+        return String.format("FLUSS://localhost:%d", port);
+    }
+}

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -23,6 +23,7 @@
 
 <suppressions>
     <suppress files="DataTypes.java" checks="MethodNameCheck"/>
+    <suppress files="FlussAdminITCase.java" checks="FileLength"/>
 
     <!-- target directory is not relevant for checkstyle -->
     <suppress


### PR DESCRIPTION
<!-- Generated-by: Codex following the guidelines in https://github.com/apache/fluss/blob/main/AGENTS.md -->

### Purpose

Linked issue: close #4027

A long-lived Java Admin client keeps using its cached coordinator connection after leadership moves to a standby. Coordinator write operations then continue to fail with NotCoordinatorLeaderException until the connection is recreated.

### Brief change log

- Allow RetryableGatewayClientProxy callers to provide a retry predicate while preserving RetriableException as the default.
- Wrap the Admin write gateway with a retry policy limited to NotCoordinatorLeaderException.
- Refresh cluster metadata and discard the stale shared coordinator connection before retrying the write once.
- Add unit coverage proving the write policy excludes generic network failures.
- Add an HA integration test that keeps one Connection and Admin open across coordinator failover and verifies dropDatabase succeeds.

### Tests

```
./mvnw -pl fluss-client -am -Dtest=RetryableGatewayClientProxyTest,CustomFlussClusterITCase#testAdminWriteRecoversAfterCoordinatorFailover -Dsurefire.failIfNoSpecifiedTests=false test
```

- RetryableGatewayClientProxyTest: 7 tests passed.
- Coordinator failover regression: 1 test passed.
- Checkstyle and Spotless checks passed as part of the Maven run.

### API and Format

No public API or storage format changes. The new retry-predicate overload is internal.

### Documentation

No documentation changes. This fixes existing Admin failover behavior.
