### PR TITLE
[rust] Return TableNotExist for missing tables

### DIFF
--- a/fluss-rust/crates/fluss/src/client/connection.rs
+++ b/fluss-rust/crates/fluss/src/client/connection.rs
@@ -21,7 +21,7 @@ use crate::client::lookup::LookupClient;
 use crate::client::metadata::Metadata;
 use crate::client::table::FlussTable;
 use crate::config::Config;
-use crate::error::{Error, FlussError, Result};
+use crate::error::{Error, Result};
 use crate::metadata::TablePath;
 
 #[cfg(feature = "integration_tests")]
@@ -183,19 +183,13 @@ impl FlussConnection {
     }
 
     pub async fn get_table(&self, table_path: &TablePath) -> Result<FlussTable<'_>> {
+        if self.metadata.fetch_table_id(table_path).await?.is_none() {
+            return Err(Error::table_not_exist(format!(
+                "Table not found: {table_path}"
+            )));
+        }
         self.metadata.update_table_metadata(table_path).await?;
-        let table_info = self
-            .metadata
-            .get_cluster()
-            .get_table(table_path)
-            .map_err(|e| {
-                if e.api_error() == Some(FlussError::InvalidTableException) {
-                    Error::table_not_exist(format!("Table not found: {table_path}"))
-                } else {
-                    e
-                }
-            })?
-            .clone();
+        let table_info = self.metadata.get_cluster().get_table(table_path)?.clone();
         Ok(FlussTable::new(self, self.metadata.clone(), table_info))
     }
 }

--- a/fluss-rust/crates/fluss/tests/integration/admin.rs
+++ b/fluss-rust/crates/fluss/tests/integration/admin.rs
@@ -426,6 +426,28 @@ mod admin_test {
         );
     }
 
+    #[tokio::test]
+    async fn test_get_nonexistent_table_returns_table_not_exist() {
+        let cluster = get_shared_cluster();
+        let connection = cluster.get_fluss_connection().await;
+        let table_path = TablePath::new(
+            "fluss",
+            format!("nonexistent_table_{}", uuid::Uuid::new_v4().simple()),
+        );
+
+        let error = match connection.get_table(&table_path).await {
+            Ok(_) => panic!("getting a nonexistent table should fail"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error.api_error(),
+            Some(FlussError::TableNotExist),
+            "Expected TableNotExist error, got {:?}",
+            error
+        );
+    }
+
     /// Helper to assert that an error is a FlussAPIError with the expected code.
     fn assert_api_error(error: fluss::error::Error, expected: FlussError) {
         assert_eq!(


### PR DESCRIPTION
  ### Generative AI disclosure

  - [ ] No generative AI tools used
  - [x] Yes - OpenAI Codex

  ### Purpose

  Linked issue: close #4270

  `FlussConnection::get_table` currently returns `InvalidTableException` when the requested table does not exist. This prevents callers from reliably distinguishing a
  missing table from network, timeout, or other RPC failures.

  This change makes `get_table` return `FlussError::TableNotExist` when the table is absent while preserving other errors unchanged.

  ### Brief change log

  - Check whether the requested table exists before refreshing its metadata.
  - Return a typed `TableNotExist` error when the table is absent.
  - Preserve network and other RPC errors without converting them.
  - Add an integration test covering the error classification.

  ### Tests

  The following checks were run:

  - `cargo fmt --all -- --check`
  - `RUST_TEST_THREADS=1 RUST_LOG=DEBUG RUST_BACKTRACE=full cargo test --features integration_tests --test test_fluss -p fluss-rs -- --nocapture`

  The new integration test passed:

  - `test_get_nonexistent_table_returns_table_not_exist`

  Full integration-suite result:

  - 77 tests passed.
  - 5 filter-pushdown tests failed
  - These failures happen during statistics-enabled table creation and are unrelated to the `get_table` error-classification change.

  ### API and Format

This change does not modify the public API, wire protocol, or storage format. It corrects the error code returned by the existing `FlussConnection::get_table` API.