### PR TITLE
[lake/iceberg] Fix Iceberg table rebinding with different Fluss properties

### DIFF
--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalog.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalog.java
@@ -519,6 +519,9 @@ public class IcebergLakeCatalog implements LakeCatalog {
     boolean isIcebergPropertiesCompatible(
             Map<String, String> existingProperties, Map<String, String> expectedProperties) {
         for (Map.Entry<String, String> entry : expectedProperties.entrySet()) {
+            if (entry.getKey().startsWith(FLUSS_CONF_PREFIX)) {
+                continue;
+            }
             String actual = existingProperties.get(entry.getKey());
             if (actual == null || !actual.equals(entry.getValue())) {
                 return false;

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalogTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalogTest.java
@@ -1775,6 +1775,11 @@ class IcebergLakeCatalogTest {
         existing.put("engine.internal", "whatever");
         assertThat(flussIcebergCatalog.isIcebergPropertiesCompatible(existing, expected)).isTrue();
 
+        // Fluss properties are metadata owned by Fluss and may differ between descriptors.
+        expected.put("fluss.table.replication.factor", "1");
+        existing.put("fluss.table.replication.factor", "2");
+        assertThat(flussIcebergCatalog.isIcebergPropertiesCompatible(existing, expected)).isTrue();
+
         // Existing missing an expected key -> incompatible.
         existing = new HashMap<>();
         existing.put("k1", "v1");


### PR DESCRIPTION
<!--
Generated-by: Codex (GPT-5)
-->

### Purpose

Linked issue: close #4218

Prevent Fluss-owned `fluss.*` metadata from making an existing Iceberg table appear incompatible during idempotent table creation. Iceberg-native properties remain strictly validated.

### Brief change log

- Ignore properties with the `fluss.` prefix during existing Iceberg table compatibility checks.
- Keep Iceberg-native property mismatches incompatible.
- Add unit coverage for differing `fluss.table.replication.factor`.
- Iceberg format-version migration is not changed by this PR.

### Tests

- `./mvnw -q -pl fluss-lake/fluss-lake-iceberg -am -DskipITs -Dtest=IcebergLakeCatalogTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Result: 42 tests passed.

### API and Format

No API or storage format changes.

### Documentation

No documentation changes.

### Generative AI disclosure

- [ ] No generative AI tools used
- [x] Yes (Codex)