### PR TITLE
[server] Clarify minimum ISR write rejection diagnostics

### DIFF
--- a/fluss-dist/src/main/resources/server.yaml
+++ b/fluss-dist/src/main/resources/server.yaml
@@ -39,6 +39,10 @@ default.bucket.number: 1
 # factor is specified for the table.
 default.replication.factor: 1
 
+# The minimum number of in-sync replicas required for writes configured with acks=all (-1).
+# A replicated production deployment commonly sets this to 2 or higher. The default is 1.
+log.replica.min-in-sync-replicas-number: 1
+
 # The local data directory to be used for Fluss to storing kv and log data.
 data.dir: /tmp/fluss-data
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -2439,12 +2439,13 @@ public final class Replica {
 
     private void validateInSyncReplicaSize(int requiredAcks) {
         int inSyncSize = isrState.isr().size();
-        if (inSyncSize < minInSyncReplicasSupplier.getAsInt() && requiredAcks == -1) {
+        int minInSyncReplicas = minInSyncReplicasSupplier.getAsInt();
+        if (inSyncSize < minInSyncReplicas && requiredAcks == -1) {
             throw new NotEnoughReplicasException(
                     String.format(
-                            "The size of the current ISR %s is insufficient to satisfy "
-                                    + "the required acks %s for table bucket %s.",
-                            isrState.isr(), requiredAcks, tableBucket));
+                            "The current ISR %s has %d replicas, below the configured minimum ISR "
+                                    + "%d required for acks=all on table bucket %s.",
+                            isrState.isr(), inSyncSize, minInSyncReplicas, tableBucket));
         }
     }
 


### PR DESCRIPTION
### Purpose

Closes #4300. Part of #4185, under independent core changes.

When acks=all is rejected because the ISR is too small, report both the current replica count and configured minimum. Add the existing minimum-ISR option to the server configuration example with its default value of 1.

Two files, 9 insertions and 4 deletions. These changes originate from retired Kafka PR #4187; the validation semantics and configuration default are unchanged.

### Validation

Java 11 at `8c5e371dea4a4b3ee1743e347b545d67ed4055fa`, based on Apache main `5d8c478118db6c79ff6296281129b9ca0d3f1ccc`:

- Production compilation, Spotless, Checkstyle, RAT and `git diff --check` passed.
- `mvn -o -pl fluss-dist spotless:check validate` passed.
- `mvn -o -pl fluss-server -am spotless:check test -Dtest=ReplicaTest,ReplicaManagerTest -Dsurefire.failIfNoSpecifiedTests=false` is blocked during test compilation: `RemoteLogFetcherTest` lines 238-239 call a private `updateRemoteLogStartOffset(long)` and a removed `updateRemoteLogEndOffset(long)` on `LogTablet`.
- The same errors were reproduced on an unmodified checkout of the exact main baseline. The selected server tests did not execute. Re-run them after the upstream baseline is repaired; the full repository suite was not run.

### Review

This PR has no dependency on the Kafka compatibility sequence or #3412. It remains Draft pending server-test validation and human review.

Generative AI disclosure: Codex assisted with extraction, validation and commit organization.
