### PR TITLE
[spark] Fix Fluss Spark read paths

### DIFF
--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSource.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSource.java
@@ -114,6 +114,9 @@ public class IcebergLakeSource implements LakeSource<IcebergSplit> {
     public RecordReader createRecordReader(ReaderContext<IcebergSplit> context) throws IOException {
         Catalog catalog = IcebergCatalogUtils.createIcebergCatalog(icebergConfig);
         Table table = catalog.loadTable(toIceberg(tablePath));
+        if (context.requireSortedRecords()) {
+            return new IcebergSortedRecordReader(table, context.lakeSplit(), project);
+        }
         return new IcebergRecordReader(context.lakeSplit().fileScanTask(), table, project);
     }
 

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergRecordReader.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergRecordReader.java
@@ -93,8 +93,7 @@ public class IcebergRecordReader implements RecordReader {
 
         private final org.apache.iceberg.io.CloseableIterator<Record> icebergRecordIterator;
 
-        private final ProjectedRow projectedRow;
-        private final IcebergRecordAsFlussRow icebergRecordAsFlussRow;
+        private final int[] projectedPositions;
 
         public IcebergRecordAsFlussRecordIterator(
                 CloseableIterable<Record> icebergRecordIterator, Types.StructType struct) {
@@ -107,8 +106,7 @@ public class IcebergRecordReader implements RecordReader {
                     IcebergUtils.isLegacyTable(new Schema(struct.fields()))
                             ? struct.fields().size() - LEGACY_SYSTEM_COLUMNS.size()
                             : struct.fields().size();
-            projectedRow = ProjectedRow.from(IntStream.range(0, businessFieldCount).toArray());
-            icebergRecordAsFlussRow = new IcebergRecordAsFlussRow();
+            projectedPositions = IntStream.range(0, businessFieldCount).toArray();
         }
 
         @Override
@@ -136,8 +134,8 @@ public class IcebergRecordReader implements RecordReader {
                     NO_SYSTEM_COLUMN_VALUE,
                     NO_SYSTEM_COLUMN_VALUE,
                     ChangeType.INSERT,
-                    projectedRow.replaceRow(
-                            icebergRecordAsFlussRow.replaceIcebergRecord(icebergRecord)));
+                    ProjectedRow.from(projectedPositions)
+                            .replaceRow(new IcebergRecordAsFlussRow(icebergRecord)));
         }
     }
 }

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergSortedRecordReader.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/source/IcebergSortedRecordReader.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.iceberg.source;
+
+import org.apache.fluss.lake.source.SortedRecordReader;
+import org.apache.fluss.record.LogRecord;
+import org.apache.fluss.row.InternalRow;
+import org.apache.fluss.utils.CloseableIterator;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.apache.fluss.utils.Preconditions.checkState;
+
+/** Sorted Iceberg reader used by primary-key lake union reads. */
+public class IcebergSortedRecordReader implements SortedRecordReader {
+
+    private final @Nullable IcebergRecordReader delegate;
+    private final List<Types.NestedField> keyFields;
+    private final int[] keyPositions;
+
+    /**
+     * Creates an Iceberg sorted reader.
+     *
+     * @param table Iceberg table to read
+     * @param split file split, or null when only the comparator is required
+     * @param project top-level projection, or null for the full table projection
+     */
+    public IcebergSortedRecordReader(
+            Table table, @Nullable IcebergSplit split, @Nullable int[][] project) {
+        this.delegate =
+                split == null
+                        ? null
+                        : new IcebergRecordReader(split.fileScanTask(), table, project);
+        SortOrder sortOrder = createSortOrder(table.schema(), project);
+        this.keyFields = sortOrder.keyFields;
+        this.keyPositions = sortOrder.keyPositions;
+    }
+
+    @Override
+    public CloseableIterator<LogRecord> read() throws IOException {
+        if (delegate == null) {
+            return CloseableIterator.wrap(Collections.emptyIterator());
+        }
+
+        List<LogRecord> records = new ArrayList<>();
+        CloseableIterator<LogRecord> iterator = delegate.read();
+        try {
+            while (iterator.hasNext()) {
+                records.add(iterator.next());
+            }
+        } finally {
+            iterator.close();
+        }
+        records.sort((record1, record2) -> compareRows(record1.getRow(), record2.getRow()));
+        return CloseableIterator.wrap(records.iterator());
+    }
+
+    @Override
+    public Comparator<InternalRow> order() {
+        return this::compareKeyRows;
+    }
+
+    private int compareRows(InternalRow row1, InternalRow row2) {
+        for (int i = 0; i < keyFields.size(); i++) {
+            int position = keyPositions[i];
+            checkState(
+                    !row1.isNullAt(position) && !row2.isNullAt(position),
+                    "Iceberg identifier field at position %s must not be null.",
+                    position);
+            int result = compareValue(row1, row2, position, keyFields.get(i).type());
+            if (result != 0) {
+                return result;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Compares rows containing only primary-key fields.
+     *
+     * <p>The client-side sort/merge reader passes primary-key projections to {@link #order()}, so
+     * their positions always start at zero regardless of the positions in the Iceberg table.
+     */
+    private int compareKeyRows(InternalRow row1, InternalRow row2) {
+        for (int i = 0; i < keyFields.size(); i++) {
+            checkState(
+                    !row1.isNullAt(i) && !row2.isNullAt(i),
+                    "Iceberg identifier field at key position %s must not be null.",
+                    i);
+            int result = compareValue(row1, row2, i, keyFields.get(i).type());
+            if (result != 0) {
+                return result;
+            }
+        }
+        return 0;
+    }
+
+    private int compareValue(InternalRow row1, InternalRow row2, int position, Type type) {
+        switch (type.typeId()) {
+            case BOOLEAN:
+                return Boolean.compare(row1.getBoolean(position), row2.getBoolean(position));
+            case INTEGER:
+            case DATE:
+            case TIME:
+                return Integer.compare(row1.getInt(position), row2.getInt(position));
+            case LONG:
+                return Long.compare(row1.getLong(position), row2.getLong(position));
+            case FLOAT:
+                return Float.compare(row1.getFloat(position), row2.getFloat(position));
+            case DOUBLE:
+                return Double.compare(row1.getDouble(position), row2.getDouble(position));
+            case STRING:
+                return row1.getString(position).compareTo(row2.getString(position));
+            case DECIMAL:
+                Types.DecimalType decimalType = (Types.DecimalType) type;
+                return row1.getDecimal(position, decimalType.precision(), decimalType.scale())
+                        .compareTo(
+                                row2.getDecimal(
+                                        position, decimalType.precision(), decimalType.scale()));
+            case TIMESTAMP:
+                return compareTimestamp(
+                        row1, row2, position, ((Types.TimestampType) type).shouldAdjustToUTC());
+            case TIMESTAMP_NANO:
+                return compareTimestamp(
+                        row1, row2, position, ((Types.TimestampNanoType) type).shouldAdjustToUTC());
+            case BINARY:
+            case FIXED:
+                return compareBytes(row1.getBytes(position), row2.getBytes(position));
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported Iceberg identifier type: " + type.typeId());
+        }
+    }
+
+    private int compareTimestamp(
+            InternalRow row1, InternalRow row2, int position, boolean shouldAdjustToUTC) {
+        if (shouldAdjustToUTC) {
+            return row1.getTimestampLtz(position, 6).compareTo(row2.getTimestampLtz(position, 6));
+        }
+        return row1.getTimestampNtz(position, 6).compareTo(row2.getTimestampNtz(position, 6));
+    }
+
+    private int compareBytes(byte[] bytes1, byte[] bytes2) {
+        int length = Math.min(bytes1.length, bytes2.length);
+        for (int i = 0; i < length; i++) {
+            int result = Byte.compare(bytes1[i], bytes2[i]);
+            if (result != 0) {
+                return result;
+            }
+        }
+        return Integer.compare(bytes1.length, bytes2.length);
+    }
+
+    private static SortOrder createSortOrder(Schema schema, @Nullable int[][] project) {
+        List<Types.NestedField> keyFields = new ArrayList<>();
+        List<Integer> originalPositions = new ArrayList<>();
+        List<Types.NestedField> columns = schema.columns();
+        for (int i = 0; i < columns.size(); i++) {
+            Types.NestedField field = columns.get(i);
+            if (schema.identifierFieldIds().contains(field.fieldId())) {
+                keyFields.add(field);
+                originalPositions.add(i);
+            }
+        }
+
+        int[] keyPositions = new int[keyFields.size()];
+        for (int i = 0; i < originalPositions.size(); i++) {
+            int position = findProjectedPosition(originalPositions.get(i), project);
+            checkState(
+                    position >= 0,
+                    "Iceberg identifier field at position %s is missing from the projection.",
+                    originalPositions.get(i));
+            keyPositions[i] = position;
+        }
+        return new SortOrder(keyFields, keyPositions);
+    }
+
+    private static int findProjectedPosition(int originalPosition, @Nullable int[][] project) {
+        if (project == null) {
+            return originalPosition;
+        }
+        for (int i = 0; i < project.length; i++) {
+            if (project[i].length > 0 && project[i][0] == originalPosition) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static final class SortOrder {
+        private final List<Types.NestedField> keyFields;
+        private final int[] keyPositions;
+
+        private SortOrder(List<Types.NestedField> keyFields, int[] keyPositions) {
+            this.keyFields = keyFields;
+            this.keyPositions = keyPositions;
+        }
+    }
+}

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSourceTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/source/IcebergLakeSourceTest.java
@@ -21,11 +21,14 @@ package org.apache.fluss.lake.iceberg.source;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.lake.source.LakeSource;
 import org.apache.fluss.lake.source.RecordReader;
+import org.apache.fluss.lake.source.SortedRecordReader;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.predicate.Predicate;
 import org.apache.fluss.predicate.PredicateBuilder;
 import org.apache.fluss.record.LogRecord;
 import org.apache.fluss.row.BinaryString;
+import org.apache.fluss.row.GenericRow;
+import org.apache.fluss.row.TimestampLtz;
 import org.apache.fluss.types.DataTypes;
 import org.apache.fluss.types.IntType;
 import org.apache.fluss.types.RowType;
@@ -87,6 +90,84 @@ class IcebergLakeSourceTest extends IcebergSourceTestBase {
 
         assertThat(result.acceptedPredicates()).isEmpty();
         assertThat(result.remainingPredicates()).isEmpty();
+    }
+
+    @Test
+    void testSortedReaderSupportsMissingLakeSplit() throws Exception {
+        TablePath tablePath = TablePath.of("fluss", "test_sorted_reader_without_split");
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                required(1, "event_time", Types.TimestampType.withZone()),
+                                optional(2, "name", Types.StringType.get())),
+                        Collections.singleton(1));
+        createTable(tablePath, schema, PartitionSpec.unpartitioned());
+
+        LakeSource<IcebergSplit> lakeSource = lakeStorage.createLakeSource(tablePath);
+        RecordReader recordReader =
+                lakeSource.createRecordReader(
+                        new LakeSource.ReaderContext<IcebergSplit>() {
+                            @Override
+                            public IcebergSplit lakeSplit() {
+                                return null;
+                            }
+
+                            @Override
+                            public boolean requireSortedRecords() {
+                                return true;
+                            }
+                        });
+
+        assertThat(recordReader).isInstanceOf(SortedRecordReader.class);
+        SortedRecordReader sortedRecordReader = (SortedRecordReader) recordReader;
+        assertThat(
+                        sortedRecordReader
+                                .order()
+                                .compare(
+                                        GenericRow.of(TimestampLtz.fromEpochMillis(1)),
+                                        GenericRow.of(TimestampLtz.fromEpochMillis(2))))
+                .isNegative();
+        try (CloseableIterator<LogRecord> iterator = sortedRecordReader.read()) {
+            assertThat(iterator.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    void testSortedReaderComparesPrimaryKeyProjection() throws Exception {
+        TablePath tablePath = TablePath.of("fluss", "test_sorted_reader_key_projection");
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                optional(1, "name", Types.StringType.get()),
+                                required(2, "event_time", Types.TimestampType.withZone()),
+                                optional(3, "value", Types.StringType.get())),
+                        Collections.singleton(2));
+        createTable(tablePath, schema, PartitionSpec.unpartitioned());
+
+        LakeSource<IcebergSplit> lakeSource = lakeStorage.createLakeSource(tablePath);
+        lakeSource.withProject(new int[][] {{0}, {1}});
+        SortedRecordReader sortedRecordReader =
+                (SortedRecordReader)
+                        lakeSource.createRecordReader(
+                                new LakeSource.ReaderContext<IcebergSplit>() {
+                                    @Override
+                                    public IcebergSplit lakeSplit() {
+                                        return null;
+                                    }
+
+                                    @Override
+                                    public boolean requireSortedRecords() {
+                                        return true;
+                                    }
+                                });
+
+        assertThat(
+                        sortedRecordReader
+                                .order()
+                                .compare(
+                                        GenericRow.of(TimestampLtz.fromEpochMillis(1)),
+                                        GenericRow.of(TimestampLtz.fromEpochMillis(2))))
+                .isNegative();
     }
 
     @Test

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussAppendPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussAppendPartitionReader.scala
@@ -44,6 +44,11 @@ class FlussAppendPartitionReader(
   // Iterator for current batch of records
   private var currentRecords: java.util.Iterator[ScanRecord] = java.util.Collections.emptyIterator()
 
+  // The scanner may advance a bucket without returning materialized records, for example when
+  // records are filtered out. Apply this offset only after all records in the current batch have
+  // been consumed so that records returned in the same batch are not skipped.
+  private var currentBatchConsumedUpToOffset: Option[Long] = None
+
   // The latest offset of fluss is -2
   private var currentOffset: Long = flussPartition.startOffset.max(0L)
 
@@ -58,33 +63,48 @@ class FlussAppendPartitionReader(
 
   private def pollMoreRecords(): Unit = {
     val scanRecords = logScanner.poll(POLL_TIMEOUT)
-    if ((scanRecords == null || scanRecords.isEmpty) && currentOffset < flussPartition.stopOffset) {
-      throw new IllegalStateException(s"No more data from fluss server," +
-        s" but current offset $currentOffset not reach the stop offset ${flussPartition.stopOffset}")
+    if (scanRecords == null) {
+      currentBatchConsumedUpToOffset = None
+      currentRecords = java.util.Collections.emptyIterator()
+    } else {
+      currentBatchConsumedUpToOffset =
+        Option(scanRecords.consumedUpToOffset(tableBucket)).map(_.longValue())
+      currentRecords = scanRecords.records(tableBucket).iterator()
     }
-    currentRecords = scanRecords.records(tableBucket).iterator()
+  }
+
+  private def advanceCurrentBatch(): Unit = {
+    currentBatchConsumedUpToOffset.foreach {
+      consumedUpToOffset => currentOffset = math.max(currentOffset, consumedUpToOffset)
+    }
+    currentBatchConsumedUpToOffset = None
   }
 
   override def next0(): Boolean = {
     while (!closed && !reachedWindowEnd && currentOffset < flussPartition.stopOffset) {
       if (!currentRecords.hasNext) {
+        advanceCurrentBatch()
+        if (currentOffset >= flussPartition.stopOffset) {
+          return false
+        }
         pollMoreRecords()
       }
       if (!currentRecords.hasNext) {
-        throw new IllegalStateException(s"No more data from fluss server," +
-          s" but current offset $currentOffset not reach the stop offset ${flussPartition.stopOffset}")
-      }
-
-      val scanRecord = currentRecords.next()
-      currentOffset = scanRecord.logOffset() + 1
-      timeRange match {
-        case Some(range) if range.isAfter(scanRecord.timestamp()) => reachedWindowEnd = true
-        // The record precedes the requested window: the start offset resolved from the start
-        // timestamp is only time-index accurate on tiered segments, so it can undershoot.
-        case Some(range) if !range.contains(scanRecord.timestamp()) => // skip
-        case _ =>
-          currentRow = convertToSparkRow(scanRecord)
-          return true
+        // An empty poll can be a timeout or a progress-only batch. Keep polling; a progress-only
+        // batch is committed above on the next loop iteration.
+        advanceCurrentBatch()
+      } else {
+        val scanRecord = currentRecords.next()
+        currentOffset = scanRecord.logOffset() + 1
+        timeRange match {
+          case Some(range) if range.isAfter(scanRecord.timestamp()) => reachedWindowEnd = true
+          // The record precedes the requested window: the start offset resolved from the start
+          // timestamp is only time-index accurate on tiered segments, so it can undershoot.
+          case Some(range) if !range.contains(scanRecord.timestamp()) => // skip
+          case _ =>
+            currentRow = convertToSparkRow(scanRecord)
+            return true
+        }
       }
     }
     false

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/utils/LogChangesIterator.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/utils/LogChangesIterator.scala
@@ -64,9 +64,15 @@ case class LogChangesIterator(
       }
   }
 
-  private var recordsIterator = SingleElementHeadIterator.addElementToHead(
-    sortedLogRecords.head,
-    CloseableIterator.wrap(sortedLogRecords.tail.toIterator.asJava))
+  private var recordsIterator: CloseableIterator[ScanRecord] = {
+    if (sortedLogRecords.isEmpty) {
+      CloseableIterator.emptyIterator[ScanRecord]()
+    } else {
+      SingleElementHeadIterator.addElementToHead(
+        sortedLogRecords.head,
+        CloseableIterator.wrap(sortedLogRecords.tail.toIterator.asJava))
+    }
+  }
 
   private var currentScanRecord: ScanRecord = _
 

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/utils/LogChangesIteratorTest.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/utils/LogChangesIteratorTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.spark.utils
+
+import org.apache.fluss.row.InternalRow
+
+import org.assertj.core.api.Assertions.assertThat
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.Comparator
+
+class LogChangesIteratorTest extends AnyFunSuite {
+
+  test("empty log records produce an empty iterator") {
+    val iterator = LogChangesIterator(
+      Array.empty,
+      Array.empty,
+      new Comparator[InternalRow] {
+        override def compare(o1: InternalRow, o2: InternalRow): Int = 0
+      })
+
+    assertThat(iterator.hasNext).isFalse
+    iterator.close()
+  }
+}


### PR DESCRIPTION
Fix Spark reads for Iceberg sort-merge tables and append log scans.

Handle empty and progress-only log scan batches without reporting a false end of data, and preserve consumed offsets when reading full projections. Use independent rows and the correct timestamp representation in Iceberg sort-merge reads to avoid projection and timestamp failures.

Add regression coverage for the affected Iceberg and log-change reader paths.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink], [rust], [python], [c++], [elixir]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose


Fix Spark read failures when querying Fluss tables with full-column projections such as `SELECT *`.

The Spark append reader previously treated an empty `ScanRecords` result as end-of-data. However, a scan result may be empty while the scanner has already advanced its consumed offset, or may simply be an empty poll caused by a timeout. This caused Spark tasks to fail with an incorrect `No more data from fluss server` exception.

This change also fixes Iceberg sort-merge reading and empty log-change iterator handling.

### Brief change log

- Handle progress-only and empty poll results in `FlussAppendPartitionReader`.
- Advance the local offset using `consumedUpToOffset` after the current batch is consumed.
- Fix Iceberg sorted reads for primary-key projections and timestamp types.
- Avoid sharing mutable row objects between Iceberg records.
- Handle empty input correctly in `LogChangesIterator`.
- Add regression test coverage for the affected read paths.

### Tests

- `IcebergLakeSourceTest`: 5 tests passed.
- Spark common module compilation passed.
- Spark 3.5 connector packaging passed with:

  ```bash
  mvn -pl fluss-spark/fluss-spark-3.5 \
      -am \
      -DskipTests \
      -Dcheckstyle.skip=true \
      -Drat.skip=true \
      package
