### PR TITLE
[server] Expose KV WAL memory pool metrics for primary key tables

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/memory/LazyMemorySegmentPool.java
+++ b/fluss-common/src/main/java/org/apache/fluss/memory/LazyMemorySegmentPool.java
@@ -64,7 +64,7 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
     @GuardedBy("lock")
     private boolean closed;
 
-    private int pageUsage;
+    private volatile int pageUsage;
 
     @VisibleForTesting
     LazyMemorySegmentPool(
@@ -244,7 +244,7 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
 
     /** Returns the number of pages currently allocated to callers. */
     public int usedPages() {
-        return inLock(lock, () -> pageUsage);
+        return pageUsage;
     }
 
     @Override
@@ -269,7 +269,6 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
         }
     }
 
-    /** Returns the number of threads currently blocked waiting for pages. */
     public int queued() {
         return inLock(lock, waiters::size);
     }

--- a/fluss-common/src/main/java/org/apache/fluss/memory/LazyMemorySegmentPool.java
+++ b/fluss-common/src/main/java/org/apache/fluss/memory/LazyMemorySegmentPool.java
@@ -242,6 +242,11 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
         return inLock(lock, () -> this.maxPages - this.pageUsage);
     }
 
+    /** Returns the number of pages currently allocated to callers. */
+    public int usedPages() {
+        return inLock(lock, () -> pageUsage);
+    }
+
     @Override
     public long availableMemory() {
         return ((long) freePages()) * pageSize;
@@ -264,6 +269,7 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
         }
     }
 
+    /** Returns the number of threads currently blocked waiting for pages. */
     public int queued() {
         return inLock(lock, waiters::size);
     }

--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -250,6 +250,16 @@ public class MetricNames {
     public static final String ROCKSDB_SHARED_WRITE_BUFFER_CAPACITY =
             "rocksdbSharedWriteBufferCapacity";
 
+    // Server-level WAL memory pool metrics for primary key tables
+    /** Memory used by the WAL memory pool for primary key tables in this server (bytes). */
+    public static final String WAL_MEMORY_POOL_USAGE = "walMemoryPoolUsage";
+
+    /** Total capacity of the WAL memory pool for primary key tables in this server (bytes). */
+    public static final String WAL_MEMORY_POOL_CAPACITY = "walMemoryPoolCapacity";
+
+    /** Number of threads currently waiting for pages from the WAL memory pool. */
+    public static final String WAL_MEMORY_POOL_WAITING_THREADS = "walMemoryPoolWaitingThreads";
+
     // Table-level RocksDB memory metrics (Sum aggregation)
     /** Total memtable memory usage across all buckets of this table. */
     public static final String ROCKSDB_MEMTABLE_MEMORY_USAGE_TOTAL =

--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -250,16 +250,6 @@ public class MetricNames {
     public static final String ROCKSDB_SHARED_WRITE_BUFFER_CAPACITY =
             "rocksdbSharedWriteBufferCapacity";
 
-    // Server-level WAL memory pool metrics for primary key tables
-    /** Memory used by the WAL memory pool for primary key tables in this server (bytes). */
-    public static final String WAL_MEMORY_POOL_USAGE = "walMemoryPoolUsage";
-
-    /** Total capacity of the WAL memory pool for primary key tables in this server (bytes). */
-    public static final String WAL_MEMORY_POOL_CAPACITY = "walMemoryPoolCapacity";
-
-    /** Number of threads currently waiting for pages from the WAL memory pool. */
-    public static final String WAL_MEMORY_POOL_WAITING_THREADS = "walMemoryPoolWaitingThreads";
-
     // Table-level RocksDB memory metrics (Sum aggregation)
     /** Total memtable memory usage across all buckets of this table. */
     public static final String ROCKSDB_MEMTABLE_MEMORY_USAGE_TOTAL =
@@ -280,6 +270,13 @@ public class MetricNames {
     /** Total pinned memory in block cache across all buckets of this table. */
     public static final String ROCKSDB_BLOCK_CACHE_PINNED_USAGE_TOTAL =
             "rocksdbBlockCachePinnedUsageTotal";
+
+    // Server-level KV WAL memory pool metrics for primary key tables
+    /** Memory used by the KV WAL memory pool for primary key tables in this server (bytes). */
+    public static final String KV_WAL_MEMORY_POOL_USAGE = "kvWalMemoryPoolUsage";
+
+    /** Total capacity of the KV WAL memory pool for primary key tables in this server (bytes). */
+    public static final String KV_WAL_MEMORY_POOL_CAPACITY = "kvWalMemoryPoolCapacity";
 
     // --------------------------------------------------------------------------------------------
     // metrics for table bucket

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/KvManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/KvManager.java
@@ -205,7 +205,11 @@ public final class KvManager extends TabletManagerBase implements ServerReconfig
             this.sharedWriteBufferManager = createdWriteBufferManager;
             tabletServerMetricGroup.setSharedWriteBufferMetrics(
                     this::getSharedWriteBufferUsage, sharedWriteBufferCapacity);
-            tabletServerMetricGroup.setWalMemoryPoolMetrics(memorySegmentPool);
+            // bind the pool as the data source locally so the supplier does not capture the
+            // whole KvManager, and convert pages to bytes here rather than in the metric group
+            LazyMemorySegmentPool walPool = memorySegmentPool;
+            tabletServerMetricGroup.registerKvWalMemoryPoolMetrics(
+                    () -> (long) walPool.usedPages() * walPool.pageSize(), walPool.totalSize());
         } catch (RuntimeException | Error e) {
             IOUtils.closeQuietly(createdWriteBufferManager);
             IOUtils.closeQuietly(createdWriteBufferAccountingCache);

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/KvManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/KvManager.java
@@ -29,7 +29,6 @@ import org.apache.fluss.exception.KvStorageException;
 import org.apache.fluss.fs.FileSystem;
 import org.apache.fluss.fs.FsPath;
 import org.apache.fluss.memory.LazyMemorySegmentPool;
-import org.apache.fluss.memory.MemorySegmentPool;
 import org.apache.fluss.metadata.KvFormat;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.SchemaGetter;
@@ -137,7 +136,7 @@ public final class KvManager extends TabletManagerBase implements ServerReconfig
     private final BufferAllocator arrowBufferAllocator;
 
     /** The memory segment pool to allocate memorySegment. */
-    private final MemorySegmentPool memorySegmentPool;
+    private final LazyMemorySegmentPool memorySegmentPool;
 
     private final FsPath remoteKvDir;
 
@@ -206,6 +205,7 @@ public final class KvManager extends TabletManagerBase implements ServerReconfig
             this.sharedWriteBufferManager = createdWriteBufferManager;
             tabletServerMetricGroup.setSharedWriteBufferMetrics(
                     this::getSharedWriteBufferUsage, sharedWriteBufferCapacity);
+            tabletServerMetricGroup.setWalMemoryPoolMetrics(memorySegmentPool);
         } catch (RuntimeException | Error e) {
             IOUtils.closeQuietly(createdWriteBufferManager);
             IOUtils.closeQuietly(createdWriteBufferAccountingCache);

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
@@ -17,6 +17,7 @@
 
 package org.apache.fluss.server.metrics.group;
 
+import org.apache.fluss.memory.LazyMemorySegmentPool;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
@@ -213,6 +214,19 @@ public class TabletServerMetricGroup extends AbstractMetricGroup {
         this.sharedWriteBufferUsageSupplier =
                 checkNotNull(usageSupplier, "usageSupplier must not be null");
         this.sharedWriteBufferCapacity = capacity;
+    }
+
+    /**
+     * Registers gauges for the server-wide WAL memory pool used by primary key tables. Called once
+     * by KvManager when creating the server buffer pool.
+     *
+     * @param walMemoryPool the server-wide WAL memory segment pool
+     */
+    public void setWalMemoryPoolMetrics(LazyMemorySegmentPool walMemoryPool) {
+        LazyMemorySegmentPool pool = checkNotNull(walMemoryPool, "walMemoryPool must not be null");
+        gauge(MetricNames.WAL_MEMORY_POOL_USAGE, () -> (long) pool.usedPages() * pool.pageSize());
+        gauge(MetricNames.WAL_MEMORY_POOL_CAPACITY, pool::totalSize);
+        gauge(MetricNames.WAL_MEMORY_POOL_WAITING_THREADS, pool::queued);
     }
 
     @Override

--- a/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroup.java
@@ -17,7 +17,6 @@
 
 package org.apache.fluss.server.metrics.group;
 
-import org.apache.fluss.memory.LazyMemorySegmentPool;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
@@ -220,13 +219,12 @@ public class TabletServerMetricGroup extends AbstractMetricGroup {
      * Registers gauges for the server-wide WAL memory pool used by primary key tables. Called once
      * by KvManager when creating the server buffer pool.
      *
-     * @param walMemoryPool the server-wide WAL memory segment pool
+     * @param usageSupplier supplier for the bytes currently allocated from the pool
+     * @param capacity the total pool capacity in bytes
      */
-    public void setWalMemoryPoolMetrics(LazyMemorySegmentPool walMemoryPool) {
-        LazyMemorySegmentPool pool = checkNotNull(walMemoryPool, "walMemoryPool must not be null");
-        gauge(MetricNames.WAL_MEMORY_POOL_USAGE, () -> (long) pool.usedPages() * pool.pageSize());
-        gauge(MetricNames.WAL_MEMORY_POOL_CAPACITY, pool::totalSize);
-        gauge(MetricNames.WAL_MEMORY_POOL_WAITING_THREADS, pool::queued);
+    public void registerKvWalMemoryPoolMetrics(LongSupplier usageSupplier, long capacity) {
+        gauge(MetricNames.KV_WAL_MEMORY_POOL_USAGE, usageSupplier::getAsLong);
+        gauge(MetricNames.KV_WAL_MEMORY_POOL_CAPACITY, () -> capacity);
     }
 
     @Override

--- a/fluss-server/src/test/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroupTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroupTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.fluss.server.metrics.group;
 
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.MemorySize;
+import org.apache.fluss.memory.LazyMemorySegmentPool;
+import org.apache.fluss.memory.MemorySegment;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
@@ -26,6 +31,9 @@ import org.apache.fluss.metrics.registry.NOPMetricRegistry;
 import org.apache.fluss.server.kv.rocksdb.RocksDBStatistics;
 
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -75,6 +83,36 @@ class TabletServerMetricGroupTest {
                 .isEqualTo(40L);
         assertThat(gaugeValue(metricGroup, MetricNames.ROCKSDB_SHARED_WRITE_BUFFER_CAPACITY))
                 .isEqualTo(128L);
+    }
+
+    @Test
+    void testWalMemoryPoolMetrics() throws IOException {
+        // 128kb total memory with 64kb pages gives a pool of 2 pages
+        Configuration conf = new Configuration();
+        conf.set(ConfigOptions.SERVER_BUFFER_MEMORY_SIZE, MemorySize.parse("128kb"));
+        conf.set(ConfigOptions.SERVER_BUFFER_PAGE_SIZE, MemorySize.parse("64kb"));
+        LazyMemorySegmentPool pool = LazyMemorySegmentPool.createServerBufferPool(conf);
+
+        TabletServerMetricGroup metricGroup =
+                new TabletServerMetricGroup(
+                        NOPMetricRegistry.INSTANCE, "cluster", "rack", "host", 0);
+        metricGroup.setWalMemoryPoolMetrics(pool);
+
+        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_USAGE)).isEqualTo(0L);
+        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_CAPACITY))
+                .isEqualTo(128 * 1024L);
+        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_WAITING_THREADS))
+                .isEqualTo(0);
+
+        List<MemorySegment> pages = pool.allocatePages(2);
+        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_USAGE))
+                .isEqualTo(2 * 64 * 1024L);
+
+        pool.returnPage(pages.get(0));
+        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_USAGE))
+                .isEqualTo(64 * 1024L);
+        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_WAITING_THREADS))
+                .isEqualTo(0);
     }
 
     private static Object gaugeValue(TabletServerMetricGroup metricGroup, String metricName) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroupTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/metrics/group/TabletServerMetricGroupTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.fluss.server.metrics.group;
 
-import org.apache.fluss.config.ConfigOptions;
-import org.apache.fluss.config.Configuration;
-import org.apache.fluss.config.MemorySize;
-import org.apache.fluss.memory.LazyMemorySegmentPool;
-import org.apache.fluss.memory.MemorySegment;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
@@ -31,9 +26,6 @@ import org.apache.fluss.metrics.registry.NOPMetricRegistry;
 import org.apache.fluss.server.kv.rocksdb.RocksDBStatistics;
 
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -86,33 +78,15 @@ class TabletServerMetricGroupTest {
     }
 
     @Test
-    void testWalMemoryPoolMetrics() throws IOException {
-        // 128kb total memory with 64kb pages gives a pool of 2 pages
-        Configuration conf = new Configuration();
-        conf.set(ConfigOptions.SERVER_BUFFER_MEMORY_SIZE, MemorySize.parse("128kb"));
-        conf.set(ConfigOptions.SERVER_BUFFER_PAGE_SIZE, MemorySize.parse("64kb"));
-        LazyMemorySegmentPool pool = LazyMemorySegmentPool.createServerBufferPool(conf);
-
+    void testWalMemoryPoolMetrics() {
         TabletServerMetricGroup metricGroup =
                 new TabletServerMetricGroup(
                         NOPMetricRegistry.INSTANCE, "cluster", "rack", "host", 0);
-        metricGroup.setWalMemoryPoolMetrics(pool);
+        metricGroup.registerKvWalMemoryPoolMetrics(() -> 100L, 256L);
 
-        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_USAGE)).isEqualTo(0L);
-        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_CAPACITY))
-                .isEqualTo(128 * 1024L);
-        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_WAITING_THREADS))
-                .isEqualTo(0);
-
-        List<MemorySegment> pages = pool.allocatePages(2);
-        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_USAGE))
-                .isEqualTo(2 * 64 * 1024L);
-
-        pool.returnPage(pages.get(0));
-        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_USAGE))
-                .isEqualTo(64 * 1024L);
-        assertThat(gaugeValue(metricGroup, MetricNames.WAL_MEMORY_POOL_WAITING_THREADS))
-                .isEqualTo(0);
+        assertThat(gaugeValue(metricGroup, MetricNames.KV_WAL_MEMORY_POOL_USAGE)).isEqualTo(100L);
+        assertThat(gaugeValue(metricGroup, MetricNames.KV_WAL_MEMORY_POOL_CAPACITY))
+                .isEqualTo(256L);
     }
 
     private static Object gaugeValue(TabletServerMetricGroup metricGroup, String metricName) {

--- a/website/docs/maintenance/observability/monitor-metrics.md
+++ b/website/docs/maintenance/observability/monitor-metrics.md
@@ -463,8 +463,8 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </thead>
   <tbody>
     <tr>
-      <th rowspan="37"><strong>tabletserver</strong></th>
-      <td style={{textAlign: 'center', verticalAlign: 'middle' }} rowspan="25">-</td>
+      <th rowspan="40"><strong>tabletserver</strong></th>
+      <td style={{textAlign: 'center', verticalAlign: 'middle' }} rowspan="28">-</td>
       <td>messagesInPerSecond</td>
       <td>The number of messages written per second to this server.</td>
       <td>Meter</td>
@@ -588,6 +588,21 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>preWriteBufferTruncateAsErrorPerSecond</td>
       <td>The number of kv pre-write buffer truncate due to the error happened when writing cdc to log per second.</td>
       <td>Meter</td>
+    </tr>
+    <tr>
+      <td>walMemoryPoolUsage</td>
+      <td>Memory currently allocated from the server-wide WAL memory pool for primary key tables in this server (in bytes). The pool capacity is configured by <code>server.buffer.memory-size</code>.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>walMemoryPoolCapacity</td>
+      <td>Total capacity of the server-wide WAL memory pool for primary key tables in this server (in bytes).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>walMemoryPoolWaitingThreads</td>
+      <td>The number of threads currently blocked waiting for pages from the server-wide WAL memory pool. A non-zero value indicates the pool is exhausted and writes to primary key tables are being throttled.</td>
+      <td>Gauge</td>
     </tr>
     <tr>
       <td rowspan="4">historical</td>

--- a/website/docs/maintenance/observability/monitor-metrics.md
+++ b/website/docs/maintenance/observability/monitor-metrics.md
@@ -463,8 +463,8 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </thead>
   <tbody>
     <tr>
-      <th rowspan="40"><strong>tabletserver</strong></th>
-      <td style={{textAlign: 'center', verticalAlign: 'middle' }} rowspan="28">-</td>
+      <th rowspan="39"><strong>tabletserver</strong></th>
+      <td style={{textAlign: 'center', verticalAlign: 'middle' }} rowspan="27">-</td>
       <td>messagesInPerSecond</td>
       <td>The number of messages written per second to this server.</td>
       <td>Meter</td>
@@ -590,18 +590,13 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>Meter</td>
     </tr>
     <tr>
-      <td>walMemoryPoolUsage</td>
+      <td>kvWalMemoryPoolUsage</td>
       <td>Memory currently allocated from the server-wide WAL memory pool for primary key tables in this server (in bytes). The pool capacity is configured by <code>server.buffer.memory-size</code>.</td>
       <td>Gauge</td>
     </tr>
     <tr>
-      <td>walMemoryPoolCapacity</td>
+      <td>kvWalMemoryPoolCapacity</td>
       <td>Total capacity of the server-wide WAL memory pool for primary key tables in this server (in bytes).</td>
-      <td>Gauge</td>
-    </tr>
-    <tr>
-      <td>walMemoryPoolWaitingThreads</td>
-      <td>The number of threads currently blocked waiting for pages from the server-wide WAL memory pool. A non-zero value indicates the pool is exhausted and writes to primary key tables are being throttled.</td>
       <td>Gauge</td>
     </tr>
     <tr>


### PR DESCRIPTION
### Purpose

Linked issue: close #4249 

The server-wide WAL memory pool (`server.buffer.memory-size`, used by all primary key
table buckets to build changelog WAL) is currently unobservable: no metric exposes its
usage or allocation contention, which made pool exhaustion incidents hard to diagnose.

### Brief change log

- Add `walMemoryPoolUsage` / `walMemoryPoolCapacity` / `walMemoryPoolWaitingThreads`
  gauges to the tabletserver metric group.
- `LazyMemorySegmentPool` exposes `usedPages()`; waiting threads reuse the existing
  `queued()`, mirroring the client-side `bufferWaitingThreads` metric.
- Registered by `KvManager` right after the pool is created, following the existing
  `setSharedWriteBufferMetrics` pattern.

### Tests

- `TabletServerMetricGroupTest#testWalMemoryPoolMetrics`: verifies gauge registration
  and that usage tracks page allocation/release dynamically.

### API and Format

No changes.

### Documentation

`monitor-metrics.md`: document the three new tabletserver gauges.