### PR TITLE
[rpc] Handle endpoint changes for cached server connections

### DIFF
--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/RpcClient.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/RpcClient.java
@@ -53,8 +53,17 @@ public interface RpcClient extends AutoCloseable {
     boolean connect(ServerNode node);
 
     /**
-     * Disconnects the connection to the given server node, if there is one. Any in-flight/pending
-     * requests for this connection will receive disconnections.
+     * Disconnects the connection to the given server endpoint, if there is one. Any in-flight or
+     * pending requests for this connection will receive disconnections.
+     *
+     * @param node The server node to disconnect
+     * @return A future that is completed when the disconnection is complete
+     */
+    CompletableFuture<Void> disconnect(ServerNode node);
+
+    /**
+     * Disconnects all connections associated with the given logical server uid. Any in-flight or
+     * pending requests for these connections will receive disconnections.
      *
      * @param serverUid The uid of the server node
      * @return A future that is completed when the disconnection is complete
@@ -62,12 +71,13 @@ public interface RpcClient extends AutoCloseable {
     CompletableFuture<Void> disconnect(String serverUid);
 
     /**
-     * Check if we are currently ready to send another request to the given server but don't attempt
-     * to connect if we aren't.
+     * Check if we are currently ready to send another request to the given server endpoint but
+     * don't attempt to connect if we aren't.
      *
-     * @return true if the node is ready
+     * @param node The server node to check
+     * @return true if the connection to the node is ready
      */
-    boolean isReady(String serverUid);
+    boolean isReady(ServerNode node);
 
     /**
      * Send an RPC request to the given server and return a future for the response. If the

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/NettyClient.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/NettyClient.java
@@ -121,11 +121,32 @@ public final class NettyClient implements RpcClient {
     }
 
     /**
-     * Disconnects the connection to the given server node, if there is one. Any inflight/pending
-     * requests for this connection will receive disconnections.
+     * Disconnects the connection to the given server endpoint, if there is one. Any
+     * inflight/pending requests for this connection will receive disconnections.
+     *
+     * @param node The server node to disconnect
+     * @return A future that completes when the connection is fully closed
+     */
+    @Override
+    public CompletableFuture<Void> disconnect(ServerNode node) {
+        LOG.debug("Disconnecting from server {}.", node);
+        checkArgument(!isClosed, "Netty client is closed.");
+
+        ServerConnection connection = connections.remove(ConnectionKey.from(node));
+
+        if (connection == null) {
+            return FutureUtils.completedVoidFuture();
+        }
+
+        return connection.close();
+    }
+
+    /**
+     * Disconnects all connections associated with the given logical server uid. Any
+     * inflight/pending requests for these connections will receive disconnections.
      *
      * @param serverUid The uid of the server node
-     * @return A future that completes when the connection is fully closed
+     * @return A future that completes when all associated connections are fully closed
      */
     @Override
     public CompletableFuture<Void> disconnect(String serverUid) {
@@ -149,22 +170,19 @@ public final class NettyClient implements RpcClient {
     }
 
     /**
-     * Check if we are currently ready to send another request to the given server but don't attempt
-     * to connect if we aren't.
+     * Check if we are currently ready to send another request to the given server endpoint but
+     * don't attempt to connect if we aren't.
      *
-     * @return true if the node is ready
+     * @param node The server node to check
+     * @return true if the connection to the node is ready
      */
     @Override
-    public boolean isReady(String serverUid) {
+    public boolean isReady(ServerNode node) {
         checkArgument(!isClosed, "Netty client is closed.");
 
-        for (Map.Entry<ConnectionKey, ServerConnection> entry : connections.entrySet()) {
-            if (entry.getKey().belongsTo(serverUid) && entry.getValue().isReady()) {
-                return true;
-            }
-        }
+        ServerConnection connection = connections.get(ConnectionKey.from(node));
 
-        return false;
+        return connection != null && connection.isReady();
     }
 
     /** Send an RPC request to the given server and return a future for the response. */
@@ -239,9 +257,11 @@ public final class NettyClient implements RpcClient {
             if (this == o) {
                 return true;
             }
+
             if (!(o instanceof ConnectionKey)) {
                 return false;
             }
+
             ConnectionKey that = (ConnectionKey) o;
             return port == that.port && serverUid.equals(that.serverUid) && host.equals(that.host);
         }

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/NettyClient.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/NettyClient.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -66,10 +67,10 @@ public final class NettyClient implements RpcClient {
     private final EventLoopGroup eventGroup;
 
     /**
-     * Managed connections to Netty servers. The key is the server uid (e.g., "cs-2", "ts-3"), the
-     * value is the connection.
+     * Managed connections to Netty servers. Connections are identified by server uid, host and
+     * port.
      */
-    private final Map<String, ServerConnection> connections;
+    private final Map<ConnectionKey, ServerConnection> connections;
 
     /** Metric groups for client. */
     private final ClientMetricGroup clientMetricGroup;
@@ -130,11 +131,21 @@ public final class NettyClient implements RpcClient {
     public CompletableFuture<Void> disconnect(String serverUid) {
         LOG.debug("Disconnecting from server {}.", serverUid);
         checkArgument(!isClosed, "Netty client is closed.");
-        ServerConnection connection = connections.remove(serverUid);
-        if (connection != null) {
-            return connection.close();
+
+        List<CompletableFuture<Void>> shutdownFutures = new ArrayList<>();
+
+        for (Map.Entry<ConnectionKey, ServerConnection> entry : connections.entrySet()) {
+            if (entry.getKey().belongsTo(serverUid)
+                    && connections.remove(entry.getKey(), entry.getValue())) {
+                shutdownFutures.add(entry.getValue().close());
+            }
         }
-        return FutureUtils.completedVoidFuture();
+
+        if (shutdownFutures.isEmpty()) {
+            return FutureUtils.completedVoidFuture();
+        }
+
+        return CompletableFuture.allOf(shutdownFutures.toArray(new CompletableFuture<?>[0]));
     }
 
     /**
@@ -146,11 +157,14 @@ public final class NettyClient implements RpcClient {
     @Override
     public boolean isReady(String serverUid) {
         checkArgument(!isClosed, "Netty client is closed.");
-        ServerConnection connection = connections.get(serverUid);
-        if (connection == null) {
-            return false;
+
+        for (Map.Entry<ConnectionKey, ServerConnection> entry : connections.entrySet()) {
+            if (entry.getKey().belongsTo(serverUid) && entry.getValue().isReady()) {
+                return true;
+            }
         }
-        return connection.isReady();
+
+        return false;
     }
 
     /** Send an RPC request to the given server and return a future for the response. */
@@ -166,7 +180,7 @@ public final class NettyClient implements RpcClient {
         try {
             isClosed = true;
             final List<CompletableFuture<Void>> shutdownFutures = new ArrayList<>();
-            for (Map.Entry<String, ServerConnection> conn : connections.entrySet()) {
+            for (Map.Entry<ConnectionKey, ServerConnection> conn : connections.entrySet()) {
                 if (connections.remove(conn.getKey(), conn.getValue())) {
                     shutdownFutures.add(conn.getValue().close());
                 }
@@ -181,9 +195,9 @@ public final class NettyClient implements RpcClient {
     }
 
     private ServerConnection getOrCreateConnection(ServerNode node) {
-        String serverId = node.uid();
+        ConnectionKey connectionKey = ConnectionKey.from(node);
         return connections.computeIfAbsent(
-                serverId,
+                connectionKey,
                 ignored -> {
                     LOG.debug("Creating connection to server {}.", node);
                     return new ServerConnection(
@@ -191,12 +205,53 @@ public final class NettyClient implements RpcClient {
                             node,
                             clientMetricGroup,
                             authenticatorSupplier.get(),
-                            (con, ignore) -> connections.remove(serverId, con));
+                            (con, ignore) -> connections.remove(connectionKey, con));
                 });
     }
 
     @VisibleForTesting
-    Map<String, ServerConnection> connections() {
-        return connections;
+    Collection<ServerConnection> connections() {
+        return connections.values();
+    }
+
+    private static final class ConnectionKey {
+
+        private final String serverUid;
+        private final String host;
+        private final int port;
+
+        private ConnectionKey(String serverUid, String host, int port) {
+            this.serverUid = serverUid;
+            this.host = host;
+            this.port = port;
+        }
+
+        private static ConnectionKey from(ServerNode node) {
+            return new ConnectionKey(node.uid(), node.host(), node.port());
+        }
+
+        private boolean belongsTo(String serverUid) {
+            return this.serverUid.equals(serverUid);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ConnectionKey)) {
+                return false;
+            }
+            ConnectionKey that = (ConnectionKey) o;
+            return port == that.port && serverUid.equals(that.serverUid) && host.equals(that.host);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = serverUid.hashCode();
+            result = 31 * result + host.hashCode();
+            result = 31 * result + port;
+            return result;
+        }
     }
 }

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/ServerConnection.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/ServerConnection.java
@@ -115,7 +115,9 @@ final class ServerConnection {
             BiConsumer<ServerConnection, Throwable> closeCallback) {
         this.node = node;
         this.state = ConnectionState.CONNECTING;
-        this.connectionMetrics = clientMetricGroup.createConnectionMetricGroup(node.uid());
+        this.connectionMetrics =
+                clientMetricGroup.createConnectionMetricGroup(
+                        node.uid() + "@" + node.host() + ":" + node.port());
         this.authenticator = authenticator;
         this.backoff = new ExponentialBackoff(100L, 2, 5000L, 0.2);
         whenClose(closeCallback);

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/NettyClientTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/NettyClientTest.java
@@ -25,6 +25,7 @@ import org.apache.fluss.config.Configuration;
 import org.apache.fluss.metrics.groups.MetricGroup;
 import org.apache.fluss.metrics.util.NOPMetricsGroup;
 import org.apache.fluss.rpc.TestingGatewayService;
+import org.apache.fluss.rpc.TestingTabletGatewayService;
 import org.apache.fluss.rpc.messages.ApiMessage;
 import org.apache.fluss.rpc.messages.ApiVersionsRequest;
 import org.apache.fluss.rpc.messages.GetTableInfoRequest;
@@ -147,8 +148,9 @@ final class NettyClientTest {
                         .setClientSoftwareVersion("1.0");
         nettyClient.sendRequest(serverNode, ApiKeys.API_VERSIONS, request).get();
         assertThat(nettyClient.connections().size()).isEqualTo(1);
-        assertThat(nettyClient.connections().get(serverNode.uid()).getServerNode())
-                .isEqualTo(serverNode);
+        assertThat(nettyClient.connections())
+                .extracting(ServerConnection::getServerNode)
+                .containsExactly(serverNode);
 
         // close the netty server.
         nettyServer.close();
@@ -166,8 +168,134 @@ final class NettyClientTest {
         buildNettyServer(1);
         nettyClient.sendRequest(serverNode, ApiKeys.API_VERSIONS, request).get();
         assertThat(nettyClient.connections().size()).isEqualTo(1);
-        assertThat(nettyClient.connections().get(serverNode.uid()).getServerNode())
-                .isEqualTo(serverNode);
+        assertThat(nettyClient.connections())
+                .extracting(ServerConnection::getServerNode)
+                .containsExactly(serverNode);
+    }
+
+    @Test
+    void testSameServerUidWithChangedEndpointUsesNewEndpoint() throws Exception {
+        try (NetUtils.Port firstPort = getAvailablePort();
+                NetUtils.Port secondPort = getAvailablePort()) {
+
+            TestingTabletGatewayService firstService = new TestingTabletGatewayService();
+            TestingTabletGatewayService secondService = new TestingTabletGatewayService();
+
+            MetricGroup firstMetricGroup = NOPMetricsGroup.newInstance();
+            MetricGroup secondMetricGroup = NOPMetricsGroup.newInstance();
+
+            ServerNode firstNode =
+                    new ServerNode(1, "localhost", firstPort.getPort(), ServerType.TABLET_SERVER);
+
+            ServerNode secondNode =
+                    new ServerNode(1, "localhost", secondPort.getPort(), ServerType.TABLET_SERVER);
+
+            try (NettyServer firstServer =
+                            new NettyServer(
+                                    conf,
+                                    Collections.singleton(
+                                            new Endpoint(
+                                                    firstNode.host(),
+                                                    firstNode.port(),
+                                                    "INTERNAL")),
+                                    firstService,
+                                    firstMetricGroup,
+                                    RequestsMetrics.createTabletServerRequestMetrics(
+                                            firstMetricGroup));
+                    NettyServer secondServer =
+                            new NettyServer(
+                                    conf,
+                                    Collections.singleton(
+                                            new Endpoint(
+                                                    secondNode.host(),
+                                                    secondNode.port(),
+                                                    "INTERNAL")),
+                                    secondService,
+                                    secondMetricGroup,
+                                    RequestsMetrics.createTabletServerRequestMetrics(
+                                            secondMetricGroup))) {
+
+                firstServer.start();
+                secondServer.start();
+
+                ApiVersionsRequest request =
+                        new ApiVersionsRequest()
+                                .setClientSoftwareName("testing_client")
+                                .setClientSoftwareVersion("1.0");
+
+                nettyClient.sendRequest(firstNode, ApiKeys.API_VERSIONS, request).get();
+
+                assertThat(firstService.getProcessorThreadNames()).hasSize(2);
+                assertThat(secondService.getProcessorThreadNames()).isEmpty();
+
+                nettyClient.sendRequest(secondNode, ApiKeys.API_VERSIONS, request).get();
+
+                assertThat(secondService.getProcessorThreadNames()).hasSize(2);
+                assertThat(firstService.getProcessorThreadNames()).hasSize(2);
+            }
+        }
+    }
+
+    @Test
+    void testDisconnectClosesAllConnectionsForSameServerUid() throws Exception {
+        try (NetUtils.Port firstPort = getAvailablePort();
+                NetUtils.Port secondPort = getAvailablePort()) {
+
+            TestingTabletGatewayService firstService = new TestingTabletGatewayService();
+            TestingTabletGatewayService secondService = new TestingTabletGatewayService();
+
+            MetricGroup firstMetricGroup = NOPMetricsGroup.newInstance();
+            MetricGroup secondMetricGroup = NOPMetricsGroup.newInstance();
+
+            ServerNode firstNode =
+                    new ServerNode(1, "localhost", firstPort.getPort(), ServerType.TABLET_SERVER);
+
+            ServerNode secondNode =
+                    new ServerNode(1, "localhost", secondPort.getPort(), ServerType.TABLET_SERVER);
+
+            try (NettyServer firstServer =
+                            new NettyServer(
+                                    conf,
+                                    Collections.singleton(
+                                            new Endpoint(
+                                                    firstNode.host(),
+                                                    firstNode.port(),
+                                                    "INTERNAL")),
+                                    firstService,
+                                    firstMetricGroup,
+                                    RequestsMetrics.createTabletServerRequestMetrics(
+                                            firstMetricGroup));
+                    NettyServer secondServer =
+                            new NettyServer(
+                                    conf,
+                                    Collections.singleton(
+                                            new Endpoint(
+                                                    secondNode.host(),
+                                                    secondNode.port(),
+                                                    "INTERNAL")),
+                                    secondService,
+                                    secondMetricGroup,
+                                    RequestsMetrics.createTabletServerRequestMetrics(
+                                            secondMetricGroup))) {
+
+                firstServer.start();
+                secondServer.start();
+
+                ApiVersionsRequest request =
+                        new ApiVersionsRequest()
+                                .setClientSoftwareName("testing_client")
+                                .setClientSoftwareVersion("1.0");
+
+                nettyClient.sendRequest(firstNode, ApiKeys.API_VERSIONS, request).get();
+                nettyClient.sendRequest(secondNode, ApiKeys.API_VERSIONS, request).get();
+
+                assertThat(nettyClient.connections()).hasSize(2);
+
+                nettyClient.disconnect(firstNode.uid()).get();
+
+                assertThat(nettyClient.connections()).isEmpty();
+            }
+        }
     }
 
     @Test

--- a/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/NettyClientTest.java
+++ b/fluss-rpc/src/test/java/org/apache/fluss/rpc/netty/client/NettyClientTest.java
@@ -124,17 +124,23 @@ final class NettyClientTest {
     void testRequestsProcessedInOrder() throws Exception {
         int numRequests = 100;
         List<CompletableFuture<ApiMessage>> futures = new ArrayList<>();
+
         for (int i = 0; i < numRequests; i++) {
             ApiVersionsRequest request =
                     new ApiVersionsRequest()
                             .setClientSoftwareName("testing_client" + i)
                             .setClientSoftwareVersion("1.0");
+
             futures.add(nettyClient.sendRequest(serverNode, ApiKeys.API_VERSIONS, request));
         }
+
         FutureUtils.waitForAll(futures).get();
+
         // we have one more api version request for rpc handshake.
         assertThat(service.getProcessorThreadNames()).hasSize(numRequests + 1);
+
         Set<String> deduplicatedThreadNames = new HashSet<>(service.getProcessorThreadNames());
+
         // there should only one thread to process the requests
         // since all requests are from the same client.
         assertThat(deduplicatedThreadNames).hasSize(1);
@@ -146,14 +152,17 @@ final class NettyClientTest {
                 new ApiVersionsRequest()
                         .setClientSoftwareName("testing_client_100")
                         .setClientSoftwareVersion("1.0");
+
         nettyClient.sendRequest(serverNode, ApiKeys.API_VERSIONS, request).get();
-        assertThat(nettyClient.connections().size()).isEqualTo(1);
+
+        assertThat(nettyClient.connections()).hasSize(1);
         assertThat(nettyClient.connections())
                 .extracting(ServerConnection::getServerNode)
                 .containsExactly(serverNode);
 
         // close the netty server.
         nettyServer.close();
+
         assertThatThrownBy(
                         () ->
                                 nettyClient
@@ -162,12 +171,15 @@ final class NettyClientTest {
                 .rootCause()
                 .isInstanceOf(ConnectException.class)
                 .hasMessageContaining("Connection refused");
-        assertThat(nettyClient.connections().size()).isEqualTo(0);
+
+        assertThat(nettyClient.connections()).isEmpty();
 
         // restart the netty server.
         buildNettyServer(1);
+
         nettyClient.sendRequest(serverNode, ApiKeys.API_VERSIONS, request).get();
-        assertThat(nettyClient.connections().size()).isEqualTo(1);
+
+        assertThat(nettyClient.connections()).hasSize(1);
         assertThat(nettyClient.connections())
                 .extracting(ServerConnection::getServerNode)
                 .containsExactly(serverNode);
@@ -223,15 +235,103 @@ final class NettyClientTest {
                                 .setClientSoftwareName("testing_client")
                                 .setClientSoftwareVersion("1.0");
 
+                // Establish only the first endpoint connection.
                 nettyClient.sendRequest(firstNode, ApiKeys.API_VERSIONS, request).get();
 
                 assertThat(firstService.getProcessorThreadNames()).hasSize(2);
                 assertThat(secondService.getProcessorThreadNames()).isEmpty();
 
+                // Readiness must be endpoint-specific. The second node has the same UID,
+                // but there is no connection to its host/port yet.
+                assertThat(nettyClient.isReady(firstNode)).isTrue();
+                assertThat(nettyClient.isReady(secondNode)).isFalse();
+
+                // Send to the changed endpoint.
                 nettyClient.sendRequest(secondNode, ApiKeys.API_VERSIONS, request).get();
 
                 assertThat(secondService.getProcessorThreadNames()).hasSize(2);
                 assertThat(firstService.getProcessorThreadNames()).hasSize(2);
+
+                // Both physical endpoint connections now coexist.
+                assertThat(nettyClient.isReady(firstNode)).isTrue();
+                assertThat(nettyClient.isReady(secondNode)).isTrue();
+                assertThat(nettyClient.connections()).hasSize(2);
+            }
+        }
+    }
+
+    @Test
+    void testDisconnectSpecificEndpoint() throws Exception {
+        try (NetUtils.Port firstPort = getAvailablePort();
+                NetUtils.Port secondPort = getAvailablePort()) {
+
+            TestingTabletGatewayService firstService = new TestingTabletGatewayService();
+            TestingTabletGatewayService secondService = new TestingTabletGatewayService();
+
+            MetricGroup firstMetricGroup = NOPMetricsGroup.newInstance();
+            MetricGroup secondMetricGroup = NOPMetricsGroup.newInstance();
+
+            ServerNode firstNode =
+                    new ServerNode(1, "localhost", firstPort.getPort(), ServerType.TABLET_SERVER);
+
+            ServerNode secondNode =
+                    new ServerNode(1, "localhost", secondPort.getPort(), ServerType.TABLET_SERVER);
+
+            try (NettyServer firstServer =
+                            new NettyServer(
+                                    conf,
+                                    Collections.singleton(
+                                            new Endpoint(
+                                                    firstNode.host(),
+                                                    firstNode.port(),
+                                                    "INTERNAL")),
+                                    firstService,
+                                    firstMetricGroup,
+                                    RequestsMetrics.createTabletServerRequestMetrics(
+                                            firstMetricGroup));
+                    NettyServer secondServer =
+                            new NettyServer(
+                                    conf,
+                                    Collections.singleton(
+                                            new Endpoint(
+                                                    secondNode.host(),
+                                                    secondNode.port(),
+                                                    "INTERNAL")),
+                                    secondService,
+                                    secondMetricGroup,
+                                    RequestsMetrics.createTabletServerRequestMetrics(
+                                            secondMetricGroup))) {
+
+                firstServer.start();
+                secondServer.start();
+
+                ApiVersionsRequest request =
+                        new ApiVersionsRequest()
+                                .setClientSoftwareName("testing_client")
+                                .setClientSoftwareVersion("1.0");
+
+                nettyClient.sendRequest(firstNode, ApiKeys.API_VERSIONS, request).get();
+                nettyClient.sendRequest(secondNode, ApiKeys.API_VERSIONS, request).get();
+
+                assertThat(nettyClient.connections()).hasSize(2);
+                assertThat(nettyClient.isReady(firstNode)).isTrue();
+                assertThat(nettyClient.isReady(secondNode)).isTrue();
+
+                // Disconnect only the first physical endpoint.
+                nettyClient.disconnect(firstNode).get();
+
+                assertThat(nettyClient.isReady(firstNode)).isFalse();
+                assertThat(nettyClient.isReady(secondNode)).isTrue();
+
+                assertThat(nettyClient.connections())
+                        .extracting(ServerConnection::getServerNode)
+                        .containsExactly(secondNode);
+
+                // Verify that the remaining endpoint is still usable.
+                nettyClient.sendRequest(secondNode, ApiKeys.API_VERSIONS, request).get();
+
+                // handshake + first application request + request above
+                assertThat(secondService.getProcessorThreadNames()).hasSize(3);
             }
         }
     }
@@ -290,10 +390,15 @@ final class NettyClientTest {
                 nettyClient.sendRequest(secondNode, ApiKeys.API_VERSIONS, request).get();
 
                 assertThat(nettyClient.connections()).hasSize(2);
+                assertThat(nettyClient.isReady(firstNode)).isTrue();
+                assertThat(nettyClient.isReady(secondNode)).isTrue();
 
+                // UID-level disconnect must close every physical endpoint for the logical server.
                 nettyClient.disconnect(firstNode.uid()).get();
 
                 assertThat(nettyClient.connections()).isEmpty();
+                assertThat(nettyClient.isReady(firstNode)).isFalse();
+                assertThat(nettyClient.isReady(secondNode)).isFalse();
             }
         }
     }
@@ -316,6 +421,7 @@ final class NettyClientTest {
     @Test
     void testMultipleEndpoint() throws Exception {
         MetricGroup metricGroup = NOPMetricsGroup.newInstance();
+
         try (NetUtils.Port availablePort1 = getAvailablePort();
                 NetUtils.Port availablePort2 = getAvailablePort();
                 NettyServer multipleEndpointsServer =
@@ -330,11 +436,14 @@ final class NettyClientTest {
                                 metricGroup,
                                 RequestsMetrics.createCoordinatorServerRequestMetrics(
                                         metricGroup))) {
+
             multipleEndpointsServer.start();
+
             ApiVersionsRequest request =
                     new ApiVersionsRequest()
                             .setClientSoftwareName("testing_client_100")
                             .setClientSoftwareVersion("1.0");
+
             nettyClient
                     .sendRequest(
                             new ServerNode(
@@ -345,9 +454,12 @@ final class NettyClientTest {
                             ApiKeys.API_VERSIONS,
                             request)
                     .get();
-            assertThat(nettyClient.connections().size()).isEqualTo(1);
+
+            assertThat(nettyClient.connections()).hasSize(1);
+
             try (NettyClient client =
                     new NettyClient(conf, TestingClientMetricGroup.newInstance())) {
+
                 client.sendRequest(
                                 new ServerNode(
                                         2,
@@ -357,7 +469,8 @@ final class NettyClientTest {
                                 ApiKeys.API_VERSIONS,
                                 request)
                         .get();
-                assertThat(client.connections().size()).isEqualTo(1);
+
+                assertThat(client.connections()).hasSize(1);
             }
         }
     }
@@ -368,6 +481,7 @@ final class NettyClientTest {
                 new ApiVersionsRequest()
                         .setClientSoftwareName("testing_client_100")
                         .setClientSoftwareVersion("1.0");
+
         // close the netty server.
         nettyServer.close();
 
@@ -378,6 +492,7 @@ final class NettyClientTest {
                                         .sendRequest(serverNode, ApiKeys.API_VERSIONS, request)
                                         .get())
                 .hasMessageContaining("Disconnected from node");
+
         assertThat(nettyClient.connections()).isEmpty();
     }
 
@@ -386,8 +501,11 @@ final class NettyClientTest {
             serverNode =
                     new ServerNode(
                             serverId, "localhost", availablePort.getPort(), ServerType.COORDINATOR);
+
             service = new TestingGatewayService();
+
             MetricGroup metricGroup = NOPMetricsGroup.newInstance();
+
             nettyServer =
                     new NettyServer(
                             conf,
@@ -396,6 +514,7 @@ final class NettyClientTest {
                             service,
                             metricGroup,
                             RequestsMetrics.createCoordinatorServerRequestMetrics(metricGroup));
+
             nettyServer.start();
         }
     }


### PR DESCRIPTION
<!--
Generated-by: ChatGPT (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

Linked issue: #4256

`NettyClient` currently caches connections only by server UID. During a rolling upgrade, the same TabletServer UID may be advertised with a different host or port while the previous endpoint remains reachable.

In that case, even after metadata is refreshed with the new endpoint, connection lookup can continue returning the connection to the previous endpoint. Requests may therefore keep reaching the wrong TabletServer.

This change makes the physical RPC connection identity endpoint-aware by using server UID, host, and port.

This is related to #4216, which also handles same-UID endpoint changes but replaces the existing connection. This change keeps connections to different physical endpoints independently keyed so the RPC layer does not have to decide which reachable endpoint is newer.

### Brief change log

- Key cached Netty connections by server UID, host, and port instead of server UID alone.
- Allow different physical endpoints for the same logical server UID to use independent connections.
- Make readiness checks endpoint-specific using `ServerNode`.
- Add `disconnect(ServerNode)` for disconnecting a specific endpoint.
- Keep `disconnect(serverUid)` as a logical-server operation that closes all connections associated with that UID.
- Use endpoint-specific connection metric identities so multiple connections sharing a UID do not overwrite each other's metric bookkeeping.
- Add regression coverage verifying that a changed endpoint for the same UID is actually used while the previous endpoint remains reachable.
- Add coverage for endpoint-specific readiness and disconnect behavior.
- Add lifecycle coverage verifying that disconnecting a UID closes all associated endpoint connections.

### Tests

- `.\mvnw.cmd test -Dtest=NettyClientTest -pl fluss-rpc`
  - 10 tests passed
  - 0 failures
  - 0 errors

- `.\mvnw.cmd verify -pl fluss-rpc -Dtest="!ApiErrorTest"`
  - 90 tests run
  - 0 failures
  - 0 errors
  - 2 skipped

- Checkstyle passed with 0 violations.
- Spotless passed.
- `git diff --check` passed.

A full `fluss-rpc` verify on Windows also encounters the existing `ApiErrorTest#testStringifyException` line-ending assertion, which expects LF while the Windows JVM stack trace uses CRLF. This test is unrelated to this change.

The regression coverage intentionally isolates the transport-level condition: two reachable TabletServers use the same UID with different endpoints, and requests using the updated `ServerNode` reach the updated endpoint rather than the previously cached one.

The tests also verify that readiness and endpoint-specific disconnect operate on the exact `serverUid + host + port` connection, while UID-level disconnect continues to close all physical connections associated with the logical server.

### API and Format

No user-facing API, RPC protocol, or storage format changes. The internal `RpcClient` lifecycle API is aligned with endpoint-aware connection identity.

### Documentation

No documentation changes. This fixes existing RPC connection behavior when a server endpoint changes.

### Generative AI disclosure

Yes - ChatGPT (GPT-5.6 Sol) was used for root-cause analysis, implementation review, and test planning.
