### PR TITLE
[rust] Close drained batches before sending

### DIFF
--- a/fluss-rust/crates/fluss/src/client/write/accumulator.rs
+++ b/fluss-rust/crates/fluss/src/client/write/accumulator.rs
@@ -792,6 +792,8 @@ impl RecordAccumulator {
                 }
 
                 if let Some(mut batch) = maybe_batch {
+                    // A drained batch must not accept new records when re-enqueued for retry.
+                    batch.close()?;
                     let current_batch_size = batch.estimated_size_in_bytes();
                     size += current_batch_size;
 
@@ -1350,6 +1352,79 @@ mod tests {
 
     fn enabled_idempotence() -> Arc<IdempotenceManager> {
         Arc::new(IdempotenceManager::new(true, 5))
+    }
+
+    #[tokio::test]
+    async fn test_retry_keeps_new_records_in_a_separate_batch() -> Result<()> {
+        use futures::FutureExt;
+
+        for idempotent in [false, true] {
+            for kv in [false, true] {
+                let idempotence = Arc::new(IdempotenceManager::new(idempotent, 5));
+                idempotence.set_writer_id(42);
+                let accumulator =
+                    RecordAccumulator::new(Config::default(), Arc::clone(&idempotence));
+                let table_path = TablePath::new("db".to_string(), "tbl".to_string());
+                let physical_path = Arc::new(PhysicalTablePath::of(Arc::new(table_path.clone())));
+                let table_info = Arc::new(build_table_info(table_path.clone(), 1, 1));
+                let cluster = Arc::new(build_cluster(&table_path, 1, 1));
+                let nodes = HashSet::from([cluster.get_tablet_server(1).unwrap().clone()]);
+                let row = GenericRow {
+                    values: vec![Datum::Int32(1)],
+                };
+                let record = if kv {
+                    WriteRecord::for_upsert(
+                        table_info,
+                        physical_path,
+                        1,
+                        Bytes::from_static(b"key"),
+                        None,
+                        WriteFormat::CompactedKv,
+                        None,
+                        Some(RowBytes::Owned(Bytes::from_static(b"value"))),
+                    )
+                } else {
+                    WriteRecord::for_append(table_info, physical_path, 1, &row)
+                };
+                let first = accumulator
+                    .append(&record, 0, &cluster, false)?
+                    .result_handle
+                    .unwrap();
+                let mut batches = accumulator.drain(cluster.clone(), &nodes, 1024 * 1024)?;
+                let mut batch = batches.remove(&1).unwrap().pop().unwrap();
+                let batch_id = batch.write_batch.batch_id();
+                let original = batch.write_batch.build()?;
+                accumulator.re_enqueue(batch);
+
+                let appended = accumulator.append(&record, 0, &cluster, false)?;
+                assert!(
+                    appended.new_batch_created,
+                    "a retry must not accept additional records (kv={kv}, idempotent={idempotent})"
+                );
+                let second = appended.result_handle.unwrap();
+                let mut batches = accumulator.drain(cluster.clone(), &nodes, 1024 * 1024)?;
+                let mut retry = batches.remove(&1).unwrap().pop().unwrap();
+                assert_eq!(retry.write_batch.batch_id(), batch_id);
+                assert!(retry.write_batch.is_closed());
+                assert_eq!(retry.write_batch.record_count(), 1);
+                assert_eq!(retry.write_batch.build()?, original);
+                assert!(retry.write_batch.complete(Ok(())));
+                idempotence.handle_completed_batch(&retry.table_bucket, batch_id, 42);
+                assert!(first.wait().await?.is_ok());
+                assert!(
+                    second.wait().now_or_never().is_none(),
+                    "the old batch ACK must not complete the new record"
+                );
+
+                let mut batches = accumulator.drain(cluster, &nodes, 1024 * 1024)?;
+                let next = batches.remove(&1).unwrap().pop().unwrap();
+                assert_ne!(next.write_batch.batch_id(), batch_id);
+                assert_eq!(next.write_batch.record_count(), 1);
+                assert!(next.write_batch.complete(Ok(())));
+                assert!(second.wait().await?.is_ok());
+            }
+        }
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Purpose

Fixes #4257.

A drained Arrow batch can currently accept new rows after being re-enqueued for retry. Its cached payload still contains only the original rows, but all rows share the batch's completion notification, allowing an unsent row to be acknowledged as successful.

### Brief change log

- Close each drained batch before handing it to the sender, matching Java's existing lifecycle protection.
- Add one deterministic regression covering Arrow/KV with idempotence enabled and disabled.
- Verify that a later append creates a separate batch, the retry payload stays unchanged, and the retry's successful completion does not complete the new row.

### Tests

- The new regression fails on unmodified main (`0bb363ed4`) because the new row is appended to the retry batch.
- `cargo test --locked --offline -p fluss-rs --features storage-all`: passed, including 775 unit tests, the vendored-proto check, and runnable doctests. Existing ignored tests remain ignored.
- `cargo fmt -p fluss-rs -- --check`: passed.
- `cargo clippy --locked --offline -p fluss-rs --all-targets --features storage-all -- -D warnings`: passed.
- `./mvnw -o spotless:check validate` with JDK 11: passed.
- `git diff --check`: passed.

### API and Format

No public API, protocol, or storage format changes.

### Documentation

No new feature or configuration.

### Generative AI disclosure

OpenAI Codex assisted with the implementation, tests, and description. Human maintainer review is requested.
