### PR TITLE
[server] Detach flushed entries from previousEntry chains in KvPreWriteBuffer

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBuffer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBuffer.java
@@ -32,11 +32,13 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.apache.fluss.utils.Preconditions.checkArgument;
 import static org.apache.fluss.utils.UnsafeUtils.BYTE_ARRAY_BASE_OFFSET;
@@ -262,10 +264,39 @@ public class KvPreWriteBuffer {
             pendingFlushBytes -= entryBytes(entry.getKey(), entry.getValue());
             kvEntryMap.remove(entry.getKey(), entry);
         }
+        // Newer buffered versions of the same key may still reference the flushed entries
+        // through their previousEntry chain; cut such chains at the flushed boundary so the
+        // flushed entries become unreachable instead of being retained while no longer
+        // counted by pendingFlushBytes.
+        Set<Key> flushedKeys = new HashSet<>();
+        for (KvEntry entry : preparedFlush.entries) {
+            if (flushedKeys.add(entry.getKey())) {
+                detachFromFlushedChain(kvEntryMap.get(entry.getKey()));
+            }
+        }
         if (allKvEntries.isEmpty()) {
             maxLogSequenceNumber = -1;
         }
         return preparedFlush.rowCountDiff;
+    }
+
+    /**
+     * Cuts the previous-entry chain of the newest still-buffered version of a key at its first
+     * reference to a FLUSHED entry, if any. References to ACTIVE/PREPARED entries are left intact
+     * since truncation rollback relies on them; a FLUSHED previous version is already invisible
+     * to that rollback (see {@link #previousEntryInBuffer}) and covered by the kv storage, so
+     * cutting is unobservable.
+     */
+    private static void detachFromFlushedChain(@Nullable KvEntry newest) {
+        KvEntry cur = newest;
+        while (cur != null
+                && cur.previousEntry != null
+                && cur.previousEntry.state != EntryState.FLUSHED) {
+            cur = cur.previousEntry;
+        }
+        if (cur != null) {
+            cur.previousEntry = null;
+        }
     }
 
     /** Aborts a prepared async flush and makes its entries active again. */
@@ -348,8 +379,9 @@ public class KvPreWriteBuffer {
         private final Value value;
         private final long logSequenceNumber;
 
-        // the previous mapped value in the buffer before this key-value put
-        @Nullable private final KvEntry previousEntry;
+        // the previous mapped value in the buffer before this key-value put; null once the
+        // referenced entry has been flushed (see detachFromFlushedChain)
+        @Nullable private KvEntry previousEntry;
 
         private EntryState state = EntryState.ACTIVE;
 
@@ -393,6 +425,12 @@ public class KvPreWriteBuffer {
 
         long getLogSequenceNumber() {
             return logSequenceNumber;
+        }
+
+        @VisibleForTesting
+        @Nullable
+        KvEntry getPreviousEntry() {
+            return previousEntry;
         }
 
         @Override

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBuffer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBuffer.java
@@ -283,9 +283,9 @@ public class KvPreWriteBuffer {
     /**
      * Cuts the previous-entry chain of the newest still-buffered version of a key at its first
      * reference to a FLUSHED entry, if any. References to ACTIVE/PREPARED entries are left intact
-     * since truncation rollback relies on them; a FLUSHED previous version is already invisible
-     * to that rollback (see {@link #previousEntryInBuffer}) and covered by the kv storage, so
-     * cutting is unobservable.
+     * since truncation rollback relies on them; a FLUSHED previous version is already invisible to
+     * that rollback (see {@link #previousEntryInBuffer}) and covered by the kv storage, so cutting
+     * is unobservable.
      */
     private static void detachFromFlushedChain(@Nullable KvEntry newest) {
         KvEntry cur = newest;

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBuffer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBuffer.java
@@ -32,13 +32,11 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import static org.apache.fluss.utils.Preconditions.checkArgument;
 import static org.apache.fluss.utils.UnsafeUtils.BYTE_ARRAY_BASE_OFFSET;
@@ -157,6 +155,11 @@ public class KvPreWriteBuffer {
                                 v == null
                                         ? KvEntry.of(changeType, key, value, lsn)
                                         : KvEntry.of(changeType, key, value, lsn, v));
+        // link the previous version forward to the new entry, so each version knows its
+        // successor and completeFlush can detach it in constant time
+        if (kvEntry.previousEntry != null) {
+            kvEntry.previousEntry.nextEntry = kvEntry;
+        }
         // append the entry to the tail of the list for all kv entries
         allKvEntries.addLast(kvEntry);
         // update the max lsn
@@ -208,6 +211,11 @@ public class KvPreWriteBuffer {
             }
             pendingFlushBytes -= entryBytes(entry.getKey(), entry.getValue());
             boolean removed = kvEntryMap.remove(entry.getKey(), entry);
+            // the removed entry is no longer the successor of its previous version; clear the
+            // forward link so the truncated entry does not stay reachable through it
+            if (entry.previousEntry != null) {
+                entry.previousEntry.nextEntry = null;
+            }
             // if the latest entry is removed, we need to rollback the previous entry to the map
             if (removed) {
                 KvEntry previousEntry = previousEntryInBuffer(entry.previousEntry);
@@ -263,40 +271,17 @@ public class KvPreWriteBuffer {
             entry.state = EntryState.FLUSHED;
             pendingFlushBytes -= entryBytes(entry.getKey(), entry.getValue());
             kvEntryMap.remove(entry.getKey(), entry);
-        }
-        // Newer buffered versions of the same key may still reference the flushed entries
-        // through their previousEntry chain; cut such chains at the flushed boundary so the
-        // flushed entries become unreachable instead of being retained while no longer
-        // counted by pendingFlushBytes.
-        Set<Key> flushedKeys = new HashSet<>();
-        for (KvEntry entry : preparedFlush.entries) {
-            if (flushedKeys.add(entry.getKey())) {
-                detachFromFlushedChain(kvEntryMap.get(entry.getKey()));
+            // the immediate successor is the only live referencer of a flushed entry; clearing
+            // its reference makes the flushed entry (and, transitively, its older versions)
+            // unreachable instead of being retained while no longer counted by pendingFlushBytes
+            if (entry.nextEntry != null) {
+                entry.nextEntry.previousEntry = null;
             }
         }
         if (allKvEntries.isEmpty()) {
             maxLogSequenceNumber = -1;
         }
         return preparedFlush.rowCountDiff;
-    }
-
-    /**
-     * Cuts the previous-entry chain of the newest still-buffered version of a key at its first
-     * reference to a FLUSHED entry, if any. References to ACTIVE/PREPARED entries are left intact
-     * since truncation rollback relies on them; a FLUSHED previous version is already invisible to
-     * that rollback (see {@link #previousEntryInBuffer}) and covered by the kv storage, so cutting
-     * is unobservable.
-     */
-    private static void detachFromFlushedChain(@Nullable KvEntry newest) {
-        KvEntry cur = newest;
-        while (cur != null
-                && cur.previousEntry != null
-                && cur.previousEntry.state != EntryState.FLUSHED) {
-            cur = cur.previousEntry;
-        }
-        if (cur != null) {
-            cur.previousEntry = null;
-        }
     }
 
     /** Aborts a prepared async flush and makes its entries active again. */
@@ -380,8 +365,12 @@ public class KvPreWriteBuffer {
         private final long logSequenceNumber;
 
         // the previous mapped value in the buffer before this key-value put; null once the
-        // referenced entry has been flushed (see detachFromFlushedChain)
+        // referenced entry has been flushed (see completeFlush)
         @Nullable private KvEntry previousEntry;
+
+        // the newer version of the same key that references this entry as its previous version;
+        // null once that version has been truncated (see truncateTo)
+        @Nullable private KvEntry nextEntry;
 
         private EntryState state = EntryState.ACTIVE;
 
@@ -431,6 +420,12 @@ public class KvPreWriteBuffer {
         @Nullable
         KvEntry getPreviousEntry() {
             return previousEntry;
+        }
+
+        @VisibleForTesting
+        @Nullable
+        KvEntry getNextEntry() {
+            return nextEntry;
         }
 
         @Override

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
@@ -454,6 +454,69 @@ class KvPreWriteBufferTest {
         assertThat(buffer.pendingFlushBytes()).isEqualTo(0);
     }
 
+    @Test
+    void testCompleteFlushDetachesFlushedEntriesFromPreviousChain() {
+        KvPreWriteBuffer buffer = new KvPreWriteBuffer(TestingMetricGroups.TABLET_SERVER_METRICS);
+        KvPreWriteBuffer.Key key = toKey("k");
+
+        buffer.insert(key, "v1".getBytes(), 1);
+        buffer.insert(key, "v2".getBytes(), 2);
+        buffer.insert(key, "v3".getBytes(), 3);
+        KvPreWriteBuffer.KvEntry v3 = buffer.getKvEntryMap().get(key);
+        buffer.insert(key, "v4".getBytes(), 4);
+        KvPreWriteBuffer.KvEntry v4 = buffer.getKvEntryMap().get(key);
+
+        // flush covers v1 and v2; v3 and v4 stay buffered
+        flushBuffer(buffer, 3);
+
+        // the buffered chain is cut at the flushed boundary: v3 no longer references
+        // the flushed v2, while the reference to the still-buffered v3 is kept for rollback
+        assertThat(v3.getPreviousEntry()).isNull();
+        assertThat(v4.getPreviousEntry()).isSameAs(v3);
+
+        // read semantics are unchanged and only v3/v4 stay in the byte accounting
+        assertThat(getValue(buffer, "k")).isEqualTo("v4");
+        assertThat(buffer.pendingFlushBytes()).isEqualTo(6);
+
+        // across further flush cycles the chain never grows back: after flushing v3~v5,
+        // the remaining v6 references no flushed version any more
+        buffer.insert(key, "v5".getBytes(), 5);
+        buffer.insert(key, "v6".getBytes(), 6);
+        KvPreWriteBuffer.KvEntry v6 = buffer.getKvEntryMap().get(key);
+        flushBuffer(buffer, 6);
+        assertThat(v6.getPreviousEntry()).isNull();
+        assertThat(getValue(buffer, "k")).isEqualTo("v6");
+    }
+
+    @Test
+    void testTruncateRollbackSemanticsAfterFlushDetachment() {
+        KvPreWriteBuffer buffer = new KvPreWriteBuffer(TestingMetricGroups.TABLET_SERVER_METRICS);
+        KvPreWriteBuffer.Key key = toKey("k");
+
+        // v1@1, v2@2, v3@3; flush covers v1 and v2, v3 stays buffered
+        buffer.insert(key, "v1".getBytes(), 1);
+        buffer.insert(key, "v2".getBytes(), 2);
+        buffer.insert(key, "v3".getBytes(), 3);
+        flushBuffer(buffer, 3);
+
+        // truncating v3 rolls back to the newest version below the truncation point; all
+        // older versions are flushed, so the rollback target is the kv storage and the key
+        // disappears from the buffer - the same behavior as before the chain detachment
+        buffer.truncateTo(1, TruncateReason.ERROR);
+        assertThat(getValue(buffer, "k")).isNull();
+        assertThat(buffer.getKvEntryMap()).doesNotContainKey(key);
+        assertThat(buffer.getAllKvEntries()).isEmpty();
+
+        // rollback to a still-buffered previous version must keep working: after flushing v4,
+        // truncating v6 rolls the map back to the buffered v5
+        buffer.insert(key, "v4".getBytes(), 4);
+        buffer.insert(key, "v5".getBytes(), 5);
+        flushBuffer(buffer, 5);
+        buffer.insert(key, "v6".getBytes(), 6);
+        buffer.truncateTo(6, TruncateReason.ERROR);
+        assertThat(getValue(buffer, "k")).isEqualTo("v5");
+    }
+
     private static String getValue(KvPreWriteBuffer preWriteBuffer, String keyStr) {
         KvPreWriteBuffer.Key key = toKey(keyStr);
         KvPreWriteBuffer.Value value = preWriteBuffer.get(key);

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
@@ -470,9 +470,10 @@ class KvPreWriteBufferTest {
         flushBuffer(buffer, 3);
 
         // the buffered chain is cut at the flushed boundary: v3 no longer references
-        // the flushed v2, while the reference to the still-buffered v3 is kept for rollback
+        // the flushed v2, while the references to the still-buffered v3 are kept for rollback
         assertThat(v3.getPreviousEntry()).isNull();
         assertThat(v4.getPreviousEntry()).isSameAs(v3);
+        assertThat(v3.getNextEntry()).isSameAs(v4);
 
         // read semantics are unchanged and only v3/v4 stay in the byte accounting
         assertThat(getValue(buffer, "k")).isEqualTo("v4");
@@ -515,6 +516,8 @@ class KvPreWriteBufferTest {
         buffer.insert(key, "v6".getBytes(), 6);
         buffer.truncateTo(6, TruncateReason.ERROR);
         assertThat(getValue(buffer, "k")).isEqualTo("v5");
+        // the retained predecessor no longer links forward to the truncated entry
+        assertThat(buffer.getKvEntryMap().get(key).getNextEntry()).isNull();
     }
 
     private static String getValue(KvPreWriteBuffer preWriteBuffer, String keyStr) {


### PR DESCRIPTION

### Purpose


Linked issue: close #4243

<!-- What is the purpose of the change -->

### Brief change log

For each key that had entries flushed, cut the `previousEntry` chain of the newest still-buffered version at its first reference to a FLUSHED entry. Reachability is transitive, so this single cut makes the whole flushed suffix eligible for GC.

References to ACTIVE/PREPARED entries are never touched, and FLUSHED references are already invisible to truncation rollback (`previousEntryInBuffer`), so rollback semantics are preserved.


### Tests


Two new cases in `KvPreWriteBufferTest`: chain detachment at the flushed boundary (and not growing back across flush cycles), and unchanged truncation rollback behavior.

### API and Format



### Documentation


