### PR TITLE
[client] Resolve dynamic partition bucket counts before sending

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/metadata/MetadataUpdater.java
@@ -96,7 +96,7 @@ public class MetadataUpdater {
         return cluster.getPartitionId(physicalTablePath);
     }
 
-    public Long getPartitionIdOrElseThrow(PhysicalTablePath physicalTablePath) {
+    public long getPartitionIdOrElseThrow(PhysicalTablePath physicalTablePath) {
         return cluster.getPartitionIdOrElseThrow(physicalTablePath);
     }
 

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/BucketAssigner.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/BucketAssigner.java
@@ -35,16 +35,18 @@ interface BucketAssigner {
      * assigner, this method can change the chosen sticky bucket for the new batch.
      *
      * @param cluster The current cluster metadata
+     * @param bucketCount The current number of buckets
      * @param prevBucketId The bucket previously selected for the record that triggered a new batch
      */
-    void onNewBatch(Cluster cluster, int prevBucketId);
+    void onNewBatch(Cluster cluster, int bucketCount, int prevBucketId);
 
     /**
      * Assign the bucket the given bucket key.
      *
      * @param bucketKey the bucket key
      * @param cluster the cluster
+     * @param bucketCount the current number of buckets
      * @return the bucket id
      */
-    int assignBucket(@Nullable byte[] bucketKey, Cluster cluster);
+    int assignBucket(@Nullable byte[] bucketKey, Cluster cluster, int bucketCount);
 }

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/BucketAssignerFactory.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/BucketAssignerFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.client.write;
+
+import org.apache.fluss.bucketing.BucketingFunction;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.metadata.PhysicalTablePath;
+import org.apache.fluss.metadata.TableInfo;
+
+/** Creates bucket assigners for individual write contexts. */
+@FunctionalInterface
+interface BucketAssignerFactory {
+
+    /** Creates an assigner for the given table and physical write target. */
+    BucketAssigner createBucketAssigner(TableInfo tableInfo, PhysicalTablePath path);
+
+    /** Returns a factory using the configured strategy for tables without bucket keys. */
+    static BucketAssignerFactory defaultFactory(Configuration conf) {
+        ConfigOptions.NoKeyAssigner noKeyAssigner =
+                conf.get(ConfigOptions.CLIENT_WRITER_BUCKET_NO_KEY_ASSIGNER);
+        return (tableInfo, path) -> {
+            if (!tableInfo.getBucketKeys().isEmpty()) {
+                return new HashBucketAssigner(
+                        BucketingFunction.of(
+                                tableInfo.getTableConfig().getDataLakeFormat().orElse(null)));
+            } else if (noKeyAssigner == ConfigOptions.NoKeyAssigner.ROUND_ROBIN) {
+                return new RoundRobinBucketAssigner(path);
+            } else if (noKeyAssigner == ConfigOptions.NoKeyAssigner.STICKY) {
+                return new StickyBucketAssigner(path);
+            } else {
+                throw new IllegalStateException("Unknown no-key assigner: " + noKeyAssigner);
+            }
+        };
+    }
+}

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/HashBucketAssigner.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/HashBucketAssigner.java
@@ -25,19 +25,18 @@ import org.apache.fluss.bucketing.FlussBucketingFunction;
 @Internal
 public class HashBucketAssigner extends StaticBucketAssigner {
 
-    private final int numBuckets;
     private final BucketingFunction function;
 
-    public HashBucketAssigner(int numBuckets) {
-        this(numBuckets, new FlussBucketingFunction());
+    public HashBucketAssigner() {
+        this(new FlussBucketingFunction());
     }
 
-    public HashBucketAssigner(int numBuckets, BucketingFunction function) {
-        this.numBuckets = numBuckets;
+    public HashBucketAssigner(BucketingFunction function) {
         this.function = function;
     }
 
-    public int assignBucket(byte[] bucketKeys) {
-        return function.bucketing(bucketKeys, numBuckets);
+    @Override
+    public int assignBucket(byte[] bucketKeys, int bucketCount) {
+        return function.bucketing(bucketKeys, bucketCount);
     }
 }

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/RecordAccumulator.java
@@ -24,6 +24,7 @@ import org.apache.fluss.cluster.BucketLocation;
 import org.apache.fluss.cluster.Cluster;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.exception.BucketRescaleException;
 import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.exception.TableNotExistException;
 import org.apache.fluss.memory.LazyMemorySegmentPool;
@@ -60,7 +61,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -86,8 +86,8 @@ public final class RecordAccumulator {
 
     private volatile boolean closed;
     private final AtomicInteger flushesInProgress;
-    private final AtomicInteger appendsInProgress;
     private final int batchSize;
+    private final BucketAssignerFactory bucketAssignerFactory;
 
     /**
      * An artificial delay time to add before declaring a records instance that isn't full ready for
@@ -154,9 +154,24 @@ public final class RecordAccumulator {
             IdempotenceManager idempotenceManager,
             WriterMetricGroup writerMetricGroup,
             Clock clock) {
+        this(
+                conf,
+                idempotenceManager,
+                writerMetricGroup,
+                clock,
+                BucketAssignerFactory.defaultFactory(conf));
+    }
+
+    @VisibleForTesting
+    RecordAccumulator(
+            Configuration conf,
+            IdempotenceManager idempotenceManager,
+            WriterMetricGroup writerMetricGroup,
+            Clock clock,
+            BucketAssignerFactory bucketAssignerFactory) {
+        this.bucketAssignerFactory = checkNotNull(bucketAssignerFactory);
         this.closed = false;
         this.flushesInProgress = new AtomicInteger(0);
-        this.appendsInProgress = new AtomicInteger(0);
 
         this.batchTimeoutMs =
                 Math.min(
@@ -193,79 +208,74 @@ public final class RecordAccumulator {
                 MetricNames.WRITER_BUFFER_WAITING_THREADS, writerBufferPool::queued);
     }
 
-    /**
-     * Add a record to the accumulator, return to append result.
-     *
-     * <p>The append result will contain the future metadata, and flag for whether the appended
-     * batch is full or a new batch is created.
-     */
-    public RecordAppendResult append(
-            WriteRecord writeRecord,
-            WriteCallback callback,
-            Cluster cluster,
-            int bucketId,
-            int bucketCount,
-            boolean abortIfBatchFull)
+    /** Assigns and appends a record using the layout owned by its write context. */
+    public RecordAppendResult append(WriteRecord record, WriteCallback callback, Cluster cluster)
             throws Exception {
-        PhysicalTablePath physicalTablePath = writeRecord.getPhysicalTablePath();
-        TableInfo tableInfo = writeRecord.getTableInfo();
-        // The metadata may return null for the partition id, but it is fine to pass null here,
-        // because we will fill the partitionId in bucketReady() before send the batch.
-        Optional<Long> partitionIdOpt = cluster.getPartitionId(physicalTablePath);
-        BucketAndWriteBatches bucketAndWriteBatches =
+        PhysicalTablePath path = record.getPhysicalTablePath();
+        TableInfo tableInfo = record.getTableInfo();
+        BucketAndWriteBatches context =
                 writeBatches.computeIfAbsent(
-                        physicalTablePath,
-                        k ->
-                                new BucketAndWriteBatches(
-                                        partitionIdOpt.orElse(null),
-                                        tableInfo.isPartitioned(),
-                                        physicalTablePath));
-
-        // We keep track of the number of appending thread to make sure we do not miss batches in
-        // abortIncompleteBatches().
-        appendsInProgress.incrementAndGet();
-        List<MemorySegment> memorySegments = Collections.emptyList();
-        try {
-            // check if we have an in-progress batch
-            Deque<WriteBatch> dq =
-                    bucketAndWriteBatches.batches.computeIfAbsent(
-                            bucketId, k -> new ArrayDeque<>());
-            synchronized (dq) {
-                RecordAppendResult appendResult = tryAppend(writeRecord, callback, bucketCount, dq);
-                if (appendResult != null) {
-                    return appendResult;
-                }
+                        path, k -> createBucketAndWriteBatches(tableInfo, path, cluster));
+        checkAndCacheHistoricalPartitionEnabled(tableInfo);
+        RecordAppendResult appendResult;
+        if (context.bucketCount == null) {
+            synchronized (context) {
+                appendResult = tryAppend(record, callback, cluster, context);
             }
-
-            // we don't have an in-progress record batch try to allocate a new batch
-            if (abortIfBatchFull) {
-                // Return a result that will cause another call to append.
-                return new RecordAppendResult(true, false, true);
-            }
-
-            memorySegments = allocateMemorySegments(writeRecord, physicalTablePath);
-            synchronized (dq) {
-                RecordAppendResult appendResult =
-                        appendNewBatch(
-                                writeRecord,
-                                callback,
-                                bucketId,
-                                bucketCount,
-                                tableInfo,
-                                dq,
-                                memorySegments);
-                if (appendResult.newBatchCreated) {
-                    memorySegments = Collections.emptyList();
-                }
-                return appendResult;
-            }
-        } finally {
-            // Other append operations by the Sender thread may have created a new batch, causing
-            // the temporarily allocated memorySegments here to go unused, and therefore, it needs
-            // to be released.
-            writerBufferPool.returnAll(memorySegments);
-            appendsInProgress.decrementAndGet();
+        } else {
+            appendResult = tryAppend(record, callback, cluster, context);
         }
+        BucketAssignment newBatchAssignment = appendResult.newBatchAssignment;
+        if (newBatchAssignment == null) {
+            return appendResult;
+        }
+
+        // Resolving routing may need to free batches to satisfy this allocation.
+        List<MemorySegment> memorySegments = allocateMemorySegments(record, path);
+        try {
+            RecordAppendResult result =
+                    appendWithAllocatedMemory(
+                            record,
+                            callback,
+                            cluster,
+                            context,
+                            newBatchAssignment.bucketId,
+                            newBatchAssignment.bucketCount,
+                            memorySegments);
+            if (result.newBatchCreated) {
+                memorySegments = Collections.emptyList();
+            }
+            return result;
+        } finally {
+            writerBufferPool.returnAll(memorySegments);
+        }
+    }
+
+    private BucketAndWriteBatches createBucketAndWriteBatches(
+            TableInfo tableInfo, PhysicalTablePath path, Cluster cluster) {
+        int tempBucketCount =
+                cluster.getBucketCount(TableOrPartition.ofTable(tableInfo.getTableId()))
+                        .orElse(tableInfo.getNumBuckets());
+        Long partitionId = null;
+        Integer bucketCount = tempBucketCount;
+        if (tableInfo.isPartitioned()) {
+            // The metadata may return null for the partition id, and bucketCount,
+            // but it is fine to pass null here, because we will fill the partitionId and
+            // bucketCount in bucketReady() before send the batch.
+            partitionId = cluster.getPartitionId(path).orElse(null);
+            bucketCount =
+                    partitionId == null
+                            ? null
+                            : cluster.getBucketCount(TableOrPartition.ofPartition(partitionId))
+                                    .orElse(null);
+        }
+        return new BucketAndWriteBatches(
+                partitionId,
+                bucketCount,
+                tempBucketCount,
+                bucketAssignerFactory.createBucketAssigner(tableInfo, path),
+                tableInfo.isPartitioned(),
+                path);
     }
 
     /**
@@ -289,7 +299,6 @@ public final class RecordAccumulator {
         Set<Integer> readyNodes = new HashSet<>();
         long nextReadyCheckDelayMs = batchTimeoutMs;
         Set<PhysicalTablePath> unknownLeaderTables = new HashSet<>();
-        Set<PhysicalTablePath> invalidBucketRoutingTables = new HashSet<>();
         // Go table by table so that we can get queue sizes for buckets in a table and calculate
         // cumulative frequency table (used in bucket assigner).
 
@@ -299,15 +308,13 @@ public final class RecordAccumulator {
                             bucketAndWriteBatches,
                             readyNodes,
                             unknownLeaderTables,
-                            invalidBucketRoutingTables,
                             cluster,
                             nextReadyCheckDelayMs);
         }
 
         // TODO and the earliest time at which any non-send-able bucket will be ready;
 
-        return new ReadyCheckResult(
-                readyNodes, nextReadyCheckDelayMs, unknownLeaderTables, invalidBucketRoutingTables);
+        return new ReadyCheckResult(readyNodes, nextReadyCheckDelayMs, unknownLeaderTables);
     }
 
     /**
@@ -341,7 +348,7 @@ public final class RecordAccumulator {
     public boolean reEnqueue(ReadyWriteBatch readyWriteBatch) {
         WriteBatch batch = readyWriteBatch.writeBatch();
         Deque<WriteBatch> deque =
-                getOrCreateDeque(readyWriteBatch.tableBucket(), batch.physicalTablePath());
+                getDequeOrThrow(readyWriteBatch.tableBucket(), batch.physicalTablePath());
         synchronized (deque) {
             if (batch.isDone()) {
                 return false;
@@ -367,12 +374,25 @@ public final class RecordAccumulator {
      * no incomplete batch. This method never moves queued or inflight batches between physical
      * partitions.
      *
+     * <p>Tables with historical partition support cannot be rescaled, so every target uses the
+     * table's fixed bucket count.
+     *
      * @throws FlussRuntimeException if a different target was fixed previously
      */
     void routeWritesTo(
-            PhysicalTablePath originalPath, PhysicalTablePath targetPath, long targetPartitionId) {
+            TableInfo tableInfo,
+            PhysicalTablePath originalPath,
+            PhysicalTablePath targetPath,
+            long targetPartitionId) {
+        int bucketCount = tableInfo.getNumBuckets();
         BucketAndWriteBatches resolvedTarget =
-                new BucketAndWriteBatches(targetPartitionId, true, targetPath);
+                new BucketAndWriteBatches(
+                        targetPartitionId,
+                        bucketCount,
+                        bucketCount,
+                        bucketAssignerFactory.createBucketAssigner(tableInfo, targetPath),
+                        true,
+                        targetPath);
         // Install the route atomically before append can create the first queue for this path.
         BucketAndWriteBatches existing = writeBatches.putIfAbsent(originalPath, resolvedTarget);
         if (existing == null) {
@@ -396,6 +416,7 @@ public final class RecordAccumulator {
                                     originalPath, targetPath, existing.targetPath));
                 }
                 existing.switchToHistoricalTarget(targetPath, targetPartitionId);
+                existing.bucketCount = bucketCount;
                 return;
             }
 
@@ -451,18 +472,11 @@ public final class RecordAccumulator {
         return Boolean.TRUE.equals(historicalPartitionEnabledByTable.get(tablePath));
     }
 
-    /**
-     * Reroutes queued batches for {@code originalPath} to the historical target.
-     *
-     * @return {@code true} if the batches were rerouted successfully or were already targeting the
-     *     historical partition; {@code false} if any queued batch was routed with a bucket count
-     *     that differs from the historical partition's bucket count
-     */
-    boolean rerouteQueuedWritesToHistorical(
+    /** Reroutes queued batches to the historical target, retaining their fixed bucket layout. */
+    void rerouteQueuedWritesToHistorical(
             PhysicalTablePath originalPath,
             PhysicalTablePath historicalPath,
-            long historicalPartitionId,
-            @Nullable Integer historicalBucketCount) {
+            long historicalPartitionId) {
         BucketAndWriteBatches writeTarget =
                 checkNotNull(
                         writeBatches.get(originalPath),
@@ -472,17 +486,7 @@ public final class RecordAccumulator {
         synchronized (writeTarget) {
             if (writeTarget.isHistoricalWriteTarget()) {
                 writeTarget.partitionId = historicalPartitionId;
-                return true;
-            }
-            if (historicalBucketCount != null) {
-                for (Deque<WriteBatch> deque : writeTarget.batches.values()) {
-                    for (WriteBatch batch : deque) {
-                        if (batch.getBucketCount() > 0
-                                && batch.getBucketCount() != historicalBucketCount) {
-                            return false;
-                        }
-                    }
-                }
+                return;
             }
             // New appends observe the historical route and are marked as historical. Existing
             // queued batches are converted below before the Sender can drain again.
@@ -510,7 +514,6 @@ public final class RecordAccumulator {
                 }
             }
         }
-        return true;
     }
 
     /** Aborts incomplete batches whose current RPC target is {@code targetPath}. */
@@ -531,14 +534,14 @@ public final class RecordAccumulator {
     }
 
     private void abortBatch(final Exception reason, WriteBatch batch) {
-        Deque<WriteBatch> dq = getDeque(batch.physicalTablePath(), batch.bucketId());
+        Deque<WriteBatch> deque = getDequeOrThrow(batch.physicalTablePath(), batch.bucketId());
         boolean aborted;
-        synchronized (dq) {
+        synchronized (deque) {
             aborted = batch.trySetAborted();
             if (aborted) {
                 batch.abortRecordAppends();
             }
-            dq.remove(batch);
+            deque.remove(batch);
         }
 
         // A response may have completed the batch after abortAllBatches() took its snapshot. In
@@ -552,17 +555,16 @@ public final class RecordAccumulator {
         }
     }
 
-    /** Get the deque for the given table-bucket, creating it if necessary. */
-    private Deque<WriteBatch> getOrCreateDeque(
+    /** Get the deque for the given table-bucket, or throw exception if it doesn't exist. */
+    private Deque<WriteBatch> getDequeOrThrow(
             TableBucket tableBucket, PhysicalTablePath physicalTablePath) {
-        BucketAndWriteBatches bucketAndWriteBatches =
-                writeBatches.computeIfAbsent(
-                        physicalTablePath,
-                        k ->
-                                new BucketAndWriteBatches(
-                                        tableBucket.getPartitionId(),
-                                        physicalTablePath.getPartitionName() != null,
-                                        physicalTablePath));
+        BucketAndWriteBatches bucketAndWriteBatches = writeBatches.get(physicalTablePath);
+        if (bucketAndWriteBatches == null) {
+            throw new TableNotExistException(
+                    String.format(
+                            "Table %s does not exist in the accumulator for bucket %d.",
+                            physicalTablePath, tableBucket.getBucket()));
+        }
         return bucketAndWriteBatches.batches.computeIfAbsent(
                 tableBucket.getBucket(), k -> new ArrayDeque<>());
     }
@@ -626,8 +628,8 @@ public final class RecordAccumulator {
 
     /**
      * Get the ready deque for the given table path and bucket id, or null if it does not exist. A
-     * deque is considered ready if it's not a partitioned table or the partition is created and
-     * partition_id is fetched.
+     * deque is ready only after its bucket count and, for a partitioned table, partition ID have
+     * been resolved and any incompatible tentative batches have been aborted.
      */
     @VisibleForTesting
     Deque<WriteBatch> getReadyDeque(PhysicalTablePath path, int bucketId) {
@@ -637,7 +639,9 @@ public final class RecordAccumulator {
         }
 
         // for the partitioned tables, we need to check whether the partition is ready
-        if (bucketAndWriteBatches.isPartitionedTable && bucketAndWriteBatches.partitionId == null) {
+        if (bucketAndWriteBatches.bucketCount == null
+                || (bucketAndWriteBatches.isPartitionedTable
+                        && bucketAndWriteBatches.partitionId == null)) {
             return null;
         }
 
@@ -649,7 +653,8 @@ public final class RecordAccumulator {
      *
      * <p>Note: this method does not check whether the partition is ready for partitioned tables.
      */
-    private Deque<WriteBatch> getDeque(PhysicalTablePath path, int bucketId) {
+    @VisibleForTesting
+    Deque<WriteBatch> getDequeOrThrow(PhysicalTablePath path, int bucketId) {
         BucketAndWriteBatches bucketAndWriteBatches = writeBatches.get(path);
         if (bucketAndWriteBatches == null) {
             return null;
@@ -695,40 +700,36 @@ public final class RecordAccumulator {
             BucketAndWriteBatches bucketAndWriteBatches,
             Set<Integer> readyNodes,
             Set<PhysicalTablePath> unknownLeaderTables,
-            Set<PhysicalTablePath> invalidBucketRoutingTables,
             Cluster cluster,
             long nextReadyCheckDelayMs) {
-        // first check this table has partitionId.
         PhysicalTablePath targetPath = bucketAndWriteBatches.targetPath;
-        if (bucketAndWriteBatches.isPartitionedTable && bucketAndWriteBatches.partitionId == null) {
-            Optional<Long> optionIdOpt = cluster.getPartitionId(targetPath);
-            if (optionIdOpt.isPresent()) {
-                bucketAndWriteBatches.partitionId = optionIdOpt.get();
-            } else {
-                LOG.debug(
-                        "Partition not exists for {}, bucket will not be set to ready", targetPath);
-                // TODO: we shouldn't add unready partitions to unknownLeaderTables,
-                //  because it cases PartitionNotExistException later
+        Long partitionId =
+                bucketAndWriteBatches.isPartitionedTable
+                        ? cluster.getPartitionId(targetPath).orElse(null)
+                        : null;
+        Long tableId = cluster.getTableId(targetPath.getTablePath()).orElse(null);
+        if (tableId == null || (bucketAndWriteBatches.isPartitionedTable && partitionId == null)) {
+            unknownLeaderTables.add(targetPath);
+            return nextReadyCheckDelayMs;
+        }
+        if (bucketAndWriteBatches.bucketCount == null) {
+            Integer actualBucketCount =
+                    cluster.getBucketCount(TableOrPartition.of(tableId, partitionId)).orElse(null);
+            if (actualBucketCount == null) {
                 unknownLeaderTables.add(targetPath);
                 return nextReadyCheckDelayMs;
             }
+            // Resolve both values from this snapshot. Do not cache a partition ID while its count
+            // is missing: a later snapshot may already refer to a recreated partition.
+            applyNewBucketCount(bucketAndWriteBatches, partitionId, actualBucketCount);
         }
 
-        Integer actualBucketCount =
-                bucketAndWriteBatches.isPartitionedTable
-                        ? cluster.getBucketCount(
-                                        TableOrPartition.ofPartition(
-                                                bucketAndWriteBatches.partitionId))
-                                .orElse(null)
-                        : null;
         Map<Integer, Deque<WriteBatch>> batches = bucketAndWriteBatches.batches;
         // Collect the queue sizes for available buckets to be used in adaptive bucket allocate.
-
         boolean exhausted = writerBufferPool.queued() > 0;
         for (Map.Entry<Integer, Deque<WriteBatch>> entry : batches.entrySet()) {
             Deque<WriteBatch> deque = entry.getValue();
 
-            final WriteBatch batch;
             final long waitedTimeMs;
             final int dequeSize;
             final boolean full;
@@ -740,7 +741,7 @@ public final class RecordAccumulator {
             synchronized (deque) {
                 // Deque are often empty in this path, esp with large bucket counts,
                 // so we exit early if we can.
-                batch = deque.peekFirst();
+                WriteBatch batch = deque.peekFirst();
                 if (batch == null) {
                     continue;
                 }
@@ -750,54 +751,116 @@ public final class RecordAccumulator {
                 full = dequeSize > 1 || batch.isClosed();
             }
 
-            if (actualBucketCount != null && batch.getBucketCount() != actualBucketCount) {
-                invalidBucketRoutingTables.add(targetPath);
-                return nextReadyCheckDelayMs;
+            int bucketId = entry.getKey();
+            TableBucket tableBucket = cluster.getTableBucket(tableId, targetPath, bucketId);
+
+            // If this bucket is throttled, don't mark its node as ready.
+            // Instead, factor the remaining throttle time into the next check delay.
+            Long throttleExpiry = throttleExpiryMs.get(tableBucket);
+            if (throttleExpiry != null) {
+                long now = clock.milliseconds();
+                if (now < throttleExpiry) {
+                    nextReadyCheckDelayMs = Math.min(nextReadyCheckDelayMs, throttleExpiry - now);
+                    continue;
+                }
+                // Expired — evict here to reclaim entries for buckets whose deque
+                // has gone empty and won't reach the drain-time throttle check.
+                throttleExpiryMs.remove(tableBucket);
             }
 
-            int bucketId = entry.getKey();
-            Optional<Long> tableIdOpt = cluster.getTableId(targetPath.getTablePath());
-            if (!tableIdOpt.isPresent()) {
+            Integer leader = cluster.leaderFor(tableBucket);
+            if (leader == null) {
+                // This is a bucket for which leader is not known, but messages are
+                // available to send. Note that entries are currently not removed from
+                // batches when deque is empty.
                 unknownLeaderTables.add(targetPath);
             } else {
-                TableBucket tableBucket =
-                        cluster.getTableBucket(tableIdOpt.get(), targetPath, bucketId);
-
-                // If this bucket is throttled, don't mark its node as ready.
-                // Instead, factor the remaining throttle time into the next check delay.
-                Long throttleExpiry = throttleExpiryMs.get(tableBucket);
-                if (throttleExpiry != null) {
-                    long now = clock.milliseconds();
-                    if (now < throttleExpiry) {
-                        nextReadyCheckDelayMs =
-                                Math.min(nextReadyCheckDelayMs, throttleExpiry - now);
-                        continue;
-                    }
-                    // Expired — evict here to reclaim entries for buckets whose deque
-                    // has gone empty and won't reach the drain-time throttle check.
-                    throttleExpiryMs.remove(tableBucket);
-                }
-
-                Integer leader = cluster.leaderFor(tableBucket);
-                if (leader == null) {
-                    // This is a bucket for which leader is not known, but messages are
-                    // available to send. Note that entries are currently not removed from
-                    // batches when deque is empty.
-                    unknownLeaderTables.add(targetPath);
-                } else {
-                    nextReadyCheckDelayMs =
-                            batchReady(
-                                    exhausted,
-                                    leader,
-                                    waitedTimeMs,
-                                    full,
-                                    readyNodes,
-                                    nextReadyCheckDelayMs);
-                }
+                nextReadyCheckDelayMs =
+                        batchReady(
+                                exhausted,
+                                leader,
+                                waitedTimeMs,
+                                full,
+                                readyNodes,
+                                nextReadyCheckDelayMs);
             }
         }
 
         return nextReadyCheckDelayMs;
+    }
+
+    private void applyNewBucketCount(
+            BucketAndWriteBatches context, @Nullable Long partitionId, int newBucketCount) {
+        List<WriteBatch> aborted = new ArrayList<>();
+        synchronized (context) {
+            if (context.bucketCount == null) {
+                boolean failBatches =
+                        context.tempBucketCount != newBucketCount
+                                && (isHashAssigner(context.bucketAssigner)
+                                        || hasOutOfRangeBatches(context, newBucketCount));
+                for (Deque<WriteBatch> deque : context.batches.values()) {
+                    synchronized (deque) {
+                        if (failBatches) {
+                            WriteBatch batch;
+                            while ((batch = deque.pollFirst()) != null) {
+                                if (batch.trySetAborted()) {
+                                    // This also releases an Arrow batch's writer without building
+                                    // it.
+                                    batch.abortRecordAppends();
+                                    aborted.add(batch);
+                                }
+                            }
+                        } else {
+                            for (WriteBatch batch : deque) {
+                                batch.setBucketCount(newBucketCount);
+                            }
+                        }
+                    }
+                }
+                context.partitionId = partitionId;
+                // Publish last so the Sender can drain only after every queued batch agrees
+                // with the resolved layout.
+                context.bucketCount = newBucketCount;
+            }
+        }
+
+        if (!aborted.isEmpty()) {
+            BucketRescaleException failure =
+                    new BucketRescaleException(
+                            String.format(
+                                    "Bucket rescale changed the bucket count for %s "
+                                            + "from %d to %d. Buffered records using the "
+                                            + "temporary count were not sent. Retry the "
+                                            + "failed records with the same writer to "
+                                            + "use the updated bucket count.",
+                                    context.targetPath, context.tempBucketCount, newBucketCount));
+            // Callbacks may retry using the resolved count. Invoke them outside the context and
+            // deque locks, after detaching every incompatible batch across all bucket queues.
+            for (WriteBatch batch : aborted) {
+                try {
+                    batch.completeAbort(failure);
+                } finally {
+                    deallocate(batch);
+                }
+            }
+        }
+    }
+
+    private boolean isHashAssigner(BucketAssigner assigner) {
+        return assigner instanceof HashBucketAssigner;
+    }
+
+    private boolean hasOutOfRangeBatches(BucketAndWriteBatches context, int bucketCount) {
+        for (Map.Entry<Integer, Deque<WriteBatch>> entry : context.batches.entrySet()) {
+            if (entry.getKey() >= bucketCount) {
+                synchronized (entry.getValue()) {
+                    if (!entry.getValue().isEmpty()) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private long batchReady(
@@ -835,39 +898,85 @@ public final class RecordAccumulator {
         return flushesInProgress.get() > 0;
     }
 
+    private RecordAppendResult tryAppend(
+            WriteRecord record,
+            WriteCallback callback,
+            Cluster cluster,
+            BucketAndWriteBatches context)
+            throws Exception {
+        int bucketCount = context.routingBucketCount();
+        int bucketId =
+                context.bucketAssigner.assignBucket(record.getBucketKey(), cluster, bucketCount);
+        Deque<WriteBatch> deque =
+                context.batches.computeIfAbsent(bucketId, k -> new ArrayDeque<>());
+        synchronized (deque) {
+            RecordAppendResult result = tryAppend(record, callback, bucketCount, deque);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (context.bucketAssigner.abortIfBatchFull()) {
+            context.bucketAssigner.onNewBatch(cluster, bucketCount, bucketId);
+            bucketId =
+                    context.bucketAssigner.assignBucket(
+                            record.getBucketKey(), cluster, bucketCount);
+        }
+        return new RecordAppendResult(new BucketAssignment(bucketId, bucketCount));
+    }
+
+    private RecordAppendResult appendWithAllocatedMemory(
+            WriteRecord record,
+            WriteCallback callback,
+            Cluster cluster,
+            BucketAndWriteBatches context,
+            int bucketId,
+            int bucketCount,
+            List<MemorySegment> segments)
+            throws Exception {
+        // Tentative routing resolution and historical target switches must wait for registration.
+        // Resolved normal buckets append independently using only their deque locks.
+        if (context.bucketCount == null
+                || isHistoricalPartitionEnabled(record.getPhysicalTablePath().getTablePath())) {
+            synchronized (context) {
+                return appendNewBatch(
+                        record, callback, cluster, context, bucketId, bucketCount, segments);
+            }
+        }
+        return appendNewBatch(record, callback, cluster, context, bucketId, bucketCount, segments);
+    }
+
     private RecordAppendResult appendNewBatch(
             WriteRecord writeRecord,
             WriteCallback callback,
+            Cluster cluster,
+            BucketAndWriteBatches context,
             int bucketId,
             int bucketCount,
-            TableInfo tableInfo,
-            Deque<WriteBatch> deque,
             List<MemorySegment> segments)
             throws Exception {
-        PhysicalTablePath physicalTablePath = writeRecord.getPhysicalTablePath();
-        BucketAndWriteBatches bucketAndWriteBatches =
-                checkNotNull(
-                        writeBatches.get(physicalTablePath),
-                        "Write batches for %s must exist.",
-                        physicalTablePath);
-        // Historical-enabled tables coordinate with routeWritesTo(). Other tables reuse the
-        // deque monitor already held by the caller, avoiding cross-bucket serialization.
-        Object routeLock =
-                isHistoricalPartitionEnabled(physicalTablePath.getTablePath())
-                        ? bucketAndWriteBatches
-                        : deque;
-        synchronized (routeLock) {
+        // Memory allocation runs without locks, so the count may have been resolved meanwhile.
+        int currentBucketCount = context.routingBucketCount();
+        if (bucketCount != currentBucketCount) {
+            bucketCount = currentBucketCount;
+            bucketId =
+                    context.bucketAssigner.assignBucket(
+                            writeRecord.getBucketKey(), cluster, bucketCount);
+        }
+        Deque<WriteBatch> deque =
+                context.batches.computeIfAbsent(bucketId, k -> new ArrayDeque<>());
+        synchronized (deque) {
             RecordAppendResult appendResult = tryAppend(writeRecord, callback, bucketCount, deque);
             if (appendResult != null) {
-                // Somebody else found us a batch, return the one we waited for! Hopefully this
-                // doesn't happen often...
+                // Somebody else found us a batch while we were allocating memory.
                 return appendResult;
             }
 
+            PhysicalTablePath physicalTablePath = writeRecord.getPhysicalTablePath();
+            TableInfo tableInfo = writeRecord.getTableInfo();
             PreAllocatedPagedOutputView outputView = new PreAllocatedPagedOutputView(segments);
             int schemaId = tableInfo.getSchemaId();
             WriteFormat writeFormat = writeRecord.getWriteFormat();
-            boolean isHistoricalPartition = bucketAndWriteBatches.isHistoricalWriteTarget();
+            boolean isHistoricalPartition = context.isHistoricalWriteTarget();
             final WriteBatch batch =
                     createWriteBatch(
                             writeRecord,
@@ -883,7 +992,7 @@ public final class RecordAccumulator {
             batch.tryAppend(writeRecord, callback);
             deque.addLast(batch);
             incomplete.add(batch);
-            return new RecordAppendResult(deque.size() > 1 || batch.isClosed(), true, false);
+            return new RecordAppendResult(deque.size() > 1 || batch.isClosed(), true);
         }
     }
 
@@ -898,6 +1007,7 @@ public final class RecordAccumulator {
             int schemaId,
             boolean isHistoricalPartition) {
         // If the table is kv table we need to create a kv batch, otherwise we create a log batch.
+        int writeLimit = outputView.getPreAllocatedSize();
         switch (writeFormat) {
             case COMPACTED_KV:
             case INDEXED_KV:
@@ -908,7 +1018,7 @@ public final class RecordAccumulator {
                         physicalTablePath,
                         tableInfo.getSchemaId(),
                         writeFormat.toKvFormat(),
-                        outputView.getPreAllocatedSize(),
+                        writeLimit,
                         outputView,
                         writeRecord.getTargetColumns(),
                         writeRecord.getMergeMode(),
@@ -920,7 +1030,7 @@ public final class RecordAccumulator {
                         arrowWriterPool.getOrCreateWriter(
                                 tableInfo.getTableId(),
                                 schemaId,
-                                outputView.getPreAllocatedSize(),
+                                writeLimit,
                                 tableInfo.getRowType(),
                                 tableInfo.getTableConfig().getArrowCompressionInfo());
                 LogRecordBatchStatisticsCollector statisticsCollector = null;
@@ -948,7 +1058,7 @@ public final class RecordAccumulator {
                         bucketCount,
                         physicalTablePath,
                         schemaId,
-                        outputView.getPreAllocatedSize(),
+                        writeLimit,
                         outputView,
                         isHistoricalPartition,
                         clock.milliseconds());
@@ -960,7 +1070,7 @@ public final class RecordAccumulator {
                         bucketCount,
                         physicalTablePath,
                         tableInfo.getSchemaId(),
-                        outputView.getPreAllocatedSize(),
+                        writeLimit,
                         outputView,
                         isHistoricalPartition,
                         clock.milliseconds());
@@ -994,7 +1104,7 @@ public final class RecordAccumulator {
                 // need to introduce a more reasonable way to solve these two problems.
                 last.close();
             } else {
-                return new RecordAppendResult(deque.size() > 1 || last.isClosed(), false, false);
+                return new RecordAppendResult(deque.size() > 1 || last.isClosed(), false);
             }
         }
         return null;
@@ -1395,14 +1505,31 @@ public final class RecordAccumulator {
     public static final class RecordAppendResult {
         public final boolean batchIsFull;
         public final boolean newBatchCreated;
-        /** Whether this record was abort because the new batch created in record accumulator. */
-        public final boolean abortRecordForNewBatch;
 
-        public RecordAppendResult(
-                boolean batchIsFull, boolean newBatchCreated, boolean abortRecordForNewBatch) {
+        @Nullable private final BucketAssignment newBatchAssignment;
+
+        /** Creates the result describing batch fullness and whether a batch was created. */
+        public RecordAppendResult(boolean batchIsFull, boolean newBatchCreated) {
             this.batchIsFull = batchIsFull;
             this.newBatchCreated = newBatchCreated;
-            this.abortRecordForNewBatch = abortRecordForNewBatch;
+            this.newBatchAssignment = null;
+        }
+
+        private RecordAppendResult(BucketAssignment newBatchAssignment) {
+            this.batchIsFull = false;
+            this.newBatchCreated = false;
+            this.newBatchAssignment = newBatchAssignment;
+        }
+    }
+
+    /** Routing retained only when an append needs to allocate memory for a new batch. */
+    private static final class BucketAssignment {
+        private final int bucketId;
+        private final int bucketCount;
+
+        private BucketAssignment(int bucketId, int bucketCount) {
+            this.bucketId = bucketId;
+            this.bucketCount = bucketCount;
         }
     }
 
@@ -1411,23 +1538,30 @@ public final class RecordAccumulator {
         public final Set<Integer> readyNodes;
         public final long nextReadyCheckDelayMs;
         public final Set<PhysicalTablePath> unknownLeaderTables;
-        public final Set<PhysicalTablePath> invalidBucketRoutingTables;
 
         public ReadyCheckResult(
                 Set<Integer> readyNodes,
                 long nextReadyCheckDelayMs,
-                Set<PhysicalTablePath> unknownLeaderTables,
-                Set<PhysicalTablePath> invalidBucketRoutingTables) {
+                Set<PhysicalTablePath> unknownLeaderTables) {
             this.readyNodes = readyNodes;
             this.nextReadyCheckDelayMs = nextReadyCheckDelayMs;
             this.unknownLeaderTables = unknownLeaderTables;
-            this.invalidBucketRoutingTables = invalidBucketRoutingTables;
         }
     }
 
     /** Close this accumulator to reject new appends. */
     public void close() {
         closed = true;
+        for (BucketAndWriteBatches context : writeBatches.values()) {
+            synchronized (context) {
+                // Resolved normal appends only hold their deque lock during registration.
+                for (Deque<WriteBatch> deque : context.batches.values()) {
+                    synchronized (deque) {
+                        // Wait for registration before fatal cleanup takes its snapshot.
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -1457,8 +1591,21 @@ public final class RecordAccumulator {
     /** Per table bucket and write batches. */
     private static class BucketAndWriteBatches {
         public final boolean isPartitionedTable;
+
+        /**
+         * The temporary bucket count used for routing before the authoritative bucket count is
+         * known.
+         */
+        private final int tempBucketCount;
+
+        /** The bucket assigner to assign record to bucket id for the given path. */
+        private final BucketAssigner bucketAssigner;
+
         /** The physical partition used for metadata lookup, leader discovery, and write RPCs. */
         private volatile PhysicalTablePath targetPath;
+
+        /** Null until every queued batch agrees with the authoritative layout. */
+        private volatile @Nullable Integer bucketCount;
 
         public volatile @Nullable Long partitionId;
         // Write batches for each bucket in queue.
@@ -1466,11 +1613,22 @@ public final class RecordAccumulator {
 
         private BucketAndWriteBatches(
                 @Nullable Long partitionId,
+                @Nullable Integer bucketCount,
+                int tempBucketCount,
+                BucketAssigner bucketAssigner,
                 boolean isPartitionedTable,
                 PhysicalTablePath targetPath) {
             this.partitionId = partitionId;
+            this.bucketCount = bucketCount;
+            this.tempBucketCount = tempBucketCount;
+            this.bucketAssigner = bucketAssigner;
             this.isPartitionedTable = isPartitionedTable;
             this.targetPath = targetPath;
+        }
+
+        private int routingBucketCount() {
+            Integer current = bucketCount;
+            return current == null ? tempBucketCount : current;
         }
 
         public boolean isHistoricalWriteTarget() {

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/RoundRobinBucketAssigner.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/RoundRobinBucketAssigner.java
@@ -31,25 +31,27 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Internal
 public class RoundRobinBucketAssigner extends DynamicBucketAssigner {
     private final PhysicalTablePath physicalTablePath;
-    private final int bucketNumber;
     private final AtomicInteger counter = new AtomicInteger(new Random().nextInt());
 
-    public RoundRobinBucketAssigner(PhysicalTablePath physicalTablePath, int bucketNumber) {
+    public RoundRobinBucketAssigner(PhysicalTablePath physicalTablePath) {
         this.physicalTablePath = physicalTablePath;
-        this.bucketNumber = bucketNumber;
     }
 
     @Override
-    public int assignBucket(Cluster cluster) {
+    public int assignBucket(Cluster cluster, int bucketCount) {
         int nextValue = counter.getAndIncrement();
         List<BucketLocation> bucketsForTable =
                 cluster.getAvailableBucketsForPhysicalTablePath(physicalTablePath);
         if (!bucketsForTable.isEmpty()) {
             int bucket = MathUtils.toPositive(nextValue) % bucketsForTable.size();
-            return bucketsForTable.get(bucket).getBucketId();
+            int bucketId = bucketsForTable.get(bucket).getBucketId();
+            // Metadata may already expose the final layout while the context is still tentative.
+            return bucketId < bucketCount
+                    ? bucketId
+                    : MathUtils.toPositive(nextValue) % bucketCount;
         } else {
             // no buckets are available, give a non-available bucket.
-            return MathUtils.toPositive(nextValue) % bucketNumber;
+            return MathUtils.toPositive(nextValue) % bucketCount;
         }
     }
 
@@ -59,7 +61,7 @@ public class RoundRobinBucketAssigner extends DynamicBucketAssigner {
     }
 
     @Override
-    public void onNewBatch(Cluster cluster, int prevBucketId) {
+    public void onNewBatch(Cluster cluster, int bucketCount, int prevBucketId) {
         // do nothing
     }
 }

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/Sender.java
@@ -22,7 +22,6 @@ import org.apache.fluss.client.metadata.MetadataUpdater;
 import org.apache.fluss.client.metrics.WriterMetricGroup;
 import org.apache.fluss.client.write.RecordAccumulator.ReadyCheckResult;
 import org.apache.fluss.cluster.Cluster;
-import org.apache.fluss.exception.InvalidBucketRoutingException;
 import org.apache.fluss.exception.InvalidMetadataException;
 import org.apache.fluss.exception.LeaderNotAvailableException;
 import org.apache.fluss.exception.OutOfOrderSequenceException;
@@ -32,8 +31,6 @@ import org.apache.fluss.exception.StorageBackpressureException;
 import org.apache.fluss.exception.UnknownTableOrBucketException;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.TableBucket;
-import org.apache.fluss.metadata.TableOrPartition;
-import org.apache.fluss.metadata.TablePartition;
 import org.apache.fluss.rpc.gateway.TabletServerGateway;
 import org.apache.fluss.rpc.messages.PbProduceLogRespForBucket;
 import org.apache.fluss.rpc.messages.PbPutKvRespForBucket;
@@ -59,7 +56,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 
 import static org.apache.fluss.client.utils.ClientRpcMessageUtils.makeProduceLogRequest;
 import static org.apache.fluss.client.utils.ClientRpcMessageUtils.makePutKvRequest;
@@ -122,13 +118,6 @@ public class Sender implements Runnable {
 
     private final WriterMetricGroup writerMetricGroup;
 
-    /**
-     * Called when a write batch is rejected for invalid bucket routing so the owning {@link
-     * WriterClient} can remove the stale {@link BucketAssigner}. The next {@code send} will refresh
-     * metadata and create a new assigner with the updated bucket count.
-     */
-    private final Consumer<TableBucket> bucketAssignerInvalidator;
-
     public Sender(
             RecordAccumulator accumulator,
             int maxRequestTimeoutMs,
@@ -137,8 +126,7 @@ public class Sender implements Runnable {
             int retries,
             MetadataUpdater metadataUpdater,
             IdempotenceManager idempotenceManager,
-            WriterMetricGroup writerMetricGroup,
-            Consumer<TableBucket> bucketAssignerInvalidator) {
+            WriterMetricGroup writerMetricGroup) {
         this.accumulator = accumulator;
         this.maxRequestSize = maxRequestSize;
         this.maxRequestTimeoutMs = maxRequestTimeoutMs;
@@ -152,7 +140,6 @@ public class Sender implements Runnable {
 
         this.idempotenceManager = idempotenceManager;
         this.writerMetricGroup = writerMetricGroup;
-        this.bucketAssignerInvalidator = bucketAssignerInvalidator;
 
         // TODO add retry logic while send failed. See FLUSS-56364375
     }
@@ -211,6 +198,10 @@ public class Sender implements Runnable {
 
     /** Run a single iteration of sending. */
     public void runOnce() throws Exception {
+        if (fatalError.get() != null) {
+            maybeAbortBatches(fatalError.get());
+            return;
+        }
         if (idempotenceManager.idempotenceEnabled()) {
             // may be wait for writer id.
             Set<PhysicalTablePath> targetTables = accumulator.getPhysicalTablePathsInBatches();
@@ -239,6 +230,11 @@ public class Sender implements Runnable {
         return running;
     }
 
+    @Nullable
+    Throwable getFatalError() {
+        return fatalError.get();
+    }
+
     private void addToInflightBatches(Map<Integer, List<ReadyWriteBatch>> batches) {
         synchronized (inFlightBatchesLock) {
             batches.values().forEach(this::addToInflightBatches);
@@ -254,26 +250,6 @@ public class Sender implements Runnable {
 
         // get the list of buckets with data ready to send.
         ReadyCheckResult readyCheckResult = accumulator.ready(clusterSnapshot);
-
-        if (!readyCheckResult.invalidBucketRoutingTables.isEmpty()) {
-            for (PhysicalTablePath physicalTablePath :
-                    readyCheckResult.invalidBucketRoutingTables) {
-                accumulator.abortBatches(
-                        physicalTablePath,
-                        new InvalidBucketRoutingException(
-                                "The bucket count changed before queued records for "
-                                        + physicalTablePath
-                                        + " could be sent. Retry the failed records."));
-                Long tableId =
-                        clusterSnapshot.getTableId(physicalTablePath.getTablePath()).orElse(null);
-                Long partitionId = clusterSnapshot.getPartitionId(physicalTablePath).orElse(null);
-                if (tableId != null) {
-                    bucketAssignerInvalidator.accept(new TableBucket(tableId, partitionId, 0));
-                }
-            }
-            metadataUpdater.invalidPhysicalTableBucketAndPartitionMeta(
-                    readyCheckResult.invalidBucketRoutingTables);
-        }
 
         // if there are any buckets whose leaders are not known yet, force metadata update
         if (!readyCheckResult.unknownLeaderTables.isEmpty()) {
@@ -309,6 +285,10 @@ public class Sender implements Runnable {
             addToInflightBatches(batches);
             // TODO add logic for batch expire.
 
+            if (fatalError.get() != null) {
+                maybeAbortBatches(fatalError.get());
+                return;
+            }
             sendWriteRequests(batches);
 
             // move metrics update to the end to make sure the batches has been built.
@@ -317,6 +297,9 @@ public class Sender implements Runnable {
     }
 
     private void completeBatch(ReadyWriteBatch readyWriteBatch) {
+        if (fatalError.get() != null) {
+            return;
+        }
         if (idempotenceManager.idempotenceEnabled()) {
             idempotenceManager.handleCompletedBatch(readyWriteBatch);
         }
@@ -328,6 +311,9 @@ public class Sender implements Runnable {
     /** Complete batch with bucket and log end offset info (for KV batches). */
     private void completeBatch(
             ReadyWriteBatch readyWriteBatch, TableBucket bucket, long logEndOffset) {
+        if (fatalError.get() != null) {
+            return;
+        }
         if (idempotenceManager.idempotenceEnabled()) {
             idempotenceManager.handleCompletedBatch(readyWriteBatch);
         }
@@ -511,7 +497,7 @@ public class Sender implements Runnable {
             short acks,
             boolean logBatches,
             List<ReadyWriteBatch> writeBatches) {
-        if (writeBatches.isEmpty()) {
+        if (writeBatches.isEmpty() || fatalError.get() != null) {
             return;
         }
         try {
@@ -700,13 +686,15 @@ public class Sender implements Runnable {
         metadataUpdater.invalidPhysicalTableBucketMeta(invalidMetadataTablesSet);
     }
 
-    private void recordFatalError(Throwable t) {
-        // Request callbacks may run on a network thread. Only publish the fatal state here; the
-        // sender thread aborts incomplete batches in run() before destroying accumulator resources.
-        accumulator.close();
+    /** Stops appends and sending after a fatal write or partition-creation failure. */
+    void recordFatalError(Throwable t) {
+        // Publish the cause before rejecting appends, so concurrent writes report the original
+        // failure. Wait for batch registration before stopping the sender; its final cleanup then
+        // also includes batches whose append had already passed the closed check.
         if (fatalError.compareAndSet(null, t)) {
             LOG.error("Fatal error in Fluss write sender:", t);
         }
+        accumulator.close();
         running = false;
         forceClose = true;
         wakeup();
@@ -728,23 +716,11 @@ public class Sender implements Runnable {
             accumulator.updateThrottle(readyWriteBatch.tableBucket(), 1.0f);
         }
         if (error.error() == Errors.INVALID_BUCKET_ROUTING) {
-            // The bucketId in this batch was computed with invalid routing information, and the
-            // server rejected it during pre-append validation, so it was provably never written.
-            // Reclaim its batch sequence (adjustBatchSequences=true): otherwise a permanent hole is
-            // left at this sequence, and the next batch that reaches the server on this bucket
-            // (created after the metadata refresh, carrying a valid routing count) would send the
-            // following sequence against a lower expected one, raising OUT_OF_ORDER_SEQUENCE and
-            // resetting the writer id — which discards idempotence for every bucket of this writer.
-            // Do not re-enqueue (the bucketId is fixed); invalidate metadata and drop the
-            // BucketAssigner so the next send re-routes with the updated count.
-            LOG.warn(
-                    "Received {} in write request on table bucket {}. Failing batch and "
-                            + "invalidating BucketAssigner.",
-                    error.error(),
-                    readyWriteBatch.tableBucket());
-            failBatch(readyWriteBatch, error.exception(), true);
+            // Tentative assignments are resolved before drain. A rejection after that barrier
+            // cannot be recovered by failing one batch: queued and in-flight writes belong to
+            // the same ordered stream. Stop accepting/draining writes and fail the writer.
+            recordFatalError(error.exception());
             invalidMetadataTables.add(writeBatch.physicalTablePath());
-            bucketAssignerInvalidator.accept(readyWriteBatch.tableBucket());
             return invalidMetadataTables;
         }
         if (error.error() == Errors.DUPLICATE_SEQUENCE_EXCEPTION) {
@@ -897,44 +873,10 @@ public class Sender implements Runnable {
         @Nullable Throwable historicalTargetCause = null;
         try {
             if (metadataUpdater.checkAndUpdatePartitionMetadata(historicalPath)) {
-                // The queued batches were routed by the original partition's bucket count; they can
-                // only land in the right buckets of the historical partition if its own count
-                // matches. Otherwise the bucket ids would be hashes against the wrong layout.
-                TablePartition historicalPartition =
-                        metadataUpdater
-                                .getCluster()
-                                .getTablePartition(historicalPath)
-                                .orElseThrow(
-                                        () ->
-                                                new PartitionNotExistException(
-                                                        "Historical partition "
-                                                                + historicalPath
-                                                                + " does not exist."));
-                Integer historicalBucketCount =
-                        metadataUpdater
-                                .getCluster()
-                                .getBucketCount(
-                                        TableOrPartition.ofPartition(
-                                                historicalPartition.getPartitionId()))
-                                .orElse(null);
-                boolean rerouted =
-                        accumulator.rerouteQueuedWritesToHistorical(
-                                targetPath,
-                                historicalPath,
-                                historicalPartition.getPartitionId(),
-                                historicalBucketCount);
-                if (!rerouted) {
-                    abortBatches(
-                            targetPath,
-                            newPartitionNotExistException(
-                                    "Cannot reroute writes from "
-                                            + targetPath
-                                            + " to the historical partition because their "
-                                            + "bucket ids were routed by a different bucket "
-                                            + "count than the historical partition's.",
-                                    historicalTargetCause));
-                    return;
-                }
+                long historicalPartitionId =
+                        metadataUpdater.getCluster().getPartitionIdOrElseThrow(historicalPath);
+                accumulator.rerouteQueuedWritesToHistorical(
+                        targetPath, historicalPath, historicalPartitionId);
                 LOG.info(
                         "Rerouted writes from partition {} to historical partition {}.",
                         targetPath,

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/StaticBucketAssigner.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/StaticBucketAssigner.java
@@ -31,12 +31,12 @@ import static org.apache.fluss.utils.Preconditions.checkNotNull;
 @Internal
 abstract class StaticBucketAssigner implements BucketAssigner {
 
-    protected abstract int assignBucket(byte[] bucketKey);
+    protected abstract int assignBucket(byte[] bucketKey, int bucketCount);
 
     @Override
-    public int assignBucket(@Nullable byte[] bucketKey, Cluster cluster) {
+    public int assignBucket(@Nullable byte[] bucketKey, Cluster cluster, int bucketCount) {
         checkNotNull(bucketKey);
-        return assignBucket(bucketKey);
+        return assignBucket(bucketKey, bucketCount);
     }
 
     @Override
@@ -45,7 +45,7 @@ abstract class StaticBucketAssigner implements BucketAssigner {
     }
 
     @Override
-    public void onNewBatch(Cluster cluster, int prevBucketId) {
+    public void onNewBatch(Cluster cluster, int bucketCount, int prevBucketId) {
         // do nothing
     }
 }

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/StickyBucketAssigner.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/StickyBucketAssigner.java
@@ -35,21 +35,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class StickyBucketAssigner extends DynamicBucketAssigner {
 
     private final PhysicalTablePath physicalTablePath;
-    private final int bucketNumber;
     private final AtomicInteger currentBucketId;
 
-    public StickyBucketAssigner(PhysicalTablePath physicalTablePath, int bucketNumber) {
+    public StickyBucketAssigner(PhysicalTablePath physicalTablePath) {
         this.physicalTablePath = physicalTablePath;
-        this.bucketNumber = bucketNumber;
         this.currentBucketId = new AtomicInteger(-1);
     }
 
     @Override
-    public int assignBucket(Cluster cluster) {
+    public int assignBucket(Cluster cluster, int bucketCount) {
         int bucketId = currentBucketId.get();
-        if (bucketId < 0) {
+        if (bucketId < 0 || bucketId >= bucketCount) {
             // initialize the currentBucketId
-            return nextBucket(cluster, bucketId);
+            return nextBucket(cluster, bucketCount, bucketId);
         }
         return bucketId;
     }
@@ -60,30 +58,32 @@ public class StickyBucketAssigner extends DynamicBucketAssigner {
     }
 
     @Override
-    public void onNewBatch(Cluster cluster, int prevBucketId) {
-        nextBucket(cluster, prevBucketId);
+    public void onNewBatch(Cluster cluster, int bucketCount, int prevBucketId) {
+        nextBucket(cluster, bucketCount, prevBucketId);
     }
 
-    private int nextBucket(Cluster cluster, int preBucketId) {
+    private int nextBucket(Cluster cluster, int bucketCount, int preBucketId) {
         int oldBucket = currentBucketId.get();
         int newBucket = oldBucket;
         // Check that the current sticky bucket for the table is either not set or that the
         // bucket that triggered the new batch matches the sticky bucket that needs to be
         // changed.
-        if (oldBucket < 0 || oldBucket == preBucketId) {
+        if (oldBucket < 0 || oldBucket >= bucketCount || oldBucket == preBucketId) {
             List<BucketLocation> availableBuckets =
                     cluster.getAvailableBucketsForPhysicalTablePath(physicalTablePath);
-            if (availableBuckets.isEmpty()) {
-                int random = MathUtils.toPositive(ThreadLocalRandom.current().nextInt());
-                newBucket = random % bucketNumber;
-            } else if (availableBuckets.size() == 1) {
-                newBucket = availableBuckets.get(0).getBucketId();
-            } else {
-                while (newBucket < 0 || newBucket == oldBucket) {
-                    int random = MathUtils.toPositive(ThreadLocalRandom.current().nextInt());
-                    newBucket =
-                            availableBuckets.get(random % availableBuckets.size()).getBucketId();
+            int random = MathUtils.toPositive(ThreadLocalRandom.current().nextInt());
+            // Use a bounded search: metadata may contain buckets outside the temporary count,
+            // or the old bucket may be the only available one within the current count.
+            for (int i = 0; i < availableBuckets.size(); i++) {
+                int index = (random % availableBuckets.size() + i) % availableBuckets.size();
+                int candidate = availableBuckets.get(index).getBucketId();
+                if (candidate < bucketCount && candidate != oldBucket) {
+                    newBucket = candidate;
+                    break;
                 }
+            }
+            if (availableBuckets.isEmpty() || newBucket < 0 || newBucket >= bucketCount) {
+                newBucket = random % bucketCount;
             }
 
             // Only change the sticky partition if it is null or prevPartition matches the current
@@ -91,7 +91,7 @@ public class StickyBucketAssigner extends DynamicBucketAssigner {
             if (oldBucket < 0) {
                 currentBucketId.set(newBucket);
             } else {
-                currentBucketId.compareAndSet(preBucketId, newBucket);
+                currentBucketId.compareAndSet(oldBucket, newBucket);
             }
             return currentBucketId.get();
         }

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/WriteBatch.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/WriteBatch.java
@@ -54,7 +54,7 @@ public abstract class WriteBatch {
 
     // The bucket count used to calculate this batch's bucketId; carried into the request so the
     // TabletServer can validate it against the actual count (INVALID_BUCKET_ROUTING on mismatch).
-    private final int bucketCount;
+    private int bucketCount;
 
     protected final List<WriteCallback> callbacks = new ArrayList<>();
     private final AtomicReference<FinalState> finalState = new AtomicReference<>(null);
@@ -213,6 +213,11 @@ public abstract class WriteBatch {
 
     public int getBucketCount() {
         return bucketCount;
+    }
+
+    /** Updates the routing count of an unsent batch whose bucket ID remains valid. */
+    void setBucketCount(int bucketCount) {
+        this.bucketCount = bucketCount;
     }
 
     public long tableId() {

--- a/fluss-client/src/main/java/org/apache/fluss/client/write/WriterClient.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/write/WriterClient.java
@@ -18,25 +18,20 @@
 package org.apache.fluss.client.write;
 
 import org.apache.fluss.annotation.Internal;
-import org.apache.fluss.bucketing.BucketingFunction;
 import org.apache.fluss.client.admin.Admin;
 import org.apache.fluss.client.metadata.MetadataUpdater;
 import org.apache.fluss.client.metrics.WriterMetricGroup;
 import org.apache.fluss.client.write.RecordAccumulator.RecordAppendResult;
-import org.apache.fluss.cluster.Cluster;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.exception.IllegalConfigurationException;
 import org.apache.fluss.exception.PartitionNotExistException;
 import org.apache.fluss.metadata.PhysicalTablePath;
-import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableInfo;
-import org.apache.fluss.metadata.TableOrPartition;
 import org.apache.fluss.rpc.gateway.TabletServerGateway;
 import org.apache.fluss.rpc.metrics.ClientMetricGroup;
 import org.apache.fluss.utils.AutoPartitionStrategy;
-import org.apache.fluss.utils.CopyOnWriteMap;
 import org.apache.fluss.utils.clock.SystemClock;
 import org.apache.fluss.utils.concurrent.ExecutorThreadFactory;
 
@@ -49,15 +44,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.fluss.config.ConfigOptions.NoKeyAssigner.ROUND_ROBIN;
-import static org.apache.fluss.config.ConfigOptions.NoKeyAssigner.STICKY;
-import static org.apache.fluss.utils.ExceptionUtils.toException;
 import static org.apache.fluss.utils.PartitionUtils.HISTORICAL_PARTITION_VALUE;
 import static org.apache.fluss.utils.PartitionUtils.generateAutoPartitionTime;
 
@@ -98,7 +88,6 @@ public class WriterClient {
     private final Sender sender;
     private final ExecutorService ioThreadPool;
     private final MetadataUpdater metadataUpdater;
-    private final Map<TableOrPartition, BucketAssigner> bucketAssigners = new CopyOnWriteMap<>();
     private final IdempotenceManager idempotenceManager;
     private final WriterMetricGroup writerMetricGroup;
     private final DynamicPartitionCreator dynamicPartitionCreator;
@@ -142,7 +131,7 @@ public class WriterClient {
                             metadataUpdater,
                             admin,
                             conf.get(ConfigOptions.CLIENT_WRITER_DYNAMIC_CREATE_PARTITION_ENABLED),
-                            this::maybeAbortBatches);
+                            sender::recordFatalError);
         } catch (Throwable t) {
             LOG.error("Failed to construct writer.", t);
             close(Duration.ofMillis(0));
@@ -201,79 +190,40 @@ public class WriterClient {
 
             TableInfo tableInfo = record.getTableInfo();
             PhysicalTablePath physicalTablePath = record.getPhysicalTablePath();
-            // The path the record is physically written to. A retired partition's records land in
-            // the historical partition, whose own bucket count must drive the assignment.
-            PhysicalTablePath routingPath = physicalTablePath;
+            // Resolve retired partitions before appending so their records target the historical
+            // partition.
             if (tableInfo.isPartitioned()) {
                 boolean historicalPartitionEnabled =
                         accumulator.checkAndCacheHistoricalPartitionEnabled(tableInfo);
                 if (historicalPartitionEnabled
                         && mayBeExpiredHistoricalPartition(
                                 physicalTablePath, tableInfo, Instant.now())) {
-                    routingPath = resolveHistoricalWriteTarget(physicalTablePath);
+                    resolveHistoricalWriteTarget(physicalTablePath, tableInfo);
                 } else {
                     dynamicPartitionCreator.checkAndCreatePartitionAsync(
                             physicalTablePath, tableInfo);
                 }
             }
 
-            Cluster cluster = metadataUpdater.getCluster();
-            long tableId = tableInfo.getTableId();
-            Long partitionId =
-                    tableInfo.isPartitioned()
-                            ? cluster.getPartitionId(routingPath).orElse(null)
-                            : null;
-            int bucketCount =
-                    partitionId == null
-                            ? tableInfo.getNumBuckets()
-                            : cluster.getBucketCountOrFallback(tableInfo, partitionId);
-            final PhysicalTablePath finalRoutingPath = routingPath;
-            BucketAssigner bucketAssigner =
-                    bucketAssigners.computeIfAbsent(
-                            TableOrPartition.of(tableId, partitionId),
-                            k ->
-                                    createBucketAssigner(
-                                            tableInfo, finalRoutingPath, bucketCount, conf));
-
-            // Append the record to the accumulator.
-            int bucketId = bucketAssigner.assignBucket(record.getBucketKey(), cluster);
-
             RecordAppendResult result =
-                    accumulator.append(
-                            record,
-                            callback,
-                            cluster,
-                            bucketId,
-                            bucketCount,
-                            bucketAssigner.abortIfBatchFull());
-
-            if (result.abortRecordForNewBatch) {
-                int prevBucketId = bucketId;
-                bucketAssigner.onNewBatch(cluster, prevBucketId);
-                bucketId = bucketAssigner.assignBucket(record.getBucketKey(), cluster);
-                LOG.trace(
-                        "Retrying append due to new batch creation for table {} bucket {}, the old bucket was {}.",
-                        physicalTablePath,
-                        bucketId,
-                        prevBucketId);
-                result =
-                        accumulator.append(record, callback, cluster, bucketId, bucketCount, false);
-            }
+                    accumulator.append(record, callback, metadataUpdater.getCluster());
 
             if (result.batchIsFull || result.newBatchCreated) {
                 LOG.trace(
-                        "Waking up the sender since table {} bucket {} is either full or getting a new batch",
-                        record.getPhysicalTablePath(),
-                        bucketId);
+                        "Waking up the sender since table {} is either full or getting a new batch",
+                        record.getPhysicalTablePath());
                 sender.wakeup();
             }
         } catch (Exception e) {
+            // A partition-creation failure may close the accumulator before this record is
+            // registered. Preserve that failure instead of reporting only "Writer closed".
+            Throwable fatalError = sender.getFatalError();
             throw new FlussRuntimeException(
                     String.format(
                             "Failed to send record to table %s. Writer state: %s",
                             record.getPhysicalTablePath(),
                             sender != null && sender.isRunning() ? "running" : "closed"),
-                    e);
+                    fatalError == null ? e : fatalError);
         }
     }
 
@@ -312,14 +262,14 @@ public class WriterClient {
         return partitionName.compareTo(earliestRetainedPartition) < 0;
     }
 
-    /** Returns the path the records of this original partition are physically written to. */
-    private PhysicalTablePath resolveHistoricalWriteTarget(PhysicalTablePath originalPath) {
+    /** Resolves the physical write target for the original partition. */
+    private void resolveHistoricalWriteTarget(PhysicalTablePath originalPath, TableInfo tableInfo) {
         // Keep refreshing while the target is still the original partition so its retirement can
         // be detected before more records are appended to the stale route. Ideally, the Client
         // should learn the server-authoritative partition status without synchronously refreshing
         // metadata on the per-record path; see https://github.com/apache/fluss/issues/4161.
         if (accumulator.hasHistoricalWriteTarget(originalPath)) {
-            return PhysicalTablePath.of(originalPath.getTablePath(), HISTORICAL_PARTITION_VALUE);
+            return;
         }
 
         PhysicalTablePath targetPath = originalPath;
@@ -344,16 +294,8 @@ public class WriterClient {
             }
         }
 
-        accumulator.routeWritesTo(
-                originalPath, targetPath, metadataUpdater.getPartitionIdOrElseThrow(targetPath));
-        return targetPath;
-    }
-
-    private void maybeAbortBatches(Throwable t) {
-        if (accumulator.hasIncomplete()) {
-            LOG.error("Aborting all pending write batches due to fatal error", t);
-            accumulator.abortAllBatches(toException(t));
-        }
+        long partitionId = metadataUpdater.getCluster().getPartitionIdOrElseThrow(targetPath);
+        accumulator.routeWritesTo(tableInfo, originalPath, targetPath, partitionId);
     }
 
     // Verify that writer instance has not been closed. This method throws IllegalStateException if
@@ -431,8 +373,7 @@ public class WriterClient {
                 retries,
                 metadataUpdater,
                 idempotenceManager,
-                writerMetricGroup,
-                this::invalidateBucketAssigner);
+                writerMetricGroup);
     }
 
     public void close(Duration timeout) {
@@ -483,42 +424,5 @@ public class WriterClient {
 
     private ExecutorService createThreadPool() {
         return Executors.newFixedThreadPool(1, new ExecutorThreadFactory(SENDER_THREAD_PREFIX));
-    }
-
-    /**
-     * Removes the {@link BucketAssigner} associated with the given table bucket. Called by {@link
-     * Sender} when a write batch is rejected for invalid bucket routing, so the next {@code send}
-     * creates a new assigner with the refreshed bucket count.
-     */
-    private void invalidateBucketAssigner(TableBucket tableBucket) {
-        bucketAssigners.remove(TableOrPartition.ofTable(tableBucket.getTableId()));
-        if (tableBucket.getPartitionId() != null) {
-            bucketAssigners.remove(TableOrPartition.ofPartition(tableBucket.getPartitionId()));
-        }
-    }
-
-    private BucketAssigner createBucketAssigner(
-            TableInfo tableInfo,
-            PhysicalTablePath physicalTablePath,
-            int bucketCount,
-            Configuration conf) {
-        List<String> bucketKeys = tableInfo.getBucketKeys();
-        if (!bucketKeys.isEmpty()) {
-            BucketingFunction function =
-                    BucketingFunction.of(
-                            tableInfo.getTableConfig().getDataLakeFormat().orElse(null));
-            return new HashBucketAssigner(bucketCount, function);
-        } else {
-            ConfigOptions.NoKeyAssigner noKeyAssigner =
-                    conf.get(ConfigOptions.CLIENT_WRITER_BUCKET_NO_KEY_ASSIGNER);
-            if (noKeyAssigner == ROUND_ROBIN) {
-                return new RoundRobinBucketAssigner(physicalTablePath, bucketCount);
-            } else if (noKeyAssigner == STICKY) {
-                return new StickyBucketAssigner(physicalTablePath, bucketCount);
-            } else {
-                throw new IllegalArgumentException(
-                        "Unsupported append only row bucket assigner: " + noKeyAssigner);
-            }
-        }
     }
 }

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/FlussLakeTableITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/FlussLakeTableITCase.java
@@ -273,7 +273,7 @@ class FlussLakeTableITCase {
                 KeyEncoder.ofBucketKeyEncoder(
                         rowType, tableDescriptor.getBucketKeys(), dataLakeFormat);
         HashBucketAssigner bucketAssigner =
-                new HashBucketAssigner(DEFAULT_BUCKET_COUNT, BucketingFunction.of(dataLakeFormat));
+                new HashBucketAssigner(BucketingFunction.of(dataLakeFormat));
         Map<String, Long> partitionIdByNames = null;
         if (isPartitioned) {
             partitionIdByNames =
@@ -299,7 +299,8 @@ class FlussLakeTableITCase {
                                         tableId,
                                         partitionIdByNames.get(partition),
                                         bucketAssigner.assignBucket(
-                                                bucketKeyEncoder.encodeKey(row)));
+                                                bucketKeyEncoder.encodeKey(row),
+                                                DEFAULT_BUCKET_COUNT));
                         expectedRows
                                 .computeIfAbsent(assignedBucket, (k) -> new ArrayList<>())
                                 .add(row);
@@ -312,7 +313,8 @@ class FlussLakeTableITCase {
                     TableBucket assignedBucket =
                             new TableBucket(
                                     tableId,
-                                    bucketAssigner.assignBucket(bucketKeyEncoder.encodeKey(row)));
+                                    bucketAssigner.assignBucket(
+                                            bucketKeyEncoder.encodeKey(row), DEFAULT_BUCKET_COUNT));
                     expectedRows.computeIfAbsent(assignedBucket, (k) -> new ArrayList<>()).add(row);
                 }
             }

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/PartitionBucketCountRescaleITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/PartitionBucketCountRescaleITCase.java
@@ -28,8 +28,8 @@ import org.apache.fluss.client.table.writer.AppendWriter;
 import org.apache.fluss.client.table.writer.UpsertResult;
 import org.apache.fluss.client.table.writer.UpsertWriter;
 import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.exception.BucketRescaleException;
 import org.apache.fluss.exception.InvalidAlterTableException;
-import org.apache.fluss.exception.InvalidBucketRoutingException;
 import org.apache.fluss.metadata.PartitionInfo;
 import org.apache.fluss.metadata.Schema;
 import org.apache.fluss.metadata.TableBucket;
@@ -43,6 +43,8 @@ import org.apache.fluss.types.RowType;
 import org.apache.fluss.utils.CloseableIterator;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -280,8 +282,10 @@ class PartitionBucketCountRescaleITCase extends ClientToServerITCaseBase {
         assertRowsPerPartition(schema.getRowType(), actualByPartitionId, expectedByPartitionId);
     }
 
-    @Test
-    void testStaleTableHandleWritesToDynamicallyCreatedPartitionAfterAlter() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = {1, NEW_BUCKET_NUM})
+    void testStaleTableHandleWritesToDynamicallyCreatedPartitionAfterAlter(int newBucketCount)
+            throws Exception {
         // Old writers hold a stale table-level bucket count; new partitions must route by
         // their actual (post-ALTER) count, otherwise lookups miss.
         clientConf.set(ConfigOptions.CLIENT_WRITER_DYNAMIC_CREATE_PARTITION_ENABLED, true);
@@ -296,50 +300,34 @@ class PartitionBucketCountRescaleITCase extends ClientToServerITCaseBase {
         // open the handle BEFORE the ALTER, then rescale on the server side
         Table staleTable = conn.getTable(tablePath);
         UpsertWriter upsertWriter = staleTable.newUpsert().createWriter();
-        alterBucketNum(tablePath, NEW_BUCKET_NUM);
+        alterBucketNum(tablePath, newBucketCount);
 
-        // The stale handle initially routes by the old table-level count. Dynamic creation stays
-        // asynchronous; once the new partition metadata arrives, affected batches fail instead of
-        // being sent with a bucket id computed from the wrong count.
-        List<InternalRow> rows = new ArrayList<>();
-        List<CompletableFuture<UpsertResult>> initialFutures = new ArrayList<>();
-        for (int j = 0; j < RECORDS_PER_PARTITION; j++) {
-            InternalRow record = row(j, "v" + j, "auto");
-            rows.add(record);
-            initialFutures.add(upsertWriter.upsert(record));
-        }
-        upsertWriter.flush();
-
-        List<InternalRow> failedRows = new ArrayList<>();
-        for (int i = 0; i < initialFutures.size(); i++) {
-            try {
-                initialFutures.get(i).get();
-            } catch (ExecutionException e) {
-                assertThat(e.getCause()).isInstanceOf(InvalidBucketRoutingException.class);
-                failedRows.add(rows.get(i));
+        // Retry failed records with the same writer before sending the next version, so
+        // application-level retries preserve each key's update order.
+        for (int version = 1; version <= 2; version++) {
+            List<CompletableFuture<UpsertResult>> futures = new ArrayList<>();
+            for (int key = 0; key < RECORDS_PER_PARTITION; key++) {
+                futures.add(upsertWriter.upsert(row(key, "v" + version, "auto")));
             }
-        }
-        assertThat(failedRows).isNotEmpty();
-
-        // Retry only failed records. The first rejection invalidated stale routing metadata and the
-        // assigner, so the same stale table handle now resolves the partition's actual count.
-        List<CompletableFuture<UpsertResult>> retryFutures = new ArrayList<>();
-        for (InternalRow failedRow : failedRows) {
-            retryFutures.add(upsertWriter.upsert(failedRow));
-        }
-        upsertWriter.flush();
-        for (CompletableFuture<UpsertResult> retryFuture : retryFutures) {
-            retryFuture.get();
+            upsertWriter.flush();
+            for (int key = 0; key < RECORDS_PER_PARTITION; key++) {
+                try {
+                    futures.get(key).get();
+                } catch (ExecutionException e) {
+                    assertThat(e.getCause()).isInstanceOf(BucketRescaleException.class);
+                    upsertWriter.upsert(row(key, "v" + version, "auto")).get();
+                }
+            }
         }
 
         // the dynamically created partition carries the post-ALTER bucket count
         List<PartitionInfo> partitionInfos = admin.listPartitionInfos(tablePath).get();
-        assertThat(bucketCountByName(partitionInfos)).containsEntry("auto", NEW_BUCKET_NUM);
+        assertThat(bucketCountByName(partitionInfos)).containsEntry("auto", newBucketCount);
 
-        // every key must be found after retrying the batches rejected during the rescale window
+        // Every key retains its latest version after application-level retries.
         Lookuper lookuper = staleTable.newLookup().createLookuper();
         for (int j = 0; j < RECORDS_PER_PARTITION; j++) {
-            InternalRow expected = row(j, "v" + j, "auto");
+            InternalRow expected = row(j, "v2", "auto");
             InternalRow looked = lookuper.lookup(row(j, "auto")).get().getSingletonRow();
             assertThatRow(looked).withSchema(schema.getRowType()).isEqualTo(expected);
         }

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/PartitionedTableITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/PartitionedTableITCase.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.fluss.record.TestData.DATA1_TABLE_PATH_PK;
 import static org.apache.fluss.testutils.DataTestUtils.row;
@@ -164,8 +165,10 @@ class PartitionedTableITCase extends ClientToServerITCaseBase {
 
     @Test
     void testWriteToNonExistsPartitionWhenEnabledDynamicPartition() throws Exception {
-        Schema schema = createPartitionedTable(DATA1_TABLE_PATH_PK, false);
-        Table table = conn.getTable(DATA1_TABLE_PATH_PK);
+        // Keep this case independent of other tests that delete and recreate their tables.
+        TablePath tablePath = TablePath.of("test_db_1", "test_dynamic_created_partitions");
+        Schema schema = createPartitionedTable(tablePath, false);
+        Table table = conn.getTable(tablePath);
         AppendWriter appendWriter = table.newAppend().createWriter();
         int partitionSize = 5;
 
@@ -185,7 +188,7 @@ class PartitionedTableITCase extends ClientToServerITCaseBase {
                 waitValue(
                         () -> {
                             List<PartitionInfo> partitionInfos =
-                                    admin.listPartitionInfos(DATA1_TABLE_PATH_PK).get();
+                                    admin.listPartitionInfos(tablePath).get();
                             if (partitionInfos.size() == partitionSize) {
                                 return Optional.of(partitionInfos);
                             } else {
@@ -220,14 +223,22 @@ class PartitionedTableITCase extends ClientToServerITCaseBase {
             upsertWriter.upsert(row).get();
         }
 
-        // Dynamic partition creation is synchronous (the bucket id needs the partition's own
-        // bucket count), so a partition that cannot be created fails the record right away.
-        assertThatThrownBy(() -> upsertWriter.upsert(row(10, "a" + 10, "10")).get())
+        // Asynchronous creation may fail before or after the batch is registered. Both paths
+        // must preserve the creation error and stop accepting writes to unresolved partitions.
+        assertThatThrownBy(
+                        () ->
+                                upsertWriter
+                                        .upsert(row(10, "a" + 10, "10"))
+                                        .get(10, TimeUnit.SECONDS))
                 .rootCause()
                 .isInstanceOf(TooManyPartitionsException.class)
                 .hasMessageContaining(
                         "Exceed the maximum number of partitions for table "
                                 + "test_db_1.test_pk_table_1, only allow 10 partitions.");
+        assertThatThrownBy(() -> upsertWriter.upsert(row(11, "late", "11")).get())
+                .rootCause()
+                .isInstanceOf(TooManyPartitionsException.class);
+        upsertWriter.flush();
     }
 
     private Schema createPartitionedTable(TablePath tablePath, boolean isPrimaryTable)

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/batch/BatchScannerITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/batch/BatchScannerITCase.java
@@ -81,8 +81,7 @@ class BatchScannerITCase extends ClientToServerITCaseBase {
             new CompactedKeyEncoder(
                     DEFAULT_SCHEMA.getRowType(), DEFAULT_SCHEMA.getPrimaryKeyIndexes());
 
-    private static final HashBucketAssigner DEFAULT_BUCKET_ASSIGNER =
-            new HashBucketAssigner(DEFAULT_BUCKET_NUM);
+    private static final HashBucketAssigner DEFAULT_BUCKET_ASSIGNER = new HashBucketAssigner();
 
     private static final String DEFAULT_DB = "test-snapshot-scan-db";
 

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/BucketRoutingTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/BucketRoutingTest.java
@@ -1,0 +1,1183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fluss.client.write;
+
+import org.apache.fluss.client.metrics.TestingWriterMetricGroup;
+import org.apache.fluss.cluster.BucketLocation;
+import org.apache.fluss.cluster.Cluster;
+import org.apache.fluss.cluster.ServerNode;
+import org.apache.fluss.cluster.ServerType;
+import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.config.Configuration;
+import org.apache.fluss.config.MemorySize;
+import org.apache.fluss.exception.BucketRescaleException;
+import org.apache.fluss.exception.FlussRuntimeException;
+import org.apache.fluss.metadata.PhysicalTablePath;
+import org.apache.fluss.metadata.Schema;
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.metadata.TableInfo;
+import org.apache.fluss.metadata.TableOrPartition;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.metrics.Gauge;
+import org.apache.fluss.metrics.MetricNames;
+import org.apache.fluss.record.DefaultKvRecordBatch;
+import org.apache.fluss.record.KvRecord;
+import org.apache.fluss.record.KvRecordReadContext;
+import org.apache.fluss.record.LogRecord;
+import org.apache.fluss.record.LogRecordReadContext;
+import org.apache.fluss.record.MemoryLogRecords;
+import org.apache.fluss.record.TestingSchemaGetter;
+import org.apache.fluss.row.InternalRow;
+import org.apache.fluss.types.DataTypes;
+import org.apache.fluss.utils.CloseableIterator;
+import org.apache.fluss.utils.InternalRowUtils;
+import org.apache.fluss.utils.clock.Clock;
+import org.apache.fluss.utils.clock.SystemClock;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.apache.fluss.testutils.DataTestUtils.compactedRow;
+import static org.apache.fluss.testutils.DataTestUtils.indexedRow;
+import static org.apache.fluss.testutils.DataTestUtils.row;
+import static org.apache.fluss.testutils.common.CommonTestUtils.retry;
+import static org.apache.fluss.utils.PartitionUtils.HISTORICAL_PARTITION_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests the ordering barrier between tentative routing and the resolved partition layout. */
+class BucketRoutingTest {
+    private static final PhysicalTablePath PATH =
+            PhysicalTablePath.of(TablePath.of("db", "routing"), "p");
+    private static final long PARTITION_ID = 42;
+    private static final ServerNode NODE =
+            new ServerNode(1, "localhost", 1234, ServerType.TABLET_SERVER);
+
+    @ParameterizedTest
+    @MethodSource("hashLayouts")
+    void testResolveHashBatchesAndRetryAfterRescale(WriteFormat format, int oldCount, int newCount)
+            throws Exception {
+        TableInfo table = tableInfo(oldCount, true, format.isKv());
+        RecordAccumulator accumulator = accumulator(ConfigOptions.NoKeyAssigner.STICKY);
+        Cluster resolved = cluster(newCount, true);
+        List<CompletableFuture<Integer>> completions = new ArrayList<>();
+        List<WriteBatch> originals = new ArrayList<>();
+        AtomicInteger callbackCount = new AtomicInteger();
+        try {
+            // Append multiple keys and batches with no partition ID. Refreshing metadata on an
+            // append must not switch just the newer records to another layout.
+            for (int version = 1; version <= 2; version++) {
+                for (int key = 0; key < 12; key++) {
+                    CompletableFuture<Integer> completion = new CompletableFuture<>();
+                    completions.add(completion);
+                    final int value = version;
+                    WriteRecord record = record(table, format, key, version);
+                    accumulator.append(
+                            record,
+                            (bucket, offset, error) -> {
+                                callbackCount.incrementAndGet();
+                                if (error == null) {
+                                    completion.complete(value);
+                                } else {
+                                    completion.completeExceptionally(error);
+                                }
+                            },
+                            version == 1 ? Cluster.empty() : resolved);
+                }
+                for (int bucket = 0; bucket < oldCount; bucket++) {
+                    Deque<WriteBatch> deque = accumulator.getDequeOrThrow(PATH, bucket);
+                    if (deque != null) {
+                        assertThat(deque)
+                                .allSatisfy(
+                                        batch ->
+                                                assertThat(batch.getBucketCount())
+                                                        .isEqualTo(oldCount));
+                        deque.peekLast().close();
+                    }
+                }
+            }
+            for (int bucket = 0; bucket < oldCount; bucket++) {
+                if (accumulator.getDequeOrThrow(PATH, bucket) != null) {
+                    originals.addAll(accumulator.getDequeOrThrow(PATH, bucket));
+                }
+            }
+            CompletableFuture<Void> originalCompletion =
+                    CompletableFuture.runAsync(
+                            () -> {
+                                try {
+                                    for (WriteBatch batch : originals) {
+                                        batch.getRequestFuture().await();
+                                    }
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                    throw new RuntimeException(e);
+                                }
+                            });
+            assertThat(accumulator.drain(resolved, Collections.singleton(1), Integer.MAX_VALUE))
+                    .isEmpty();
+            assertThat(accumulator.ready(cluster(newCount, false)).readyNodes).isEmpty();
+            assertThat(accumulator.getReadyDeque(PATH, 0)).isNull();
+            accumulator.beginFlush();
+            accumulator.ready(resolved);
+            if (oldCount != newCount) {
+                assertThat(completions)
+                        .allSatisfy(
+                                future ->
+                                        assertThatThrownBy(future::get)
+                                                .hasCauseInstanceOf(BucketRescaleException.class)
+                                                .hasStackTraceContaining("Bucket rescale")
+                                                .hasStackTraceContaining(
+                                                        "from " + oldCount + " to " + newCount)
+                                                .hasStackTraceContaining(
+                                                        "Retry the failed records"));
+                originalCompletion.get(10, TimeUnit.SECONDS);
+                assertThat(accumulator.hasIncomplete()).isFalse();
+                assertThat(accumulator.hasUnDrained()).isFalse();
+                // Application retries reuse this accumulator and the resolved count.
+                for (int version = 1; version <= 2; version++) {
+                    for (int key = 0; key < 12; key++) {
+                        accumulator.append(
+                                record(table, format, key, version),
+                                (bucket, offset, error) -> {},
+                                resolved);
+                    }
+                }
+            } else {
+                assertThat(originalCompletion).isNotDone();
+                assertThat(completions).allSatisfy(future -> assertThat(future).isNotDone());
+            }
+
+            // Later writes use the same authoritative layout as the retried records.
+            for (int key = 0; key < 12; key++) {
+                accumulator.append(
+                        record(table, format, key, 3), (bucket, offset, error) -> {}, resolved);
+            }
+            Map<Integer, List<Integer>> versions = new HashMap<>();
+            HashBucketAssigner assigner = new HashBucketAssigner();
+            while (accumulator.hasUnDrained()) {
+                List<ReadyWriteBatch> batches =
+                        accumulator
+                                .drain(resolved, Collections.singleton(1), Integer.MAX_VALUE)
+                                .get(1);
+                assertThat(batches).isNotEmpty();
+                for (ReadyWriteBatch ready : batches) {
+                    WriteBatch batch = ready.writeBatch();
+                    assertThat(ready.tableBucket().getPartitionId()).isEqualTo(PARTITION_ID);
+                    assertThat(batch.getBucketCount()).isEqualTo(newCount);
+                    for (InternalRow row : readRows(batch, table, format)) {
+                        int key = row.getInt(0);
+                        assertThat(batch.bucketId())
+                                .isEqualTo(
+                                        assigner.assignBucket(new byte[] {(byte) key}, newCount));
+                        versions.computeIfAbsent(key, k -> new ArrayList<>()).add(row.getInt(1));
+                    }
+                    batch.complete(ready.tableBucket(), 10L);
+                    accumulator.deallocate(batch);
+                }
+            }
+            assertThat(versions).hasSize(12);
+            assertThat(versions.values())
+                    .allSatisfy(values -> assertThat(values).containsExactly(1, 2, 3));
+            originalCompletion.get(10, TimeUnit.SECONDS);
+            accumulator.awaitFlushCompletion();
+            assertThat(completions).allSatisfy(future -> assertThat(future).isDone());
+            assertThat(accumulator.hasIncomplete()).isFalse();
+            assertThat(callbackCount.get()).isEqualTo(24);
+        } finally {
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.close();
+            accumulator.destroyResources();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("noKeyLayouts")
+    void testResolveBatchesWithoutBucketKey(
+            WriteFormat format, int newCount, boolean highBucketHasRecords) throws Exception {
+        TableInfo table = tableInfo(3, false, false);
+        TestingBucketAssigner bucketAssigner = new TestingBucketAssigner();
+        RecordAccumulator accumulator =
+                new RecordAccumulator(
+                        configuration(ConfigOptions.NoKeyAssigner.STICKY, 64 * 1024),
+                        new IdempotenceManager(false, 5, null, null),
+                        TestingWriterMetricGroup.newInstance(),
+                        SystemClock.getInstance(),
+                        (tableInfo, path) -> bucketAssigner);
+        List<CompletableFuture<Exception>> completions = new ArrayList<>();
+        try {
+            // Leave an empty high bucket queue behind. Empty queues must not fail a shrink.
+            bucketAssigner.setBucketId(2);
+            accumulator.append(
+                    record(table, format, 0, 0), (bucket, offset, error) -> {}, Cluster.empty());
+            accumulator.abortAllBatches(new RuntimeException("discard seed batch"));
+            for (int i = 0; i < 12; i++) {
+                CompletableFuture<Exception> completion = new CompletableFuture<>();
+                completions.add(completion);
+                bucketAssigner.setBucketId(highBucketHasRecords && i % 2 == 1 ? 2 : 0);
+                accumulator.append(
+                        record(table, format, i, 1),
+                        (bucket, offset, error) -> completion.complete(error),
+                        Cluster.empty());
+            }
+            List<WriteBatch> originals = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                Deque<WriteBatch> deque = accumulator.getDequeOrThrow(PATH, i);
+                if (deque != null) {
+                    originals.addAll(deque);
+                }
+            }
+            Cluster resolved = cluster(newCount, true);
+            accumulator.beginFlush();
+            accumulator.ready(resolved);
+            if (newCount < 3 && highBucketHasRecords) {
+                // All batches fail, including the records assigned to bucket 0.
+                for (CompletableFuture<Exception> completion : completions) {
+                    assertThat(completion.get(10, TimeUnit.SECONDS))
+                            .isInstanceOf(BucketRescaleException.class);
+                }
+                assertThat(accumulator.hasUnDrained()).isFalse();
+                assertThat(accumulator.hasIncomplete()).isFalse();
+                bucketAssigner.setBucketId(0);
+                accumulator.append(
+                        record(table, format, 0, 2), (bucket, offset, error) -> {}, resolved);
+            } else {
+                assertThat(completions).allSatisfy(future -> assertThat(future).isNotDone());
+            }
+            List<WriteBatch> drained = new ArrayList<>();
+            while (accumulator.hasUnDrained()) {
+                for (ReadyWriteBatch ready :
+                        accumulator
+                                .drain(resolved, Collections.singleton(1), Integer.MAX_VALUE)
+                                .get(1)) {
+                    WriteBatch batch = ready.writeBatch();
+                    assertThat(batch.bucketId()).isBetween(0, newCount - 1);
+                    assertThat(batch.getBucketCount()).isEqualTo(newCount);
+                    drained.add(batch);
+                    batch.complete();
+                    accumulator.deallocate(batch);
+                }
+            }
+            if (newCount >= 3 || !highBucketHasRecords) {
+                assertThat(drained).containsExactlyInAnyOrderElementsOf(originals);
+            }
+            accumulator.awaitFlushCompletion();
+        } finally {
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @Test
+    void testRescaleDoesNotFailAnotherPartition() throws Exception {
+        TableInfo table = tableInfo(2, true, false);
+        PhysicalTablePath otherPath = PhysicalTablePath.of(PATH.getTablePath(), "other");
+        RecordAccumulator accumulator = accumulator(ConfigOptions.NoKeyAssigner.STICKY);
+        CompletableFuture<Exception> rescaled = new CompletableFuture<>();
+        CompletableFuture<Exception> other = new CompletableFuture<>();
+        try {
+            accumulator.append(
+                    record(table, WriteFormat.ARROW_LOG, 0, 1),
+                    (bucket, offset, error) -> rescaled.complete(error),
+                    Cluster.empty());
+            accumulator.append(
+                    WriteRecord.forArrowAppend(
+                            table, otherPath, row(0, 1, "other"), new byte[] {0}),
+                    (bucket, offset, error) -> other.complete(error),
+                    Cluster.empty());
+            accumulator.ready(cluster(4, true));
+            assertThat(rescaled.get(10, TimeUnit.SECONDS))
+                    .isInstanceOf(BucketRescaleException.class);
+            assertThat(other).isNotDone();
+            assertThat(accumulator.hasIncomplete()).isTrue();
+        } finally {
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ConfigOptions.NoKeyAssigner.class)
+    void testAssignerCountChanges(ConfigOptions.NoKeyAssigner strategy) {
+        BucketAssigner assigner =
+                strategy == ConfigOptions.NoKeyAssigner.STICKY
+                        ? new StickyBucketAssigner(PATH)
+                        : new RoundRobinBucketAssigner(PATH);
+        for (int count : new int[] {4, 1, 2, 5}) {
+            for (int i = 0; i < 30; i++) {
+                int bucket = assigner.assignBucket(null, cluster(5, true), count);
+                assertThat(bucket).isBetween(0, count - 1);
+                assigner.onNewBatch(cluster(5, true), count, bucket);
+            }
+        }
+    }
+
+    @Test
+    void testNonPartitionedTableUsesMetadataBucketCount() throws Exception {
+        TableInfo table =
+                TableInfo.of(
+                        PATH.getTablePath(),
+                        10,
+                        1,
+                        TableDescriptor.builder()
+                                .schema(tableInfo(3, false, false).getSchema())
+                                .distributedBy(3)
+                                .build(),
+                        "/tmp/fluss-routing",
+                        0,
+                        0);
+        PhysicalTablePath path = PhysicalTablePath.of(PATH.getTablePath());
+        Cluster partialMetadata =
+                new Cluster(
+                        Collections.singletonMap(1, NODE),
+                        null,
+                        Collections.singletonMap(
+                                path,
+                                Collections.singletonList(
+                                        new BucketLocation(
+                                                path, new TableBucket(10, 0), 1, new int[] {1}))),
+                        Collections.singletonMap(path.getTablePath(), 10L),
+                        Collections.emptyMap(),
+                        Collections.singletonMap(TableOrPartition.ofTable(10), 1));
+        RecordAccumulator accumulator = accumulator(ConfigOptions.NoKeyAssigner.STICKY);
+        try {
+            accumulator.append(
+                    WriteRecord.forArrowAppend(table, path, row(0, 1, "p"), null),
+                    (bucket, offset, error) -> {},
+                    partialMetadata);
+            assertThat(accumulator.getReadyDeque(path, 0).getFirst().getBucketCount()).isEqualTo(1);
+        } finally {
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @Test
+    void testTemporaryBucketCountUsesFirstClusterSnapshot() throws Exception {
+        TableInfo table = tableInfo(2, true, true);
+        Cluster tableMetadata =
+                new Cluster(
+                        Collections.emptyMap(),
+                        null,
+                        Collections.emptyMap(),
+                        Collections.singletonMap(PATH.getTablePath(), table.getTableId()),
+                        Collections.emptyMap(),
+                        Collections.singletonMap(TableOrPartition.ofTable(table.getTableId()), 4));
+        RecordAccumulator accumulator = accumulator(ConfigOptions.NoKeyAssigner.STICKY);
+        List<CompletableFuture<Exception>> completions = new ArrayList<>();
+        List<WriteBatch> originals = new ArrayList<>();
+        try {
+            for (int key = 0; key < 12; key++) {
+                CompletableFuture<Exception> completion = new CompletableFuture<>();
+                completions.add(completion);
+                accumulator.append(
+                        record(table, WriteFormat.COMPACTED_KV, key, 1),
+                        (bucket, offset, error) -> completion.complete(error),
+                        key == 0 ? tableMetadata : Cluster.empty());
+            }
+            for (int bucket = 0; bucket < 4; bucket++) {
+                Deque<WriteBatch> deque = accumulator.getDequeOrThrow(PATH, bucket);
+                if (deque != null) {
+                    originals.addAll(deque);
+                }
+            }
+            assertThat(originals)
+                    .isNotEmpty()
+                    .allSatisfy(batch -> assertThat(batch.getBucketCount()).isEqualTo(4));
+            assertThat(accumulator.ready(tableMetadata).readyNodes).isEmpty();
+            Cluster resolved = cluster(4, true);
+            accumulator.ready(resolved);
+            assertThat(completions).allSatisfy(future -> assertThat(future).isNotDone());
+            List<WriteBatch> drained = new ArrayList<>();
+            while (accumulator.hasUnDrained()) {
+                for (ReadyWriteBatch ready :
+                        accumulator
+                                .drain(resolved, Collections.singleton(1), Integer.MAX_VALUE)
+                                .get(1)) {
+                    drained.add(ready.writeBatch());
+                    ready.writeBatch().complete();
+                    accumulator.deallocate(ready.writeBatch());
+                }
+            }
+            assertThat(drained).containsExactlyInAnyOrderElementsOf(originals);
+            for (CompletableFuture<Exception> completion : completions) {
+                assertThat(completion.get(10, TimeUnit.SECONDS)).isNull();
+            }
+        } finally {
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @Test
+    void testResolvePartitionIdAndBucketCountFromSameSnapshot() throws Exception {
+        TableInfo table = tableInfo(4, true, true);
+        RecordAccumulator accumulator = accumulator(ConfigOptions.NoKeyAssigner.STICKY);
+        CompletableFuture<Exception> completion = new CompletableFuture<>();
+        try {
+            Cluster partialMetadata = cluster(4, false);
+            accumulator.append(
+                    record(table, WriteFormat.COMPACTED_KV, 0, 1),
+                    (bucket, offset, error) -> completion.complete(error),
+                    partialMetadata);
+            assertThat(accumulator.ready(partialMetadata).readyNodes).isEmpty();
+            assertThat(accumulator.getReadyDeque(PATH, 0)).isNull();
+            // The path now resolves to a recreated partition. The old partition's count is still
+            // cached, so reusing the earlier partition ID would incorrectly abort this batch.
+            long newPartitionId = PARTITION_ID + 1;
+            Cluster newPartition = cluster(4, true, newPartitionId);
+            Map<TableOrPartition, Integer> counts =
+                    new HashMap<>(newPartition.getBucketCountByTableOrPartition());
+            counts.put(TableOrPartition.ofPartition(PARTITION_ID), 1);
+            Cluster resolved =
+                    new Cluster(
+                            newPartition.getAliveTabletServers(),
+                            null,
+                            newPartition.getBucketLocationsByPath(),
+                            newPartition.getTableIdByPath(),
+                            newPartition.getPartitionIdByPath(),
+                            counts);
+            assertThat(accumulator.ready(resolved).readyNodes).containsExactly(1);
+            assertThat(completion).isNotDone();
+            List<ReadyWriteBatch> drained =
+                    accumulator.drain(resolved, Collections.singleton(1), Integer.MAX_VALUE).get(1);
+            assertThat(drained).hasSize(1);
+            ReadyWriteBatch ready = drained.get(0);
+            assertThat(ready.tableBucket().getPartitionId()).isEqualTo(newPartitionId);
+            assertThat(ready.writeBatch().getBucketCount()).isEqualTo(4);
+            ready.writeBatch().complete();
+            accumulator.deallocate(ready.writeBatch());
+            assertThat(completion.get(10, TimeUnit.SECONDS)).isNull();
+        } finally {
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @Test
+    void testStickyAssignerChangesBucketWhenBatchIsFull() throws Exception {
+        TableInfo table = tableInfo(2, false, false);
+        RecordAccumulator accumulator = accumulator(ConfigOptions.NoKeyAssigner.STICKY);
+        Cluster resolved = cluster(2, true);
+        try {
+            accumulator.append(
+                    record(table, WriteFormat.COMPACTED_LOG, 0, 1),
+                    (bucket, offset, error) -> {},
+                    resolved);
+            int firstBucket =
+                    accumulator.getDequeOrThrow(PATH, 0) != null
+                                    && !accumulator.getDequeOrThrow(PATH, 0).isEmpty()
+                            ? 0
+                            : 1;
+            Deque<WriteBatch> firstDeque = accumulator.getDequeOrThrow(PATH, firstBucket);
+            assertThat(firstDeque).hasSize(1);
+            WriteBatch firstBatch = firstDeque.getFirst();
+            accumulator.append(
+                    record(table, WriteFormat.COMPACTED_LOG, 0, 2),
+                    (bucket, offset, error) -> {},
+                    resolved);
+            firstBatch.close();
+            assertThat(readRows(firstBatch, table, WriteFormat.COMPACTED_LOG))
+                    .extracting(row -> row.getInt(1))
+                    .containsExactly(1, 2);
+            accumulator.append(
+                    record(table, WriteFormat.COMPACTED_LOG, 0, 3),
+                    (bucket, offset, error) -> {},
+                    resolved);
+            assertThat(firstDeque).containsExactly(firstBatch);
+            Deque<WriteBatch> nextDeque = accumulator.getDequeOrThrow(PATH, 1 - firstBucket);
+            assertThat(nextDeque).hasSize(1);
+            WriteBatch nextBatch = nextDeque.getFirst();
+            nextBatch.close();
+            assertThat(readRows(nextBatch, table, WriteFormat.COMPACTED_LOG))
+                    .extracting(row -> row.getInt(1))
+                    .containsExactly(3);
+        } finally {
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 4})
+    void testResolveWhileAppendWaitsForExhaustedBuffer(int newCount) throws Exception {
+        TestingWriterMetricGroup metrics = TestingWriterMetricGroup.newInstance();
+        RecordAccumulator accumulator =
+                accumulator(ConfigOptions.NoKeyAssigner.STICKY, 512, metrics);
+        TableInfo table = tableInfo(1, true, true);
+        Cluster resolved = cluster(newCount, true);
+        try {
+            for (int version = 1; version <= 2; version++) {
+                accumulator.append(
+                        record(table, WriteFormat.COMPACTED_KV, 0, version),
+                        (bucket, offset, error) -> {},
+                        Cluster.empty());
+                accumulator.getDequeOrThrow(PATH, 0).peekLast().close();
+            }
+            CompletableFuture<Void> append =
+                    CompletableFuture.runAsync(
+                            () -> {
+                                try {
+                                    accumulator.append(
+                                            record(table, WriteFormat.COMPACTED_KV, 0, 3),
+                                            (bucket, offset, error) -> {},
+                                            resolved);
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+            Gauge<?> waiting =
+                    (Gauge<?>) metrics.getMetrics().get(MetricNames.WRITER_BUFFER_WAITING_THREADS);
+            retry(Duration.ofSeconds(10), () -> assertThat(waiting.getValue()).isEqualTo(1));
+            // Resolving routing must release failed batches without waiting for pooled memory.
+            // A blocked append uses the actual count after acquiring the released memory.
+            accumulator.ready(resolved);
+            List<Integer> versions = new ArrayList<>();
+            if (newCount == 1) {
+                // An unchanged layout reuses the original batches. Drain one to free memory.
+                ReadyWriteBatch first =
+                        accumulator
+                                .drain(resolved, Collections.singleton(1), Integer.MAX_VALUE)
+                                .get(1)
+                                .get(0);
+                for (InternalRow row :
+                        readRows(first.writeBatch(), table, WriteFormat.COMPACTED_KV)) {
+                    versions.add(row.getInt(1));
+                }
+                first.writeBatch().complete();
+                accumulator.deallocate(first.writeBatch());
+            }
+            append.get(10, TimeUnit.SECONDS);
+            while (accumulator.hasUnDrained()) {
+                for (ReadyWriteBatch ready :
+                        accumulator
+                                .drain(resolved, Collections.singleton(1), Integer.MAX_VALUE)
+                                .get(1)) {
+                    assertThat(ready.writeBatch().getBucketCount()).isEqualTo(newCount);
+                    for (InternalRow row :
+                            readRows(ready.writeBatch(), table, WriteFormat.COMPACTED_KV)) {
+                        versions.add(row.getInt(1));
+                    }
+                    ready.writeBatch().complete();
+                    accumulator.deallocate(ready.writeBatch());
+                }
+            }
+            if (newCount == 1) {
+                assertThat(versions).containsExactly(1, 2, 3);
+            } else {
+                assertThat(versions).containsExactly(3);
+            }
+            Gauge<?> available =
+                    (Gauge<?>) metrics.getMetrics().get(MetricNames.WRITER_BUFFER_AVAILABLE_BYTES);
+            assertThat(available.getValue()).isEqualTo(512L);
+        } finally {
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 4})
+    void testResolveWaitsForTentativeAppend(int newCount) throws Exception {
+        CompletableFuture<Void> assigning = new CompletableFuture<>();
+        CompletableFuture<Void> resumeAppend = new CompletableFuture<>();
+        AtomicBoolean pauseAssignment = new AtomicBoolean();
+        HashBucketAssigner assigner =
+                new HashBucketAssigner() {
+                    @Override
+                    public int assignBucket(byte[] bucketKey, int bucketCount) {
+                        if (pauseAssignment.get()) {
+                            assigning.complete(null);
+                            resumeAppend.join();
+                        }
+                        return super.assignBucket(bucketKey, bucketCount);
+                    }
+                };
+        RecordAccumulator accumulator =
+                new RecordAccumulator(
+                        configuration(ConfigOptions.NoKeyAssigner.STICKY, 64 * 1024),
+                        new IdempotenceManager(false, 5, null, null),
+                        TestingWriterMetricGroup.newInstance(),
+                        SystemClock.getInstance(),
+                        (table, path) -> assigner);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        TableInfo table = tableInfo(2, true, true);
+        Cluster resolved = cluster(newCount, true);
+        CompletableFuture<Exception> first = new CompletableFuture<>();
+        CompletableFuture<Exception> second = new CompletableFuture<>();
+        AtomicReference<Thread> resolvingThread = new AtomicReference<>();
+        try {
+            accumulator.append(
+                    record(table, WriteFormat.COMPACTED_KV, 0, 1),
+                    (bucket, offset, error) -> first.complete(error),
+                    Cluster.empty());
+            pauseAssignment.set(true);
+            Future<?> append =
+                    executor.submit(
+                            () -> {
+                                accumulator.append(
+                                        record(table, WriteFormat.COMPACTED_KV, 0, 2),
+                                        (bucket, offset, error) -> second.complete(error),
+                                        Cluster.empty());
+                                return null;
+                            });
+            assigning.get(10, TimeUnit.SECONDS);
+            Future<?> resolve =
+                    executor.submit(
+                            () -> {
+                                resolvingThread.set(Thread.currentThread());
+                                accumulator.ready(resolved);
+                            });
+            retry(
+                    Duration.ofSeconds(10),
+                    () -> {
+                        assertThat(resolvingThread.get()).isNotNull();
+                        assertThat(resolvingThread.get().getState())
+                                .isEqualTo(Thread.State.BLOCKED);
+                    });
+            assertThat(resolve.isDone()).isFalse();
+            assertThat(accumulator.getReadyDeque(PATH, 0)).isNull();
+            assertThat(accumulator.getReadyDeque(PATH, 1)).isNull();
+            resumeAppend.complete(null);
+            append.get(10, TimeUnit.SECONDS);
+            resolve.get(10, TimeUnit.SECONDS);
+            if (newCount != 2) {
+                assertThat(first.get(10, TimeUnit.SECONDS))
+                        .isInstanceOf(BucketRescaleException.class);
+                assertThat(second.get(10, TimeUnit.SECONDS))
+                        .isInstanceOf(BucketRescaleException.class);
+                assertThat(accumulator.hasIncomplete()).isFalse();
+                assertThat(accumulator.hasUnDrained()).isFalse();
+            } else {
+                List<ReadyWriteBatch> drained =
+                        accumulator
+                                .drain(resolved, Collections.singleton(1), Integer.MAX_VALUE)
+                                .get(1);
+                assertThat(drained).hasSize(1);
+                WriteBatch batch = drained.get(0).writeBatch();
+                assertThat(readRows(batch, table, WriteFormat.COMPACTED_KV))
+                        .extracting(row -> row.getInt(1))
+                        .containsExactly(1, 2);
+                batch.complete();
+                accumulator.deallocate(batch);
+                assertThat(first.get(10, TimeUnit.SECONDS)).isNull();
+                assertThat(second.get(10, TimeUnit.SECONDS)).isNull();
+            }
+        } finally {
+            resumeAppend.complete(null);
+            executor.shutdown();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false, false", "false, true", "true, false", "true, true"})
+    void testResolvedBucketsAppendIndependently(boolean initiallyResolved, boolean samePartition)
+            throws Exception {
+        RecordAccumulator accumulator = accumulator(ConfigOptions.NoKeyAssigner.STICKY);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        TableInfo table = tableInfo(2, true, true);
+        Cluster resolved = cluster(4, true);
+        HashBucketAssigner assigner = new HashBucketAssigner();
+        int firstBucket = assigner.assignBucket(new byte[] {0}, 4);
+        int secondKey = 1;
+        while (assigner.assignBucket(new byte[] {(byte) secondKey}, 4) == firstBucket) {
+            secondKey++;
+        }
+        PhysicalTablePath secondPath =
+                samePartition ? PATH : PhysicalTablePath.of(PATH.getTablePath(), "other");
+        Cluster secondCluster =
+                samePartition ? resolved : cluster(4, true, PARTITION_ID + 1, secondPath);
+        WriteRecord secondRecord =
+                record(table, WriteFormat.COMPACTED_KV, secondKey, 1, secondPath);
+        int secondBucket = assigner.assignBucket(secondRecord.getBucketKey(), 4);
+        AtomicReference<Thread> firstThread = new AtomicReference<>();
+        try {
+            accumulator.append(
+                    record(table, WriteFormat.COMPACTED_KV, 0, 1),
+                    (bucket, offset, error) -> {},
+                    initiallyResolved ? resolved : Cluster.empty());
+            accumulator.ready(resolved);
+            if (!initiallyResolved) {
+                accumulator.append(
+                        record(table, WriteFormat.COMPACTED_KV, 0, 1),
+                        (bucket, offset, error) -> {},
+                        resolved);
+            }
+            Deque<WriteBatch> firstDeque = accumulator.getReadyDeque(PATH, firstBucket);
+            Future<?> firstAppend;
+            Future<?> secondAppend;
+            synchronized (firstDeque) {
+                firstAppend =
+                        executor.submit(
+                                () -> {
+                                    firstThread.set(Thread.currentThread());
+                                    accumulator.append(
+                                            record(table, WriteFormat.COMPACTED_KV, 0, 2),
+                                            (bucket, offset, error) -> {},
+                                            resolved);
+                                    return null;
+                                });
+                retry(
+                        Duration.ofSeconds(10),
+                        () -> {
+                            assertThat(firstThread.get()).isNotNull();
+                            assertThat(firstThread.get().getState())
+                                    .isEqualTo(Thread.State.BLOCKED);
+                        });
+                // Resolved normal buckets must not hold the context lock. Another bucket can
+                // create and register a batch even when it belongs to the same partition.
+                secondAppend =
+                        executor.submit(
+                                () -> {
+                                    accumulator.append(
+                                            secondRecord,
+                                            (bucket, offset, error) -> {},
+                                            secondCluster);
+                                    return null;
+                                });
+                secondAppend.get(10, TimeUnit.SECONDS);
+                assertThat(firstAppend.isDone()).isFalse();
+            }
+            firstAppend.get(10, TimeUnit.SECONDS);
+            secondAppend.get(10, TimeUnit.SECONDS);
+            assertThat(accumulator.getReadyDeque(secondPath, secondBucket)).hasSize(1);
+        } finally {
+            executor.shutdown();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @Test
+    void testResolvedNewBatchesAppendIndependently() throws Exception {
+        CompletableFuture<Void> creatingBatch = new CompletableFuture<>();
+        CompletableFuture<Void> resumeAppend = new CompletableFuture<>();
+        AtomicBoolean pauseNextBatch = new AtomicBoolean(true);
+        Clock clock =
+                new Clock() {
+                    @Override
+                    public long milliseconds() {
+                        if (pauseNextBatch.compareAndSet(true, false)) {
+                            creatingBatch.complete(null);
+                            resumeAppend.join();
+                        }
+                        return System.currentTimeMillis();
+                    }
+
+                    @Override
+                    public long nanoseconds() {
+                        return System.nanoTime();
+                    }
+                };
+        RecordAccumulator accumulator =
+                accumulator(
+                        ConfigOptions.NoKeyAssigner.STICKY,
+                        64 * 1024,
+                        TestingWriterMetricGroup.newInstance(),
+                        clock);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        TableInfo table = tableInfo(2, true, true);
+        Cluster resolved = cluster(2, true);
+        HashBucketAssigner assigner = new HashBucketAssigner();
+        int firstBucket = assigner.assignBucket(new byte[] {0}, 2);
+        int secondKey = 1;
+        while (assigner.assignBucket(new byte[] {(byte) secondKey}, 2) == firstBucket) {
+            secondKey++;
+        }
+        WriteRecord secondRecord = record(table, WriteFormat.COMPACTED_KV, secondKey, 1);
+        try {
+            Future<?> firstAppend =
+                    executor.submit(
+                            () -> {
+                                accumulator.append(
+                                        record(table, WriteFormat.COMPACTED_KV, 0, 1),
+                                        (bucket, offset, error) -> {},
+                                        resolved);
+                                return null;
+                            });
+            // Pause the first bucket while it creates a new batch, before registration.
+            creatingBatch.get(10, TimeUnit.SECONDS);
+            executor.submit(
+                            () -> {
+                                accumulator.append(
+                                        secondRecord, (bucket, offset, error) -> {}, resolved);
+                                return null;
+                            })
+                    .get(10, TimeUnit.SECONDS);
+            assertThat(firstAppend.isDone()).isFalse();
+            resumeAppend.complete(null);
+            firstAppend.get(10, TimeUnit.SECONDS);
+            assertThat(accumulator.getReadyDeque(PATH, 0)).hasSize(1);
+            assertThat(accumulator.getReadyDeque(PATH, 1)).hasSize(1);
+        } finally {
+            resumeAppend.complete(null);
+            executor.shutdown();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testBatchRegistrationBlocksCloseOrHistoricalRouting(boolean historicalRouting)
+            throws Exception {
+        CompletableFuture<Void> creatingBatch = new CompletableFuture<>();
+        CompletableFuture<Void> resumeAppend = new CompletableFuture<>();
+        AtomicBoolean pauseClock = new AtomicBoolean();
+        Clock clock =
+                new Clock() {
+                    @Override
+                    public long milliseconds() {
+                        if (pauseClock.get()) {
+                            creatingBatch.complete(null);
+                            resumeAppend.join();
+                        }
+                        return System.currentTimeMillis();
+                    }
+
+                    @Override
+                    public long nanoseconds() {
+                        return System.nanoTime();
+                    }
+                };
+        RecordAccumulator accumulator =
+                accumulator(
+                        ConfigOptions.NoKeyAssigner.STICKY,
+                        64 * 1024,
+                        TestingWriterMetricGroup.newInstance(),
+                        clock);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        TableInfo table = tableInfo(1, true, true, historicalRouting);
+        accumulator.checkAndCacheHistoricalPartitionEnabled(table);
+        Cluster resolved = cluster(1, true);
+        CompletableFuture<Exception> completion = new CompletableFuture<>();
+        AtomicReference<Thread> barrierThread = new AtomicReference<>();
+        try {
+            accumulator.append(
+                    record(table, WriteFormat.COMPACTED_KV, 0, 1),
+                    (bucket, offset, error) -> {},
+                    resolved);
+            accumulator.getReadyDeque(PATH, 0).peekLast().close();
+            pauseClock.set(true);
+            Future<?> append =
+                    executor.submit(
+                            () -> {
+                                accumulator.append(
+                                        record(table, WriteFormat.COMPACTED_KV, 0, 2),
+                                        (bucket, offset, error) -> completion.complete(error),
+                                        resolved);
+                                return null;
+                            });
+            // Batch creation reads the clock after checking closed, before registering the
+            // new batch as incomplete. Neither close nor a historical route switch may overtake
+            // registration, even though ordinary resolved appends skip the context lock.
+            creatingBatch.get(10, TimeUnit.SECONDS);
+            Future<?> barrier =
+                    executor.submit(
+                            () -> {
+                                barrierThread.set(Thread.currentThread());
+                                if (historicalRouting) {
+                                    accumulator.routeWritesTo(
+                                            table,
+                                            PATH,
+                                            PhysicalTablePath.of(
+                                                    PATH.getTablePath(),
+                                                    HISTORICAL_PARTITION_VALUE),
+                                            PARTITION_ID + 1);
+                                } else {
+                                    accumulator.close();
+                                }
+                            });
+            retry(
+                    Duration.ofSeconds(10),
+                    () -> {
+                        assertThat(barrierThread.get()).isNotNull();
+                        assertThat(barrierThread.get().getState()).isEqualTo(Thread.State.BLOCKED);
+                    });
+            assertThat(barrier.isDone()).isFalse();
+            resumeAppend.complete(null);
+            append.get(10, TimeUnit.SECONDS);
+            if (historicalRouting) {
+                assertThatThrownBy(() -> barrier.get(10, TimeUnit.SECONDS))
+                        .hasRootCauseInstanceOf(FlussRuntimeException.class)
+                        .hasStackTraceContaining("incomplete writes");
+                assertThat(accumulator.hasHistoricalWriteTarget(PATH)).isFalse();
+                accumulator.close();
+            } else {
+                barrier.get(10, TimeUnit.SECONDS);
+            }
+            RuntimeException failure = new RuntimeException("fatal write failure");
+            accumulator.abortAllBatches(failure);
+            assertThat(completion.get(10, TimeUnit.SECONDS)).isSameAs(failure);
+            assertThat(accumulator.hasIncomplete()).isFalse();
+            assertThat(accumulator.hasUnDrained()).isFalse();
+            assertThatThrownBy(
+                            () ->
+                                    accumulator.append(
+                                            record(table, WriteFormat.COMPACTED_KV, 0, 3),
+                                            (bucket, offset, error) -> {},
+                                            resolved))
+                    .hasMessageContaining("Writer closed");
+        } finally {
+            resumeAppend.complete(null);
+            executor.shutdown();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+            accumulator.close();
+            accumulator.abortAllBatches(new RuntimeException("test cleanup"));
+            accumulator.destroyResources();
+        }
+    }
+
+    private static Stream<Arguments> noKeyLayouts() {
+        return Stream.of(WriteFormat.ARROW_LOG, WriteFormat.COMPACTED_LOG, WriteFormat.INDEXED_LOG)
+                .flatMap(
+                        format ->
+                                Stream.of(1, 2, 3, 5)
+                                        .flatMap(
+                                                count ->
+                                                        Stream.of(false, true)
+                                                                .map(
+                                                                        highBucket ->
+                                                                                Arguments.of(
+                                                                                        format,
+                                                                                        count,
+                                                                                        highBucket))));
+    }
+
+    private static Stream<Arguments> hashLayouts() {
+        return Arrays.stream(WriteFormat.values())
+                .flatMap(
+                        format ->
+                                Stream.of(
+                                        Arguments.of(format, 2, 4),
+                                        Arguments.of(format, 4, 2),
+                                        Arguments.of(format, 2, 2)));
+    }
+
+    private static RecordAccumulator accumulator(ConfigOptions.NoKeyAssigner strategy) {
+        return accumulator(strategy, 64 * 1024, TestingWriterMetricGroup.newInstance());
+    }
+
+    private static RecordAccumulator accumulator(
+            ConfigOptions.NoKeyAssigner strategy,
+            int memorySize,
+            TestingWriterMetricGroup metrics) {
+        return accumulator(strategy, memorySize, metrics, SystemClock.getInstance());
+    }
+
+    private static RecordAccumulator accumulator(
+            ConfigOptions.NoKeyAssigner strategy,
+            int memorySize,
+            TestingWriterMetricGroup metrics,
+            Clock clock) {
+        return new RecordAccumulator(
+                configuration(strategy, memorySize),
+                new IdempotenceManager(false, 5, null, null),
+                metrics,
+                clock);
+    }
+
+    private static Configuration configuration(
+            ConfigOptions.NoKeyAssigner strategy, int memorySize) {
+        Configuration conf = new Configuration();
+        conf.set(ConfigOptions.CLIENT_WRITER_BUCKET_NO_KEY_ASSIGNER, strategy);
+        conf.set(ConfigOptions.CLIENT_WRITER_BATCH_SIZE, new MemorySize(256));
+        conf.set(ConfigOptions.CLIENT_WRITER_BUFFER_PAGE_SIZE, new MemorySize(256));
+        conf.set(ConfigOptions.CLIENT_WRITER_BUFFER_MEMORY_SIZE, new MemorySize(memorySize));
+        conf.set(ConfigOptions.CLIENT_WRITER_BATCH_TIMEOUT, Duration.ZERO);
+        return conf;
+    }
+
+    private static TableInfo tableInfo(int count, boolean hash, boolean primaryKey) {
+        return tableInfo(count, hash, primaryKey, false);
+    }
+
+    private static TableInfo tableInfo(
+            int count, boolean hash, boolean primaryKey, boolean historicalPartitionEnabled) {
+        Schema.Builder schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column("v", DataTypes.INT())
+                        .column("dt", DataTypes.STRING());
+        if (primaryKey) {
+            schema.primaryKey("id", "dt");
+        }
+        TableDescriptor.Builder descriptor =
+                TableDescriptor.builder()
+                        .schema(schema.build())
+                        .partitionedBy("dt")
+                        .property(
+                                ConfigOptions.TABLE_DATALAKE_HISTORICAL_PARTITION_ENABLED,
+                                historicalPartitionEnabled);
+        if (hash) {
+            descriptor.distributedBy(count, "id");
+        } else {
+            descriptor.distributedBy(count);
+        }
+        return TableInfo.of(
+                PATH.getTablePath(),
+                10,
+                1,
+                descriptor.build(),
+                "/tmp/fluss-routing",
+                0,
+                0,
+                historicalPartitionEnabled ? 0 : 1);
+    }
+
+    private static Cluster cluster(int count, boolean includeCount) {
+        return cluster(count, includeCount, PARTITION_ID);
+    }
+
+    private static Cluster cluster(int count, boolean includeCount, long partitionId) {
+        return cluster(count, includeCount, partitionId, PATH);
+    }
+
+    private static Cluster cluster(
+            int count, boolean includeCount, long partitionId, PhysicalTablePath path) {
+        List<BucketLocation> locations = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            locations.add(
+                    new BucketLocation(
+                            path, new TableBucket(10, partitionId, i), 1, new int[] {1}));
+        }
+        return new Cluster(
+                Collections.singletonMap(1, NODE),
+                null,
+                Collections.singletonMap(path, locations),
+                Collections.singletonMap(path.getTablePath(), 10L),
+                Collections.singletonMap(path, partitionId),
+                includeCount
+                        ? Collections.singletonMap(TableOrPartition.ofPartition(partitionId), count)
+                        : Collections.emptyMap());
+    }
+
+    private static WriteRecord record(TableInfo table, WriteFormat format, int key, int version) {
+        return record(table, format, key, version, PATH);
+    }
+
+    private static WriteRecord record(
+            TableInfo table, WriteFormat format, int key, int version, PhysicalTablePath path) {
+        Object[] fields = {key, version, path.getPartitionName()};
+        byte[] bucketKey = table.getBucketKeys().isEmpty() ? null : new byte[] {(byte) key};
+        switch (format) {
+            case COMPACTED_KV:
+            case INDEXED_KV:
+                return WriteRecord.forUpsert(
+                        table,
+                        path,
+                        format == WriteFormat.COMPACTED_KV
+                                ? compactedRow(table.getRowType(), fields)
+                                : indexedRow(table.getRowType(), fields),
+                        bucketKey,
+                        bucketKey,
+                        format,
+                        null);
+            case COMPACTED_LOG:
+                return WriteRecord.forCompactedAppend(
+                        table, path, compactedRow(table.getRowType(), fields), bucketKey);
+            case INDEXED_LOG:
+                return WriteRecord.forIndexedAppend(
+                        table, path, indexedRow(table.getRowType(), fields), bucketKey);
+            case ARROW_LOG:
+                return WriteRecord.forArrowAppend(table, path, row(fields), bucketKey);
+            default:
+                throw new IllegalArgumentException("Unexpected format: " + format);
+        }
+    }
+
+    private static List<InternalRow> readRows(WriteBatch batch, TableInfo table, WriteFormat format)
+            throws Exception {
+        List<InternalRow> rows = new ArrayList<>();
+        TestingSchemaGetter getter = new TestingSchemaGetter(1, table.getSchema());
+        if (format.isKv()) {
+            for (KvRecord record :
+                    DefaultKvRecordBatch.pointToBytesView(batch.build())
+                            .records(
+                                    KvRecordReadContext.createReadContext(
+                                            format.toKvFormat(), getter))) {
+                rows.add(InternalRowUtils.copyRow(record.getRow(), table.getRowType()));
+            }
+        } else {
+            LogRecordReadContext context;
+            if (format == WriteFormat.ARROW_LOG) {
+                context =
+                        LogRecordReadContext.createArrowReadContext(table.getRowType(), 1, getter);
+            } else if (format == WriteFormat.INDEXED_LOG) {
+                context =
+                        LogRecordReadContext.createIndexedReadContext(
+                                table.getRowType(), 1, getter);
+            } else {
+                context =
+                        LogRecordReadContext.createCompactedRowReadContext(
+                                table.getRowType(), 1, getter);
+            }
+            try (LogRecordReadContext ignored = context;
+                    CloseableIterator<LogRecord> records =
+                            MemoryLogRecords.pointToBytesView(batch.build())
+                                    .batchIterator()
+                                    .next()
+                                    .records(context)) {
+                while (records.hasNext()) {
+                    rows.add(InternalRowUtils.copyRow(records.next().getRow(), table.getRowType()));
+                }
+            }
+        }
+        return rows;
+    }
+}

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/HashBucketAssignerTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/HashBucketAssignerTest.java
@@ -61,12 +61,12 @@ class HashBucketAssignerTest {
         InternalRow row3 = row(1, 2, "4", 5L);
         InternalRow row4 = row(1, 1, "4", 5L);
 
-        HashBucketAssigner hashBucketAssigner = new HashBucketAssigner(3);
+        HashBucketAssigner hashBucketAssigner = new HashBucketAssigner();
 
-        int bucket1 = hashBucketAssigner.assignBucket(keyEncoder.encodeKey(row1));
-        int bucket2 = hashBucketAssigner.assignBucket(keyEncoder.encodeKey(row2));
-        int bucket3 = hashBucketAssigner.assignBucket(keyEncoder.encodeKey(row3));
-        int bucket4 = hashBucketAssigner.assignBucket(keyEncoder.encodeKey(row4));
+        int bucket1 = hashBucketAssigner.assignBucket(keyEncoder.encodeKey(row1), 3);
+        int bucket2 = hashBucketAssigner.assignBucket(keyEncoder.encodeKey(row2), 3);
+        int bucket3 = hashBucketAssigner.assignBucket(keyEncoder.encodeKey(row3), 3);
+        int bucket4 = hashBucketAssigner.assignBucket(keyEncoder.encodeKey(row4), 3);
 
         assertThat(bucket1).isEqualTo(bucket2);
         assertThat(bucket1).isNotEqualTo(bucket3);
@@ -96,9 +96,9 @@ class HashBucketAssignerTest {
         }
 
         for (int bucketNumber = 3; bucketNumber < 10; bucketNumber++) {
-            HashBucketAssigner hashBucketAssigner = new HashBucketAssigner(bucketNumber);
+            HashBucketAssigner hashBucketAssigner = new HashBucketAssigner();
             for (byte[] key : keyList) {
-                int bucket = hashBucketAssigner.assignBucket(key);
+                int bucket = hashBucketAssigner.assignBucket(key, bucketNumber);
                 assertThat(bucket >= 0).isTrue();
                 assertThat(bucket < bucketNumber).isTrue();
             }
@@ -136,12 +136,12 @@ class HashBucketAssignerTest {
                 KeyEncoder.ofBucketKeyEncoder(
                         schema.getRowType(), bucketKey, DataLakeFormat.PAIMON);
         HashBucketAssigner bucketAssigner =
-                new HashBucketAssigner(3, BucketingFunction.of(DataLakeFormat.PAIMON));
+                new HashBucketAssigner(BucketingFunction.of(DataLakeFormat.PAIMON));
 
-        int row1Bucket = bucketAssigner.assignBucket(keyEncoder.encodeKey(row1));
-        int row2Bucket = bucketAssigner.assignBucket(keyEncoder.encodeKey(row2));
-        int row3Bucket = bucketAssigner.assignBucket(keyEncoder.encodeKey(row3));
-        int row4Bucket = bucketAssigner.assignBucket(keyEncoder.encodeKey(row4));
+        int row1Bucket = bucketAssigner.assignBucket(keyEncoder.encodeKey(row1), 3);
+        int row2Bucket = bucketAssigner.assignBucket(keyEncoder.encodeKey(row2), 3);
+        int row3Bucket = bucketAssigner.assignBucket(keyEncoder.encodeKey(row3), 3);
+        int row4Bucket = bucketAssigner.assignBucket(keyEncoder.encodeKey(row4), 3);
 
         if (isPartitioned) {
             // bucket key is the column 'a'

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/RecordAccumulatorTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/RecordAccumulatorTest.java
@@ -95,7 +95,7 @@ class RecordAccumulatorTest {
                     1,
                     TableDescriptor.builder()
                             .schema(DATA1_SCHEMA)
-                            .distributedBy(3)
+                            .distributedBy(10)
                             .property(ConfigOptions.TABLE_LOG_ARROW_COMPRESSION_TYPE.key(), "zstd")
                             .build(),
                     DEFAULT_REMOTE_DATA_DIR,
@@ -132,6 +132,7 @@ class RecordAccumulatorTest {
                 }
             };
     private final ManualClock clock = new ManualClock(System.currentTimeMillis());
+    private final TestingBucketAssigner bucketAssigner = new TestingBucketAssigner();
     private Configuration conf;
     private Cluster cluster;
     private SchemaGetter schemaGetter;
@@ -157,9 +158,12 @@ class RecordAccumulatorTest {
         // add bucket into cluster.
         cluster = updateCluster(Arrays.asList(bucket1, bucket2, bucket3, bucket4));
 
+        TableInfo tableInfo = withBucketCount(4);
+
         // initial data.
         for (int i = 0; i < 4; i++) {
-            accum.append(createRecord(row), writeCallback, cluster, i, numBuckets, false);
+            bucketAssigner.setBucketId(i);
+            accum.append(createRecord(row, tableInfo), writeCallback, cluster);
         }
 
         // drain batches from 2 nodes: node1 => tb1, node2 => tb3, because the max request size is
@@ -172,8 +176,10 @@ class RecordAccumulatorTest {
         verifyTableBucketInBatches(batches1, tb1, tb3);
 
         // add record for tb1, tb3
-        accum.append(createRecord(row), writeCallback, cluster, 0, numBuckets, false);
-        accum.append(createRecord(row), writeCallback, cluster, 2, numBuckets, false);
+        bucketAssigner.setBucketId(0);
+        accum.append(createRecord(row, tableInfo), writeCallback, cluster);
+        bucketAssigner.setBucketId(2);
+        accum.append(createRecord(row, tableInfo), writeCallback, cluster);
 
         // drain batches from 2 nodes: node1 => tb2, node2 => tb4, because the max request size is
         // full after the first batch drained. The drain index should start from next table bucket,
@@ -197,7 +203,7 @@ class RecordAccumulatorTest {
     @Test
     void testDrainCompressedBatches() throws Exception {
         int batchSize = 10 * 1024;
-        int bucketNum = 10;
+        int bucketNum = ZSTD_TABLE_INFO.getNumBuckets();
         RecordAccumulator accum =
                 createTestRecordAccumulator(
                         Integer.MAX_VALUE, batchSize, batchSize, Integer.MAX_VALUE);
@@ -216,7 +222,7 @@ class RecordAccumulatorTest {
             appendUntilBatchFull(accum, i);
         }
 
-        // all 3 buckets are located in node1
+        // All buckets are located in node1.
         Map<Integer, List<ReadyWriteBatch>> batches =
                 accum.drain(cluster, Collections.singleton(node1.id()), batchSize * bucketNum);
         // the compression ratio is smaller than 1.0,
@@ -253,14 +259,8 @@ class RecordAccumulatorTest {
             PhysicalTablePath tablePath = PhysicalTablePath.of(ZSTD_TABLE_INFO.getTablePath());
             WriteRecord record = WriteRecord.forArrowAppend(ZSTD_TABLE_INFO, tablePath, row, null);
             // append until the batch is full
-            if (accum.append(
-                            record,
-                            writeCallback,
-                            cluster,
-                            bucketId,
-                            ZSTD_TABLE_INFO.getNumBuckets(),
-                            false)
-                    .batchIsFull) {
+            bucketAssigner.setBucketId(bucketId);
+            if (accum.append(record, writeCallback, cluster).batchIsFull) {
                 break;
             }
         }
@@ -276,7 +276,8 @@ class RecordAccumulatorTest {
         int appends = expectedNumAppends(row, batchSize);
         for (int i = 0; i < appends; i++) {
             // append to the first batch
-            accum.append(createRecord(row), writeCallback, cluster, 0, numBuckets, false);
+            bucketAssigner.setBucketId(0);
+            accum.append(createRecord(row), writeCallback, cluster);
             Deque<WriteBatch> writeBatches =
                     accum.getReadyDeque(DATA1_PHYSICAL_TABLE_PATH, tb1.getBucket());
             assertThat(writeBatches).hasSize(1);
@@ -289,7 +290,8 @@ class RecordAccumulatorTest {
 
         // this appends doesn't fit in the first batch, so a new batch is created and the first
         // batch is closed.
-        accum.append(createRecord(row), writeCallback, cluster, 0, numBuckets, false);
+        bucketAssigner.setBucketId(0);
+        accum.append(createRecord(row), writeCallback, cluster);
         Deque<WriteBatch> writeBatches =
                 accum.getReadyDeque(DATA1_PHYSICAL_TABLE_PATH, tb1.getBucket());
         assertThat(writeBatches).hasSize(2);
@@ -320,24 +322,22 @@ class RecordAccumulatorTest {
     }
 
     @Test
-    void testAppendRollsNewBatchWhenBucketCountChanges() throws Exception {
+    void testAppendKeepsResolvedBucketCount() throws Exception {
         int batchSize = 1024;
         IndexedRow row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
         RecordAccumulator accum = createTestRecordAccumulator(batchSize, 10L * batchSize);
 
-        accum.append(createRecord(row), writeCallback, cluster, 0, numBuckets, false);
-        accum.append(createRecord(row), writeCallback, cluster, 0, numBuckets + 1, false);
+        accum.append(createRecord(row), writeCallback, cluster);
+        // A newer table default must not override a context's resolved layout.
+        accum.append(createRecord(row, withBucketCount(numBuckets + 1)), writeCallback, cluster);
 
         Deque<WriteBatch> writeBatches =
                 accum.getReadyDeque(DATA1_PHYSICAL_TABLE_PATH, tb1.getBucket());
-        assertThat(writeBatches).hasSize(2);
-        Iterator<WriteBatch> batchIterator = writeBatches.iterator();
-        WriteBatch oldBatch = batchIterator.next();
-        assertThat(oldBatch.isClosed()).isTrue();
-        assertThat(oldBatch.getBucketCount()).isEqualTo(numBuckets);
-        WriteBatch newBatch = batchIterator.next();
-        assertThat(newBatch.isClosed()).isFalse();
-        assertThat(newBatch.getBucketCount()).isEqualTo(numBuckets + 1);
+        assertThat(writeBatches).hasSize(1);
+        WriteBatch batch = writeBatches.getFirst();
+        assertThat(batch.isClosed()).isFalse();
+        assertThat(batch.getBucketCount()).isEqualTo(numBuckets);
+        assertThat(batch.getRecordCount()).isEqualTo(2);
     }
 
     @Test
@@ -348,15 +348,11 @@ class RecordAccumulatorTest {
         int oldSchemaId = DATA1_TABLE_INFO.getSchemaId();
         int newSchemaId = oldSchemaId + 1;
 
-        accum.append(createRecord(row), writeCallback, cluster, 0, numBuckets, false);
+        bucketAssigner.setBucketId(0);
+        accum.append(createRecord(row), writeCallback, cluster);
         // a record with a bumped schema id closes the old-schema batch and rolls a new one.
-        accum.append(
-                createRecord(row, withSchemaId(newSchemaId)),
-                writeCallback,
-                cluster,
-                0,
-                numBuckets,
-                false);
+        bucketAssigner.setBucketId(0);
+        accum.append(createRecord(row, withSchemaId(newSchemaId)), writeCallback, cluster);
 
         Deque<WriteBatch> writeBatches =
                 accum.getReadyDeque(DATA1_PHYSICAL_TABLE_PATH, tb1.getBucket());
@@ -382,7 +378,8 @@ class RecordAccumulatorTest {
         IndexedRow row1 =
                 indexedRow(DATA1_ROW_TYPE, new Object[] {100000000, new String(new char[2 * 100])});
         // row size > 10;
-        accum.append(createRecord(row1), writeCallback, cluster, 0, numBuckets, false);
+        bucketAssigner.setBucketId(0);
+        accum.append(createRecord(row1), writeCallback, cluster);
         // bucket's leader should be ready for bucket0.
         assertThat(accum.ready(cluster).readyNodes).isEqualTo(Collections.singleton(node1.id()));
 
@@ -408,75 +405,56 @@ class RecordAccumulatorTest {
 
     @Test
     void testAppendWithStickyBucketAssigner() throws Exception {
-        // Test case assumes that the records do not fill the batch completely
+        // The next record after expectedAppends must overflow the current batch.
         int batchSize = 100;
         IndexedRow row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
-
-        StickyBucketAssigner bucketAssigner =
-                new StickyBucketAssigner(DATA1_PHYSICAL_TABLE_PATH, 3);
+        StickyBucketAssigner assigner = new StickyBucketAssigner(DATA1_PHYSICAL_TABLE_PATH);
         RecordAccumulator accum =
                 createTestRecordAccumulator(
                         (int) Duration.ofMinutes(1).toMillis(),
                         batchSize,
                         batchSize,
-                        10L * batchSize);
+                        10L * batchSize,
+                        assigner);
         int expectedAppends = expectedNumAppends(row, batchSize);
 
-        // Create first batch.
-        int bucketId = bucketAssigner.assignBucket(cluster);
-        accum.append(createRecord(row), writeCallback, cluster, bucketId, numBuckets, false);
-        int appends = 1;
+        for (int i = 0; i < expectedAppends; i++) {
+            accum.append(createRecord(row), writeCallback, cluster);
+            assertThat(getBatchNumInAccum(accum)).isOne();
+            assertThat(accum.ready(cluster).readyNodes).isEmpty();
+        }
+        int firstBucket = assigner.assignBucket(cluster, numBuckets);
+        WriteBatch firstBatch =
+                accum.getReadyDeque(DATA1_PHYSICAL_TABLE_PATH, firstBucket).getFirst();
 
-        boolean switchBucket = false;
-        while (!switchBucket) {
-            // Append to the first batch.
-            bucketId = bucketAssigner.assignBucket(cluster);
-            RecordAccumulator.RecordAppendResult result =
-                    accum.append(
-                            createRecord(row), writeCallback, cluster, bucketId, numBuckets, true);
-            int numBatches = getBatchNumInAccum(accum);
-            // Only one batch is created because the bucket is sticky.
-            assertThat(numBatches).isEqualTo(1);
-
-            switchBucket = result.abortRecordForNewBatch;
-            // We only appended if we do not retry.
-            if (!switchBucket) {
-                appends++;
-                assertThat(accum.ready(cluster).readyNodes.size()).isEqualTo(0);
-            }
+        // Overflow automatically switches buckets and appends the triggering record.
+        assertThat(accum.append(createRecord(row), writeCallback, cluster).newBatchCreated)
+                .isTrue();
+        int secondBucket = assigner.assignBucket(cluster, numBuckets);
+        assertThat(secondBucket).isNotEqualTo(firstBucket);
+        assertThat(firstBatch.isClosed()).isTrue();
+        assertThat(firstBatch.getRecordCount()).isEqualTo(expectedAppends);
+        WriteBatch secondBatch =
+                accum.getReadyDeque(DATA1_PHYSICAL_TABLE_PATH, secondBucket).getFirst();
+        assertThat(secondBatch.getRecordCount()).isOne();
+        for (int i = 1; i < expectedAppends; i++) {
+            accum.append(createRecord(row), writeCallback, cluster);
+            assertThat(assigner.assignBucket(cluster, numBuckets)).isEqualTo(secondBucket);
+            assertThat(getBatchNumInAccum(accum)).isEqualTo(2);
         }
 
-        // Batch should be full.
-        assertThat(accum.ready(cluster).readyNodes.size()).isEqualTo(1);
-        assertThat(appends).isEqualTo(expectedAppends);
-        switchBucket = false;
-
-        // Writer would call this method in this case, make second batch.
-        bucketAssigner.onNewBatch(cluster, bucketId);
-        bucketId = bucketAssigner.assignBucket(cluster);
-        accum.append(createRecord(row), writeCallback, cluster, bucketId, numBuckets, false);
-        appends++;
-
-        // These append operations all go into the second batch.
-        while (!switchBucket) {
-            // Append to the first batch.
-            bucketId = bucketAssigner.assignBucket(cluster);
-            RecordAccumulator.RecordAppendResult result =
-                    accum.append(
-                            createRecord(row), writeCallback, cluster, bucketId, numBuckets, true);
-            int numBatches = getBatchNumInAccum(accum);
-            // Only one batch is created because the bucket is sticky.
-            assertThat(numBatches).isEqualTo(2);
-
-            switchBucket = result.abortRecordForNewBatch;
-            // We only appended if we do not retry.
-            if (!switchBucket) {
-                appends++;
-            }
-        }
-
-        // There should be two full batches now.
-        assertThat(appends).isEqualTo(2 * expectedAppends);
+        assertThat(accum.append(createRecord(row), writeCallback, cluster).newBatchCreated)
+                .isTrue();
+        int thirdBucket = assigner.assignBucket(cluster, numBuckets);
+        assertThat(thirdBucket).isNotEqualTo(secondBucket);
+        assertThat(secondBatch.isClosed()).isTrue();
+        assertThat(secondBatch.getRecordCount()).isEqualTo(expectedAppends);
+        assertThat(getBatchNumInAccum(accum)).isEqualTo(3);
+        assertThat(
+                        accum.getReadyDeque(DATA1_PHYSICAL_TABLE_PATH, thirdBucket)
+                                .getLast()
+                                .getRecordCount())
+                .isOne();
     }
 
     @Test
@@ -487,13 +465,8 @@ class RecordAccumulatorTest {
         List<TableBucket> buckets = Arrays.asList(tb1, tb2);
         for (TableBucket tb : buckets) {
             for (int i = 0; i < appends; i++) {
-                accum.append(
-                        createRecord(row),
-                        writeCallback,
-                        cluster,
-                        tb.getBucket(),
-                        numBuckets,
-                        false);
+                bucketAssigner.setBucketId(tb.getBucket());
+                accum.append(createRecord(row), writeCallback, cluster);
             }
         }
 
@@ -510,7 +483,8 @@ class RecordAccumulatorTest {
         RecordAccumulator accum = createTestRecordAccumulator(4 * 1024, 64 * 1024);
 
         for (int i = 0; i < 100; i++) {
-            accum.append(createRecord(row), writeCallback, cluster, i % 3, numBuckets, false);
+            bucketAssigner.setBucketId(i % 3);
+            accum.append(createRecord(row), writeCallback, cluster);
             assertThat(accum.hasIncomplete()).isTrue();
         }
 
@@ -543,20 +517,16 @@ class RecordAccumulatorTest {
 
         try {
             cluster = updateCluster(Arrays.asList(bucket1, bucket2));
+            bucketAssigner.setBucketId(tb1.getBucket());
             accum.append(
                     createRecord(row),
                     (bucket, offset, exception) -> completedFuture.complete(exception),
-                    cluster,
-                    tb1.getBucket(),
-                    numBuckets,
-                    false);
+                    cluster);
+            bucketAssigner.setBucketId(tb2.getBucket());
             accum.append(
                     createRecord(row),
                     (bucket, offset, exception) -> abortedFuture.complete(exception),
-                    cluster,
-                    tb2.getBucket(),
-                    numBuckets,
-                    false);
+                    cluster);
 
             List<ReadyWriteBatch> batches =
                     accum.drain(cluster, Collections.singleton(node1.id()), Integer.MAX_VALUE)
@@ -601,7 +571,8 @@ class RecordAccumulatorTest {
         // add bucket1 which leader is unknown into cluster.
         cluster = updateCluster(Collections.singletonList(bucket1));
 
-        accum.append(createRecord(row), writeCallback, cluster, 0, numBuckets, false);
+        bucketAssigner.setBucketId(0);
+        accum.append(createRecord(row), writeCallback, cluster);
         RecordAccumulator.ReadyCheckResult readyCheckResult = accum.ready(cluster);
         assertThat(readyCheckResult.unknownLeaderTables)
                 .isEqualTo(Collections.singleton(DATA1_PHYSICAL_TABLE_PATH));
@@ -622,7 +593,8 @@ class RecordAccumulatorTest {
     void testAwaitFlushComplete() throws Exception {
         IndexedRow row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
         RecordAccumulator accum = createTestRecordAccumulator(4 * 1024, 64 * 1024);
-        accum.append(createRecord(row), writeCallback, cluster, 0, numBuckets, false);
+        bucketAssigner.setBucketId(0);
+        accum.append(createRecord(row), writeCallback, cluster);
 
         accum.beginFlush();
         assertThat(accum.flushInProgress()).isTrue();
@@ -643,13 +615,8 @@ class RecordAccumulatorTest {
 
         // Add data for bucket 1
         for (int i = 0; i < appends; i++) {
-            accum.append(
-                    createRecord(row),
-                    writeCallback,
-                    cluster,
-                    bucket1.getBucketId(),
-                    numBuckets,
-                    false);
+            bucketAssigner.setBucketId(bucket1.getBucketId());
+            accum.append(createRecord(row), writeCallback, cluster);
         }
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster);
         assertThat(result.readyNodes).isEmpty();
@@ -659,26 +626,16 @@ class RecordAccumulatorTest {
 
         // Add data for bucket 3
         for (int i = 0; i < appends; i++) {
-            accum.append(
-                    createRecord(row),
-                    writeCallback,
-                    cluster,
-                    bucket3.getBucketId(),
-                    numBuckets,
-                    false);
+            bucketAssigner.setBucketId(bucket3.getBucketId());
+            accum.append(createRecord(row), writeCallback, cluster);
         }
         result = accum.ready(cluster);
         assertThat(result.readyNodes).hasSize(0);
         assertThat(result.nextReadyCheckDelayMs).isEqualTo(batchTimeout / 2);
 
         // Append one more data for bucket1 should make the batch full and sendable immediately
-        accum.append(
-                createRecord(row),
-                writeCallback,
-                cluster,
-                bucket1.getBucketId(),
-                numBuckets,
-                false);
+        bucketAssigner.setBucketId(bucket1.getBucketId());
+        accum.append(createRecord(row), writeCallback, cluster);
 
         result = accum.ready(cluster);
         // server for bucket1 should be ready now
@@ -702,6 +659,14 @@ class RecordAccumulatorTest {
     }
 
     private TableInfo withSchemaId(int schemaId) {
+        return withTableMetadata(schemaId, numBuckets);
+    }
+
+    private TableInfo withBucketCount(int bucketCount) {
+        return withTableMetadata(DATA1_TABLE_INFO.getSchemaId(), bucketCount);
+    }
+
+    private TableInfo withTableMetadata(int schemaId, int bucketCount) {
         return new TableInfo(
                 DATA1_TABLE_INFO.getTablePath(),
                 DATA1_TABLE_INFO.getTableId(),
@@ -709,7 +674,7 @@ class RecordAccumulatorTest {
                 DATA1_TABLE_INFO.getSchema(),
                 DATA1_TABLE_INFO.getBucketKeys(),
                 DATA1_TABLE_INFO.getPartitionKeys(),
-                numBuckets,
+                bucketCount,
                 DATA1_TABLE_INFO.getProperties(),
                 DATA1_TABLE_INFO.getCustomProperties(),
                 DATA1_TABLE_INFO.getRemoteDataDir(),
@@ -782,14 +747,20 @@ class RecordAccumulatorTest {
 
         RecordAccumulator accum =
                 new RecordAccumulator(
-                        conf, idempotenceManager, TestingWriterMetricGroup.newInstance(), clock);
+                        conf,
+                        idempotenceManager,
+                        TestingWriterMetricGroup.newInstance(),
+                        clock,
+                        (tableInfo, path) -> bucketAssigner);
 
         cluster = updateCluster(Arrays.asList(bucket1, bucket2));
         IndexedRow row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
 
         // Drain both buckets so each has 1 in-flight batch.
-        accum.append(createRecord(row), writeCallback, cluster, tb1.getBucket(), numBuckets, false);
-        accum.append(createRecord(row), writeCallback, cluster, tb2.getBucket(), numBuckets, false);
+        bucketAssigner.setBucketId(tb1.getBucket());
+        accum.append(createRecord(row), writeCallback, cluster);
+        bucketAssigner.setBucketId(tb2.getBucket());
+        accum.append(createRecord(row), writeCallback, cluster);
 
         Map<Integer, List<ReadyWriteBatch>> firstDrain =
                 accum.drain(cluster, Collections.singleton(node1.id()), Integer.MAX_VALUE);
@@ -802,8 +773,10 @@ class RecordAccumulatorTest {
         idempotenceManager.handleCompletedBatch(tb2Batch);
 
         // Append again to both. On drain, tb1 should be skipped but tb2 should still be drained.
-        accum.append(createRecord(row), writeCallback, cluster, tb1.getBucket(), numBuckets, false);
-        accum.append(createRecord(row), writeCallback, cluster, tb2.getBucket(), numBuckets, false);
+        bucketAssigner.setBucketId(tb1.getBucket());
+        accum.append(createRecord(row), writeCallback, cluster);
+        bucketAssigner.setBucketId(tb2.getBucket());
+        accum.append(createRecord(row), writeCallback, cluster);
 
         Map<Integer, List<ReadyWriteBatch>> secondDrain =
                 accum.drain(cluster, Collections.singleton(node1.id()), Integer.MAX_VALUE);
@@ -832,6 +805,16 @@ class RecordAccumulatorTest {
 
     private RecordAccumulator createTestRecordAccumulator(
             int batchTimeoutMs, int batchSize, int pageSize, long totalSize) {
+        return createTestRecordAccumulator(
+                batchTimeoutMs, batchSize, pageSize, totalSize, bucketAssigner);
+    }
+
+    private RecordAccumulator createTestRecordAccumulator(
+            int batchTimeoutMs,
+            int batchSize,
+            int pageSize,
+            long totalSize,
+            BucketAssigner assigner) {
         conf.set(ConfigOptions.CLIENT_WRITER_BATCH_TIMEOUT, Duration.ofMillis(batchTimeoutMs));
         // TODO client writer buffer maybe removed.
         conf.set(ConfigOptions.CLIENT_WRITER_BUFFER_MEMORY_SIZE, new MemorySize(totalSize));
@@ -850,7 +833,8 @@ class RecordAccumulatorTest {
                                 TabletServerGateway.class),
                         null),
                 TestingWriterMetricGroup.newInstance(),
-                clock);
+                clock,
+                (tableInfo, path) -> assigner);
     }
 
     private long getTestBatchSize(BinaryRow row) {
@@ -942,8 +926,10 @@ class RecordAccumulatorTest {
 
         // Append records to tb1 and tb2. Both tb1 and tb2 lead on node1, so draining node1
         // should only return tb2 when tb1 is throttled.
-        accum.append(createRecord(row), writeCallback, cluster, 0, numBuckets, false);
-        accum.append(createRecord(row), writeCallback, cluster, 1, numBuckets, false);
+        bucketAssigner.setBucketId(0);
+        accum.append(createRecord(row), writeCallback, cluster);
+        bucketAssigner.setBucketId(1);
+        accum.append(createRecord(row), writeCallback, cluster);
 
         // Throttle tb1
         accum.updateThrottle(tb1, 0.5f);

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/SenderTest.java
@@ -34,6 +34,7 @@ import org.apache.fluss.exception.OutOfOrderSequenceException;
 import org.apache.fluss.exception.PartitionNotExistException;
 import org.apache.fluss.exception.TableNotExistException;
 import org.apache.fluss.exception.TimeoutException;
+import org.apache.fluss.exception.TooManyPartitionsException;
 import org.apache.fluss.metadata.DataLakeFormat;
 import org.apache.fluss.metadata.PhysicalTablePath;
 import org.apache.fluss.metadata.Schema;
@@ -65,6 +66,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -124,6 +126,7 @@ final class SenderTest {
     private final TableBucket tb1 = new TableBucket(DATA1_TABLE_ID, 0);
     private TestingMetadataUpdater metadataUpdater;
     private RecordAccumulator accumulator = null;
+    private TestingBucketAssigner bucketAssigner;
     private Sender sender = null;
     private TestingWriterMetricGroup writerMetricGroup;
 
@@ -143,7 +146,7 @@ final class SenderTest {
 
     @Test
     void testPotentialExpirationUsesAutoPartitionTimeUnit() {
-        TableInfo tableInfo = createHistoricalTableInfo(AutoPartitionTimeUnit.HOUR, 48);
+        TableInfo tableInfo = createPartitionedTableInfo(AutoPartitionTimeUnit.HOUR, 48, true);
         Instant now = Instant.parse("2026-08-24T00:00:00Z");
 
         assertThat(
@@ -160,8 +163,10 @@ final class SenderTest {
                 .isFalse();
     }
 
-    @Test
-    void testReroutesWriteAfterExplicitMissingPartitionResponse() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testReroutesWriteAfterExplicitMissingPartitionResponse(boolean historicalCountKnown)
+            throws Exception {
         sender.destroyResources();
         TableInfo tableInfo = createHistoricalTableInfo();
         PhysicalTablePath originalPath = PhysicalTablePath.of(tableInfo.getTablePath(), "20990101");
@@ -173,7 +178,19 @@ final class SenderTest {
         Map<PhysicalTablePath, TableBucket> tableBucketsByPath = new HashMap<>();
         tableBucketsByPath.put(originalPath, originalBucket);
         tableBucketsByPath.put(historicalPath, historicalBucket);
-        metadataUpdater.updateCluster(partitionedCluster(tableInfo, tableBucketsByPath));
+        Map<TableOrPartition, Integer> bucketCounts = new HashMap<>();
+        bucketCounts.put(
+                TableOrPartition.ofPartition(originalBucket.getPartitionId()),
+                tableInfo.getNumBuckets());
+        if (historicalCountKnown) {
+            bucketCounts.put(
+                    TableOrPartition.ofPartition(historicalBucket.getPartitionId()),
+                    tableInfo.getNumBuckets());
+        }
+        // Historical rerouting only needs the target partition ID. Its bucket count is fixed,
+        // including when legacy metadata does not expose the historical partition's count.
+        metadataUpdater.updateCluster(
+                partitionedCluster(tableInfo, tableBucketsByPath, bucketCounts));
         IdempotenceManager idempotenceManager = createIdempotenceManager(true);
         idempotenceManager.setWriterId(0L);
         sender = setupWithIdempotenceState(idempotenceManager);
@@ -202,6 +219,8 @@ final class SenderTest {
                 .isEqualTo(historicalBucket.getPartitionId());
         assertThat(historicalRequest.getBucketsReqAt(0).getOriginalPartitionName())
                 .isEqualTo(originalPath.getPartitionName());
+        assertThat(historicalRequest.getBucketsReqAt(0).getRoutingBucketCount())
+                .isEqualTo(tableInfo.getNumBuckets());
         List<PutKvDataForBucket> historicalData = toPutKvDataForBuckets(historicalRequest);
         assertThat(historicalData).hasSize(1);
         assertThat(historicalData.get(0).records().writerId()).isEqualTo(0L);
@@ -217,15 +236,17 @@ final class SenderTest {
         assertThat(future.get()).isNull();
     }
 
-    @Test
-    void testFailsQueuedBatchWhenPartitionBucketCountChanged() throws Exception {
+    @ParameterizedTest
+    @CsvSource({"2, 4", "4, 2"})
+    void testServerValidatesResolvedBucketCount(int initialCount, int updatedCount)
+            throws Exception {
         sender.destroyResources();
-        TableInfo tableInfo = createHistoricalTableInfo();
+        TableInfo tableInfo = createPartitionedTableInfo(AutoPartitionTimeUnit.DAY, 7, false);
         PhysicalTablePath partitionPath =
                 PhysicalTablePath.of(tableInfo.getTablePath(), "20990101");
         TableBucket tableBucket = new TableBucket(tableInfo.getTableId(), 21L, 0);
         Map<TableOrPartition, Integer> bucketCounts = new HashMap<>();
-        bucketCounts.put(TableOrPartition.ofPartition(tableBucket.getPartitionId()), 4);
+        bucketCounts.put(TableOrPartition.ofPartition(tableBucket.getPartitionId()), initialCount);
         metadataUpdater.updateCluster(
                 partitionedCluster(
                         tableInfo,
@@ -234,56 +255,29 @@ final class SenderTest {
         sender = setupWithIdempotenceState();
 
         CompletableFuture<Exception> future =
-                appendKvRecord(tableInfo, partitionPath, 1, metadataUpdater.getCluster(), 2);
-        sender.runOnce();
-
-        assertThat(future.get())
-                .isInstanceOf(InvalidBucketRoutingException.class)
-                .hasMessageContaining("bucket count changed");
-        assertThatThrownBy(() -> node1Gateway().getRequest(0))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("No requests pending");
-    }
-
-    @Test
-    void testAbortsRerouteWhenQueuedBatchBucketCountDiffers() throws Exception {
-        sender.destroyResources();
-        TableInfo tableInfo = createHistoricalTableInfo();
-        PhysicalTablePath originalPath = PhysicalTablePath.of(tableInfo.getTablePath(), "20990101");
-        PhysicalTablePath historicalPath =
-                PhysicalTablePath.of(tableInfo.getTablePath(), HISTORICAL_PARTITION_VALUE);
-        TableBucket originalBucket = new TableBucket(tableInfo.getTableId(), 21L, 0);
-        TableBucket historicalBucket = new TableBucket(tableInfo.getTableId(), 22L, 0);
-        metadataUpdater = missingPartitionMetadataUpdater(tableInfo, originalPath);
-        Map<PhysicalTablePath, TableBucket> tableBucketsByPath = new HashMap<>();
-        tableBucketsByPath.put(originalPath, originalBucket);
-        tableBucketsByPath.put(historicalPath, historicalBucket);
-        // The historical partition keeps one bucket while the queued batch was routed by a
-        // rescaled partition's count of four: its bucket id cannot be moved to the historical
-        // layout, so the reroute must abort instead of silently misrouting the records.
-        Map<TableOrPartition, Integer> bucketCountByTableOrPartition = new HashMap<>();
-        bucketCountByTableOrPartition.put(
-                TableOrPartition.ofPartition(historicalBucket.getPartitionId()), 1);
+                appendKvRecord(tableInfo, partitionPath, 1, metadataUpdater.getCluster());
+        bucketCounts.put(TableOrPartition.ofPartition(tableBucket.getPartitionId()), updatedCount);
         metadataUpdater.updateCluster(
-                partitionedCluster(tableInfo, tableBucketsByPath, bucketCountByTableOrPartition));
-        sender = setupWithIdempotenceState();
-
-        CompletableFuture<Exception> future =
-                appendKvRecord(tableInfo, originalPath, 1, metadataUpdater.getCluster(), 4);
+                partitionedCluster(
+                        tableInfo,
+                        Collections.singletonMap(partitionPath, tableBucket),
+                        bucketCounts));
         sender.runOnce();
 
-        TestTabletServerGateway gateway = node1Gateway();
-        gateway.response(
-                0, createPutKvResponse(originalBucket, Errors.UNKNOWN_TABLE_OR_BUCKET_EXCEPTION));
-        sender.runOnce();
+        PutKvRequest request = (PutKvRequest) node1Gateway().getRequest(0);
+        assertThat(request.getBucketsReqsCount()).isOne();
+        assertThat(request.getBucketsReqAt(0).getRoutingBucketCount()).isEqualTo(initialCount);
+        assertThat(future).isNotDone();
+        assertThat(sender.isRunning()).isTrue();
 
-        assertThat(future.get())
-                .isInstanceOf(PartitionNotExistException.class)
-                .hasMessageContaining("different bucket count");
-        // Nothing was sent to the historical partition: aborting is the whole point.
-        assertThatThrownBy(() -> gateway.getRequest(0))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("No requests pending");
+        // Metadata changes do not rewrite or reject resolved batches. The server validates
+        // the count carried by the request and reports any stale routing.
+        finishRequest(
+                tableBucket, 0, createPutKvResponse(tableBucket, Errors.INVALID_BUCKET_ROUTING));
+        assertThat(sender.isRunning()).isFalse();
+        sender.runOnce();
+        assertThat(future.get()).isInstanceOf(InvalidBucketRoutingException.class);
+        assertThat(accumulator.hasIncomplete()).isFalse();
     }
 
     @Test
@@ -366,9 +360,9 @@ final class SenderTest {
         CompletableFuture<Exception> activeFuture =
                 appendKvRecord(tableInfo, activePath, 1, metadataUpdater.getCluster());
         accumulator.routeWritesTo(
-                firstOriginalPath, historicalPath, historicalBucket.getPartitionId());
+                tableInfo, firstOriginalPath, historicalPath, historicalBucket.getPartitionId());
         accumulator.routeWritesTo(
-                secondOriginalPath, historicalPath, historicalBucket.getPartitionId());
+                tableInfo, secondOriginalPath, historicalPath, historicalBucket.getPartitionId());
         CompletableFuture<Exception> firstHistoricalFuture =
                 appendKvRecord(tableInfo, firstOriginalPath, 2, metadataUpdater.getCluster());
         CompletableFuture<Exception> secondHistoricalFuture =
@@ -459,7 +453,8 @@ final class SenderTest {
 
         CompletableFuture<Exception> activeFuture =
                 appendKvRecord(tableInfo, activePath, 1, cluster);
-        accumulator.routeWritesTo(originalPath, historicalPath, historicalBucket.getPartitionId());
+        accumulator.routeWritesTo(
+                tableInfo, originalPath, historicalPath, historicalBucket.getPartitionId());
         CompletableFuture<Exception> historicalFuture =
                 appendKvRecord(tableInfo, originalPath, 2, cluster);
         PutKvResponse activeResponse = createPutKvResponse(activeBucket, 1L);
@@ -1534,6 +1529,7 @@ final class SenderTest {
         int[] pkIndex = DATA1_SCHEMA_PK.getPrimaryKeyIndexes();
         byte[] key = new CompactedKeyEncoder(DATA1_ROW_TYPE, pkIndex).encodeKey(row);
         CompletableFuture<Exception> future = new CompletableFuture<>();
+        bucketAssigner.setBucketId(0);
         accumulator.append(
                 WriteRecord.forUpsert(
                         DATA1_TABLE_INFO_PK,
@@ -1544,10 +1540,7 @@ final class SenderTest {
                         WriteFormat.COMPACTED_KV,
                         null),
                 (tb, leo, e) -> future.complete(e),
-                metadataUpdater.getCluster(),
-                0,
-                DATA1_TABLE_INFO_PK.getNumBuckets(),
-                false);
+                metadataUpdater.getCluster());
         sender.runOnce();
         finishRequest(tableBucket, 0, createPutKvResponse(tableBucket, SCHEMA_NOT_EXIST));
         assertThat(sender.numOfInFlightBatches(tableBucket)).isEqualTo(0);
@@ -1734,97 +1727,58 @@ final class SenderTest {
         assertThat(future2.get()).isNull();
     }
 
-    @Test
-    void testInvalidBucketRoutingFailsBatchAndInvalidatesBucketAssigner() throws Exception {
-        // Recreate sender with a tracking bucketAssignerInvalidator.
-        IdempotenceManager idempotenceManager = createIdempotenceManager(false);
-        Configuration conf = new Configuration();
-        conf.set(ConfigOptions.CLIENT_WRITER_BUFFER_MEMORY_SIZE, new MemorySize(TOTAL_MEMORY_SIZE));
-        conf.set(ConfigOptions.CLIENT_WRITER_BATCH_SIZE, new MemorySize(BATCH_SIZE));
-        conf.set(ConfigOptions.CLIENT_WRITER_BUFFER_PAGE_SIZE, new MemorySize(PAGE_SIZE));
-        conf.set(ConfigOptions.CLIENT_WRITER_BATCH_TIMEOUT, Duration.ofMillis(0));
-        accumulator =
-                new RecordAccumulator(
-                        conf, idempotenceManager, writerMetricGroup, SystemClock.getInstance());
-        AtomicReference<TableBucket> invalidatedBucket = new AtomicReference<>();
-        Sender staleSender =
-                new Sender(
-                        accumulator,
-                        REQUEST_TIMEOUT,
-                        MAX_REQUEST_SIZE,
-                        ACKS_ALL,
-                        Integer.MAX_VALUE,
-                        metadataUpdater,
-                        idempotenceManager,
-                        writerMetricGroup,
-                        invalidatedBucket::set);
-
-        // Append one record and send it.
-        CompletableFuture<Exception> future = new CompletableFuture<>();
-        appendToAccumulator(tb1, row(1, "a"), (tb, leo, e) -> future.complete(e));
-        staleSender.runOnce();
-        assertThat(staleSender.numOfInFlightBatches(tb1)).isEqualTo(1);
-
-        // Server rejects the bucketId computed with a stale count.
-        Cluster clusterBeforeError = metadataUpdater.getCluster();
-        finishRequest(tb1, 0, createProduceLogResponse(tb1, Errors.INVALID_BUCKET_ROUTING));
-
-        // The batch is failed (not re-enqueued for retry — the bucketId is stale and must not be
-        // reused).
-        assertThat(staleSender.numOfInFlightBatches(tb1)).isEqualTo(0);
-
-        // The BucketAssigner for this bucket was invalidated so the next send rebuilds it with
-        // the refreshed bucket count.
-        assertThat(invalidatedBucket.get()).isEqualTo(tb1);
-
-        // The table's bucket metadata was invalidated so the next send requests it again.
-        assertThat(metadataUpdater.getCluster()).isNotSameAs(clusterBeforeError);
-
-        // The write callback receives the non-retriable routing error.
-        Exception exception = future.get();
-        assertThat(exception).isInstanceOf(InvalidBucketRoutingException.class);
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testPartitionCreationFailureStopsCurrentAndFutureAppends(boolean batchRegistered)
+            throws Exception {
+        CompletableFuture<Exception> completion = new CompletableFuture<>();
+        if (batchRegistered) {
+            appendToAccumulator(tb1, row(1, "pending"), (tb, leo, e) -> completion.complete(e));
+        }
+        TooManyPartitionsException failure =
+                new TooManyPartitionsException("Partition limit reached");
+        sender.recordFatalError(failure);
+        assertThat(sender.isRunning()).isFalse();
+        assertThat(sender.getFatalError()).isSameAs(failure);
+        assertThatThrownBy(() -> appendToAccumulator(tb1, row(1, "late"), (tb, leo, e) -> {}))
+                .hasMessageContaining("Writer closed");
+        sender.runOnce();
+        if (batchRegistered) {
+            assertThat(completion.get(10, TimeUnit.SECONDS)).isSameAs(failure);
+        }
+        assertThat(accumulator.hasIncomplete()).isFalse();
+        assertThat(accumulator.hasUnDrained()).isFalse();
     }
 
     @Test
-    void testInvalidBucketRoutingReclaimsBatchSequenceWhenIdempotenceEnabled() throws Exception {
-        // Bucket routing is validated for hash-distributed tables, so exercise the client reclaim
-        // path on a primary-key table bucket rather than a keyless one.
-        TableBucket keyedBucket = new TableBucket(DATA1_TABLE_ID_PK, 0);
-        IdempotenceManager idempotenceManager = createIdempotenceManager(true);
-        Sender staleSender = setupWithIdempotenceState(idempotenceManager);
-        staleSender.runOnce();
-        long writerId = idempotenceManager.writerId();
-        assertThat(idempotenceManager.isWriterIdValid()).isTrue();
-        assertThat(idempotenceManager.nextSequence(keyedBucket)).isEqualTo(0);
-
-        // Drain and send one batch: it takes batch sequence 0 and nextSequence advances to 1.
-        CompletableFuture<Exception> future = new CompletableFuture<>();
-        appendKvToAccumulator(
-                keyedBucket,
-                compactedRow(DATA1_ROW_TYPE, new Object[] {1, "a"}),
-                (tb, leo, e) -> future.complete(e));
-        staleSender.runOnce();
-        assertThat(idempotenceManager.nextSequence(keyedBucket)).isEqualTo(1);
-
-        // The server rejects the batch during pre-append routing validation, so it was provably
-        // never written. Its batch sequence (0) must be reclaimed.
-        finishRequest(
-                keyedBucket, 0, createPutKvResponse(keyedBucket, Errors.INVALID_BUCKET_ROUTING));
-        staleSender.runOnce();
-
-        // The write callback receives the non-retriable routing error.
-        assertThat(future.get()).isInstanceOf(InvalidBucketRoutingException.class);
-
-        // The writer id must survive: nothing was accepted, so there is no lost message to guard.
-        assertThat(idempotenceManager.isWriterIdValid()).isTrue();
-        assertThat(idempotenceManager.writerId()).isEqualTo(writerId);
-
-        // The reclaimed sequence must roll nextSequence back to 0. Otherwise a permanent hole at
-        // sequence 0 remains: the next batch that reaches the server on this bucket (created after
-        // the metadata refresh, carrying a valid routing count) would send sequence 1 against an
-        // expected 0, triggering OUT_OF_ORDER_SEQUENCE_EXCEPTION and resetWriterId, which wipes
-        // idempotence for every bucket of this writer.
-        assertThat(idempotenceManager.nextSequence(keyedBucket)).isEqualTo(0);
+    void testInvalidBucketRoutingStopsQueuedAndInflightWrites() throws Exception {
+        TableBucket tb2 = new TableBucket(DATA1_TABLE_ID, 1);
+        CompletableFuture<Exception> first = new CompletableFuture<>();
+        CompletableFuture<Exception> inflight = new CompletableFuture<>();
+        CompletableFuture<Exception> queued = new CompletableFuture<>();
+        appendToAccumulator(tb1, row(1, "v1"), (tb, leo, e) -> first.complete(e));
+        sender.runOnce();
+        appendToAccumulator(tb2, row(2, "other bucket"), (tb, leo, e) -> inflight.complete(e));
+        sender.runOnce();
+        appendToAccumulator(tb1, row(1, "v2"), (tb, leo, e) -> queued.complete(e));
+        TestTabletServerGateway secondGateway =
+                (TestTabletServerGateway)
+                        metadataUpdater.newTabletServerClientForNode(
+                                metadataUpdater.leaderFor(DATA1_TABLE_PATH, tb2));
+        finishRequest(tb1, 0, createProduceLogResponse(tb1, Errors.INVALID_BUCKET_ROUTING));
+        assertThat(sender.isRunning()).isFalse();
+        assertThatThrownBy(() -> appendToAccumulator(tb1, row(1, "retry"), (tb, leo, e) -> {}))
+                .hasMessageContaining("Writer closed");
+        // A success arriving after rejection but before sender cleanup must not complete v2.
+        secondGateway.response(0, createProduceLogResponse(tb2, 0, 1));
+        assertThat(inflight).isNotDone();
+        sender.runOnce();
+        assertThat(first.get()).isInstanceOf(InvalidBucketRoutingException.class);
+        assertThat(inflight.get()).isInstanceOf(InvalidBucketRoutingException.class);
+        assertThat(queued.get()).isInstanceOf(InvalidBucketRoutingException.class);
+        assertThat(sender.numOfInFlightBatches(tb1)).isZero();
+        assertThat(sender.numOfInFlightBatches(tb2)).isZero();
+        assertThat(accumulator.hasIncomplete()).isFalse();
     }
 
     private TestingMetadataUpdater initializeMetadataUpdater() {
@@ -1843,11 +1797,11 @@ final class SenderTest {
     }
 
     private static TableInfo createHistoricalTableInfo() {
-        return createHistoricalTableInfo(AutoPartitionTimeUnit.DAY, 7);
+        return createPartitionedTableInfo(AutoPartitionTimeUnit.DAY, 7, true);
     }
 
-    private static TableInfo createHistoricalTableInfo(
-            AutoPartitionTimeUnit timeUnit, int numToRetain) {
+    private static TableInfo createPartitionedTableInfo(
+            AutoPartitionTimeUnit timeUnit, int numToRetain, boolean historicalPartitionEnabled) {
         Schema schema =
                 Schema.newBuilder()
                         .column("id", DataTypes.INT())
@@ -1865,7 +1819,9 @@ final class SenderTest {
                         .property(ConfigOptions.TABLE_AUTO_PARTITION_TIMEZONE, "UTC")
                         .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
                         .property(ConfigOptions.TABLE_DATALAKE_FORMAT, DataLakeFormat.PAIMON)
-                        .property(ConfigOptions.TABLE_DATALAKE_HISTORICAL_PARTITION_ENABLED, true)
+                        .property(
+                                ConfigOptions.TABLE_DATALAKE_HISTORICAL_PARTITION_ENABLED,
+                                historicalPartitionEnabled)
                         .build();
         return TableInfo.of(
                 DATA1_TABLE_PATH_PK,
@@ -1898,7 +1854,13 @@ final class SenderTest {
 
     private static Cluster partitionedCluster(
             TableInfo tableInfo, Map<PhysicalTablePath, TableBucket> tableBucketsByPath) {
-        return partitionedCluster(tableInfo, tableBucketsByPath, Collections.emptyMap());
+        Map<TableOrPartition, Integer> bucketCounts = new HashMap<>();
+        for (TableBucket bucket : tableBucketsByPath.values()) {
+            bucketCounts.put(
+                    TableOrPartition.ofPartition(bucket.getPartitionId()),
+                    tableInfo.getNumBuckets());
+        }
+        return partitionedCluster(tableInfo, tableBucketsByPath, bucketCounts);
     }
 
     private static Cluster partitionedCluster(
@@ -1933,16 +1895,6 @@ final class SenderTest {
     private CompletableFuture<Exception> appendKvRecord(
             TableInfo tableInfo, PhysicalTablePath physicalTablePath, int id, Cluster cluster)
             throws Exception {
-        return appendKvRecord(tableInfo, physicalTablePath, id, cluster, 0);
-    }
-
-    private CompletableFuture<Exception> appendKvRecord(
-            TableInfo tableInfo,
-            PhysicalTablePath physicalTablePath,
-            int id,
-            Cluster cluster,
-            int bucketCount)
-            throws Exception {
         accumulator.checkAndCacheHistoricalPartitionEnabled(tableInfo);
         BinaryRow row =
                 compactedRow(
@@ -1954,6 +1906,7 @@ final class SenderTest {
                                 tableInfo.getSchema().getPrimaryKeyIndexes())
                         .encodeKey(row);
         CompletableFuture<Exception> future = new CompletableFuture<>();
+        bucketAssigner.setBucketId(0);
         accumulator.append(
                 WriteRecord.forUpsert(
                         tableInfo,
@@ -1964,10 +1917,7 @@ final class SenderTest {
                         WriteFormat.COMPACTED_KV,
                         null),
                 (tableBucket, logEndOffset, error) -> future.complete(error),
-                cluster,
-                0,
-                bucketCount,
-                false);
+                cluster);
         return future;
     }
 
@@ -1979,14 +1929,12 @@ final class SenderTest {
     private void appendToAccumulator(
             TableInfo tableInfo, TableBucket tb, GenericRow row, WriteCallback writeCallback)
             throws Exception {
+        bucketAssigner.setBucketId(tb.getBucket());
         accumulator.append(
                 WriteRecord.forArrowAppend(
                         tableInfo, PhysicalTablePath.of(tableInfo.getTablePath()), row, null),
                 writeCallback,
-                metadataUpdater.getCluster(),
-                tb.getBucket(),
-                tableInfo.getNumBuckets(),
-                false);
+                metadataUpdater.getCluster());
     }
 
     private void appendKvToAccumulator(
@@ -2002,6 +1950,7 @@ final class SenderTest {
             throws Exception {
         int[] pkIndex = DATA1_SCHEMA_PK.getPrimaryKeyIndexes();
         byte[] key = new CompactedKeyEncoder(DATA1_ROW_TYPE, pkIndex).encodeKey(row);
+        bucketAssigner.setBucketId(tableBucket.getBucket());
         accumulator.append(
                 WriteRecord.forUpsert(
                         tableInfo,
@@ -2012,10 +1961,7 @@ final class SenderTest {
                         WriteFormat.COMPACTED_KV,
                         null),
                 writeCallback,
-                metadataUpdater.getCluster(),
-                tableBucket.getBucket(),
-                tableInfo.getNumBuckets(),
-                false);
+                metadataUpdater.getCluster());
     }
 
     private TestTabletServerGateway node1Gateway() {
@@ -2140,9 +2086,14 @@ final class SenderTest {
         conf.set(ConfigOptions.CLIENT_WRITER_BATCH_SIZE, new MemorySize(BATCH_SIZE));
         conf.set(ConfigOptions.CLIENT_WRITER_BUFFER_PAGE_SIZE, new MemorySize(PAGE_SIZE));
         conf.set(ConfigOptions.CLIENT_WRITER_BATCH_TIMEOUT, Duration.ofMillis(batchTimeoutMs));
+        bucketAssigner = new TestingBucketAssigner();
         accumulator =
                 new RecordAccumulator(
-                        conf, idempotenceManager, writerMetricGroup, SystemClock.getInstance());
+                        conf,
+                        idempotenceManager,
+                        writerMetricGroup,
+                        SystemClock.getInstance(),
+                        (tableInfo, path) -> bucketAssigner);
         return new Sender(
                 accumulator,
                 REQUEST_TIMEOUT,
@@ -2151,8 +2102,7 @@ final class SenderTest {
                 reties,
                 metadataUpdater,
                 idempotenceManager,
-                writerMetricGroup,
-                tb -> {});
+                writerMetricGroup);
     }
 
     private IdempotenceManager createIdempotenceManager(boolean idempotenceEnabled) {

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/StickyStaticBucketAssignerTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/StickyStaticBucketAssignerTest.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link StickyBucketAssigner}. */
 class StickyStaticBucketAssignerTest {
+    private final int numBuckets = 3;
     ServerNode node1 = new ServerNode(1, "localhost", 90, ServerType.TABLET_SERVER, "rack1");
     ServerNode node2 = new ServerNode(2, "localhost", 91, ServerType.TABLET_SERVER, "rack2");
     ServerNode node3 = new ServerNode(3, "localhost", 92, ServerType.TABLET_SERVER, "rack3");
@@ -62,26 +63,26 @@ class StickyStaticBucketAssignerTest {
         // init cluster.
         Cluster cluster = updateCluster(Arrays.asList(bucket1, bucket2, bucket3));
         StickyBucketAssigner stickyBucketAssigner =
-                new StickyBucketAssigner(DATA1_PHYSICAL_TABLE_PATH, 3);
-        int bucketId = stickyBucketAssigner.assignBucket(cluster);
+                new StickyBucketAssigner(DATA1_PHYSICAL_TABLE_PATH);
+        int bucketId = stickyBucketAssigner.assignBucket(cluster, numBuckets);
         assertThat(bucketId >= 0 && bucketId < 3).isTrue();
 
         for (int i = 0; i < 10; i++) {
-            int newBucketId = stickyBucketAssigner.assignBucket(cluster);
+            int newBucketId = stickyBucketAssigner.assignBucket(cluster, numBuckets);
             assertThat(newBucketId >= 0 && newBucketId < 3).isTrue();
             assertThat(newBucketId).isEqualTo(bucketId);
         }
 
         // on new batch.
-        stickyBucketAssigner.onNewBatch(cluster, bucketId);
-        int newBucketId = stickyBucketAssigner.assignBucket(cluster);
+        stickyBucketAssigner.onNewBatch(cluster, 3, bucketId);
+        int newBucketId = stickyBucketAssigner.assignBucket(cluster, numBuckets);
         assertThat(newBucketId >= 0 && newBucketId < 3).isTrue();
         assertThat(newBucketId).isNotEqualTo(bucketId);
 
         for (int i = 0; i < 100; i++) {
-            int prevBucketId = stickyBucketAssigner.assignBucket(cluster);
-            stickyBucketAssigner.onNewBatch(cluster, bucketId);
-            int nextBucketId = stickyBucketAssigner.assignBucket(cluster);
+            int prevBucketId = stickyBucketAssigner.assignBucket(cluster, numBuckets);
+            stickyBucketAssigner.onNewBatch(cluster, 3, bucketId);
+            int nextBucketId = stickyBucketAssigner.assignBucket(cluster, numBuckets);
             assertThat(prevBucketId).isEqualTo(nextBucketId);
         }
     }
@@ -91,13 +92,13 @@ class StickyStaticBucketAssignerTest {
         // init cluster.
         Cluster cluster = updateCluster(Arrays.asList(bucket1, bucket2, bucket3));
         StickyBucketAssigner stickyBucketAssigner =
-                new StickyBucketAssigner(DATA1_PHYSICAL_TABLE_PATH, 3);
-        int bucketId = stickyBucketAssigner.assignBucket(cluster);
+                new StickyBucketAssigner(DATA1_PHYSICAL_TABLE_PATH);
+        int bucketId = stickyBucketAssigner.assignBucket(cluster, numBuckets);
         for (int i = 0; i < 3; i++) {
             if (i != bucketId) {
                 // If the preBucketId != currentBucketId, the bucket id should not change.
-                stickyBucketAssigner.onNewBatch(cluster, i);
-                int newBucketId = stickyBucketAssigner.assignBucket(cluster);
+                stickyBucketAssigner.onNewBatch(cluster, 3, i);
+                int newBucketId = stickyBucketAssigner.assignBucket(cluster, numBuckets);
                 assertThat(newBucketId).isEqualTo(bucketId);
             }
         }
@@ -108,13 +109,13 @@ class StickyStaticBucketAssignerTest {
         // init cluster.
         Cluster cluster = updateCluster(Collections.singletonList(bucket1));
         StickyBucketAssigner stickyBucketAssigner =
-                new StickyBucketAssigner(DATA1_PHYSICAL_TABLE_PATH, 3);
-        int bucketId = stickyBucketAssigner.assignBucket(cluster);
+                new StickyBucketAssigner(DATA1_PHYSICAL_TABLE_PATH);
+        int bucketId = stickyBucketAssigner.assignBucket(cluster, numBuckets);
 
         for (int i = 0; i < 100; i++) {
             // If there is only one available bucket, the bucket id should not change.
-            stickyBucketAssigner.onNewBatch(cluster, bucketId);
-            assertThat(stickyBucketAssigner.assignBucket(cluster)).isEqualTo(bucketId);
+            stickyBucketAssigner.onNewBatch(cluster, 3, bucketId);
+            assertThat(stickyBucketAssigner.assignBucket(cluster, numBuckets)).isEqualTo(bucketId);
         }
     }
 
@@ -133,45 +134,46 @@ class StickyStaticBucketAssignerTest {
         Cluster cluster = updateCluster(allBuckets);
 
         // Assure we never choose bucket 1 for tp1 because it is unavailable.
-        StickyBucketAssigner stickyBucketAssigner = new StickyBucketAssigner(tp1, 3);
-        int bucketForTp1 = stickyBucketAssigner.assignBucket(cluster);
+        StickyBucketAssigner stickyBucketAssigner = new StickyBucketAssigner(tp1);
+        int bucketForTp1 = stickyBucketAssigner.assignBucket(cluster, numBuckets);
         assertThat(bucketForTp1).isNotEqualTo(1);
         for (int i = 0; i < 100; i++) {
-            stickyBucketAssigner.onNewBatch(cluster, bucketForTp1);
-            assertThat(stickyBucketAssigner.assignBucket(cluster)).isNotEqualTo(1);
+            stickyBucketAssigner.onNewBatch(cluster, 3, bucketForTp1);
+            assertThat(stickyBucketAssigner.assignBucket(cluster, numBuckets)).isNotEqualTo(1);
         }
 
         // Assure we always choose bucket 1 for tp2.
-        stickyBucketAssigner = new StickyBucketAssigner(tp2, 3);
-        int bucketForTp2 = stickyBucketAssigner.assignBucket(cluster);
+        stickyBucketAssigner = new StickyBucketAssigner(tp2);
+        int bucketForTp2 = stickyBucketAssigner.assignBucket(cluster, numBuckets);
         assertThat(bucketForTp2).isEqualTo(1);
         for (int i = 0; i < 100; i++) {
-            stickyBucketAssigner.onNewBatch(cluster, bucketForTp2);
-            assertThat(stickyBucketAssigner.assignBucket(cluster)).isEqualTo(1);
+            stickyBucketAssigner.onNewBatch(cluster, 3, bucketForTp2);
+            assertThat(stickyBucketAssigner.assignBucket(cluster, numBuckets)).isEqualTo(1);
         }
 
         // Assure that we can still choose one bucket even if there are no available buckets.
-        stickyBucketAssigner = new StickyBucketAssigner(tp3, 3);
-        int bucketForTp3 = stickyBucketAssigner.assignBucket(cluster);
+        stickyBucketAssigner = new StickyBucketAssigner(tp3);
+        int bucketForTp3 = stickyBucketAssigner.assignBucket(cluster, numBuckets);
         assertThat(bucketForTp3).isIn(0, 1, 2);
-        stickyBucketAssigner.onNewBatch(cluster, bucketForTp3);
-        assertThat(stickyBucketAssigner.assignBucket(cluster)).isIn(0, 1, 2);
+        stickyBucketAssigner.onNewBatch(cluster, 3, bucketForTp3);
+        assertThat(stickyBucketAssigner.assignBucket(cluster, numBuckets)).isIn(0, 1, 2);
     }
 
     @Test
     void testMultiThreadToCallOnNewBatch() {
         Cluster cluster = updateCluster(Arrays.asList(bucket1, bucket2, bucket3));
         StickyBucketAssigner stickyBucketAssigner =
-                new StickyBucketAssigner(PhysicalTablePath.of(DATA1_TABLE_PATH), 3);
-        int bucketId = stickyBucketAssigner.assignBucket(cluster);
+                new StickyBucketAssigner(PhysicalTablePath.of(DATA1_TABLE_PATH));
+        int bucketId = stickyBucketAssigner.assignBucket(cluster, numBuckets);
         Queue<Integer> bucketIds = new ConcurrentLinkedQueue<>();
         Thread[] threads = new Thread[100];
         for (int i = 0; i < 100; i++) {
             threads[i] =
                     new Thread(
                             () -> {
-                                stickyBucketAssigner.onNewBatch(cluster, bucketId);
-                                int newBucketId = stickyBucketAssigner.assignBucket(cluster);
+                                stickyBucketAssigner.onNewBatch(cluster, 3, bucketId);
+                                int newBucketId =
+                                        stickyBucketAssigner.assignBucket(cluster, numBuckets);
                                 bucketIds.add(newBucketId);
                             });
             threads[i].start();

--- a/fluss-client/src/test/java/org/apache/fluss/client/write/TestingBucketAssigner.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/write/TestingBucketAssigner.java
@@ -21,16 +21,32 @@ import org.apache.fluss.cluster.Cluster;
 
 import javax.annotation.Nullable;
 
-/**
- * An abstract bucket assigner to assign a bucket dynamically. The bucket id determined during
- * sending to Fluss cluster by the status of cluster and write batch accumulation.
- */
-abstract class DynamicBucketAssigner implements BucketAssigner {
+import static org.apache.fluss.utils.Preconditions.checkArgument;
+
+/** A bucket assigner whose routing can be controlled by tests. */
+class TestingBucketAssigner implements BucketAssigner {
+    private volatile int bucketId;
+
+    void setBucketId(int bucketId) {
+        this.bucketId = bucketId;
+    }
 
     @Override
     public int assignBucket(@Nullable byte[] bucketKey, Cluster cluster, int bucketCount) {
-        return assignBucket(cluster, bucketCount);
+        int assignedBucket = bucketId;
+        checkArgument(
+                assignedBucket >= 0 && assignedBucket < bucketCount,
+                "Bucket id %s is outside bucket count %s.",
+                assignedBucket,
+                bucketCount);
+        return assignedBucket;
     }
 
-    public abstract int assignBucket(Cluster cluster, int bucketCount);
+    @Override
+    public boolean abortIfBatchFull() {
+        return false;
+    }
+
+    @Override
+    public void onNewBatch(Cluster cluster, int bucketCount, int prevBucketId) {}
 }

--- a/fluss-common/src/main/java/org/apache/fluss/cluster/Cluster.java
+++ b/fluss-common/src/main/java/org/apache/fluss/cluster/Cluster.java
@@ -287,7 +287,7 @@ public final class Cluster {
         }
     }
 
-    public Long getPartitionIdOrElseThrow(PhysicalTablePath physicalTablePath) {
+    public long getPartitionIdOrElseThrow(PhysicalTablePath physicalTablePath) {
         Long partitionId = partitionsIdByPath.get(physicalTablePath);
         if (partitionId == null) {
             throw new PartitionNotExistException(
@@ -331,6 +331,18 @@ public final class Cluster {
      */
     public Optional<Integer> getBucketCount(TableOrPartition tableOrPartition) {
         return Optional.ofNullable(bucketCountByTableOrPartition.get(tableOrPartition));
+    }
+
+    /**
+     * Get the actual bucket count for the given table or partition, throwing an exception if its
+     * bucket layout is not available yet.
+     */
+    public int getBucketCountOrElseThrow(TableOrPartition tableOrPartition) {
+        return getBucketCount(tableOrPartition)
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "Bucket count is unavailable for " + tableOrPartition));
     }
 
     /**

--- a/fluss-common/src/main/java/org/apache/fluss/exception/BucketRescaleException.java
+++ b/fluss-common/src/main/java/org/apache/fluss/exception/BucketRescaleException.java
@@ -2,7 +2,7 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The ASF licenses this file to you under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
@@ -15,22 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.fluss.client.write;
+package org.apache.fluss.exception;
 
-import org.apache.fluss.cluster.Cluster;
-
-import javax.annotation.Nullable;
+import org.apache.fluss.annotation.PublicEvolving;
 
 /**
- * An abstract bucket assigner to assign a bucket dynamically. The bucket id determined during
- * sending to Fluss cluster by the status of cluster and write batch accumulation.
+ * Thrown when bucket rescaling invalidates records buffered with a temporary bucket count.
+ *
+ * <p>The affected records have not been sent. Applications can resubmit them using the same writer,
+ * which has already adopted the resolved bucket count.
  */
-abstract class DynamicBucketAssigner implements BucketAssigner {
+@PublicEvolving
+public class BucketRescaleException extends RuntimeException {
 
-    @Override
-    public int assignBucket(@Nullable byte[] bucketKey, Cluster cluster, int bucketCount) {
-        return assignBucket(cluster, bucketCount);
+    private static final long serialVersionUID = 1L;
+
+    /** Creates an exception describing the bucket rescale and how to retry the records. */
+    public BucketRescaleException(String message) {
+        super(message);
     }
-
-    public abstract int assignBucket(Cluster cluster, int bucketCount);
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/action/orphan/OrphanFilesCleanITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/action/orphan/OrphanFilesCleanITCase.java
@@ -1004,6 +1004,9 @@ abstract class OrphanFilesCleanITCase extends AbstractTestBase {
 
     private void upsertManifest(TableBucket tableBucket, FsPath manifestPath, long endOffset)
             throws Exception {
+        // Wait for replica initialization before injecting the manifest, otherwise the remote
+        // log manager can load these synthetic segments and expire them in the background.
+        FLUSS_CLUSTER_EXTENSION.waitUntilAllReplicaReady(tableBucket);
         FLUSS_CLUSTER_EXTENSION
                 .getZooKeeperClient()
                 .upsertRemoteLogManifestHandle(

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
@@ -2029,7 +2029,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                 new CompactedKeyEncoder(
                         DEFAULT_PK_TABLE_SCHEMA.getRowType(),
                         DEFAULT_PK_TABLE_SCHEMA.getPrimaryKeyIndexes());
-        HashBucketAssigner hashBucketAssigner = new HashBucketAssigner(DEFAULT_BUCKET_NUM);
+        HashBucketAssigner hashBucketAssigner = new HashBucketAssigner();
         Map<Integer, Integer> bucketRows = new HashMap<>();
         try (Table table = conn.getTable(tablePath)) {
             UpsertWriter upsertWriter = table.newUpsert().createWriter();
@@ -2038,7 +2038,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                 upsertWriter.upsert(row);
 
                 byte[] key = keyEncoder.encodeKey(row);
-                int bucketId = hashBucketAssigner.assignBucket(key);
+                int bucketId = hashBucketAssigner.assignBucket(key, DEFAULT_BUCKET_NUM);
 
                 bucketRows.merge(bucketId, 1, Integer::sum);
             }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/reader/FlinkSourceSplitReaderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/reader/FlinkSourceSplitReaderTest.java
@@ -692,8 +692,8 @@ class FlinkSourceSplitReaderTest extends FlinkTestBase {
                         DEFAULT_PK_TABLE_SCHEMA.getRowType(),
                         DEFAULT_PK_TABLE_SCHEMA.getPrimaryKeyIndexes());
         byte[] key = keyEncoder.encodeKey(row);
-        HashBucketAssigner hashBucketAssigner = new HashBucketAssigner(DEFAULT_BUCKET_NUM);
-        return hashBucketAssigner.assignBucket(key);
+        HashBucketAssigner hashBucketAssigner = new HashBucketAssigner();
+        return hashBucketAssigner.assignBucket(key, DEFAULT_BUCKET_NUM);
     }
 
     private List<SourceSplitBase> getHybridSnapshotLogSplits(TablePath tablePath) throws Exception {

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringSplitReaderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringSplitReaderTest.java
@@ -649,8 +649,8 @@ class TieringSplitReaderTest extends FlinkTestBase {
                         DEFAULT_PK_TABLE_SCHEMA.getRowType(),
                         DEFAULT_PK_TABLE_SCHEMA.getPrimaryKeyIndexes());
         byte[] key = keyEncoder.encodeKey(row);
-        HashBucketAssigner hashBucketAssigner = new HashBucketAssigner(DEFAULT_BUCKET_NUM);
-        return hashBucketAssigner.assignBucket(key);
+        HashBucketAssigner hashBucketAssigner = new HashBucketAssigner();
+        return hashBucketAssigner.assignBucket(key, DEFAULT_BUCKET_NUM);
     }
 
     private static class ThrowOnEmptyCompleteLakeTieringFactory extends TestingLakeTieringFactory {

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringTestBase.java
@@ -274,8 +274,7 @@ public class TieringTestBase extends AbstractTestBase {
                 KeyEncoder.ofBucketKeyEncoder(
                         rowType, tableDescriptor.getBucketKeys(), DataLakeFormat.PAIMON);
         HashBucketAssigner hashBucketAssigner =
-                new HashBucketAssigner(
-                        DEFAULT_BUCKET_NUM, BucketingFunction.of(DataLakeFormat.PAIMON));
+                new HashBucketAssigner(BucketingFunction.of(DataLakeFormat.PAIMON));
         Map<Integer, Long> bucketRows = new HashMap<>();
         try (Table table = conn.getTable(tablePath)) {
             UpsertWriter upsertWriter = table.newUpsert().createWriter();
@@ -285,7 +284,7 @@ public class TieringTestBase extends AbstractTestBase {
                 upsertWriter.upsert(row);
                 // bucket statistics
                 byte[] key = keyEncoder.encodeKey(row);
-                int bucketId = hashBucketAssigner.assignBucket(key);
+                int bucketId = hashBucketAssigner.assignBucket(key, DEFAULT_BUCKET_NUM);
                 bucketRows.merge(bucketId, 1L, Long::sum);
             }
             upsertWriter.flush();
@@ -329,8 +328,7 @@ public class TieringTestBase extends AbstractTestBase {
                 KeyEncoder.ofBucketKeyEncoder(
                         rowType, tableDescriptor.getBucketKeys(), DataLakeFormat.PAIMON);
         HashBucketAssigner hashBucketAssigner =
-                new HashBucketAssigner(
-                        DEFAULT_BUCKET_NUM, BucketingFunction.of(DataLakeFormat.PAIMON));
+                new HashBucketAssigner(BucketingFunction.of(DataLakeFormat.PAIMON));
         Map<Integer, Long> bucketRows = new HashMap<>();
         try (Table table = conn.getTable(tablePath)) {
             AppendWriter appendWriter = table.newAppend().createWriter();
@@ -339,7 +337,7 @@ public class TieringTestBase extends AbstractTestBase {
                         partitionName == null ? row(i, "v" + i) : row(i, "v" + i, partitionName);
                 appendWriter.append(row);
                 byte[] key = keyEncoder.encodeKey(row);
-                int bucketId = hashBucketAssigner.assignBucket(key);
+                int bucketId = hashBucketAssigner.assignBucket(key, DEFAULT_BUCKET_NUM);
 
                 bucketRows.merge(bucketId, 1L, Long::sum);
             }


### PR DESCRIPTION
### Purpose

Refs #4287.

A writer may buffer records before a dynamically created partition's bucket count is known. Resolve the partition ID and bucket count together before sending, so a stale table default cannot silently route records to the wrong buckets.

This PR covers tentative routing resolution and server-reported routing failures. The existing synchronous partition-existence check and shared asynchronous metadata refresh work remain follow-ups.

### Brief change log

- Let `RecordAccumulator` own each physical partition's assigner, temporary bucket count, and resolved layout. Pass the current count to `assignBucket` and `onNewBatch`.
- When the actual count differs, retain buffered batches only for non-hash assigners with every occupied bucket ID below the new count. Otherwise, fail all tentative batches for that context with `BucketRescaleException`; callers can resubmit the failed records with the same writer.
- Keep memory allocation and failure callbacks outside routing locks. Synchronize tentative routing resolution and historical target switches while preserving independent writes to resolved buckets.
- Let the server validate resolved batches using the count carried in each request; remove the redundant metadata comparison and `invalidBucketRoutingTables` result from the send path. Treat server-reported `INVALID_BUCKET_ROUTING` and partition-creation failures as fatal writer errors, including queued/in-flight batch cleanup and propagation of the original failure to later writes.
- Simplify historical routing using the existing restriction that historical partitions and bucket rescaling cannot be enabled together.

### Tests

- Passed 154 focused client tests across `BucketRoutingTest`, `RecordAccumulatorTest`, `SenderTest`, `HashBucketAssignerTest`, `StickyStaticBucketAssignerTest`, `PartitionBucketCountRescaleITCase`, `PartitionedTableITCase`, and `AutoPartitionedTableITCase`, including sending the original resolved count after metadata changes and handling server rejection for both count growth and shrinkage.
- Coverage includes growth/shrinkage, no-key retention and out-of-range rejection, retries with the same writer, consistent metadata snapshots, buffer exhaustion, independent bucket appends, historical routing, and close/fatal-error races.
- Passed `./mvnw -B spotless:check validate`.
- Full `./mvnw -B verify` stopped in `fluss-server`: `ReplicaTest.testBucketPhysicalStorageLocalLogSizeIncludesFollower` and `testPhysicalStorageLocalLogSizeIsScopedPerBucket` both reported expected `450` but actual `7220`. No server files are changed by this PR. An isolated rerun of all 16 `ReplicaTest` cases passed; the full-suite failure remains unresolved, and downstream modules were not verified by that run.

### API and Format

Adds the public evolving `BucketRescaleException` for buffered records rejected before sending. Its recovery contract permits resubmission with the same writer. Bucket assigner signature changes are internal; RPC and storage formats are unchanged.

### Documentation

The retry contract is documented in `BucketRescaleException` Javadoc. No standalone documentation changes.

Generative AI assistance: OpenAI Codex (GPT-6 Astra).
