### PR TITLE
[gateway] Reject duplicate MAP keys in entry arrays

### DIFF
--- a/fluss-gateway/src/protocol/rest/codec/decoder.rs
+++ b/fluss-gateway/src/protocol/rest/codec/decoder.rs
@@ -1272,6 +1272,15 @@ fn finish_map(
     value_type: &DataType,
     entries: Vec<(Datum<'static>, Datum<'static>)>,
 ) -> DecodeResult<Datum<'static>> {
+    let mut seen = HashSet::with_capacity(entries.len());
+    for (index, (key, _)) in entries.iter().enumerate() {
+        if !seen.insert(key) {
+            return Err(path
+                .map_part(index, "key")
+                .invalid("duplicates an earlier MAP key"));
+        }
+    }
+
     let mut writer = FlussMapWriter::new(entries.len(), key_type, value_type);
     for (key, value) in entries {
         if let Err(error) = writer.write_entry(key, value) {
@@ -1973,6 +1982,33 @@ mod tests {
         )
         .unwrap_err();
         assert!(duplicate.message().contains("duplicate key `a`"));
+    }
+
+    #[test]
+    fn rejects_duplicate_keys_in_map_entry_arrays() {
+        for (map_type, json, duplicate_path) in [
+            (
+                DataType::Map(MapType::new(
+                    DataType::String(StringType::new()),
+                    DataType::Int(IntType::new()),
+                )),
+                r#"[{"key":"role","value":1},{"key":"region","value":2},{"key":"role","value":3}]"#,
+                "v[2].key",
+            ),
+            (
+                DataType::Map(MapType::new(
+                    DataType::Int(IntType::new()),
+                    DataType::String(StringType::new()),
+                )),
+                r#"[{"key":7,"value":"first"},{"key":"7","value":"second"}]"#,
+                "v[1].key",
+            ),
+        ] {
+            let error = decode_one(map_type, json).unwrap_err();
+            assert!(!error.is_schema_mismatch(), "{json}");
+            assert!(error.message().contains(duplicate_path), "{json}");
+            assert!(error.message().contains("duplicate"), "{json}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!--
Generated-by: Codex following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: close #4204

Canonical MAP entry arrays currently accept duplicate decoded keys. When such a row is read, a later value can silently overwrite an earlier value. This change rejects the invalid MAP at the Gateway REST boundary.

### Brief change log

- Detect duplicate keys after canonical MAP entries have been decoded to their declared key type.
- Report the second occurrence with its precise `v[index].key` path as an invalid value.
- Add regression coverage for non-adjacent string duplicates and semantically equal integer keys (`7` and `"7"`).

### Tests

- `cargo test --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings -A clippy::needless_borrows_for_generic_args -A clippy::uninlined_format_args`
- `git diff --check`

### API and Format

No public API or storage format changes. Invalid canonical MAP entry arrays with duplicate keys now return HTTP 400 instead of being written.

### Documentation

No documentation changes. This fixes validation of an existing API contract.